### PR TITLE
warnings and logs

### DIFF
--- a/cmd/gotest/discover.go
+++ b/cmd/gotest/discover.go
@@ -90,6 +90,7 @@ func runDiscover(args []string) int {
 			TestOnly:   lr.IsTestOnly(),
 		}
 
+		hasWarnings := false
 		pkgs := []*packages.Package{lr.Ptest, lr.Pxtest}
 		for _, pkg := range pkgs {
 			if pkg == nil {
@@ -97,6 +98,7 @@ func runDiscover(args []string) int {
 			}
 			result := c.CollectSuiteSpecs(pkg)
 			if len(result.Errs) > 0 {
+				hasWarnings = true
 				for _, ce := range result.Errs {
 					w := discoverWarning{
 						ImportPath: lr.PkgPath,
@@ -120,7 +122,7 @@ func runDiscover(args []string) int {
 			}
 		}
 
-		if len(pkgEntry.Suites) > 0 {
+		if len(pkgEntry.Suites) > 0 || hasWarnings {
 			out.Packages = append(out.Packages, pkgEntry)
 		}
 	}

--- a/vscode-gotest/src/batchRunner.ts
+++ b/vscode-gotest/src/batchRunner.ts
@@ -30,7 +30,7 @@ export interface BatchConfig {
   run: vscode.TestRun;
   token: vscode.CancellationToken;
   controller: GoTestController;
-  outputChannel: vscode.OutputChannel;
+  outputChannel: vscode.LogOutputChannel;
   label: string;
   coverage?: {
     store: CoverageStore;
@@ -82,7 +82,7 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
     cliArgs.push(...testFlags);
 
     const cmd = await buildCliCommand(cliArgs, workspaceDir, outputChannel);
-    outputChannel.appendLine(`[${label}] ${formatCliCommand(cmd)}`);
+    outputChannel.info(`[${label}] ${formatCliCommand(cmd)}`);
 
     const streamedPkgs = new Set<string>();
     const pkgEventBuffers = new Map<string, TestEvent[]>();
@@ -221,7 +221,7 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
         try {
           funcOutput = await runGoToolCoverFunc(coverFile, workspaceDir);
         } catch {
-          outputChannel.appendLine(`[${label}] go tool cover -func failed`);
+          outputChannel.warn(`[${label}] go tool cover -func failed`);
         }
 
         if (coverage.testOnly) {
@@ -251,14 +251,14 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
           }
         }
       } catch {
-        outputChannel.appendLine(`[${label}] no coverprofile generated`);
+        outputChannel.warn(`[${label}] no coverprofile generated`);
       }
     }
 
     return { stdout: result.stdout };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    outputChannel.appendLine(`[${label}] error: ${message}`);
+    outputChannel.error(`[${label}] ${message}`);
     for (const info of pkgInfos) {
       for (const item of info.items) {
         run.errored(item, new vscode.TestMessage(message));

--- a/vscode-gotest/src/cli.ts
+++ b/vscode-gotest/src/cli.ts
@@ -34,7 +34,7 @@ const replaceBinaryCache = new Map<string, { hash: string; binPath: string }>();
 let versionWarningShown = false;
 
 export async function validateGoBinary(
-  log?: vscode.OutputChannel,
+  log?: vscode.LogOutputChannel,
   workspaceDir?: string,
 ): Promise<string | undefined> {
   const goBin = await resolveGoBinary(log, workspaceDir);
@@ -43,10 +43,10 @@ export async function validateGoBinary(
       timeout: 5_000,
       cwd: workspaceDir,
     });
-    log?.appendLine(`[go] binary validated: ${stdout.trim()}`);
+    log?.debug(`[go] binary validated: ${stdout.trim()}`);
     return goBin;
   } catch {
-    log?.appendLine(`[go] binary "${goBin}" failed validation`);
+    log?.warn(`[go] binary "${goBin}" failed validation`);
     clearGoBinaryCache();
     return undefined;
   }
@@ -55,7 +55,7 @@ export async function validateGoBinary(
 export async function buildCliCommand(
   subcommandArgs: string[],
   workspaceDir?: string,
-  log?: vscode.OutputChannel,
+  log?: vscode.LogOutputChannel,
 ): Promise<CliCommand> {
   const config = scopedConfig(workspaceDir);
 
@@ -69,12 +69,10 @@ export async function buildCliCommand(
   if (cliPath) {
     const resolved = resolveCliPath(cliPath, workspaceDir);
     if (await fileExists(resolved)) {
-      log?.appendLine(`[cli] cliPath override: ${resolved}`);
+      log?.debug(`[cli] cliPath override: ${resolved}`);
       return { bin: resolved, args: subcommandArgs };
     }
-    log?.appendLine(
-      `[cli] cliPath "${resolved}" not found, probing alternatives`,
-    );
+    log?.debug(`[cli] cliPath "${resolved}" not found, probing alternatives`);
   }
 
   // 2. Project-pinned version from go.mod
@@ -95,22 +93,20 @@ export async function buildCliCommand(
             log,
           );
           if (bin) {
-            log?.appendLine(`[cli] using go.mod (replace): ${bin}`);
+            log?.debug(`[cli] using go.mod (replace): ${bin}`);
             return { bin, args: subcommandArgs };
           }
-          log?.appendLine(`[cli] replace build failed, falling back to go run`);
+          log?.debug(`[cli] replace build failed, falling back to go run`);
         }
 
         const qualified = `${modulePath}@${version}`;
-        log?.appendLine(`[cli] using go.mod: ${goBin} run ${qualified}`);
+        log?.debug(`[cli] using go.mod: ${goBin} run ${qualified}`);
         return {
           bin: goBin,
           args: ["run", qualified, "--", ...subcommandArgs],
         };
       }
-      log?.appendLine(
-        `[cli] go.mod pins ${version}, requires >= ${MIN_CLI_VERSION}`,
-      );
+      log?.warn(`[cli] go.mod pins ${version}, requires >= ${MIN_CLI_VERSION}`);
       showVersionWarning(version, effectiveDir, log);
     }
   }
@@ -126,17 +122,17 @@ export async function buildCliCommand(
       const goBin = await resolveGoBinary(log, workspaceDir);
       const bin = await buildCachedBinary(goBin, effectiveDir, modulePath, log);
       if (bin) {
-        log?.appendLine(`[cli] using local module: ${bin}`);
+        log?.debug(`[cli] using local module: ${bin}`);
         return { bin, args: subcommandArgs };
       }
-      log?.appendLine(`[cli] local module build failed, continuing`);
+      log?.debug(`[cli] local module build failed, continuing`);
     }
   }
 
   // 3. Globally installed binary
   const gotest = await findInstalledGotest(workspaceDir, log);
   if (gotest) {
-    log?.appendLine(`[cli] using installed binary: ${gotest}`);
+    log?.debug(`[cli] using installed binary: ${gotest}`);
     return { bin: gotest, args: subcommandArgs };
   }
 
@@ -145,7 +141,7 @@ export async function buildCliCommand(
   const qualified = modulePath.includes("@")
     ? modulePath
     : `${modulePath}@latest`;
-  log?.appendLine(`[cli] using fallback: ${goBin} run ${qualified}`);
+  log?.debug(`[cli] using fallback: ${goBin} run ${qualified}`);
   return { bin: goBin, args: ["run", qualified, "--", ...subcommandArgs] };
 }
 
@@ -179,7 +175,7 @@ function resolveCliPath(cliPath: string, workspaceDir?: string): string {
 function showVersionWarning(
   version: string,
   effectiveDir: string,
-  log?: vscode.OutputChannel,
+  log?: vscode.LogOutputChannel,
 ): void {
   if (versionWarningShown) {
     return;
@@ -195,18 +191,18 @@ function showVersionWarning(
       try {
         const goBin = await resolveGoBinary(log, effectiveDir);
         const args = ["get", `${DEFAULT_MODULE_PATH}@latest`];
-        log?.appendLine(`[cli] upgrading: ${goBin} ${args.join(" ")}`);
+        log?.info(`[cli] upgrading: ${goBin} ${args.join(" ")}`);
         await execFileAsync(goBin, args, {
           cwd: effectiveDir,
           timeout: 30_000,
         });
-        log?.appendLine("[cli] upgrade complete");
+        log?.info("[cli] upgrade complete");
         vscode.window.showInformationMessage(
           "Go Test Suites: gotest dependency upgraded to latest.",
         );
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        log?.appendLine(`[cli] upgrade failed: ${msg}`);
+        log?.error(`[cli] upgrade failed: ${msg}`);
         vscode.window.showErrorMessage(
           `Go Test Suites: upgrade failed. ${msg}`,
         );
@@ -293,7 +289,7 @@ async function buildCachedBinary(
   goBin: string,
   workspaceDir: string,
   modulePath: string,
-  log?: vscode.OutputChannel,
+  log?: vscode.LogOutputChannel,
 ): Promise<string | undefined> {
   const goModPath = path.join(workspaceDir, "go.mod");
   let goModContent: string;
@@ -355,7 +351,7 @@ async function buildCachedBinary(
   const binPath = path.join(cacheDir, `gotest-${dirHash}`);
 
   try {
-    log?.appendLine(`[cli] building gotest from replace directive...`);
+    log?.debug(`[cli] building gotest from replace directive...`);
     await execFileAsync(goBin, ["build", "-o", binPath, modulePath], {
       cwd: workspaceDir,
       timeout: 60_000,
@@ -364,7 +360,7 @@ async function buildCachedBinary(
     return binPath;
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
-    log?.appendLine(`[cli] replace build error: ${msg}`);
+    log?.warn(`[cli] replace build error: ${msg}`);
     return undefined;
   }
 }

--- a/vscode-gotest/src/coverOnSave.ts
+++ b/vscode-gotest/src/coverOnSave.ts
@@ -18,7 +18,7 @@ export class CoverOnSave implements vscode.Disposable {
     private readonly controller: GoTestController,
     private readonly cache: DiscoveryCache,
     private readonly store: CoverageStore,
-    private readonly outputChannel: vscode.OutputChannel,
+    private readonly outputChannel: vscode.LogOutputChannel,
   ) {}
 
   run(importPath: string): Promise<void> {
@@ -62,7 +62,7 @@ export class CoverOnSave implements vscode.Disposable {
         workspaceDir,
         this.outputChannel,
       );
-      this.outputChannel.appendLine(`[coverage:save] ${formatCliCommand(cmd)}`);
+      this.outputChannel.info(`[coverage:save] ${formatCliCommand(cmd)}`);
 
       await spawnTestProcess(
         cmd.bin,
@@ -80,14 +80,12 @@ export class CoverOnSave implements vscode.Disposable {
       try {
         funcOutput = await runGoToolCoverFunc(coverFile, workspaceDir);
       } catch {
-        this.outputChannel.appendLine(
-          "[coverage:save] go tool cover -func failed",
-        );
+        this.outputChannel.warn("[coverage:save] go tool cover -func failed");
       }
       this.store.update(importPath, coverContent, funcOutput);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      this.outputChannel.appendLine(`[coverage:save] failed: ${message}`);
+      this.outputChannel.error(`[coverage:save] ${message}`);
       return;
     } finally {
       if (this.activeRun === cts) this.activeRun = undefined;

--- a/vscode-gotest/src/coverage.ts
+++ b/vscode-gotest/src/coverage.ts
@@ -245,7 +245,7 @@ export class CoverageRunner implements vscode.Disposable {
     private readonly controller: GoTestController,
     private readonly cache: DiscoveryCache,
     private readonly store: CoverageStore,
-    private readonly outputChannel: vscode.OutputChannel,
+    private readonly outputChannel: vscode.LogOutputChannel,
     private readonly onJsonOutput: (json: string) => void,
   ) {}
 
@@ -254,7 +254,7 @@ export class CoverageRunner implements vscode.Disposable {
     token: vscode.CancellationToken,
   ): Promise<void> {
     if (this.activeRun) {
-      this.outputChannel.appendLine("[coverage] cancelling previous run");
+      this.outputChannel.info("[coverage] cancelling previous run");
       this.activeRun.cancel();
     }
     const cts = new vscode.CancellationTokenSource();

--- a/vscode-gotest/src/debug.ts
+++ b/vscode-gotest/src/debug.ts
@@ -7,7 +7,7 @@ export class DebugLauncher implements vscode.Disposable {
   private readonly prepareProcesses = new Map<string, ChildProcess>();
   private sessionListener: vscode.Disposable | undefined;
 
-  constructor(private readonly outputChannel: vscode.OutputChannel) {}
+  constructor(private readonly outputChannel: vscode.LogOutputChannel) {}
 
   async debug(
     request: vscode.TestRunRequest,
@@ -40,7 +40,7 @@ export class DebugLauncher implements vscode.Disposable {
         workspaceFolder.uri.fsPath,
         this.outputChannel,
       );
-      this.outputChannel.appendLine(`[debug] ${formatCliCommand(cmd)}`);
+      this.outputChannel.info(`[debug] ${formatCliCommand(cmd)}`);
 
       const timeout =
         scopedConfig(workspaceFolder.uri.fsPath).get<number>(
@@ -88,7 +88,7 @@ export class DebugLauncher implements vscode.Disposable {
       debugConfig.env = { GOTEST_SHARED_STATE_FILE: prepare.stateFile };
     }
 
-    this.outputChannel.appendLine(
+    this.outputChannel.info(
       `[debug] launching: ${JSON.stringify(debugConfig)}`,
     );
 
@@ -174,7 +174,7 @@ export class DebugLauncher implements vscode.Disposable {
       });
 
       child.stderr.on("data", (data: Buffer) => {
-        this.outputChannel.appendLine(
+        this.outputChannel.debug(
           `[debug:prepare] ${data.toString().trimEnd()}`,
         );
       });

--- a/vscode-gotest/src/discovery.ts
+++ b/vscode-gotest/src/discovery.ts
@@ -108,7 +108,7 @@ export class DiscoveryService {
 
   constructor(
     private readonly cache: DiscoveryCache,
-    private readonly outputChannel: vscode.OutputChannel,
+    private readonly outputChannel: vscode.LogOutputChannel,
   ) {}
 
   async discover(workspaceDir: string, patterns?: string[]): Promise<void> {
@@ -159,7 +159,7 @@ export class DiscoveryService {
     patterns?: string[],
   ): Promise<void> {
     if (!(await this.isGoWorkspace(workspaceDir))) {
-      this.outputChannel.appendLine(
+      this.outputChannel.info(
         `[discovery] skipping non-Go workspace: ${workspaceDir}`,
       );
       return;
@@ -171,7 +171,7 @@ export class DiscoveryService {
         workspaceDir,
         this.outputChannel,
       );
-      this.outputChannel.appendLine(`[discovery] ${formatCliCommand(cmd)}`);
+      this.outputChannel.info(`[discovery] ${formatCliCommand(cmd)}`);
 
       const { stdout } = await execFileAsync(cmd.bin, cmd.args, {
         cwd: workspaceDir,
@@ -187,13 +187,13 @@ export class DiscoveryService {
       this.hasShownError = false;
       for (const w of warnings) {
         const loc = w.file ? ` (${w.file}:${w.line ?? 0})` : "";
-        this.outputChannel.appendLine(
-          `[discovery] warning: ${w.importPath}${loc}: ${w.message}`,
+        this.outputChannel.warn(
+          `[discovery] ${w.importPath}${loc}: ${w.message}`,
         );
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      this.outputChannel.appendLine(`[discovery] error: ${message}`);
+      this.outputChannel.error(`[discovery] ${message}`);
       if (!this.hasShownError) {
         this.hasShownError = true;
         vscode.window

--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -24,14 +24,14 @@ import { copyCoverageSummary, copyTestResults } from "./reporting.js";
 let flushOnDeactivate: (() => Promise<void>) | undefined;
 
 export function activate(context: vscode.ExtensionContext): void {
-  const outputChannel = vscode.window.createOutputChannel("Go Test Suites");
-  outputChannel.appendLine("Go Test Suites extension activated");
+  const outputChannel = vscode.window.createOutputChannel("Go Test Suites", {
+    log: true,
+  });
+  outputChannel.info("[activate] extension activated");
 
   const workspaceFolders = vscode.workspace.workspaceFolders;
   if (!workspaceFolders || workspaceFolders.length === 0) {
-    outputChannel.appendLine(
-      "[activate] No workspace folder found, skipping activation.",
-    );
+    outputChannel.info("[activate] no workspace folder, skipping activation");
     return;
   }
 
@@ -163,7 +163,7 @@ export function activate(context: vscode.ExtensionContext): void {
     controller,
     cache,
   }).catch((err) => {
-    outputChannel.appendLine(`[activate] async initialization failed: ${err}`);
+    outputChannel.error(`[activate] async initialization failed: ${err}`);
   });
 }
 
@@ -226,7 +226,7 @@ function registerCommands(deps: {
   coverageStore: CoverageStore;
   testResultStore: TestResultStore;
   cache: DiscoveryCache;
-  outputChannel: vscode.OutputChannel;
+  outputChannel: vscode.LogOutputChannel;
 }): vscode.Disposable[] {
   const {
     controller,
@@ -248,9 +248,7 @@ function registerCommands(deps: {
       async (testId: string) => {
         const item = controller.findItem(testId);
         if (!item) {
-          outputChannel.appendLine(
-            `[command] runTest: item not found: ${testId}`,
-          );
+          outputChannel.warn(`[command] runTest: item not found: ${testId}`);
           return;
         }
         const cts = new vscode.CancellationTokenSource();
@@ -268,9 +266,7 @@ function registerCommands(deps: {
       async (testId: string) => {
         const item = controller.findItem(testId);
         if (!item) {
-          outputChannel.appendLine(
-            `[command] debugTest: item not found: ${testId}`,
-          );
+          outputChannel.warn(`[command] debugTest: item not found: ${testId}`);
           return;
         }
         const cts = new vscode.CancellationTokenSource();
@@ -382,7 +378,7 @@ function setupFileWatchers(
   discoveryService: DiscoveryService,
   coverageStore: CoverageStore,
   coverOnSave: CoverOnSave,
-  outputChannel: vscode.OutputChannel,
+  outputChannel: vscode.LogOutputChannel,
 ): vscode.Disposable[] {
   const coverOnSaveTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const triggerCoverOnSave = (importPath: string, uri: vscode.Uri) => {
@@ -444,11 +440,9 @@ function setupFileWatchers(
     if (!importPath) return;
 
     if (coverageStore.invalidate(importPath)) {
-      outputChannel.appendLine(`[coverage] invalidated ${importPath}`);
+      outputChannel.debug(`[coverage] invalidated ${importPath}`);
       coverageStore.save().catch((err) => {
-        outputChannel.appendLine(
-          `[coverage] save after invalidate failed: ${err}`,
-        );
+        outputChannel.error(`[coverage] save after invalidate failed: ${err}`);
       });
     }
 
@@ -474,7 +468,7 @@ function setupFileWatchers(
 
 async function initializeAsync(deps: {
   workspaceFolders: readonly vscode.WorkspaceFolder[];
-  outputChannel: vscode.OutputChannel;
+  outputChannel: vscode.LogOutputChannel;
   discoveryService: DiscoveryService;
   coverageStore: CoverageStore;
   testResultStore: TestResultStore;
@@ -494,7 +488,7 @@ async function initializeAsync(deps: {
   const firstDir = workspaceFolders[0].uri.fsPath;
   const goBin = await validateGoBinary(outputChannel, firstDir);
   if (!goBin) {
-    outputChannel.appendLine("[activate] Go binary not found or not working");
+    outputChannel.error("[activate] Go binary not found or not working");
     const choice = await vscode.window.showErrorMessage(
       "Go Test Suites: could not find a working 'go' installation. Ensure Go is installed and on your PATH.",
       "Open Output",
@@ -517,7 +511,7 @@ async function initializeAsync(deps: {
         run.addCoverage(fc);
       }
       run.end();
-      outputChannel.appendLine(
+      outputChannel.info(
         `[coverage] restored ${coverages.length} file(s) from storage`,
       );
     }
@@ -543,7 +537,7 @@ async function initializeAsync(deps: {
       else if (result.status === "skip") resultRun.skipped(item);
     });
     resultRun.end();
-    outputChannel.appendLine(
+    outputChannel.info(
       `[results] restored ${testResultStore.size} result(s) from storage`,
     );
   }

--- a/vscode-gotest/src/goBinary.ts
+++ b/vscode-gotest/src/goBinary.ts
@@ -16,7 +16,7 @@ export function clearGoBinaryCache(): void {
 }
 
 export async function resolveGoBinary(
-  log?: vscode.OutputChannel,
+  log?: vscode.LogOutputChannel,
   workspaceDir?: string,
 ): Promise<string> {
   const cacheKey = workspaceDir ?? "";
@@ -42,20 +42,20 @@ export async function resolveGoBinary(
 
 async function resolveProjectGoBinary(
   workspaceDir: string,
-  log?: vscode.OutputChannel,
+  log?: vscode.LogOutputChannel,
 ): Promise<string | undefined> {
   const goVersion = await readGoVersionFromMod(workspaceDir);
   if (!goVersion) {
     return undefined;
   }
 
-  log?.appendLine(`[go] go.mod declares go ${goVersion}`);
+  log?.debug(`[go] go.mod declares go ${goVersion}`);
 
   // ~/sdk/go1.26.2/bin/go
   const home = process.env.HOME ?? "";
   const sdkBin = path.join(home, "sdk", `go${goVersion}`, "bin", "go");
   if (await fileExists(sdkBin)) {
-    log?.appendLine(`[go] resolved go ${goVersion} via SDK: ${sdkBin}`);
+    log?.debug(`[go] resolved go ${goVersion} via SDK: ${sdkBin}`);
     return sdkBin;
   }
 
@@ -63,58 +63,54 @@ async function resolveProjectGoBinary(
   const versionedName = `go${goVersion}`;
   const shellVersioned = await whichFromShell(versionedName);
   if (shellVersioned) {
-    log?.appendLine(
-      `[go] resolved go ${goVersion} via shell: ${shellVersioned}`,
-    );
+    log?.debug(`[go] resolved go ${goVersion} via shell: ${shellVersioned}`);
     return shellVersioned;
   }
 
   const whichVersioned = await which(versionedName);
   if (whichVersioned) {
-    log?.appendLine(
-      `[go] resolved go ${goVersion} via PATH: ${whichVersioned}`,
-    );
+    log?.debug(`[go] resolved go ${goVersion} via PATH: ${whichVersioned}`);
     return whichVersioned;
   }
 
-  log?.appendLine(
+  log?.debug(
     `[go] go ${goVersion} not found, falling back to generic detection`,
   );
   return undefined;
 }
 
 async function resolveGenericGoBinary(
-  log?: vscode.OutputChannel,
+  log?: vscode.LogOutputChannel,
 ): Promise<string> {
   const goroot = process.env.GOROOT;
   if (goroot) {
     const goBin = path.join(goroot, "bin", "go");
     if (await fileExists(goBin)) {
-      log?.appendLine(`[go] resolved via GOROOT: ${goBin}`);
+      log?.debug(`[go] resolved via GOROOT: ${goBin}`);
       return goBin;
     }
   }
 
   const shellGo = await whichFromShell("go");
   if (shellGo) {
-    log?.appendLine(`[go] resolved via shell: ${shellGo}`);
+    log?.debug(`[go] resolved via shell: ${shellGo}`);
     return shellGo;
   }
 
   const whichGo = await which("go");
   if (whichGo) {
-    log?.appendLine(`[go] resolved via PATH: ${whichGo}`);
+    log?.debug(`[go] resolved via PATH: ${whichGo}`);
     return whichGo;
   }
 
   for (const candidate of await commonGoPaths()) {
     if (await fileExists(candidate)) {
-      log?.appendLine(`[go] resolved at common path: ${candidate}`);
+      log?.debug(`[go] resolved at common path: ${candidate}`);
       return candidate;
     }
   }
 
-  log?.appendLine("[go] could not resolve binary, using bare 'go'");
+  log?.warn("[go] could not resolve binary, using bare 'go'");
   return "go";
 }
 
@@ -133,7 +129,7 @@ async function readGoVersionFromMod(
 
 export async function findInstalledGotest(
   workspaceDir?: string,
-  log?: vscode.OutputChannel,
+  log?: vscode.LogOutputChannel,
 ): Promise<string | undefined> {
   if (cachedGotestBinary) {
     if (await fileExists(cachedGotestBinary)) {
@@ -186,7 +182,7 @@ export async function findInstalledGotest(
       }
     }
   } catch {
-    log?.appendLine("[cli] failed to query go env for gotest location");
+    log?.debug("[cli] failed to query go env for gotest location");
   }
 
   const whichGotest = await which("gotest");

--- a/vscode-gotest/src/runner.ts
+++ b/vscode-gotest/src/runner.ts
@@ -21,7 +21,7 @@ export class TestRunner {
   constructor(
     private readonly controller: GoTestController,
     private readonly cache: DiscoveryCache,
-    private readonly outputChannel: vscode.OutputChannel,
+    private readonly outputChannel: vscode.LogOutputChannel,
     private readonly coverageStore?: CoverageStore,
   ) {}
 
@@ -36,7 +36,7 @@ export class TestRunner {
     token: vscode.CancellationToken,
   ): Promise<void> {
     if (this.activeRun) {
-      this.outputChannel.appendLine("[runner] cancelling previous run");
+      this.outputChannel.info("[runner] cancelling previous run");
       this.activeRun.cancel();
     }
     const cts = new vscode.CancellationTokenSource();

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -301,6 +301,12 @@ export function spawnTestProcess(
 
     child.on("close", (code) => {
       cancelListener.dispose();
+      if (onStdoutLine) {
+        const remaining = lineBuffer.trim();
+        if (remaining) {
+          onStdoutLine(remaining);
+        }
+      }
       if (stderr) {
         for (const line of stderr.split("\n")) {
           if (line.trim()) {

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -260,7 +260,7 @@ export function spawnTestProcess(
   args: string[],
   cwd: string,
   token: vscode.CancellationToken,
-  outputChannel: vscode.OutputChannel,
+  outputChannel: vscode.LogOutputChannel,
   label: string,
   env?: Record<string, string>,
   onStdoutLine?: (line: string) => void,
@@ -310,7 +310,7 @@ export function spawnTestProcess(
       if (stderr) {
         for (const line of stderr.split("\n")) {
           if (line.trim()) {
-            outputChannel.appendLine(`[${label}] stderr: ${line}`);
+            outputChannel.warn(`[${label}] stderr: ${line}`);
           }
         }
       }
@@ -319,7 +319,7 @@ export function spawnTestProcess(
 
     child.on("error", (err: Error) => {
       cancelListener.dispose();
-      outputChannel.appendLine(`[${label}] error: ${err.message}`);
+      outputChannel.error(`[${label}] ${err.message}`);
       reject(err);
     });
   });

--- a/vscode-gotest/src/scaffold.ts
+++ b/vscode-gotest/src/scaffold.ts
@@ -111,7 +111,7 @@ export class ScaffoldCodeActionProvider
 }
 
 export async function runScaffoldCommand(
-  outputChannel: vscode.OutputChannel,
+  outputChannel: vscode.LogOutputChannel,
   discoverCallback: () => void,
   workspaceDir?: string,
 ): Promise<void> {
@@ -129,7 +129,7 @@ export async function runScaffoldCommand(
 
 export async function executeScaffold(
   target: string,
-  outputChannel: vscode.OutputChannel,
+  outputChannel: vscode.LogOutputChannel,
   discoverCallback: () => void,
   workspaceDir?: string,
 ): Promise<void> {
@@ -140,7 +140,7 @@ export async function executeScaffold(
   }
 
   const cmd = await buildCliCommand(["scaffold", target], effectiveDir);
-  outputChannel.appendLine(`[scaffold] ${formatCliCommand(cmd)}`);
+  outputChannel.info(`[scaffold] ${formatCliCommand(cmd)}`);
 
   try {
     const stdout = await spawnScaffold(cmd, effectiveDir);

--- a/vscode-gotest/src/specView.ts
+++ b/vscode-gotest/src/specView.ts
@@ -81,7 +81,7 @@ export class SpecViewPanel implements vscode.Disposable {
   private panel: vscode.WebviewPanel | undefined;
   private disposables: vscode.Disposable[] = [];
 
-  constructor(private readonly outputChannel: vscode.OutputChannel) {}
+  constructor(private readonly outputChannel: vscode.LogOutputChannel) {}
 
   show(): void {
     if (this.panel) {
@@ -129,7 +129,7 @@ export class SpecViewPanel implements vscode.Disposable {
       this.panel.webview.html = this.buildHtml(content);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      this.outputChannel.appendLine(`[specView] error: ${message}`);
+      this.outputChannel.error(`[specView] ${message}`);
     }
   }
 

--- a/vscode-gotest/src/testController.ts
+++ b/vscode-gotest/src/testController.ts
@@ -16,7 +16,7 @@ export class GoTestController implements vscode.Disposable {
   constructor(
     private readonly cache: DiscoveryCache,
     private readonly resultStore: TestResultStore,
-    private readonly outputChannel: vscode.OutputChannel,
+    private readonly outputChannel: vscode.LogOutputChannel,
     runHandler: (
       request: vscode.TestRunRequest,
       token: vscode.CancellationToken,

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -26,7 +26,7 @@ class WatchProcess implements vscode.Disposable {
     private readonly pkgScope: string,
     private readonly cwd: string,
     private readonly cmd: CliCommand,
-    private readonly outputChannel: vscode.OutputChannel,
+    private readonly outputChannel: vscode.LogOutputChannel,
     private readonly onCycleStart: () => void,
     private readonly onEvents: (jsonLines: string) => void,
     private readonly onError: (msg: string) => void,
@@ -36,7 +36,7 @@ class WatchProcess implements vscode.Disposable {
   }
 
   private start(): void {
-    this.outputChannel.appendLine(
+    this.outputChannel.info(
       `[watch] spawning: ${formatCliCommand(this.cmd)} (cwd: ${this.cwd})`,
     );
 
@@ -50,7 +50,7 @@ class WatchProcess implements vscode.Disposable {
     });
 
     this.child.stderr?.on("data", (data: Buffer) => {
-      this.outputChannel.appendLine(`[watch] stderr: ${data.toString()}`);
+      this.outputChannel.warn(`[watch] stderr: ${data.toString().trimEnd()}`);
     });
 
     this.child.on("close", () => {
@@ -60,7 +60,7 @@ class WatchProcess implements vscode.Disposable {
     });
 
     this.child.on("error", (err: Error) => {
-      this.outputChannel.appendLine(`[watch] process error: ${err.message}`);
+      this.outputChannel.error(`[watch] process error: ${err.message}`);
       if (!this.disposed) {
         this.maybeRestart();
       }
@@ -100,7 +100,7 @@ class WatchProcess implements vscode.Disposable {
         this.cycleBuffer += trimmed + "\n";
       } catch {
         // Non-JSON line, skip
-        this.outputChannel.appendLine(`[watch] non-JSON line: ${trimmed}`);
+        this.outputChannel.debug(`[watch] non-JSON line: ${trimmed}`);
       }
     }
 
@@ -129,7 +129,7 @@ class WatchProcess implements vscode.Disposable {
     this.consecutiveCrashes++;
 
     if (this.consecutiveCrashes >= WatchProcess.MAX_CONSECUTIVE_CRASHES) {
-      this.outputChannel.appendLine(
+      this.outputChannel.error(
         `[watch] ${this.consecutiveCrashes} consecutive crashes, stopping (scope: ${this.pkgScope})`,
       );
       this.onError(
@@ -145,7 +145,7 @@ class WatchProcess implements vscode.Disposable {
       WatchProcess.MAX_RESTART_DELAY_MS,
     );
 
-    this.outputChannel.appendLine(
+    this.outputChannel.warn(
       `[watch] restarting in ${delay / 1000}s (crash ${this.consecutiveCrashes}/${WatchProcess.MAX_CONSECUTIVE_CRASHES}, scope: ${this.pkgScope})`,
     );
 
@@ -194,7 +194,7 @@ export class WatchManager implements vscode.Disposable {
   constructor(
     private readonly controller: GoTestController,
     private readonly cache: DiscoveryCache,
-    private readonly outputChannel: vscode.OutputChannel,
+    private readonly outputChannel: vscode.LogOutputChannel,
     private readonly onCycleComplete: (jsonOutput: string) => void,
   ) {
     this.statusBar = vscode.window.createStatusBarItem(
@@ -250,7 +250,7 @@ export class WatchManager implements vscode.Disposable {
       },
       // onError
       (msg: string) => {
-        this.outputChannel.appendLine(`[watch] error: ${msg}`);
+        this.outputChannel.error(`[watch] ${msg}`);
         vscode.window.showWarningMessage(`gotest watch: ${msg}`);
       },
       // onExit


### PR DESCRIPTION
- Packages that have issues are now included in discovery results instead of silently dropped, so users can see which packages need attention
- Extension logging now uses severity levels (debug/info/warn/error) so users can filter noise and focus on what matters