### PR TITLE
Docs improvements and spec output fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # gotest — Agent Reference
 
-gotest is a code-generation framework for Go test suites. You write suite structs with lifecycle methods and test cases; the `gotest generate` command produces the test harness (TestMain, test functions, lifecycle wiring). The generated code is not hand-edited.
+gotest is a code-generation framework for Go test suites.
+You write suite structs with lifecycle methods and test cases; the `gotest generate` command produces the test harness (TestMain, test functions, lifecycle wiring).
+The generated code is not hand-edited.
 
 All assertions accept both `*gotest.T` and `*testing.T` as first argument.
 
@@ -8,21 +10,40 @@ All assertions accept both `*gotest.T` and `*testing.T` as first argument.
 
 These override any default instincts from stdlib `testing` or other Go test frameworks.
 
-**Never call `t.T().Helper()`.** gotest uses `CallerTrace` to automatically walk the call stack and attribute assertion failures to the correct user code location. Calling `t.T().Helper()` is harmless but unnecessary noise — it's already handled by the framework. Same applies to `t.Helper()` in methods that accept `*testing.T` directly.
+**Never call `t.T().Helper()`.**
+gotest uses `CallerTrace` to automatically walk the call stack and attribute assertion failures to the correct user code location.
+Calling `t.T().Helper()` is harmless but unnecessary noise — it's already handled by the framework.
+Same applies to `t.Helper()` in methods that accept `*testing.T` directly.
 
-**Never call `t.T().Cleanup()` inside suite methods.** Use `BeforeAll`/`AfterAll` for suite-level resources and `BeforeEach`/`AfterEach` for per-test resources. The generated harness manages cleanup ordering (LIFO). Calling `t.T().Cleanup()` inside suite methods breaks the predictable lifecycle.
+**Never call `t.T().Cleanup()` inside suite methods.**
+Use `BeforeAll`/`AfterAll` for suite-level resources and `BeforeEach`/`AfterEach` for per-test resources.
+The generated harness manages cleanup ordering (LIFO).
+Calling `t.T().Cleanup()` inside suite methods breaks the predictable lifecycle.
 
-**Never call `t.T().Fatalf()` in reusable test helpers.** Use gotest assertions instead. Helpers that call `t.T()` panic inside `Eventually`/`Consistently` because the collecting T has no underlying `*testing.T`. This is the most common source of runtime panics in gotest code.
+**Never call `t.T().Fatalf()` in reusable test helpers.**
+Use gotest assertions instead.
+Helpers that call `t.T()` panic inside `Eventually`/`Consistently` because the collecting T has no underlying `*testing.T`.
+This is the most common source of runtime panics in gotest code.
 
-**Never use `t.T().Skip()` for environment gating.** Use `SuiteGuard() string` instead. SuiteGuard runs before shared fixture wiring and `t.Parallel()`, avoiding wasted work. `t.T().Skip()` inside `BeforeAll` runs after those expensive operations.
+**Never use `t.T().Skip()` for environment gating.**
+Use `SuiteGuard() string` instead.
+SuiteGuard runs before shared fixture wiring and `t.Parallel()`, avoiding wasted work.
+`t.T().Skip()` inside `BeforeAll` runs after those expensive operations.
 
-**`Nil`/`NotNil` assertions do not exist.** This is deliberate. Go generics cannot constrain to "nillable types", so a generic `NotNil(t, x)` would silently accept non-nillable types (e.g. `int`, `struct{}`), creating logical bugs with no compile-time warning. Use `NotZero`/`Zero` for pointer, interface, and channel nil checks (these types satisfy `comparable`). For slices, maps, and channels, prefer `Empty`/`NotEmpty` — a nil slice and an empty slice are equivalent for most test intent. Use `True(t, x != nil)` only when the nil vs empty distinction actually matters.
+**`Nil`/`NotNil` assertions do not exist.**
+This is deliberate.
+Go generics cannot constrain to "nillable types", so a generic `NotNil(t, x)` would silently accept non-nillable types (e.g. `int`, `struct{}`), creating logical bugs with no compile-time warning.
+Use `NotZero`/`Zero` for pointer, interface, and channel nil checks (these types satisfy `comparable`).
+For slices, maps, and channels, prefer `Empty`/`NotEmpty` — a nil slice and an empty slice are equivalent for most test intent.
+Use `True(t, x != nil)` only when the nil vs empty distinction actually matters.
 
-**`HasPrefix`/`HasSuffix` assertions do not exist.** Use `Regexp(t, "^prefix", str)` or `Regexp(t, "suffix$", str)`.
+**`HasPrefix`/`HasSuffix` assertions do not exist.**
+Use `Regexp(t, "^prefix", str)` or `Regexp(t, "suffix$", str)`.
 
 ## Assertions
 
-All assertion functions call `FailNow()` on failure (fatal — test stops immediately). All accept optional trailing `msgAndArgs ...any` for custom error messages.
+All assertion functions call `FailNow()` on failure (fatal — test stops immediately).
+All accept optional trailing `msgAndArgs ...any` for custom error messages.
 
 ### Unconditional Failure
 
@@ -30,7 +51,8 @@ All assertion functions call `FailNow()` on failure (fatal — test stops immedi
 gotest.Fail(t, msgAndArgs ...any)                    // immediately fails with message
 ```
 
-Use in unreachable branches (`default` in exhaustive switches, after calls that must not return). Prefer over `gotest.True(t, false, "msg")`.
+Use in unreachable branches (`default` in exhaustive switches, after calls that must not return).
+Prefer over `gotest.True(t, false, "msg")`.
 
 ### Equality
 
@@ -53,7 +75,8 @@ gotest.Zero[V comparable](t, value V)               // value == zero value for t
 gotest.NotZero[V comparable](t, value V)             // value != zero value for type
 ```
 
-`comparable` includes: pointers, interfaces, channels, numerics, strings, bools, structs of comparables, arrays of comparables. It excludes: slices, maps, functions.
+`comparable` includes: pointers, interfaces, channels, numerics, strings, bools, structs of comparables, arrays of comparables.
+It excludes: slices, maps, functions.
 
 For nil checks on slices, maps, or functions: `gotest.True(t, x != nil)`.
 
@@ -145,9 +168,14 @@ t.Consistently(2*time.Second, 100*time.Millisecond, func(poll *gotest.T) {
 })
 ```
 
-The method form creates a **collecting T** with `t: nil`. On each tick, the callback runs; if any assertion fails, it retries on the next tick. On timeout, the last failure is reported.
+The method form creates a **collecting T** with `t: nil`.
+On each tick, the callback runs; if any assertion fails, it retries on the next tick.
+On timeout, the last failure is reported.
 
-**Critical constraint:** Inside the callback, `poll.T()` panics. All code in the callback must use gotest assertions only. Any helper that calls `t.T()` will panic. This is by design — the collecting T intercepts failures without aborting, enabling retry semantics.
+**Critical constraint:** Inside the callback, `poll.T()` panics.
+All code in the callback must use gotest assertions only.
+Any helper that calls `t.T()` will panic.
+This is by design — the collecting T intercepts failures without aborting, enabling retry semantics.
 
 ## Suite Conventions
 
@@ -181,7 +209,8 @@ func (s *MyTestSuite) BeforeEach(t *gotest.T) {}  // before each test
 func (s *MyTestSuite) AfterEach(t *gotest.T)  {}  // after each test
 ```
 
-All are optional. Execution order: BeforeAll -> (BeforeEach -> Test -> AfterEach)* -> AfterAll.
+All are optional.
+Execution order: BeforeAll -> (BeforeEach -> Test -> AfterEach)* -> AfterAll.
 For parallel test cases, AfterAll waits for all parallel tests to complete.
 
 ### SuiteConfig (optional)
@@ -206,7 +235,8 @@ func (s *MyTestSuite) SuiteGuard() string {
 }
 ```
 
-Returns empty string to run, non-empty to skip with that reason. Runs before shared fixture wiring, before `t.Parallel()`, before any expensive work.
+Returns empty string to run, non-empty to skip with that reason.
+Runs before shared fixture wiring, before `t.Parallel()`, before any expensive work.
 
 ### Focus & Exclude prefixes
 
@@ -225,11 +255,16 @@ Focus and exclude apply independently at both suite and test case levels.
 
 ## Parallel Semantics
 
-**Suite-level** (`*TestSuiteParallel` suffix): The entire suite runs concurrently with other top-level tests. Methods within the suite run sequentially relative to each other. Safe to share suite struct state `s` across methods.
+**Suite-level** (`*TestSuiteParallel` suffix): The entire suite runs concurrently with other top-level tests.
+Methods within the suite run sequentially relative to each other.
+Safe to share suite struct state `s` across methods.
 
-**Method-level** (`TestParallel*` prefix): Individual test cases run concurrently within the same suite. Suite struct state `s` is shared — writing to `s` fields from parallel methods is a data race. Use method-local variables or synchronization.
+**Method-level** (`TestParallel*` prefix): Individual test cases run concurrently within the same suite.
+Suite struct state `s` is shared — writing to `s` fields from parallel methods is a data race.
+Use method-local variables or synchronization.
 
-These are independent. A `TestSuiteParallel` can also have `TestParallel*` methods (suite runs parallel with others AND methods run parallel within it).
+These are independent.
+A `TestSuiteParallel` can also have `TestParallel*` methods (suite runs parallel with others AND methods run parallel within it).
 
 ## Other T Methods
 

--- a/README.md
+++ b/README.md
@@ -10,15 +10,25 @@
 
 Go tests that write themselves, organize themselves, and explain themselves.
 
-`gotest` closes the gap between `func TestX(t *testing.T)` and a well-organized test suite through code generation. You write structs, name them well, and the tool handles the rest. No runtime dependencies. No reflection. No lock-in. Just standard Go tests with lifecycle management and structured organization.
+`gotest` closes the gap between `func TestX(t *testing.T)` and a well-organized test suite through code generation.
+You write structs, name them well, and the tool handles the rest.
+No runtime dependencies.
+No reflection.
+No lock-in.
+Just standard Go tests with lifecycle management and structured organization.
 
 ## Why gotest?
 
-Go's `testing` package gives you `func TestX(t *testing.T)` and nothing more. Setup/teardown logic is copy-pasted or buried in `TestMain`. As test suites grow, organization becomes a discipline problem rather than a tooling one.
+Go's `testing` package gives you `func TestX(t *testing.T)` and nothing more.
+Setup/teardown logic is copy-pasted or buried in `TestMain`.
+As test suites grow, organization becomes a discipline problem rather than a tooling one.
 
-**testify/suite** solves organization but adds runtime reflection, interface dispatch, and a `suite.Run(t, new(MySuite))` ceremony in every file. Test output is standard — but the mechanism behind it isn't.
+**testify/suite** solves organization but adds runtime reflection, interface dispatch, and a `suite.Run(t, new(MySuite))` ceremony in every file.
+Test output is standard — but the mechanism behind it isn't.
 
-**gotest** takes a different approach: you write structs with naming conventions, and a code generator produces the `func Test*` wrappers, lifecycle wiring, and `t.Run` nesting that you'd write by hand. The generated code is deleted after tests run. What remains is standard `go test` output, zero runtime dependencies, and no lock-in — `gotest clean` removes all traces, and your test structs still compile.
+**gotest** takes a different approach: you write structs with naming conventions, and a code generator produces the `func Test*` wrappers, lifecycle wiring, and `t.Run` nesting that you'd write by hand.
+The generated code is deleted after tests run.
+What remains is standard `go test` output, zero runtime dependencies, and no lock-in — `gotest clean` removes all traces, and your test structs still compile.
 
 ## Install
 
@@ -77,7 +87,8 @@ Output is standard `go test` output:
 --- PASS: TestUserServiceTestSuite (0.01s)
 ```
 
-No generated code leaks into your workflow. `gotest` generates it before tests run and cleans it up after.
+No generated code leaks into your workflow.
+`gotest` generates it before tests run and cleans it up after.
 
 ## Features
 
@@ -92,7 +103,9 @@ func (s *MySuite) BeforeEach(t *gotest.T) {} // before each test method
 func (s *MySuite) AfterEach(t *gotest.T)  {} // after each test method
 ```
 
-`*gotest.T` exposes `t.Context()` (mirrors Go 1.24's `testing.T.Context()`), plus the full DSL (`t.It()`, `t.When()`, `t.MatchSnapshot()`). Use `*testing.T` for plain stdlib tests — the functional assertions (`gotest.Equal(t, ...)`) still work with either type. You can mix freely within a single suite:
+`*gotest.T` exposes `t.Context()` (mirrors Go 1.24's `testing.T.Context()`), plus the full DSL (`t.It()`, `t.When()`, `t.MatchSnapshot()`).
+Use `*testing.T` for plain stdlib tests — the functional assertions (`gotest.Equal(t, ...)`) still work with either type.
+You can mix freely within a single suite:
 
 ```go
 func (s *MySuite) BeforeEach(t *testing.T) {} // stdlib is fine here
@@ -100,7 +113,9 @@ func (s *MySuite) TestPlain(t *testing.T)  {} // no gotest import needed
 func (s *MySuite) TestRich(t *gotest.T)    {} // full DSL available
 ```
 
-**Resource management through suite fields.** Resources that need setup and teardown (database pools, caches, services) should be stored as suite fields and managed through `BeforeEach`/`AfterEach`. Avoid using `defer` or `t.T().Cleanup()` in test methods — these bypass the suite lifecycle and scatter resource management across test code:
+**Resource management through suite fields.**
+Resources that need setup and teardown (database pools, caches, services) should be stored as suite fields and managed through `BeforeEach`/`AfterEach`.
+Avoid using `defer` or `t.T().Cleanup()` in test methods — these bypass the suite lifecycle and scatter resource management across test code:
 
 ```go
 type AuthServiceTestSuite struct {
@@ -132,7 +147,8 @@ func (s *AuthServiceTestSuite) TestPermissions(t *gotest.T) {
 }
 ```
 
-When different test methods need fundamentally different service configurations, split them into separate suites — each with its own `BeforeEach`/`AfterEach`. This keeps resource management declarative and predictable.
+When different test methods need fundamentally different service configurations, split them into separate suites — each with its own `BeforeEach`/`AfterEach`.
+This keeps resource management declarative and predictable.
 
 Fixture hooks receive `context.Context` and return `error` — the generated wrapper reports failures with automatic attribution:
 
@@ -143,13 +159,18 @@ func (f *MyFixture) BeforeEach(ctx context.Context) error { return nil }
 func (f *MyFixture) AfterEach(ctx context.Context) error  { return nil }
 ```
 
-Setup hooks (`BeforeAll`, `BeforeEach`) receive `t.Context()` — cancelled when the test ends, carries the test deadline. Cleanup hooks (`AfterAll`, `AfterEach`) receive `context.Background()` — cleanup must proceed even after the test context is cancelled. Requires Go 1.24+.
+Setup hooks (`BeforeAll`, `BeforeEach`) receive `t.Context()` — cancelled when the test ends, carries the test deadline.
+Cleanup hooks (`AfterAll`, `AfterEach`) receive `context.Background()` — cleanup must proceed even after the test context is cancelled.
+Requires Go 1.24+.
 
-All hooks are optional. `AfterAll` runs via `t.Cleanup` (LIFO). `AfterEach` is deferred, so it runs even on `t.Fatal()`.
+All hooks are optional.
+`AfterAll` runs via `t.Cleanup` (LIFO).
+`AfterEach` is deferred, so it runs even on `t.Fatal()`.
 
 ### Fixtures
 
-Fixtures replace `TestMain` + package-level singletons with convention-driven setup. Any struct ending in `Fixture` is a package fixture; ending in `SharedFixture` is a cross-package shared fixture.
+Fixtures replace `TestMain` + package-level singletons with convention-driven setup.
+Any struct ending in `Fixture` is a package fixture; ending in `SharedFixture` is a cross-package shared fixture.
 
 ```go
 // fixture_test.go
@@ -188,7 +209,9 @@ func (s *BatchTestSuite) TestDispatch(t *gotest.T) {
 }
 ```
 
-Fixtures support the same lifecycle hooks as suites. `BeforeAll`/`AfterAll` run once around all suites bound to the fixture. `BeforeEach`/`AfterEach` wrap every individual test case, running outside the suite's own hooks:
+Fixtures support the same lifecycle hooks as suites.
+`BeforeAll`/`AfterAll` run once around all suites bound to the fixture.
+`BeforeEach`/`AfterEach` wrap every individual test case, running outside the suite's own hooks:
 
 ```
 Fixture.BeforeEach
@@ -227,7 +250,8 @@ For cross-package shared state (e.g. a database container shared across integrat
 
 ### Configuration
 
-Every fixture and suite runs with sensible defaults — 2-minute fixture timeout, 30-second per-test timeout. Override with optional marker methods:
+Every fixture and suite runs with sensible defaults — 2-minute fixture timeout, 30-second per-test timeout.
+Override with optional marker methods:
 
 ```go
 func (f *InfraFixture) FixtureConfig() gotest.FixtureConfig {
@@ -250,7 +274,8 @@ func (s *BatchTestSuite) SuiteConfig() gotest.SuiteConfig {
 }
 ```
 
-Only non-zero fields override. Use negative duration to explicitly disable a timeout (`Timeout: -1`).
+Only non-zero fields override.
+Use negative duration to explicitly disable a timeout (`Timeout: -1`).
 
 Preset constructors for common scenarios:
 
@@ -290,7 +315,8 @@ func (s *IntegrationTestSuite) SuiteGuard() string {
 }
 ```
 
-Returns a non-empty reason to skip the entire suite. Unlike `X_` (static exclude), `SuiteGuard` makes the decision at runtime — useful for integration tests that need external services.
+Returns a non-empty reason to skip the entire suite.
+Unlike `X_` (static exclude), `SuiteGuard` makes the decision at runtime — useful for integration tests that need external services.
 
 ### BDD Vocabulary
 
@@ -304,13 +330,17 @@ func (s *Suite) TestCreate(t *gotest.T) {
 }
 ```
 
-`When` groups context. `It` specifies behavior. Both map to `t.Run` under the hood.
+`When` groups context.
+`It` specifies behavior.
+Both map to `t.Run` under the hood.
 
 ### Parallel Tests
 
 **Suite-level parallelism** is automatic — the `gotest` runner executes each suite's test binary as a separate subprocess, giving full process isolation with zero shared state between suites.
 
-**Method-level parallelism** is opt-in via `SuiteConfig{Parallel: true}`. When enabled, each test method runs concurrently. Because the suite struct is shared, parallel methods can't safely mutate it — instead, `BeforeEach` returns a per-test context struct that each method receives as a second argument:
+**Method-level parallelism** is opt-in via `SuiteConfig{Parallel: true}`.
+When enabled, each test method runs concurrently.
+Because the suite struct is shared, parallel methods can't safely mutate it — instead, `BeforeEach` returns a per-test context struct that each method receives as a second argument:
 
 ```go
 type MethodParallelCtx struct {
@@ -395,7 +425,8 @@ t.Each(cases, func(it *gotest.T, tc Case) {
 })
 ```
 
-Each entry becomes a subtest. Uses `Desc` or `Name` field for the test name, falls back to `#0`, `#1`, etc.
+Each entry becomes a subtest.
+Uses `Desc` or `Name` field for the test name, falls back to `#0`, `#1`, etc.
 
 ### Async Assertions
 
@@ -411,7 +442,8 @@ t.Consistently(500*time.Millisecond, 50*time.Millisecond, func(poll *gotest.T) {
 })
 ```
 
-Poll callbacks receive a `*gotest.T` — use the full assertion library inside. Failures during polling are collected, not propagated, until the timeout.
+Poll callbacks receive a `*gotest.T` — use the full assertion library inside.
+Failures during polling are collected, not propagated, until the timeout.
 
 ### Snapshot Testing
 
@@ -422,7 +454,10 @@ func (s *Suite) TestRender(t *gotest.T) {
 }
 ```
 
-Snapshots are stored in `testdata/__snapshots__/`. On first run, the snapshot is created. On subsequent runs, the output is compared. Update all snapshots with:
+Snapshots are stored in `testdata/__snapshots__/`.
+On first run, the snapshot is created.
+On subsequent runs, the output is compared.
+Update all snapshots with:
 
 ```bash
 gotest --update-snapshots ./...
@@ -460,7 +495,8 @@ MySuite struct      ƒƒ_psuite_test.go        func TestMySuite(t *testing.T)
                                                  ...
 ```
 
-The generated code is what a careful developer would write by hand: `t.Run`, `t.Cleanup`, `defer`, `sync.WaitGroup`. No reflection, no interface dispatch.
+The generated code is what a careful developer would write by hand: `t.Run`, `t.Cleanup`, `defer`, `sync.WaitGroup`.
+No reflection, no interface dispatch.
 
 ## Naming Conventions
 
@@ -524,7 +560,8 @@ gotest watch ./... -v
 gotest watch ./... --spec     # watch + spec view
 ```
 
-Only the affected package is re-run. Combine with `F_` prefix for a tight feedback loop — only focused tests run on each save.
+Only the affected package is re-run.
+Combine with `F_` prefix for a tight feedback loop — only focused tests run on each save.
 
 ## Commands
 
@@ -552,11 +589,13 @@ Catch common mistakes in test suites with static analysis:
 gotest lint ./...
 ```
 
-Detects: lifecycle hook typos, value receivers on suite methods, missing `AfterAll` when `BeforeAll` exists, committed `F_` prefixes, and orphaned generated files. Also available as a standalone binary (`gotest-lint`) compatible with `golangci-lint` via `go/analysis`.
+Detects: lifecycle hook typos, value receivers on suite methods, missing `AfterAll` when `BeforeAll` exists, committed `F_` prefixes, and orphaned generated files.
+Also available as a standalone binary (`gotest-lint`) compatible with `golangci-lint` via `go/analysis`.
 
 ## VS Code Extension
 
-The **[Go Test Suites](https://marketplace.visualstudio.com/items?itemName=mvrahden.vscode-gotest)** extension brings first-class IDE support: suite-aware Test Explorer, CodeLens run/debug buttons, coverage gutters, watch mode, spec view, focus/exclude quick fixes, and suite scaffolding. Install via `code --install-extension mvrahden.vscode-gotest`.
+The **[Go Test Suites](https://marketplace.visualstudio.com/items?itemName=mvrahden.vscode-gotest)** extension brings first-class IDE support: suite-aware Test Explorer, CodeLens run/debug buttons, coverage gutters, watch mode, spec view, focus/exclude quick fixes, and suite scaffolding.
+Install via `code --install-extension mvrahden.vscode-gotest`.
 
 ## License
 

--- a/docs/fixtures.md
+++ b/docs/fixtures.md
@@ -1,6 +1,7 @@
 # Fixtures
 
-Fixtures replace `TestMain` + package-level singletons with convention-driven setup. Any struct whose name ends in `Fixture` is a package fixture; any struct ending in `SharedFixture` is a cross-package shared fixture.
+Fixtures replace `TestMain` + package-level singletons with convention-driven setup.
+Any struct whose name ends in `Fixture` is a package fixture; any struct ending in `SharedFixture` is a cross-package shared fixture.
 
 ## Package Fixture (`*Fixture` suffix)
 
@@ -47,10 +48,12 @@ func (s *BatchTestSuite) TestDispatch(t *gotest.T) {
 ### Rules
 
 - One root `*Fixture` per package (nested child fixtures are allowed).
-- The fixture struct must have `BeforeAll(ctx context.Context) error`. `AfterAll(ctx context.Context) error` is optional.
+- The fixture struct must have `BeforeAll(ctx context.Context) error`.
+  `AfterAll(ctx context.Context) error` is optional.
 - `BeforeEach(t *gotest.T)` and `AfterEach(t *gotest.T)` are optional and run around every test case in all child suites.
 - TestSuites reference the fixture via a named pointer field (`Fixture *E2ESetupFixture`).
-- The code generator owns `TestMain` when a fixture is present. Remove any user-defined `TestMain`.
+- The code generator owns `TestMain` when a fixture is present.
+  Remove any user-defined `TestMain`.
 
 ### Generated test output
 
@@ -63,7 +66,8 @@ Filter with `-run Test_E2ESetupFixture/BatchTestSuite` to run only batch tests.
 
 ## Nested Fixtures (Level 2)
 
-Fixtures can reference other fixtures via named pointer fields to form a dependency tree. The root fixture's `BeforeAll` runs first, then each child fixture's `BeforeAll`.
+Fixtures can reference other fixtures via named pointer fields to form a dependency tree.
+The root fixture's `BeforeAll` runs first, then each child fixture's `BeforeAll`.
 
 ```go
 type InfraFixture struct {
@@ -99,7 +103,9 @@ Filter with `-run Test_InfraFixture/ReconcilerTestSuite` to skip the API stack e
 
 ## Shared Fixtures (Level 3, `*SharedFixture` suffix)
 
-Shared fixtures run in a subprocess managed by the `gotest` CLI. They start once per CLI invocation and are shared across all packages. State crosses the process boundary via JSON serialization, with `Hydrate` handling reconstruction of non-serializable resources.
+Shared fixtures run in a subprocess managed by the `gotest` CLI.
+They start once per CLI invocation and are shared across all packages.
+State crosses the process boundary via JSON serialization, with `Hydrate` handling reconstruction of non-serializable resources.
 
 ```go
 // tests/fixtures/postgres.go
@@ -143,7 +149,9 @@ func (f *PostgresSharedFixture) connect(ctx context.Context) error {
 
 ### Rules
 
-- Shared fixture types must live in a **non-internal** package (not under `internal/`). The setup subprocess compiles outside the module tree and cannot import `internal/` paths. Shared fixtures may freely import and depend on `internal/` packages — only the fixture type's own package path is restricted.
+- Shared fixture types must live in a **non-internal** package (not under `internal/`).
+  The setup subprocess compiles outside the module tree and cannot import `internal/` paths.
+  Shared fixtures may freely import and depend on `internal/` packages — only the fixture type's own package path is restricted.
 - `BeforeAll(ctx context.Context) error` and `AfterAll(ctx context.Context) error` — runs in the subprocess.
 - `Hydrate(ctx context.Context) error` and `Dehydrate(ctx context.Context) error` — runs in the test process, optional.
 - `BeforeEach`/`AfterEach` are not allowed on shared fixtures.
@@ -152,9 +160,11 @@ func (f *PostgresSharedFixture) connect(ctx context.Context) error {
 
 ### State transfer
 
-In the example above, `ConnStr` and `Port` are transferable (not assigned in `Hydrate`'s call chain). `Pool` is local (assigned in `connect()`, which is called from `Hydrate`).
+In the example above, `ConnStr` and `Port` are transferable (not assigned in `Hydrate`'s call chain).
+`Pool` is local (assigned in `connect()`, which is called from `Hydrate`).
 
-Convention: in `Hydrate`, assign to local fields. Read transferred fields but do not reassign them — use local variables for any transformation.
+Convention: in `Hydrate`, assign to local fields.
+Read transferred fields but do not reassign them — use local variables for any transformation.
 
 ### Using shared fixtures in test suites
 
@@ -172,7 +182,8 @@ func (s *UserTestSuite) TestCreate(t *gotest.T) {
 }
 ```
 
-A standalone suite can reference multiple shared fixtures. Suites without any shared fixture fields coexist in the same package without issue.
+A standalone suite can reference multiple shared fixtures.
+Suites without any shared fixture fields coexist in the same package without issue.
 
 **Fixture-bound suites** wire shared fixtures through a package fixture to add package-specific resources:
 
@@ -252,7 +263,8 @@ Key improvements:
 
 ## Resource Management
 
-Test resources that need setup and teardown (database connections, caches, services) should be stored as suite fields and managed through lifecycle hooks. Avoid using `defer` or `t.T().Cleanup()` in test methods — these bypass the suite lifecycle.
+Test resources that need setup and teardown (database connections, caches, services) should be stored as suite fields and managed through lifecycle hooks.
+Avoid using `defer` or `t.T().Cleanup()` in test methods — these bypass the suite lifecycle.
 
 ```go
 type OrderTestSuite struct {
@@ -281,4 +293,5 @@ func (s *OrderTestSuite) TestCreate(t *gotest.T) {
 }
 ```
 
-When different test methods need fundamentally different service configurations, split them into separate suites — each with its own `BeforeEach`/`AfterEach`. This keeps resource management declarative and co-located.
+When different test methods need fundamentally different service configurations, split them into separate suites — each with its own `BeforeEach`/`AfterEach`.
+This keeps resource management declarative and co-located.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2,9 +2,17 @@
 
 Go tests that write themselves, organize themselves, and explain themselves.
 
-`gotest` closes the gap between `func TestX(t *testing.T)` and a well-organized test suite through code generation. Developers write structs, name them well, and the tool handles the rest. No runtime dependencies. No reflection. No lock-in. Just standard Go tests with lifecycle management and structured organization.
+`gotest` closes the gap between `func TestX(t *testing.T)` and a well-organized test suite through code generation.
+Developers write structs, name them well, and the tool handles the rest.
+No runtime dependencies.
+No reflection.
+No lock-in.
+Just standard Go tests with lifecycle management and structured organization.
 
-A Go developer should be able to `go install` this tool and immediately write better-organized tests without learning a framework. The naming conventions are the API. The generated code is the implementation. The output is `go test` output.
+A Go developer should be able to `go install` this tool and immediately write better-organized tests without learning a framework.
+The naming conventions are the API.
+The generated code is the implementation.
+The output is `go test` output.
 
 ---
 
@@ -14,29 +22,41 @@ Ranked. When they conflict, higher-ranked principles win.
 
 ### 1. Standard Go output, always
 
-Every generated test is a `func Test*(t *testing.T)`. Every line of output is standard `go test` output. Every CI system, IDE, coverage tool, and profiler works unchanged.
+Every generated test is a `func Test*(t *testing.T)`.
+Every line of output is standard `go test` output.
+Every CI system, IDE, coverage tool, and profiler works unchanged.
 
 ### 2. The naming IS the API
 
-No config files. No struct tags. No annotations. No registration calls. A developer reads the naming conventions once and never opens documentation again.
+No config files.
+No struct tags.
+No annotations.
+No registration calls.
+A developer reads the naming conventions once and never opens documentation again.
 
 ### 3. Zero runtime cost
 
-The tool generates code at build time and cleans it up after. At test execution time, there is no `go-test` code in the call stack (except the thin `gotest.T` wrapper). No reflection, no interface dispatch, no type assertions. The generated code is what a careful developer would write by hand.
+The tool generates code at build time and cleans it up after.
+At test execution time, there is no `go-test` code in the call stack (except the thin `gotest.T` wrapper).
+No reflection, no interface dispatch, no type assertions.
+The generated code is what a careful developer would write by hand.
 
 ### 4. Invisible until needed
 
-A developer who has never heard of `go-test` can read a test suite struct and understand what it does. A developer who runs `go test` directly (without the CLI) gets a compilation error for the missing generated file — not silent wrong behavior.
+A developer who has never heard of `go-test` can read a test suite struct and understand what it does.
+A developer who runs `go test` directly (without the CLI) gets a compilation error for the missing generated file — not silent wrong behavior.
 
 ### 5. Adopt incrementally, eject freely
 
-Existing `func Test*` tests coexist with suites in the same package. Removing the tool means deleting suite structs and writing the equivalent `func Test*` functions — the generated code shows exactly what to write.
+Existing `func Test*` tests coexist with suites in the same package.
+Removing the tool means deleting suite structs and writing the equivalent `func Test*` functions — the generated code shows exactly what to write.
 
 ---
 
 ## Conceptual Model
 
-Test suites are behavioral specifications. Every level of the test hierarchy maps to a specification concept:
+Test suites are behavioral specifications.
+Every level of the test hierarchy maps to a specification concept:
 
 ```
 struct  = Subject     "UserService"
@@ -46,7 +66,8 @@ It()    = Behavior    "creates the user"
 Each()  = Variants    "standard format", "missing @", "empty string"
 ```
 
-The naming conventions at the struct/method level and the string descriptions at the `It`/`When` level together form a complete behavioral specification. The tool generates the bridge code (lifecycle, parallel coordination, focus/exclude) and can render the full specification in human-readable form.
+The naming conventions at the struct/method level and the string descriptions at the `It`/`When` level together form a complete behavioral specification.
+The tool generates the bridge code (lifecycle, parallel coordination, focus/exclude) and can render the full specification in human-readable form.
 
 ---
 
@@ -87,7 +108,10 @@ gotest [subcommand] [packages...] [go-test-flags...] [--gotest-flags...]
 
 ### Disambiguation
 
-The first positional arg is checked against the known subcommand set. If it matches, it's consumed. Otherwise, it's a package pattern. `gotest ./watch` tests the `watch` package; `gotest watch` enters watch mode.
+The first positional arg is checked against the known subcommand set.
+If it matches, it's consumed.
+Otherwise, it's a package pattern.
+`gotest ./watch` tests the `watch` package; `gotest watch` enters watch mode.
 
 ### Examples
 
@@ -128,7 +152,8 @@ Requirements:
 
 ### Lifecycle Hooks
 
-All hooks are optional. Unimplemented hooks become no-ops in the generated code.
+All hooks are optional.
+Unimplemented hooks become no-ops in the generated code.
 
 | Method | Signature | Semantics |
 |--------|-----------|-----------|
@@ -157,9 +182,11 @@ BeforeAll
 AfterAll (via t.Cleanup — LIFO, runs after all subtests)
 ```
 
-The returning form creates a typed per-test context that flows through the lifecycle bracket. Each test method receives its own context instance, enabling safe method-level parallelism without shared mutable state on the suite struct.
+The returning form creates a typed per-test context that flows through the lifecycle bracket.
+Each test method receives its own context instance, enabling safe method-level parallelism without shared mutable state on the suite struct.
 
-`AfterAll` is registered via `t.Cleanup` before `BeforeAll` runs, ensuring it executes even if `BeforeAll` registers its own cleanup functions (LIFO ordering). `AfterEach` is `defer`-ed, ensuring it runs even when `t.Fatal()` triggers `runtime.Goexit()`.
+`AfterAll` is registered via `t.Cleanup` before `BeforeAll` runs, ensuring it executes even if `BeforeAll` registers its own cleanup functions (LIFO ordering).
+`AfterEach` is `defer`-ed, ensuring it runs even when `t.Fatal()` triggers `runtime.Goexit()`.
 
 Hooks accept either `*gotest.T` or `*testing.T`.
 
@@ -176,7 +203,8 @@ When `BeforeEach` returns a value, the following rules are enforced at generatio
 
 ### Test Cases
 
-Any exported method matching `^(?:X_|F_)?Test.+$` is a test case. Each becomes a `t.Run` subtest in the generated code.
+Any exported method matching `^(?:X_|F_)?Test.+$` is a test case.
+Each becomes a `t.Run` subtest in the generated code.
 
 ```go
 func (s *Suite) TestSomething(t *gotest.T) {}
@@ -216,7 +244,8 @@ FAIL: focus prefix detected — remove F_ before merging:
 
 ### SuiteGuard
 
-A suite can define a `SuiteGuard()` method that returns a reason string. If non-empty, the entire suite is skipped at runtime with `t.Skipf("suite guard: %s", reason)`:
+A suite can define a `SuiteGuard()` method that returns a reason string.
+If non-empty, the entire suite is skipped at runtime with `t.Skipf("suite guard: %s", reason)`:
 
 ```go
 func (s *MySuite) SuiteGuard() string {
@@ -231,9 +260,13 @@ Unlike `X_` (compile-time exclusion), `SuiteGuard` evaluates at runtime — usef
 
 ### Parallel Execution
 
-**Suite-level parallelism** is handled by the `gotest` CLI runner, which executes each suite's test binary as a separate subprocess. This provides process-level isolation between suites. The generated `func Test*` does **not** call `t.Parallel()` — parallelism is at the runner level, not the Go test scheduler level.
+**Suite-level parallelism** is handled by the `gotest` CLI runner, which executes each suite's test binary as a separate subprocess.
+This provides process-level isolation between suites.
+The generated `func Test*` does **not** call `t.Parallel()` — parallelism is at the runner level, not the Go test scheduler level.
 
-**Method-level parallelism** is opt-in via `SuiteConfig{Parallel: true}`. Each generated subtest calls `it.Parallel()` and coordinates via `sync.WaitGroup`. Method-level parallelism requires a returning `BeforeEach` — per-test state lives in the returned context, not on the shared suite struct.
+**Method-level parallelism** is opt-in via `SuiteConfig{Parallel: true}`.
+Each generated subtest calls `it.Parallel()` and coordinates via `sync.WaitGroup`.
+Method-level parallelism requires a returning `BeforeEach` — per-test state lives in the returned context, not on the shared suite struct.
 
 ```go
 // Default: methods run sequentially within the suite
@@ -260,7 +293,8 @@ func (s *ParallelMethodTestSuite) TestCreate(t *gotest.T, ctx *TestCtx) {}
 func (s *ParallelMethodTestSuite) TestDelete(t *gotest.T, ctx *TestCtx) {}
 ```
 
-When method-level parallelism is enabled, the generated code uses a `sync.WaitGroup` to ensure `AfterAll` waits for all parallel subtests to complete. `wg.Done()` is `defer`-ed to prevent deadlocks on `t.Fatal()`.
+When method-level parallelism is enabled, the generated code uses a `sync.WaitGroup` to ensure `AfterAll` waits for all parallel subtests to complete.
+`wg.Done()` is `defer`-ed to prevent deadlocks on `t.Fatal()`.
 
 ### Generic Suites
 
@@ -275,11 +309,14 @@ type StringTestSuite = GenericTestSuite[string]
 type IntTestSuite    = GenericTestSuite[int]
 ```
 
-Each alias produces an independent test suite. Generic aliases only work in same-package tests (`ptest`), not `pxtest`.
+Each alias produces an independent test suite.
+Generic aliases only work in same-package tests (`ptest`), not `pxtest`.
 
 ### Fixtures
 
-Structs ending in `Fixture` are package fixtures. Structs ending in `SharedFixture` are cross-package shared fixtures. Both use `(ctx context.Context) error` lifecycle signatures:
+Structs ending in `Fixture` are package fixtures.
+Structs ending in `SharedFixture` are cross-package shared fixtures.
+Both use `(ctx context.Context) error` lifecycle signatures:
 
 ```go
 // Package fixtures — run in test process
@@ -291,9 +328,12 @@ func (f *MySharedFixture) BeforeAll(ctx context.Context) error  { return nil }
 func (f *MySharedFixture) AfterAll(ctx context.Context) error   { return nil }
 ```
 
-Package fixture setup hooks receive `t.Context()` (cancelled when the test ends). Cleanup hooks receive `context.Background()` (cleanup must proceed after test context cancellation). Shared fixture hooks receive a context with the configured timeout (from `SharedFixtureConfig()` or defaults).
+Package fixture setup hooks receive `t.Context()` (cancelled when the test ends).
+Cleanup hooks receive `context.Background()` (cleanup must proceed after test context cancellation).
+Shared fixture hooks receive a context with the configured timeout (from `SharedFixtureConfig()` or defaults).
 
-Package fixtures additionally support `BeforeEach`/`AfterEach`. Shared fixtures do not — they run once in the subprocess, not per test case.
+Package fixtures additionally support `BeforeEach`/`AfterEach`.
+Shared fixtures do not — they run once in the subprocess, not per test case.
 
 Test suites reference fixtures via named pointer fields:
 
@@ -322,7 +362,8 @@ type BatchTestSuite struct {
 
 Both paths produce the same lifecycle: deserialize from state file, call `Hydrate`, run tests, call `Dehydrate`.
 
-Fixtures may be defined in a different package from the suite. The resolver walks the type graph from targeted suites to discover all required fixtures, including cross-package dependencies.
+Fixtures may be defined in a different package from the suite.
+The resolver walks the type graph from targeted suites to discover all required fixtures, including cross-package dependencies.
 
 Fixtures nest — a root fixture's hooks run first, wrapping the child's:
 
@@ -338,7 +379,9 @@ InfraFixture.AfterAll
 
 #### SharedFixture State Transfer
 
-SharedFixtures run in a generated subprocess. State crosses the process boundary via JSON serialization. The `Hydrate` method determines which fields are local (reconstructed in the test process) versus transferable (serialized from the subprocess).
+SharedFixtures run in a generated subprocess.
+State crosses the process boundary via JSON serialization.
+The `Hydrate` method determines which fields are local (reconstructed in the test process) versus transferable (serialized from the subprocess).
 
 **Additional lifecycle hooks for shared fixtures:**
 
@@ -347,11 +390,14 @@ SharedFixtures run in a generated subprocess. State crosses the process boundary
 | `Hydrate` | Test process | `(ctx context.Context) error` | Reconstruct local resources from transferred state |
 | `Dehydrate` | Test process | `(ctx context.Context) error` | Clean up locally-created resources |
 
-`Hydrate` and `Dehydrate` are optional. If a SharedFixture has only JSON-serializable exported fields, all fields transfer automatically and no `Hydrate` is needed.
+`Hydrate` and `Dehydrate` are optional.
+If a SharedFixture has only JSON-serializable exported fields, all fields transfer automatically and no `Hydrate` is needed.
 
 **Field classification:**
 
-Fields assigned to the receiver in `Hydrate` — directly, or in receiver methods called from `Hydrate` (one level deep) — are **local**. They are excluded from serialization and reconstructed in the test process. All other exported fields are **transferable**.
+Fields assigned to the receiver in `Hydrate` — directly, or in receiver methods called from `Hydrate` (one level deep) — are **local**.
+They are excluded from serialization and reconstructed in the test process.
+All other exported fields are **transferable**.
 
 ```go
 type PostgresSharedFixture struct {
@@ -389,7 +435,8 @@ func (f *PostgresSharedFixture) connect(ctx context.Context) error {
 }
 ```
 
-**Convention:** In `Hydrate`, assign to local fields. Read transferred fields but do not reassign them — use local variables for any transformation.
+**Convention:** In `Hydrate`, assign to local fields.
+Read transferred fields but do not reassign them — use local variables for any transformation.
 
 **Classification algorithm:**
 
@@ -421,14 +468,17 @@ Test process:
 
 **Validation at generation time:**
 
-- Shared fixture types must not live in `internal/` packages. The setup subprocess compiles outside the module tree and cannot import `internal/` paths. Shared fixtures may freely depend on `internal/` packages — only the fixture type's own package path is restricted.
+- Shared fixture types must not live in `internal/` packages.
+  The setup subprocess compiles outside the module tree and cannot import `internal/` paths.
+  Shared fixtures may freely depend on `internal/` packages — only the fixture type's own package path is restricted.
 - If a transferable field's type has zero exported fields and does not implement `json.Marshaler`/`encoding.TextMarshaler`, the generator emits an error suggesting the field be handled in `Hydrate`
 - If `Hydrate` exists without `Dehydrate`, the generator emits an error
 - `Hydrate`/`Dehydrate` signatures must be `(ctx context.Context) error` with pointer receiver
 
 ### Configuration
 
-Every fixture and suite runs with sensible defaults. Optional marker methods override specific fields via overlay semantics — only non-zero fields replace the default.
+Every fixture and suite runs with sensible defaults.
+Optional marker methods override specific fields via overlay semantics — only non-zero fields replace the default.
 
 #### Config Types
 
@@ -456,7 +506,8 @@ type SuiteConfig struct {
 | `0`   | Keep default (field not overridden) |
 | `< 0` | Explicitly disabled (no timeout) |
 
-This applies to `Timeout`, `SetupTimeout`, and `RetryDelay`. Boolean fields (`FailFast`, `Parallel`) only override to `true` — a false overlay does not reset a true base.
+This applies to `Timeout`, `SetupTimeout`, and `RetryDelay`.
+Boolean fields (`FailFast`, `Parallel`) only override to `true` — a false overlay does not reset a true base.
 
 #### Marker Methods
 
@@ -468,7 +519,8 @@ func (f *MySharedFixture) SharedFixtureConfig()  gotest.FixtureConfig
 func (s *MySuite)         SuiteConfig()          gotest.SuiteConfig
 ```
 
-All three return the same `FixtureConfig` type for fixtures (package and shared) and `SuiteConfig` for suites. The method name follows the type suffix convention.
+All three return the same `FixtureConfig` type for fixtures (package and shared) and `SuiteConfig` for suites.
+The method name follows the type suffix convention.
 
 Requirements (same conventions as lifecycle hooks):
 - Pointer receiver matching the fixture/suite type name
@@ -507,21 +559,32 @@ func (f *InfraFixture) FixtureConfig() gotest.FixtureConfig {
 
 #### Generated Behavior
 
-**Package fixtures:** The test harness always resolves `DefaultFixtureConfig()`, overlays when the marker is present, then uses the config to wrap `BeforeAll` in a retry loop with `context.WithTimeout` and wrap `AfterAll` cleanup with timeout. Retry attempts are logged with attempt number.
+**Package fixtures:** The test harness always resolves `DefaultFixtureConfig()`, overlays when the marker is present, then uses the config to wrap `BeforeAll` in a retry loop with `context.WithTimeout` and wrap `AfterAll` cleanup with timeout.
+Retry attempts are logged with attempt number.
 
-**Shared fixtures:** The generated subprocess resolves `DefaultFixtureConfig()`, overlays when `SharedFixtureConfig()` is present, then wraps each SharedFixture's `BeforeAll(ctx)` in the same retry loop with `context.WithTimeout`. After `BeforeAll`, transferable fields (determined by Hydrate-assignment analysis) are serialized to stdout as JSON. `AfterAll(ctx)` gets timeout wrapping in the teardown handler. In the test harness, the deserialized fixture is hydrated via `Hydrate(ctx)` if present, and `Dehydrate(ctx)` is deferred for cleanup.
+**Shared fixtures:** The generated subprocess resolves `DefaultFixtureConfig()`, overlays when `SharedFixtureConfig()` is present, then wraps each SharedFixture's `BeforeAll(ctx)` in the same retry loop with `context.WithTimeout`.
+After `BeforeAll`, transferable fields (determined by Hydrate-assignment analysis) are serialized to stdout as JSON.
+`AfterAll(ctx)` gets timeout wrapping in the teardown handler.
+In the test harness, the deserialized fixture is hydrated via `Hydrate(ctx)` if present, and `Dehydrate(ctx)` is deferred for cleanup.
 
 **Suites:** The test harness always resolves `DefaultSuiteConfig()`, overlays when the marker is present, then wraps each test case with `NewTWithDeadline` when timeout > 0, and breaks the test case loop on first failure when `FailFast` is set.
 
-**`NewTWithDeadline`:** Creates a `*gotest.T` with a context deadline. `t.Context()` returns the deadline-aware context. Existing `NewT` callers are unaffected.
+**`NewTWithDeadline`:** Creates a `*gotest.T` with a context deadline.
+`t.Context()` returns the deadline-aware context.
+Existing `NewT` callers are unaffected.
 
 #### Feature Interactions
 
-- **Parallel suites:** `FailFast` checks run between subtests — in method-parallel suites, all parallel subtests complete before `FailFast` is evaluated. Suite-level parallelism does not affect `FailFast` (each suite's subtests are independent).
-- **Focus/Exclude:** Config applies after focus/exclude filtering. Skipped suites get unchanged skip stubs.
+- **Parallel suites:** `FailFast` checks run between subtests — in method-parallel suites, all parallel subtests complete before `FailFast` is evaluated.
+  Suite-level parallelism does not affect `FailFast` (each suite's subtests are independent).
+- **Focus/Exclude:** Config applies after focus/exclude filtering.
+  Skipped suites get unchanged skip stubs.
 - **Global `-timeout`:** `FixtureConfig.Timeout` is bounded by Go's global timeout via `context.WithTimeout` inheriting the parent's shorter deadline.
 - **Nested fixtures:** Each level resolves config independently — no inheritance between fixture levels.
-- **Hydrate/Dehydrate:** SharedFixture state is deserialized and hydrated before any test suites run. `Dehydrate` is deferred, running after all suites complete. `Hydrate` receives a context with the SharedFixture's configured timeout. `Dehydrate` receives `context.Background()`.
+- **Hydrate/Dehydrate:** SharedFixture state is deserialized and hydrated before any test suites run.
+  `Dehydrate` is deferred, running after all suites complete.
+  `Hydrate` receives a context with the SharedFixture's configured timeout.
+  `Dehydrate` receives `context.Background()`.
 
 ---
 
@@ -529,7 +592,8 @@ func (f *InfraFixture) FixtureConfig() gotest.FixtureConfig {
 
 ### Functional API
 
-Type-safe generics with compile-time safety. All functions accept any type implementing `testingT` (`Helper()` + `Errorf()` + `FailNow()`) — works with both `*gotest.T` and `*testing.T`.
+Type-safe generics with compile-time safety.
+All functions accept any type implementing `testingT` (`Helper()` + `Errorf()` + `FailNow()`) — works with both `*gotest.T` and `*testing.T`.
 
 ```go
 // Equality — [T any] catches cross-type comparison at compile time
@@ -586,7 +650,8 @@ gotest.Panics(t, f func(), msgAndArgs ...any) any
 gotest.Must[T any](val T, ok any) T
 ```
 
-All functions call `t.Helper()` so failures report the caller's file:line. Equality failures include a diff:
+All functions call `t.Helper()` so failures report the caller's file:line.
+Equality failures include a diff:
 
 ```
 Equal failed:
@@ -607,7 +672,9 @@ Zero external dependencies — uses `reflect.DeepEqual`, `cmp.Compare`, `fmt.Spr
 
 ### t.When() / t.It()
 
-`When` groups context. `It` specifies behavior. Both map to `t.Run` under the hood — the distinction is purely semantic.
+`When` groups context.
+`It` specifies behavior.
+Both map to `t.Run` under the hood — the distinction is purely semantic.
 
 ```go
 func (s *UserServiceTestSuite) TestCreate(t *gotest.T) {
@@ -682,7 +749,9 @@ t.Consistently(2*time.Second, 100*time.Millisecond, func(poll *gotest.T) {
 })
 ```
 
-The `poll *gotest.T` is a collecting wrapper — assertion failures during intermediate polls are captured but not propagated. On timeout, the last poll's assertion failures are reported. `Consistently` fails on first `false` poll and reports which poll failed.
+The `poll *gotest.T` is a collecting wrapper — assertion failures during intermediate polls are captured but not propagated.
+On timeout, the last poll's assertion failures are reported.
+`Consistently` fails on first `false` poll and reports which poll failed.
 
 ---
 
@@ -706,7 +775,8 @@ t.MatchSnapshot(result, "variant")    // custom snapshot name
 $ gotest scaffold ./pkg/user.UserService
 ```
 
-Generates a test suite skeleton with `BeforeEach`, per-method `Test*` stubs, and method signatures as comments. Methods returning `error` get happy-path and error-case stubs.
+Generates a test suite skeleton with `BeforeEach`, per-method `Test*` stubs, and method signatures as comments.
+Methods returning `error` get happy-path and error-case stubs.
 
 Interface scaffolding generates a generic contract suite:
 
@@ -791,7 +861,8 @@ Focus integration: `F_`-prefixed suites during watch mode create a tight feedbac
 gotest generate ./...
 ```
 
-Writes generated files directly to package directories. Use case: `//go:generate gotest generate ./...` for checked-in generated files.
+Writes generated files directly to package directories.
+Use case: `//go:generate gotest generate ./...` for checked-in generated files.
 
 **Clean up** orphaned files:
 
@@ -810,7 +881,8 @@ Per package directory, up to two files:
 | `ƒƒ_psuite_test.go` | Same-package (white-box) test suites |
 | `ƒƒ_pxsuite_test.go` | External-package (black-box) test suites |
 
-The `ƒƒ` Unicode prefix prevents naming collisions with user code. Files contain a `// Code generated` header.
+The `ƒƒ` Unicode prefix prevents naming collisions with user code.
+Files contain a `// Code generated` header.
 
 ### Generated Structure
 
@@ -878,13 +950,15 @@ Detects:
 
 Exit codes match `go test`: 0 = pass, 1 = test failure, 2 = build error.
 
-The `--ci` flag fails the run when any `F_` (focus) prefix is committed, preventing accidental focus leaks in CI. The local `setup-gotest` composite action installs the binary via `go install`.
+The `--ci` flag fails the run when any `F_` (focus) prefix is committed, preventing accidental focus leaks in CI.
+The local `setup-gotest` composite action installs the binary via `go install`.
 
 ---
 
 ## Coverage Aggregation
 
-The Go coverage profile is the single source of truth at every level of aggregation. No filesystem scanning, line counting heuristics, or mixed data sources.
+The Go coverage profile is the single source of truth at every level of aggregation.
+No filesystem scanning, line counting heuristics, or mixed data sources.
 
 ### Primary Metric: Statement-Weighted Coverage
 
@@ -894,7 +968,8 @@ Each profile entry has the form:
 file:startLine.startCol,endLine.endCol numStatements count
 ```
 
-`numStatements` is the number of Go statements in a basic block as determined by the compiler's instrumentation. Coverage at any scope (file, directory, workspace) is:
+`numStatements` is the number of Go statements in a basic block as determined by the compiler's instrumentation.
+Coverage at any scope (file, directory, workspace) is:
 
 ```
 covered = sum of numStatements for all blocks in scope where count > 0
@@ -902,22 +977,30 @@ total   = sum of numStatements for all blocks in scope
 percentage = covered / total (or 0% if total == 0)
 ```
 
-A directory's percentage is the weighted sum of its children (weighted by statement count, not an average of percentages). A parent's number is always derivable from its children.
+A directory's percentage is the weighted sum of its children (weighted by statement count, not an average of percentages).
+A parent's number is always derivable from its children.
 
-This is the sole numeric metric displayed in both the Test Coverage sidebar bar and the Copy Coverage report. The sidebar and report must always show identical `covered/total` values for the same scope.
+This is the sole numeric metric displayed in both the Test Coverage sidebar bar and the Copy Coverage report.
+The sidebar and report must always show identical `covered/total` values for the same scope.
 
-Declaration (function) coverage is not a sidebar or report metric. Function-level annotations are available in the editor gutter via `loadDetailedCoverage` for navigation purposes only.
+Declaration (function) coverage is not a sidebar or report metric.
+Function-level annotations are available in the editor gutter via `loadDetailedCoverage` for navigation purposes only.
 
 ### Block Deduplication
 
-When `-coverpkg` is used, each file may appear in multiple test binary profiles. Blocks are deduplicated by `file + startLine.startCol,endLine.endCol` identity: for each unique block, take `max(count)` across all entries. This matches `go tool cover` behavior.
+When `-coverpkg` is used, each file may appear in multiple test binary profiles.
+Blocks are deduplicated by `file + startLine.startCol,endLine.endCol` identity: for each unique block, take `max(count)` across all entries.
+This matches `go tool cover` behavior.
 
 ### Supplementary Coverage (Cross-Package Profiles)
 
-Test-only packages (packages with no production `.go` files) run with `-coverpkg=./...`, which instruments all packages in the module. This cross-package profile is **supplementary**: it can increase block counts for files that primary profiles already cover, but does not add new files to the aggregate.
+Test-only packages (packages with no production `.go` files) run with `-coverpkg=./...`, which instruments all packages in the module.
+This cross-package profile is **supplementary**: it can increase block counts for files that primary profiles already cover, but does not add new files to the aggregate.
 
-- **Primary profiles** come from a package's own `go test` run. They define the file scope.
-- **Supplementary profiles** come from test-only packages with `-coverpkg=./...`. After block deduplication, only files present in the primary scope are retained.
+- **Primary profiles** come from a package's own `go test` run.
+  They define the file scope.
+- **Supplementary profiles** come from test-only packages with `-coverpkg=./...`.
+  After block deduplication, only files present in the primary scope are retained.
 - If no primary profiles exist, supplementary profiles are treated as primary (fallback).
 
 ### Breadth Indicator
@@ -925,17 +1008,21 @@ Test-only packages (packages with no production `.go` files) run with `-coverpkg
 A supplementary signal showing how many source files have coverage data vs. how many exist:
 
 - **Source files:** Non-test Go files (`*.go` excluding `*_test.go`) per directory, from the filesystem.
-- **Profile files:** Files from the source file set with at least one entry in the primary coverage scope, regardless of whether that entry has `count > 0`. A file at 0% was instrumented and counts as profiled.
+- **Profile files:** Files from the source file set with at least one entry in the primary coverage scope, regardless of whether that entry has `count > 0`.
+  A file at 0% was instrumented and counts as profiled.
 
 The percentage answers: *"How well-tested is the code my tests reach?"*
 The file count answers: *"How much of my codebase do my tests reach at all?"*
 
 ### What NOT to Do
 
-- Do not count lines of code, lines with tokens, or non-blank lines as a denominator. The profile's `numStatements` is the only valid statement metric.
+- Do not count lines of code, lines with tokens, or non-blank lines as a denominator.
+  The profile's `numStatements` is the only valid statement metric.
 - Do not include `_test.go` files in any denominator.
-- Do not average per-file percentages to compute a directory percentage. Use weighted sums by statement count.
-- Do not invent a filesystem-based metric as a fallback when the profile is sparse. A sparse profile is honest.
+- Do not average per-file percentages to compute a directory percentage.
+  Use weighted sums by statement count.
+- Do not invent a filesystem-based metric as a fallback when the profile is sparse.
+  A sparse profile is honest.
 - Do not display declaration/function coverage as a separate metric in the sidebar or report.
 - Do not let supplementary (cross-package) profiles expand the file scope beyond what primary profiles define.
 
@@ -977,27 +1064,34 @@ Each alias produces an independent conformance report.
 
 ### Test dependency ordering
 
-Tests that depend on other tests are brittle. Each test sets up its own preconditions via `BeforeEach`.
+Tests that depend on other tests are brittle.
+Each test sets up its own preconditions via `BeforeEach`.
 
 ### Mocking framework
 
-Mocking is orthogonal to test organization. `gomock`, `mockery`, `moq`, and counterfeiter all work inside suites unchanged.
+Mocking is orthogonal to test organization.
+`gomock`, `mockery`, `moq`, and counterfeiter all work inside suites unchanged.
 
 ### Decorator / annotation syntax
 
-Go doesn't have decorators. Naming conventions are grepped, autocompleted, and understood at a glance. Struct tags are hidden in backtick strings.
+Go doesn't have decorators.
+Naming conventions are grepped, autocompleted, and understood at a glance.
+Struct tags are hidden in backtick strings.
 
 ### Runtime suite registration
 
-`suite.Run(t, new(MySuite))` is testify's approach. The entire point of `go-test` is to generate that boilerplate.
+`suite.Run(t, new(MySuite))` is testify's approach.
+The entire point of `go-test` is to generate that boilerplate.
 
 ### Cross-package suite inheritance
 
-Breaks Go's package isolation model. Cross-package sharing uses helper functions or fixtures, not suite inheritance.
+Breaks Go's package isolation model.
+Cross-package sharing uses helper functions or fixtures, not suite inheritance.
 
 ### Replacing `go test` output
 
-The `spec` subcommand and `--spec` flag are post-processing views over `go test -json` data. They add a layer on top; they never suppress or replace the underlying output.
+The `spec` subcommand and `--spec` flag are post-processing views over `go test -json` data.
+They add a layer on top; they never suppress or replace the underlying output.
 
 ---
 
@@ -1035,20 +1129,28 @@ about/                       Build metadata, file naming constants
 | **Resolve** | Effective suites + local fixtures | `ResolveResult` — fixture trees, shared fixture info, suite→fixture bindings |
 | **Render** | Reduced spec + resolve result | Formatted Go source bytes |
 
-Collection is a two-pass AST traversal: find type declarations matching suite patterns, then attach methods by matching receiver types. Resolution is demand-driven: it starts from targeted suites and walks the Go type graph recursively (via `types.Named`, `types.Struct`, `types.MethodSet`) to discover all required fixtures, including cross-package dependencies.
+Collection is a two-pass AST traversal: find type declarations matching suite patterns, then attach methods by matching receiver types.
+Resolution is demand-driven: it starts from targeted suites and walks the Go type graph recursively (via `types.Named`, `types.Struct`, `types.MethodSet`) to discover all required fixtures, including cross-package dependencies.
 
 ### Key Invariant
 
-The pipeline is always: **static analysis → code generation → standard `go test`**. No runtime component grows beyond the thin `gotest.T` wrapper. If a feature can't be implemented as either (a) generated code, (b) a method on `gotest.T`, or (c) post-processing of `go test -json`, it doesn't belong in this project.
+The pipeline is always: **static analysis → code generation → standard `go test`**.
+No runtime component grows beyond the thin `gotest.T` wrapper.
+If a feature can't be implemented as either (a) generated code, (b) a method on `gotest.T`, or (c) post-processing of `go test -json`, it doesn't belong in this project.
 
 ---
 
 ## Known Limitations
 
-1. **Generic aliases in `pxtest`:** Go does not allow defining methods on aliases of types from other packages. Generic suite aliases only work in same-package tests.
+1. **Generic aliases in `pxtest`:** Go does not allow defining methods on aliases of types from other packages.
+   Generic suite aliases only work in same-package tests.
 
-2. **`go.work` required for cross-module tests:** The generator golden tests require `go.work` (`go work init . && go work use ./examples`). Tests skip gracefully when absent.
+2. **`go.work` required for cross-module tests:** The generator golden tests require `go.work` (`go work init . && go work use ./examples`).
+   Tests skip gracefully when absent.
 
-3. **No incremental generation:** The tool regenerates all suite files on every run. There is no staleness detection.
+3. **No incremental generation:** The tool regenerates all suite files on every run.
+   There is no staleness detection.
 
-4. **Hydrate method walking depth:** The generator follows receiver method calls from `Hydrate` one level deep to classify local fields. Assignments hidden behind two or more levels of indirection are not detected. Opaque types (zero exported fields) are unaffected — they serialize harmlessly as `{}` and `Hydrate` overwrites the value.
+4. **Hydrate method walking depth:** The generator follows receiver method calls from `Hydrate` one level deep to classify local fields.
+   Assignments hidden behind two or more levels of indirection are not detected.
+   Opaque types (zero exported fields) are unaffected — they serialize harmlessly as `{}` and `Hydrate` overwrites the value.

--- a/examples/fixture_suite/README.md
+++ b/examples/fixture_suite/README.md
@@ -3,6 +3,5 @@
 Fixtures with suite-scoped lifecycle.
 
 A fixture is a struct with `BeforeAll`/`AfterAll` that runs once per suite.
-Suites embed the fixture pointer to access its state. `FixtureConfig()`
-returns a preset like `ContainerFixtureConfig()` to control timeouts and
-retries.
+Suites embed the fixture pointer to access its state.
+`FixtureConfig()` returns a preset like `ContainerFixtureConfig()` to control timeouts and retries.

--- a/examples/focus_exclude/README.md
+++ b/examples/focus_exclude/README.md
@@ -2,6 +2,6 @@
 
 The `F_` and `X_` prefix directives.
 
-Prefixing a suite with `F_` focuses it: only focused suites run, unfocused
-suites are skipped. Prefixing with `X_` excludes it unconditionally. The
-same prefixes apply to individual test methods within a suite.
+Prefixing a suite with `F_` focuses it: only focused suites run, unfocused suites are skipped.
+Prefixing with `X_` excludes it unconditionally.
+The same prefixes apply to individual test methods within a suite.

--- a/examples/generic_suite/README.md
+++ b/examples/generic_suite/README.md
@@ -2,6 +2,5 @@
 
 Type-parameterized suites.
 
-A generic suite like `GenericTestSuite[T]` is instantiated via type aliases
-(e.g. `StringTestSuite = GenericTestSuite[string]`). Each alias becomes its
-own test suite with the shared behavior specialized to the type argument.
+A generic suite like `GenericTestSuite[T]` is instantiated via type aliases (e.g. `StringTestSuite = GenericTestSuite[string]`).
+Each alias becomes its own test suite with the shared behavior specialized to the type argument.

--- a/examples/nested_fixture/README.md
+++ b/examples/nested_fixture/README.md
@@ -2,7 +2,6 @@
 
 Fixture composition.
 
-Fixtures can embed other fixtures to form a hierarchy. `APIFixture` embeds
-`InfraFixture`, so suites using `APIFixture` transitively access infra
-state. Suites at different levels of the hierarchy share the underlying
-fixture instances.
+Fixtures can embed other fixtures to form a hierarchy.
+`APIFixture` embeds `InfraFixture`, so suites using `APIFixture` transitively access infra state.
+Suites at different levels of the hierarchy share the underlying fixture instances.

--- a/examples/parallel_suite/README.md
+++ b/examples/parallel_suite/README.md
@@ -3,5 +3,4 @@
 Method-level parallel execution.
 
 Setting `SuiteConfig{Parallel: true}` runs each test method concurrently.
-A returning `BeforeEach` provides per-test state isolation by yielding a
-context value that is passed to the test method and `AfterEach`.
+A returning `BeforeEach` provides per-test state isolation by yielding a context value that is passed to the test method and `AfterEach`.

--- a/examples/shared_fixture/README.md
+++ b/examples/shared_fixture/README.md
@@ -2,8 +2,6 @@
 
 Cross-package fixture sharing.
 
-Shared fixtures (`PostgresSharedFixture`, `RedisSharedFixture`) are defined
-in a root package and consumed by suites in subpackages (`api/`, `web/`).
+Shared fixtures (`PostgresSharedFixture`, `RedisSharedFixture`) are defined in a root package and consumed by suites in subpackages (`api/`, `web/`).
 State is serialized to JSON between the CLI runner and each test binary.
-`Hydrate`/`Dehydrate` hooks restore non-serializable resources (e.g. pool
-handles) on the consumer side.
+`Hydrate`/`Dehydrate` hooks restore non-serializable resources (e.g. pool handles) on the consumer side.

--- a/examples/stdlib/README.md
+++ b/examples/stdlib/README.md
@@ -2,8 +2,7 @@
 
 `*testing.T` support and co-existence with standard Go tests.
 
-Suite methods can use `*testing.T` signatures instead of `*gotest.T`. The
-generated code unwraps via `T()` automatically. Framework assertions like
-`gotest.True` also accept `*testing.T`, so both stdlib and gotest styles
-can be mixed freely. Regular stdlib tests co-exist alongside suites in the
-same package.
+Suite methods can use `*testing.T` signatures instead of `*gotest.T`.
+The generated code unwraps via `T()` automatically.
+Framework assertions like `gotest.True` also accept `*testing.T`, so both stdlib and gotest styles can be mixed freely.
+Regular stdlib tests co-exist alongside suites in the same package.

--- a/internal/gotestspec/terminal.go
+++ b/internal/gotestspec/terminal.go
@@ -92,6 +92,9 @@ func renderNode(w io.Writer, n *Node, depth int, c colors) {
 	}
 
 	suffix := ""
+	if n.External {
+		suffix = fmt.Sprintf(" %s— EXTERNAL%s", c.dim, c.reset)
+	}
 	if n.Focused {
 		suffix = fmt.Sprintf(" %s— FOCUSED%s", c.yellow, c.reset)
 	} else if n.Excluded {

--- a/internal/gotestspec/tree.go
+++ b/internal/gotestspec/tree.go
@@ -209,7 +209,7 @@ func hasDuplicateSuffix(s string) bool {
 
 func stripDuplicateSuffix(s string) string {
 	idx := strings.LastIndex(s, "#")
-	if idx < 0 {
+	if idx <= 0 {
 		return s
 	}
 	suffix := s[idx+1:]
@@ -288,15 +288,15 @@ func classify(n *Node, topLevel bool) {
 			name = name[2:]
 		}
 
-		if strings.HasSuffix(name, "Fixture") && !strings.HasSuffix(name, "TestSuite") {
+		if strings.HasPrefix(name, "Test") {
+			n.Kind = KindMethod
+			n.Display = strings.TrimPrefix(name, "Test")
+		} else if strings.HasSuffix(name, "Fixture") && !strings.HasSuffix(name, "TestSuite") {
 			n.Kind = KindFixture
 			n.Display = strings.TrimSuffix(name, "Fixture")
 		} else if strings.HasSuffix(name, "TestSuite") {
 			n.Kind = KindSuite
 			n.Display = strings.TrimSuffix(name, "TestSuite")
-		} else if strings.HasPrefix(name, "Test") {
-			n.Kind = KindMethod
-			n.Display = strings.TrimPrefix(name, "Test")
 		} else {
 			n.Kind = KindBlock
 			n.Display = strings.ReplaceAll(name, "_", " ")

--- a/pkg/gotest/each_suite_test.go
+++ b/pkg/gotest/each_suite_test.go
@@ -49,13 +49,21 @@ func (s *EachTestSuite) TestCallbackAPI(t *gotest.T) {
 		})
 	})
 
-	t.When("entries lack Desc and Name", func(w *gotest.T) {
-		w.It("falls back to index-based names", func(it *gotest.T) {
+	t.When("entries are anonymous structs", func(w *gotest.T) {
+		w.It("runs each entry", func(it *gotest.T) {
 			count := 0
-			it.Each([]struct{ Val int }{
-				{10}, {20},
-			}, func(tt *gotest.T, tc struct{ Val int }) {
+			it.Each([]struct {
+				Desc string
+				Val  int
+			}{
+				{"processes first value", 10},
+				{"processes second value", 20},
+			}, func(tt *gotest.T, tc struct {
+				Desc string
+				Val  int
+			}) {
 				count++
+				gotest.Greater(tt, tc.Val, 0)
 			})
 			gotest.Equal(it, 2, count)
 		})

--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -6,11 +6,13 @@
 
 First-class VS Code integration for [go-test](https://github.com/mvrahden/go-test) — suite-based, BDD-style testing for Go.
 
-Run, debug, and watch your test suites directly from the editor. See structured results in Test Explorer, get coverage gutters, and scaffold new suites without leaving VS Code.
+Run, debug, and watch your test suites directly from the editor.
+See structured results in Test Explorer, get coverage gutters, and scaffold new suites without leaving VS Code.
 
 ## Why this extension?
 
-Go's standard `testing` package gives you `func TestX(t *testing.T)` and nothing more. [go-test](https://github.com/mvrahden/go-test) adds suite-based organization with lifecycle hooks, fixtures, focus/exclude, and BDD-style output — all through naming conventions, zero runtime dependencies.
+Go's standard `testing` package gives you `func TestX(t *testing.T)` and nothing more.
+[go-test](https://github.com/mvrahden/go-test) adds suite-based organization with lifecycle hooks, fixtures, focus/exclude, and BDD-style output — all through naming conventions, zero runtime dependencies.
 
 This extension makes that workflow native to VS Code:
 
@@ -30,7 +32,8 @@ This extension makes that workflow native to VS Code:
 - **VS Code** (1.101+)
 - **[Delve](https://github.com/go-delve/delve)** (for debugging only)
 
-The extension invokes the gotest CLI automatically — no separate install needed. It resolves the version from your `go.mod` and uses `go run` to execute it.
+The extension invokes the gotest CLI automatically — no separate install needed.
+It resolves the version from your `go.mod` and uses `go run` to execute it.
 
 ### Install
 
@@ -51,11 +54,15 @@ code --install-extension mvrahden.vscode-gotest
 
 ### Test Explorer
 
-Tests appear in a structured tree: **Package > Suite > Method > Subtest**. Run or debug at any level — a single method, an entire suite, or all tests in a package. Multi-select is fully supported. Test results persist across sessions, so you see pass/fail state immediately after reopening the editor.
+Tests appear in a structured tree: **Package > Suite > Method > Subtest**.
+Run or debug at any level — a single method, an entire suite, or all tests in a package.
+Multi-select is fully supported.
+Test results persist across sessions, so you see pass/fail state immediately after reopening the editor.
 
 ### CodeLens
 
-**Run** and **Debug** buttons appear inline above every suite and test method in `_test.go` files. Click to execute immediately.
+**Run** and **Debug** buttons appear inline above every suite and test method in `_test.go` files.
+Click to execute immediately.
 
 Package-level and file-level actions appear on the `package` declaration line:
 
@@ -64,17 +71,24 @@ Package-level and file-level actions appear on the `package` declaration line:
 
 ### Coverage
 
-Use the **Coverage** run profile in Test Explorer to run tests with `go test -coverprofile`. Results appear as native VS Code coverage gutters. Coverage data persists across sessions and accumulates across packages. Source file edits automatically invalidate stale coverage for the affected package.
+Use the **Coverage** run profile in Test Explorer to run tests with `go test -coverprofile`.
+Results appear as native VS Code coverage gutters.
+Coverage data persists across sessions and accumulates across packages.
+Source file edits automatically invalidate stale coverage for the affected package.
 
 Copy a tabular coverage summary to the clipboard via the **Go Test: Copy Coverage Summary** command.
 
 ### Watch mode
 
-Start continuous testing with **Go Test: Start Watch**. The extension spawns a `gotest watch` process that re-runs tests on file changes. Results stream into Test Explorer in real-time. A status bar item shows active watcher count and lets you stop all watchers with a click.
+Start continuous testing with **Go Test: Start Watch**.
+The extension spawns a `gotest watch` process that re-runs tests on file changes.
+Results stream into Test Explorer in real-time.
+A status bar item shows active watcher count and lets you stop all watchers with a click.
 
 ### Spec View
 
-After each test run, the **Spec View** panel renders BDD-formatted output with color-coded pass/fail/skip indicators. Open it with **Go Test: Show Spec View**.
+After each test run, the **Spec View** panel renders BDD-formatted output with color-coded pass/fail/skip indicators.
+Open it with **Go Test: Show Spec View**.
 
 - **Go-to-source** — click any suite or method to navigate to its definition
 - **Toolbar** — expand/collapse all, filter by pass/fail/skip status, search behaviors by name
@@ -104,7 +118,11 @@ The generated file opens automatically and discovery refreshes.
 
 ### Multi-root workspaces
 
-Fully supported. Each workspace folder is discovered independently. Commands resolve the correct workspace folder from the active editor, and file watchers trigger per-folder discovery. Per-project settings like `cliPath`, `testFlags`, and `buildTags` can be configured per folder via `.vscode/settings.json`. Projects using `go.work` are also supported.
+Fully supported.
+Each workspace folder is discovered independently.
+Commands resolve the correct workspace folder from the active editor, and file watchers trigger per-folder discovery.
+Per-project settings like `cliPath`, `testFlags`, and `buildTags` can be configured per folder via `.vscode/settings.json`.
+Projects using `go.work` are also supported.
 
 ## Commands
 

--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -51,11 +51,16 @@ code --install-extension mvrahden.vscode-gotest
 
 ### Test Explorer
 
-Tests appear in a structured tree: **Package > Suite > Method > Subtest**. Run or debug at any level — a single method, an entire suite, or all tests in a package. Multi-select is fully supported.
+Tests appear in a structured tree: **Package > Suite > Method > Subtest**. Run or debug at any level — a single method, an entire suite, or all tests in a package. Multi-select is fully supported. Test results persist across sessions, so you see pass/fail state immediately after reopening the editor.
 
 ### CodeLens
 
-**Run** and **Debug** buttons appear inline above every suite struct and test method in `_test.go` files. Click to execute immediately.
+**Run** and **Debug** buttons appear inline above every suite and test method in `_test.go` files. Click to execute immediately.
+
+Package-level and file-level actions appear on the `package` declaration line:
+
+- **Run Package** — run all suites in the package
+- **Run File** — run all suites defined in the current file (shown when the file contains multiple suites)
 
 ### Coverage
 
@@ -70,6 +75,12 @@ Start continuous testing with **Go Test: Start Watch**. The extension spawns a `
 ### Spec View
 
 After each test run, the **Spec View** panel renders BDD-formatted output with color-coded pass/fail/skip indicators. Open it with **Go Test: Show Spec View**.
+
+- **Go-to-source** — click any suite or method to navigate to its definition
+- **Toolbar** — expand/collapse all, filter by pass/fail/skip status, search behaviors by name
+- **Copy / Clear** — copy the full spec report to clipboard or clear results
+- **Persistence** — the panel survives editor reload and restores its last state
+- **Live updates** — auto-refreshes from test runs, coverage runs, and watch mode
 
 ### Focus and Exclude
 
@@ -93,13 +104,14 @@ The generated file opens automatically and discovery refreshes.
 
 ### Multi-root workspaces
 
-Fully supported. Each workspace folder is discovered independently. Commands resolve the correct workspace folder from the active editor, and file watchers trigger per-folder discovery. Per-project settings like `cliPath`, `testFlags`, and `buildTags` can be configured per folder via `.vscode/settings.json`.
+Fully supported. Each workspace folder is discovered independently. Commands resolve the correct workspace folder from the active editor, and file watchers trigger per-folder discovery. Per-project settings like `cliPath`, `testFlags`, and `buildTags` can be configured per folder via `.vscode/settings.json`. Projects using `go.work` are also supported.
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
 | Go Test: Run | Run a specific test by ID |
+| Go Test: Run File | Run all suites in the current file |
 | Go Test: Debug | Debug a specific test by ID |
 | Go Test: Refresh | Re-run test discovery for all workspace folders |
 | Go Test: Show Focused Tests | List all focused tests and navigate to them |
@@ -107,8 +119,9 @@ Fully supported. Each workspace folder is discovered independently. Commands res
 | Go Test: Start Watch | Start continuous testing for a package scope |
 | Go Test: Stop Watch | Stop all active watch processes |
 | Go Test: Scaffold Suite | Generate a test suite from a target |
+| Go Test: Scaffold Target | Generate a test suite for a specific target |
 | Go Test: Copy Coverage Summary | Copy coverage table to clipboard |
-| Go Test: Copy Test Results | Copy test results to clipboard |
+| Go Test: Copy Test Results | Copy test results to clipboard (also available as context menu on test items) |
 
 ## Settings
 

--- a/vscode-gotest/src/specView.ts
+++ b/vscode-gotest/src/specView.ts
@@ -796,7 +796,7 @@ function walkReportNode(
 
   let label = node.display;
   const tags: string[] = [];
-  if (node.external) tags.push("EXT.");
+  if (node.external) tags.push("EXTERNAL");
   if (node.focused) tags.push("FOCUSED");
   else if (node.excluded) tags.push("SKIPPED");
   if (tags.length > 0) label += " — " + tags.join(", ");


### PR DESCRIPTION
Fix spec report issues (empty subtest names, fixture misclassification, external label) and improve documentation with semantic line breaks and undocumented feature coverage.