### PR TITLE
Enhance

### DIFF
--- a/cmd/gotest/args.go
+++ b/cmd/gotest/args.go
@@ -11,6 +11,8 @@ type ExecConfig struct {
 
 // knownSubcommands is the set of recognized subcommands.
 var knownSubcommands = map[string]bool{
+	"discover": true,
+	"overlay":  true,
 	"generate": true,
 	"scaffold": true,
 	"migrate":  true,

--- a/cmd/gotest/cli.go
+++ b/cmd/gotest/cli.go
@@ -22,6 +22,10 @@ func main() {
 	subcmd, remaining := ParseSubcommand(os.Args[1:])
 
 	switch subcmd {
+	case "discover":
+		os.Exit(runDiscover(remaining))
+	case "overlay":
+		os.Exit(runOverlay(remaining))
 	case "scaffold":
 		os.Exit(runScaffold(remaining))
 	case "migrate":
@@ -134,6 +138,8 @@ Usage:
   gotest [subcommand] [flags] [packages...]
 
 Subcommands:
+  discover    Discover test suites and output JSON metadata
+  overlay     Generate overlay files and output overlay path as JSON
   generate    Run code generation only (no test execution)
   clean       Remove orphaned generated files
   spec        Render behavioral specification from test suites

--- a/cmd/gotest/discover.go
+++ b/cmd/gotest/discover.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/mvrahden/go-test/internal/gotestgen"
+)
+
+func runDiscover(args []string) int {
+	patterns := ExtractPackagePatterns(args)
+
+	allOutput := gotestgen.DiscoverOutput{}
+	for _, pattern := range patterns {
+		output, err := gotestgen.Discover(pattern)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+			return 2
+		}
+		allOutput.Packages = append(allOutput.Packages, output.Packages...)
+	}
+
+	data, err := json.Marshal(allOutput)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+	fmt.Println(string(data))
+	return 0
+}

--- a/cmd/gotest/overlay.go
+++ b/cmd/gotest/overlay.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mvrahden/go-test/internal/gotestgen"
+	"github.com/mvrahden/go-test/internal/gotestrunner"
+)
+
+type overlayOutput struct {
+	OverlayFile string `json:"overlayFile"`
+	Dir         string `json:"dir"`
+}
+
+func runOverlay(args []string) int {
+	patterns := ExtractPackagePatterns(args)
+
+	var allResults gotestgen.GenerateResults
+	for _, pattern := range patterns {
+		results, err := gotestrunner.SuitesGenerate(pattern)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+			return 2
+		}
+		allResults = append(allResults, results...)
+	}
+
+	tmpDir, err := gotestrunner.WriteOverlay(allResults)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+
+	out := overlayOutput{
+		OverlayFile: filepath.Join(tmpDir, "overlay.json"),
+		Dir:         tmpDir,
+	}
+	data, err := json.Marshal(out)
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+	fmt.Println(string(data))
+	return 0
+}

--- a/cmd/gotest/scaffold.go
+++ b/cmd/gotest/scaffold.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/mvrahden/go-test/internal/scaffold"
 )
 
 func runScaffold(args []string) int {
-	// Find first non-flag argument as target
 	var target string
 	for _, arg := range args {
 		if !isFlag(arg) {
@@ -19,10 +19,56 @@ func runScaffold(args []string) int {
 	}
 
 	if target == "" {
-		fmt.Fprintln(os.Stderr, "usage: gotest scaffold ./pkg/path.TypeName")
+		fmt.Fprintln(os.Stderr, "usage: gotest scaffold ./pkg/path.TypeName or ./path/file.go")
 		return 1
 	}
 
+	if strings.HasSuffix(target, ".go") {
+		return runScaffoldFile(target)
+	}
+	return runScaffoldType(target)
+}
+
+func runScaffoldFile(target string) int {
+	infos, err := scaffold.IntrospectFile(target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "scaffold: %v\n", err)
+		return 1
+	}
+
+	for _, info := range infos {
+		filename := scaffold.ToSnakeCase(info.Name) + "_suite_test.go"
+		outPath := filepath.Join(info.PkgDir, filename)
+
+		if _, err := os.Stat(outPath); err == nil {
+			fmt.Fprintf(os.Stderr, "scaffold: %s already exists\n", outPath)
+			return 1
+		}
+
+		var out []byte
+		switch {
+		case info.IsFuncBased:
+			out, err = scaffold.GenerateFuncScaffold(info)
+		case info.IsInterface:
+			out, err = scaffold.GenerateContractScaffold(info)
+		default:
+			out, err = scaffold.GenerateScaffold(info)
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "scaffold: %v\n", err)
+			return 1
+		}
+
+		if err := os.WriteFile(outPath, out, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "scaffold: failed to write %s: %v\n", outPath, err)
+			return 1
+		}
+		writeGenerated(outPath)
+	}
+	return 0
+}
+
+func runScaffoldType(target string) int {
 	pkgPattern, typeName, err := scaffold.ParseTarget(target)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "scaffold: %v\n", err)
@@ -32,6 +78,14 @@ func runScaffold(args []string) int {
 	info, err := scaffold.IntrospectType(pkgPattern, typeName)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "scaffold: %v\n", err)
+		return 1
+	}
+
+	filename := scaffold.ToSnakeCase(typeName) + "_suite_test.go"
+	outPath := filepath.Join(info.PkgDir, filename)
+
+	if _, err := os.Stat(outPath); err == nil {
+		fmt.Fprintf(os.Stderr, "scaffold: %s already exists\n", outPath)
 		return 1
 	}
 
@@ -46,25 +100,23 @@ func runScaffold(args []string) int {
 		return 1
 	}
 
-	filename := scaffold.ToSnakeCase(typeName) + "_suite_test.go"
-	outPath := filepath.Join(info.PkgDir, filename)
-
 	if err := os.WriteFile(outPath, out, 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "scaffold: failed to write %s: %v\n", outPath, err)
 		return 1
 	}
+	writeGenerated(outPath)
+	return 0
+}
 
-	// Print relative path if possible, falling back to absolute
+func writeGenerated(outPath string) {
 	cwd, cwdErr := os.Getwd()
 	if cwdErr == nil {
 		if rel, err := filepath.Rel(cwd, outPath); err == nil {
 			fmt.Printf("Generated: %s\n", rel)
-			return 0
+			return
 		}
 	}
 	fmt.Printf("Generated: %s\n", outPath)
-
-	return 0
 }
 
 func isFlag(s string) bool {

--- a/internal/gotestast/fixture.go
+++ b/internal/gotestast/fixture.go
@@ -95,7 +95,7 @@ func DetermineFixture(n ast.Node, pkg *packages.Package) (*FixtureSpec, error) {
 	}
 
 	if kind == SharedFixture {
-		spec.EnvTags = parseEnvTags(typ)
+		spec.EnvTags = ParseEnvTags(typ)
 	}
 
 	return spec, nil
@@ -213,7 +213,7 @@ func NewFixtureSpecForTestWithPkg(name string, kind FixtureKind, pkgPath string)
 	}
 }
 
-func parseEnvTags(typ *types.Struct) map[string]string {
+func ParseEnvTags(typ *types.Struct) map[string]string {
 	tags := make(map[string]string)
 	for i := 0; i < typ.NumFields(); i++ {
 		f := typ.Field(i)

--- a/internal/gotestast/spec.go
+++ b/internal/gotestast/spec.go
@@ -196,6 +196,15 @@ func (ts *TestSuiteSpec) HasParallelTestCases() bool {
 	})
 }
 
+func (ts *TestSuiteSpec) FileSet() *token.FileSet { return ts.pkg.Fset }
+func (ts *TestSuiteSpec) Pos() token.Pos           { return ts.ts.Name.Pos() }
+func (ts *TestSuiteSpec) IsFocused() bool           { return strings.HasPrefix(ts.ts.Name.Name, "F_") }
+func (ts *TestSuiteSpec) IsExcluded() bool          { return strings.HasPrefix(ts.ts.Name.Name, "X_") }
+
+func (ts *TestSuiteSpec) IsParallel() bool {
+	return strings.HasSuffix(ts.ts.Name.Name, "TestSuiteParallel")
+}
+
 func (ts *TestSuiteSpec) isFocused() bool {
 	return strings.HasPrefix(ts.ts.Name.Name, "F_")
 }
@@ -225,6 +234,10 @@ func (m *TestSuiteMethod) IsParallel() bool {
 
 // UsesStdlibT returns true if the method's parameter is *testing.T instead of *gotest.T.
 func (m *TestSuiteMethod) UsesStdlibT() bool { return m.usesStdlibT }
+
+func (m *TestSuiteMethod) Pos() token.Pos  { return m.m.Pos() }
+func (m *TestSuiteMethod) IsFocused() bool { return strings.HasPrefix(m.m.Name(), "F_") }
+func (m *TestSuiteMethod) IsExcluded() bool { return strings.HasPrefix(m.m.Name(), "X_") }
 
 func (m *TestSuiteMethod) isFocused() bool {
 	return strings.HasPrefix(m.m.Name(), "F_")

--- a/internal/gotestgen/collector.go
+++ b/internal/gotestgen/collector.go
@@ -93,30 +93,35 @@ func (collector) CollectSuiteSpecs(pkg *packages.Package) CollectorResult {
 		return CollectorResult{Errs: errs}
 	}
 
-	// detect fixture embedding in test suites
+	// detect fixture embedding in test suites (only package fixtures, not shared fixtures)
 	for _, s := range suites {
 		embedded := findEmbeddedFixtures(s.StructType(), fixtures)
-		if len(embedded) > 1 {
+		var pkgFixtures []*gotestast.FixtureSpec
+		for _, e := range embedded {
+			if e.Kind == gotestast.PackageFixture {
+				pkgFixtures = append(pkgFixtures, e)
+			}
+		}
+		if len(pkgFixtures) > 1 {
 			errs = append(errs, CollectorError{
 				Err: fmt.Errorf("test suite %q embeds multiple fixtures; at most one is allowed", s.Identifier()),
 			})
 			continue
 		}
-		if len(embedded) == 1 {
-			s.SetFixture(embedded[0])
+		if len(pkgFixtures) == 1 {
+			s.SetFixture(pkgFixtures[0])
 		}
 	}
 	if len(errs) > 0 {
 		return CollectorResult{Errs: errs}
 	}
 
-	// detect fixture-to-fixture embedding (parent fixture)
+	// detect fixture-to-fixture embedding (parent fixture, skip shared fixtures)
 	for _, f := range fixtures {
 		embedded := findEmbeddedFixtures(f.StructType(), fixtures)
-		// exclude self
 		var parents []*gotestast.FixtureSpec
 		for _, e := range embedded {
-			if e != f {
+			if e != f && e.Kind != gotestast.SharedFixture {
 				parents = append(parents, e)
 			}
 		}

--- a/internal/gotestgen/collector_test.go
+++ b/internal/gotestgen/collector_test.go
@@ -613,6 +613,54 @@ func TestCollector_NilPackage(t *testing.T) {
 	gotest.True(t, result.Fixtures == nil, "expected nil fixtures")
 }
 
+// --- Shared fixture embedding: not treated as parent ---
+
+func TestCollector_SharedFixtureNotTreatedAsParent(t *testing.T) {
+	src := "package testpkg\n\n" +
+		"import (\n" +
+		"\t\"context\"\n\n" +
+		"\t\"github.com/mvrahden/go-test/pkg/gotest\"\n" +
+		")\n\n" +
+		"type PGSharedFixture struct {\n" +
+		"\tDSN string `gotest:\"env=PG_DSN\"`\n" +
+		"}\n\n" +
+		"func (f *PGSharedFixture) BeforeAll() error { return nil }\n\n" +
+		"type E2EFixture struct {\n" +
+		"\t*PGSharedFixture\n" +
+		"}\n\n" +
+		"func (f *E2EFixture) BeforeAll(ctx context.Context) error { return nil }\n\n" +
+		"type QueryTestSuite struct {\n" +
+		"\t*E2EFixture\n" +
+		"}\n\n" +
+		"func (s *QueryTestSuite) TestInsert(t *gotest.T) {}\n"
+
+	pkg := loadTestPkgWithGotest(t, src)
+	c := collector{}
+	result := c.CollectSuiteSpecs(pkg)
+	gotest.Equal(t, 0, len(result.Errs), "expected no errors, got: %v", result.Errs)
+	gotest.Equal(t, 1, len(result.Suites))
+	gotest.Equal(t, 2, len(result.Fixtures))
+
+	var e2eFix *gotestast.FixtureSpec
+	for _, f := range result.Fixtures {
+		if f.Identifier() == "E2EFixture" {
+			e2eFix = f
+		}
+	}
+	gotest.True(t, e2eFix != nil, "expected E2EFixture")
+	gotest.True(t, e2eFix.ParentFixture == nil,
+		"shared fixture should NOT be treated as parent; ParentFixture should be nil")
+
+	// Suite should be linked to the package fixture
+	gotest.True(t, result.Suites[0].Fixture() != nil, "expected suite to have fixture")
+	gotest.Equal(t, "E2EFixture", result.Suites[0].Fixture().Identifier())
+
+	// Validation should pass (single root package fixture)
+	spec, err := c.ApplyTestSuiteSpecs(result)
+	gotest.NoError(t, err)
+	gotest.Equal(t, 1, len(spec.EffectiveTestSuites))
+}
+
 // --- helpers ---
 
 // makeFixtureSpec creates a minimal FixtureSpec for validation testing.

--- a/internal/gotestgen/discover.go
+++ b/internal/gotestgen/discover.go
@@ -1,0 +1,150 @@
+package gotestgen
+
+import (
+	"go/token"
+
+	"github.com/mvrahden/go-test/internal/gotestast"
+)
+
+type DiscoverOutput struct {
+	Packages []DiscoverPackage `json:"packages"`
+}
+
+type DiscoverPackage struct {
+	ImportPath string          `json:"importPath"`
+	Dir        string          `json:"dir"`
+	Suites     []DiscoverSuite `json:"suites"`
+}
+
+type DiscoverSuite struct {
+	Name      string           `json:"name"`
+	Parallel  bool             `json:"parallel"`
+	Focused   bool             `json:"focused"`
+	Excluded  bool             `json:"excluded"`
+	File      string           `json:"file"`
+	Line      int              `json:"line"`
+	Col       int              `json:"col"`
+	Lifecycle []string         `json:"lifecycle"`
+	Fixtures  []string         `json:"fixtures"`
+	Methods   []DiscoverMethod `json:"methods"`
+}
+
+type DiscoverMethod struct {
+	Name     string `json:"name"`
+	Parallel bool   `json:"parallel"`
+	Focused  bool   `json:"focused"`
+	Excluded bool   `json:"excluded"`
+	File     string `json:"file"`
+	Line     int    `json:"line"`
+	Col      int    `json:"col"`
+}
+
+func Discover(targetPath string) (*DiscoverOutput, error) {
+	loadResults, err := loadPackages(targetPath)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgMap := make(map[string]*DiscoverPackage)
+	var pkgOrder []string
+
+	c := collector{}
+	for _, lr := range loadResults {
+		ptestCollected := c.CollectSuiteSpecs(lr.ptest)
+		if len(ptestCollected.Errs) > 0 {
+			return nil, ptestCollected.Errs[0].Err
+		}
+		pxtestCollected := c.CollectSuiteSpecs(lr.pxtest)
+		if len(pxtestCollected.Errs) > 0 {
+			return nil, pxtestCollected.Errs[0].Err
+		}
+
+		pkg, ok := pkgMap[lr.pkgPath]
+		if !ok {
+			pkg = &DiscoverPackage{
+				ImportPath: lr.pkgPath,
+				Dir:        lr.pkgDir,
+			}
+			pkgMap[lr.pkgPath] = pkg
+			pkgOrder = append(pkgOrder, lr.pkgPath)
+		}
+
+		addSuites(pkg, ptestCollected.Suites)
+		addSuites(pkg, pxtestCollected.Suites)
+	}
+
+	output := &DiscoverOutput{Packages: make([]DiscoverPackage, 0)}
+	for _, path := range pkgOrder {
+		p := pkgMap[path]
+		if len(p.Suites) > 0 {
+			output.Packages = append(output.Packages, *p)
+		}
+	}
+	return output, nil
+}
+
+func addSuites(pkg *DiscoverPackage, suites gotestast.TestSuiteSpecSet) {
+	for _, suite := range suites {
+		pkg.Suites = append(pkg.Suites, convertSuite(suite))
+	}
+}
+
+func convertSuite(suite *gotestast.TestSuiteSpec) DiscoverSuite {
+	fset := suite.FileSet()
+	pos := fset.Position(suite.Pos())
+
+	lifecycle := collectLifecycle(suite)
+	fixtures := make([]string, 0)
+	if f := suite.Fixture(); f != nil {
+		fixtures = append(fixtures, f.Identifier())
+	}
+	methods := make([]DiscoverMethod, 0, len(suite.TestCases()))
+	for _, tc := range suite.TestCases() {
+		methods = append(methods, convertMethod(tc, fset))
+	}
+
+	ds := DiscoverSuite{
+		Name:      suite.Identifier(),
+		Parallel:  suite.IsParallel(),
+		Focused:   suite.IsFocused(),
+		Excluded:  suite.IsExcluded(),
+		File:      pos.Filename,
+		Line:      pos.Line,
+		Col:       pos.Column,
+		Lifecycle: lifecycle,
+		Fixtures:  fixtures,
+		Methods:   methods,
+	}
+
+	return ds
+}
+
+func collectLifecycle(suite *gotestast.TestSuiteSpec) []string {
+	lc := make([]string, 0)
+	if suite.BeforeAll() != nil {
+		lc = append(lc, "BeforeAll")
+	}
+	if suite.AfterAll() != nil {
+		lc = append(lc, "AfterAll")
+	}
+	if suite.BeforeEach() != nil {
+		lc = append(lc, "BeforeEach")
+	}
+	if suite.AfterEach() != nil {
+		lc = append(lc, "AfterEach")
+	}
+	return lc
+}
+
+func convertMethod(m *gotestast.TestSuiteMethod, fset *token.FileSet) DiscoverMethod {
+	pos := fset.Position(m.Pos())
+	return DiscoverMethod{
+		Name:     m.Identifier(),
+		Parallel: m.IsParallel(),
+		Focused:  m.IsFocused(),
+		Excluded: m.IsExcluded(),
+		File:     pos.Filename,
+		Line:     pos.Line,
+		Col:      pos.Column,
+	}
+}

--- a/internal/gotestgen/renderer.go
+++ b/internal/gotestgen/renderer.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"go/format"
+	"go/types"
 	"strings"
 	"text/template"
 
@@ -39,10 +40,11 @@ type FixtureViewModel struct {
 
 // SharedFixtureRef describes a shared fixture embedded in a package fixture.
 type SharedFixtureRef struct {
-	LocalVar      string            // e.g. "pgFixture"
-	QualifiedType string            // e.g. "fixtures.PostgresFixture"
-	FieldName     string            // e.g. "PostgresFixture"
+	LocalVar      string            // e.g. "sf0"
+	QualifiedType string            // e.g. "fixtures.PostgresSharedFixture"
+	FieldName     string            // e.g. "PostgresSharedFixture"
 	EnvTags       map[string]string // field -> env var
+	PkgPath       string            // import path, empty if same package
 }
 
 type renderer struct{}
@@ -54,16 +56,23 @@ func (r renderer) RenderTestSuiteSpec(pkg *packages.Package, spec SpecOutcome) (
 	if len(spec.EffectiveTestSuites) == 0 {
 		return nil, nil
 	}
-	buf := bytes.NewBuffer(nil)
-	if err := r.renderFileHeader(buf, pkg, spec); err != nil {
-		return nil, fmt.Errorf("failed rendering file header. err: %w", err)
-	}
 
 	// Split suites into fixture-bound and standalone
 	fixtureBound, standalone := splitSuitesByFixture(spec)
 
+	// Build fixture view models before rendering header (shared fixture imports needed)
+	var viewModels []*FixtureViewModel
 	if len(fixtureBound) > 0 {
-		if err := r.renderFixtures(buf, spec, fixtureBound); err != nil {
+		viewModels = buildFixtureViewModels(spec.Fixtures, fixtureBound)
+	}
+
+	buf := bytes.NewBuffer(nil)
+	if err := r.renderFileHeader(buf, pkg, spec, viewModels); err != nil {
+		return nil, fmt.Errorf("failed rendering file header. err: %w", err)
+	}
+
+	if len(fixtureBound) > 0 {
+		if err := r.renderFixtures(buf, fixtureBound, viewModels); err != nil {
 			return nil, fmt.Errorf("failed rendering fixture suites. err: %w", err)
 		}
 	}
@@ -82,7 +91,7 @@ func (r renderer) RenderTestSuiteSpec(pkg *packages.Package, spec SpecOutcome) (
 	return r.formatOutput(buf)
 }
 
-func (r *renderer) renderFileHeader(buf *bytes.Buffer, pkg *packages.Package, spec SpecOutcome) error {
+func (r *renderer) renderFileHeader(buf *bytes.Buffer, pkg *packages.Package, spec SpecOutcome, viewModels []*FixtureViewModel) error {
 	type Import struct {
 		Name string
 		Path string
@@ -105,6 +114,15 @@ func (r *renderer) renderFileHeader(buf *bytes.Buffer, pkg *packages.Package, sp
 		imports = append(imports, Import{Path: "context"})
 		imports = append(imports, Import{Path: "os"})
 	}
+	seenPkg := map[string]bool{}
+	for _, vm := range viewModels {
+		for _, sf := range vm.SharedFixtures {
+			if sf.PkgPath != "" && !seenPkg[sf.PkgPath] {
+				imports = append(imports, Import{Path: sf.PkgPath})
+				seenPkg[sf.PkgPath] = true
+			}
+		}
+	}
 	data := TplData{
 		RepoName:    about.ShortInfo(),
 		PackageName: pkg.Name,
@@ -122,16 +140,13 @@ func (r *renderer) renderTestSuites(buf *bytes.Buffer, spec SpecOutcome) error {
 	})
 }
 
-func (r *renderer) renderFixtures(buf *bytes.Buffer, spec SpecOutcome, fixtureBound []*gotestast.TestSuiteSpec) error {
-	// Build fixture view models from the spec's fixtures and fixture-bound suites
-	viewModels := buildFixtureViewModels(spec.Fixtures, fixtureBound)
+func (r *renderer) renderFixtures(buf *bytes.Buffer, fixtureBound []*gotestast.TestSuiteSpec, viewModels []*FixtureViewModel) error {
 	if len(viewModels) == 0 {
 		return nil
 	}
 
-	// Collect all fixture-bound suites for wrapper struct generation
 	return gotestTpl.ExecuteTemplate(buf, "gotest.fixture.tpl", map[string]any{
-		"RootFixtures":     viewModels,
+		"RootFixtures":       viewModels,
 		"FixtureBoundSuites": fixtureBound,
 	})
 }
@@ -166,11 +181,12 @@ func buildFixtureViewModels(fixtures []*gotestast.FixtureSpec, fixtureBound []*g
 			continue
 		}
 		vm := &FixtureViewModel{
-			Identifier: f.Identifier(),
-			BeforeAll:  f.BeforeAll != nil,
-			AfterAll:   f.AfterAll != nil,
-			BeforeEach: f.BeforeEach != nil,
-			AfterEach:  f.AfterEach != nil,
+			Identifier:     f.Identifier(),
+			BeforeAll:      f.BeforeAll != nil,
+			AfterAll:       f.AfterAll != nil,
+			BeforeEach:     f.BeforeEach != nil,
+			AfterEach:      f.AfterEach != nil,
+			SharedFixtures: detectSharedFixtureEmbeddings(f),
 		}
 		vmMap[f.Identifier()] = vm
 	}
@@ -221,4 +237,58 @@ func buildFixtureViewModels(fixtures []*gotestast.FixtureSpec, fixtureBound []*g
 	}
 
 	return roots
+}
+
+// detectSharedFixtureEmbeddings inspects a package fixture's struct type for
+// embedded pointer fields whose type name ends in "SharedFixture". For each
+// match, it parses the env tags and builds a SharedFixtureRef.
+func detectSharedFixtureEmbeddings(pkgFixture *gotestast.FixtureSpec) []SharedFixtureRef {
+	typ := pkgFixture.StructType()
+	if typ == nil {
+		return nil
+	}
+
+	var refs []SharedFixtureRef
+	sfIdx := 0
+	for i := 0; i < typ.NumFields(); i++ {
+		field := typ.Field(i)
+		if !field.Anonymous() {
+			continue
+		}
+		ptr, ok := field.Type().(*types.Pointer)
+		if !ok {
+			continue
+		}
+		named, ok := ptr.Elem().(*types.Named)
+		if !ok {
+			continue
+		}
+		name := named.Obj().Name()
+		if !strings.HasSuffix(name, "SharedFixture") {
+			continue
+		}
+
+		underlying, ok := named.Underlying().(*types.Struct)
+		if !ok {
+			continue
+		}
+		envTags := gotestast.ParseEnvTags(underlying)
+
+		qualifiedType := name
+		var pkgPath string
+		if pkg := named.Obj().Pkg(); pkg != nil && pkg.Path() != pkgFixture.PackagePath() {
+			qualifiedType = pkg.Name() + "." + name
+			pkgPath = pkg.Path()
+		}
+
+		refs = append(refs, SharedFixtureRef{
+			LocalVar:      fmt.Sprintf("sf%d", sfIdx),
+			QualifiedType: qualifiedType,
+			FieldName:     name,
+			EnvTags:       envTags,
+			PkgPath:       pkgPath,
+		})
+		sfIdx++
+	}
+	return refs
 }

--- a/internal/gotestgen/renderer_test.go
+++ b/internal/gotestgen/renderer_test.go
@@ -500,3 +500,153 @@ func (s *StdlibTestSuite) TestQuery(t *testing.T)  {}
 	// Test case should use adapter
 	gotest.True(t, strings.Contains(output, `func(t *gotest.T) { s.TestQuery(t.T()) }`), "expected TestQuery adapter")
 }
+
+func TestRenderer_SharedFixtureEmbedding(t *testing.T) {
+	src := "package testpkg\n\n" +
+		"import (\n" +
+		"\t\"context\"\n\n" +
+		"\t\"github.com/mvrahden/go-test/pkg/gotest\"\n" +
+		")\n\n" +
+		"type PostgresSharedFixture struct {\n" +
+		"\tDSN string `gotest:\"env=E2E_POSTGRES_DSN\"`\n" +
+		"}\n\n" +
+		"func (f *PostgresSharedFixture) BeforeAll() error { return nil }\n\n" +
+		"type E2EFixture struct {\n" +
+		"\t*PostgresSharedFixture\n" +
+		"\tPool string\n" +
+		"}\n\n" +
+		"func (f *E2EFixture) BeforeAll(ctx context.Context) error { return nil }\n" +
+		"func (f *E2EFixture) AfterAll(ctx context.Context) error  { return nil }\n\n" +
+		"type QueryTestSuite struct {\n" +
+		"\t*E2EFixture\n" +
+		"}\n\n" +
+		"func (s *QueryTestSuite) TestInsert(t *gotest.T) {}\n"
+
+	pkg := loadTestPkgWithGotest(t, src)
+
+	c := collector{}
+	result := c.CollectSuiteSpecs(pkg)
+	gotest.Equal(t, 0, len(result.Errs), "expected no errors, got: %v", result.Errs)
+	gotest.Equal(t, 1, len(result.Suites))
+	gotest.Equal(t, 2, len(result.Fixtures))
+
+	spec, err := c.ApplyTestSuiteSpecs(result)
+	gotest.NoError(t, err)
+	gotest.Equal(t, 1, len(spec.EffectiveTestSuites))
+
+	r := renderer{}
+	out, err := r.RenderTestSuiteSpec(pkg, spec)
+	gotest.NoError(t, err)
+	gotest.True(t, len(out) > 0, "expected non-empty output")
+
+	output := string(out)
+
+	// Shared fixture local var should be created with env var resolution
+	gotest.Contains(t, output, "sf0 := &PostgresSharedFixture{}")
+	gotest.Contains(t, output, `os.Getenv("E2E_POSTGRES_DSN")`)
+	gotest.Contains(t, output, `t.Fatal("E2E_POSTGRES_DSN not set`)
+
+	// Shared fixture should be assigned to the package fixture
+	gotest.Contains(t, output, "fixture.PostgresSharedFixture = sf0")
+
+	// Package fixture lifecycle should still work
+	gotest.Contains(t, output, "func Test_E2EFixture(t *testing.T)")
+	gotest.Contains(t, output, "fixture := &E2EFixture{}")
+	gotest.Contains(t, output, "fixture.BeforeAll(t.Context())")
+	gotest.Contains(t, output, "fixture.AfterAll(context.Background())")
+
+	// Suite should be nested under fixture
+	gotest.Contains(t, output, `t.Run("QueryTestSuite"`)
+	gotest.Contains(t, output, "E2EFixture: fixture")
+
+	// Shared fixture env var resolution should appear before fixture.BeforeAll
+	sfIdx := strings.Index(output, "sf0.DSN = os.Getenv")
+	beforeAllIdx := strings.Index(output, "fixture.BeforeAll(t.Context())")
+	gotest.True(t, sfIdx < beforeAllIdx, "shared fixture env resolution must precede fixture.BeforeAll")
+}
+
+func TestRenderer_SharedFixtureNoEnvTags(t *testing.T) {
+	src := "package testpkg\n\n" +
+		"import (\n" +
+		"\t\"context\"\n\n" +
+		"\t\"github.com/mvrahden/go-test/pkg/gotest\"\n" +
+		")\n\n" +
+		"type SetupSharedFixture struct{}\n\n" +
+		"func (f *SetupSharedFixture) BeforeAll() error { return nil }\n\n" +
+		"type AppFixture struct {\n" +
+		"\t*SetupSharedFixture\n" +
+		"}\n\n" +
+		"func (f *AppFixture) BeforeAll(ctx context.Context) error { return nil }\n\n" +
+		"type AppTestSuite struct {\n" +
+		"\t*AppFixture\n" +
+		"}\n\n" +
+		"func (s *AppTestSuite) TestRun(t *gotest.T) {}\n"
+
+	pkg := loadTestPkgWithGotest(t, src)
+
+	c := collector{}
+	result := c.CollectSuiteSpecs(pkg)
+	gotest.Equal(t, 0, len(result.Errs))
+
+	spec, err := c.ApplyTestSuiteSpecs(result)
+	gotest.NoError(t, err)
+
+	r := renderer{}
+	out, err := r.RenderTestSuiteSpec(pkg, spec)
+	gotest.NoError(t, err)
+
+	output := string(out)
+
+	// Shared fixture should be created and assigned even without env tags
+	gotest.Contains(t, output, "sf0 := &SetupSharedFixture{}")
+	gotest.Contains(t, output, "fixture.SetupSharedFixture = sf0")
+
+	// No os.Getenv calls since there are no env tags
+	gotest.True(t, !strings.Contains(output, "os.Getenv"), "should not have os.Getenv without env tags")
+}
+
+func TestBuildFixtureViewModels_SharedFixtureDetection(t *testing.T) {
+	src := "package testpkg\n\n" +
+		"import (\n" +
+		"\t\"context\"\n\n" +
+		"\t\"github.com/mvrahden/go-test/pkg/gotest\"\n" +
+		")\n\n" +
+		"type PGSharedFixture struct {\n" +
+		"\tDSN  string `gotest:\"env=PG_DSN\"`\n" +
+		"\tHost string `gotest:\"env=PG_HOST\"`\n" +
+		"}\n\n" +
+		"func (f *PGSharedFixture) BeforeAll() error { return nil }\n\n" +
+		"type DBFixture struct {\n" +
+		"\t*PGSharedFixture\n" +
+		"}\n\n" +
+		"func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }\n\n" +
+		"type DBTestSuite struct {\n" +
+		"\t*DBFixture\n" +
+		"}\n\n" +
+		"func (s *DBTestSuite) TestQuery(t *gotest.T) {}\n"
+
+	pkg := loadTestPkgWithGotest(t, src)
+	c := collector{}
+	result := c.CollectSuiteSpecs(pkg)
+	gotest.Equal(t, 0, len(result.Errs))
+
+	spec, err := c.ApplyTestSuiteSpecs(result)
+	gotest.NoError(t, err)
+
+	fixtureBound, _ := splitSuitesByFixture(spec)
+	vms := buildFixtureViewModels(spec.Fixtures, fixtureBound)
+	gotest.Equal(t, 1, len(vms))
+
+	vm := vms[0]
+	gotest.Equal(t, "DBFixture", vm.Identifier)
+	gotest.Equal(t, 1, len(vm.SharedFixtures))
+
+	sf := vm.SharedFixtures[0]
+	gotest.Equal(t, "sf0", sf.LocalVar)
+	gotest.Equal(t, "PGSharedFixture", sf.QualifiedType)
+	gotest.Equal(t, "PGSharedFixture", sf.FieldName)
+	gotest.Equal(t, "", sf.PkgPath, "same-package shared fixture should have empty PkgPath")
+	gotest.Equal(t, 2, len(sf.EnvTags))
+	gotest.Equal(t, "PG_DSN", sf.EnvTags["DSN"])
+	gotest.Equal(t, "PG_HOST", sf.EnvTags["Host"])
+}

--- a/internal/gotestgen/static/gotest.fixture.tpl
+++ b/internal/gotestgen/static/gotest.fixture.tpl
@@ -27,6 +27,9 @@ func Test_{{ $f.Identifier }}(t *testing.T) {
 {{ end }}
 
     fixture := &{{ $f.Identifier }}{}
+{{- range $sf := $f.SharedFixtures }}
+    fixture.{{ $sf.FieldName }} = {{ $sf.LocalVar }}
+{{- end }}
     t.Cleanup(func() {
 {{- if $f.AfterAll }}
         if err := fixture.AfterAll(context.Background()); err != nil {

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/format"
 	"go/types"
+	"path/filepath"
 	"sort"
 	"strings"
 	"text/template"
@@ -18,6 +19,7 @@ type TypeInfo struct {
 	PkgName     string
 	PkgDir      string // absolute dir for output file placement
 	IsInterface bool
+	IsFuncBased bool // true when scaffolding standalone functions (no struct/interface)
 	Methods     []MethodInfo
 }
 
@@ -126,6 +128,126 @@ func IntrospectType(pkgPattern, typeName string) (*TypeInfo, error) {
 	})
 
 	return info, nil
+}
+
+// IntrospectFile loads the package containing the given file and returns
+// TypeInfo for each exported struct/interface type, or a single TypeInfo
+// representing exported functions if no types are found.
+func IntrospectFile(filePath string) ([]*TypeInfo, error) {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve path %q: %w", filePath, err)
+	}
+
+	dir := filepath.Dir(absPath)
+	cfg := &packages.Config{
+		Mode:  packages.NeedName | packages.NeedTypes | packages.NeedImports | packages.NeedDeps | packages.NeedFiles | packages.NeedSyntax,
+		Dir:   dir,
+		Tests: false,
+	}
+
+	pkgs, err := packages.Load(cfg, ".")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load package in %q: %w", dir, err)
+	}
+	if len(pkgs) == 0 {
+		return nil, fmt.Errorf("no packages found in %q", dir)
+	}
+
+	pkg := pkgs[0]
+	if len(pkg.Errors) > 0 {
+		return nil, fmt.Errorf("package has errors: %v", pkg.Errors[0])
+	}
+
+	scope := pkg.Types.Scope()
+	var results []*TypeInfo
+	var funcs []MethodInfo
+
+	for _, name := range scope.Names() {
+		obj := scope.Lookup(name)
+		if !obj.Exported() {
+			continue
+		}
+
+		pos := pkg.Fset.Position(obj.Pos())
+		if pos.Filename != absPath {
+			continue
+		}
+
+		switch o := obj.(type) {
+		case *types.TypeName:
+			named, ok := o.Type().(*types.Named)
+			if !ok {
+				continue
+			}
+			info := &TypeInfo{
+				Name:    name,
+				PkgName: pkg.Name,
+				PkgDir:  determinePkgDir(pkg),
+			}
+			underlying := named.Underlying()
+			if iface, ok := underlying.(*types.Interface); ok {
+				info.IsInterface = true
+				info.Methods = extractInterfaceMethods(iface)
+			} else if _, ok := underlying.(*types.Struct); ok {
+				info.Methods = extractStructMethods(named)
+			} else {
+				continue
+			}
+			sort.Slice(info.Methods, func(i, j int) bool {
+				return info.Methods[i].Name < info.Methods[j].Name
+			})
+			results = append(results, info)
+
+		case *types.Func:
+			sig := o.Type().(*types.Signature)
+			if sig.Recv() != nil {
+				continue
+			}
+			funcs = append(funcs, MethodInfo{
+				Name:         name,
+				Signature:    formatSignature(sig),
+				ReturnsError: returnsError(sig),
+			})
+		}
+	}
+
+	if len(results) > 0 {
+		sort.Slice(results, func(i, j int) bool {
+			return results[i].Name < results[j].Name
+		})
+		return results, nil
+	}
+
+	if len(funcs) > 0 {
+		sort.Slice(funcs, func(i, j int) bool {
+			return funcs[i].Name < funcs[j].Name
+		})
+		suiteName := fileToSuiteName(filepath.Base(absPath))
+		results = append(results, &TypeInfo{
+			Name:        suiteName,
+			PkgName:     pkg.Name,
+			PkgDir:      determinePkgDir(pkg),
+			IsFuncBased: true,
+			Methods:     funcs,
+		})
+		return results, nil
+	}
+
+	return nil, fmt.Errorf("no exported types or functions found in %q", filePath)
+}
+
+func fileToSuiteName(filename string) string {
+	name := strings.TrimSuffix(filename, ".go")
+	parts := strings.Split(name, "_")
+	var result strings.Builder
+	for _, p := range parts {
+		if len(p) > 0 {
+			result.WriteString(strings.ToUpper(p[:1]))
+			result.WriteString(p[1:])
+		}
+	}
+	return result.String()
 }
 
 func determinePkgDir(pkg *packages.Package) string {
@@ -330,6 +452,45 @@ func (s *{{$.Name}}ContractTestSuite[T]) Test{{.Name}}(t *gotest.T) {
 // Instantiate the contract for a concrete implementation:
 // type My{{.Name}}TestSuite = {{.Name}}ContractTestSuite[*MyImpl]
 `))
+
+var funcTemplate = template.Must(template.New("func").Parse(`package {{.PkgName}}
+
+import (
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type {{.Name}}TestSuite struct{}
+{{range .Methods}}
+func (s *{{$.Name}}TestSuite) Test{{.Name}}(t *gotest.T) {
+{{- if .ReturnsError}}
+	t.It("succeeds", func(it *gotest.T) {
+		// TODO: test {{.Name}}{{.Signature}}
+	})
+	t.It("returns error", func(it *gotest.T) {
+		// TODO: test error case
+	})
+{{- else}}
+	t.It("works", func(it *gotest.T) {
+		// TODO: test {{.Name}}{{.Signature}}
+	})
+{{- end}}
+}
+{{end}}`))
+
+// GenerateFuncScaffold generates a test suite scaffold for standalone functions.
+func GenerateFuncScaffold(info *TypeInfo) ([]byte, error) {
+	var buf strings.Builder
+	if err := funcTemplate.Execute(&buf, info); err != nil {
+		return nil, fmt.Errorf("template execution failed: %w", err)
+	}
+
+	formatted, err := format.Source([]byte(buf.String()))
+	if err != nil {
+		return nil, fmt.Errorf("go/format failed: %w", err)
+	}
+
+	return formatted, nil
+}
 
 // GenerateScaffold generates a test suite scaffold for a struct type.
 func GenerateScaffold(info *TypeInfo) ([]byte, error) {


### PR DESCRIPTION
- discover/overlay subcommands — discover outputs test suite metadata as JSON; overlay generates test code to 
a temp dir and returns the overlay path for external tooling (IDE, gopls)
- shared fixture end-to-end wiring — collector now correctly distinguishes shared vs package fixtures in      
embedding detection; renderer populates shared fixture env vars from gotest:"env=..." tags and assigns them to
 the package fixture before lifecycle hooks run
- scaffold file-based introspection — gotest scaffold now accepts a .go file path and generates test suites   
for all exported types/functions in that file, including standalone function scaffolding