### PR TITLE
feat: structured --help, simplified CLI resolution, and extension fixes

### DIFF
--- a/cmd/gotest/args.go
+++ b/cmd/gotest/args.go
@@ -26,15 +26,12 @@ func (inv Invocation) TagArgs() []string {
 	return append([]string{"-tags=" + inv.Config.Tags}, inv.Args...)
 }
 
-// DefaultArgs returns args with tags, setup-timeout, and debounce from config,
+// DefaultArgs returns args with tags and setup-timeout from config,
 // each only if not already set via CLI flags.
 func (inv Invocation) DefaultArgs() []string {
 	out := inv.TagArgs()
 	if inv.Config.SetupTimeout.Duration() > 0 && !hasFlag(out, "--setup-timeout") {
 		out = append([]string{"--setup-timeout=" + inv.Config.SetupTimeout.Duration().String()}, out...)
-	}
-	if inv.Config.Debounce.Duration() > 0 && !hasFlag(out, "--debounce") {
-		out = append([]string{"--debounce=" + inv.Config.Debounce.Duration().String()}, out...)
 	}
 	return out
 }

--- a/cmd/gotest/cli.go
+++ b/cmd/gotest/cli.go
@@ -14,13 +14,21 @@ import (
 )
 
 func main() {
+	args := os.Args[1:]
+
+	if containsHelpFlag(args) {
+		subcmd, _ := ParseSubcommand(args)
+		showHelp(subcmd)
+		return
+	}
+
 	projectCfg, err := config.Load(".")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: loading %s: %s\n", config.FileName, err)
 		os.Exit(2)
 	}
 
-	subcmd, remaining := ParseSubcommand(os.Args[1:])
+	subcmd, remaining := ParseSubcommand(args)
 	inv := Invocation{Args: remaining, Config: projectCfg}
 
 	switch subcmd {
@@ -48,10 +56,14 @@ func main() {
 		fmt.Println(about.LongInfo())
 		return
 	case "help":
-		printUsage()
+		topic := ""
+		if len(remaining) > 0 {
+			topic = remaining[0]
+		}
+		showHelp(topic)
 		return
 	default:
-		inv.Args = os.Args[1:]
+		inv.Args = args
 		os.Exit(runTest(inv))
 	}
 }
@@ -213,37 +225,3 @@ func stripJSONFlag(args []string) (bool, []string) {
 	return found, out
 }
 
-func printUsage() {
-	fmt.Fprintf(os.Stderr, `%s — test suite runner for Go
-
-Usage:
-  gotest [gotest-flags] [--] [go-test-flags] [packages...]
-  gotest <subcommand> [flags] [packages...]
-
-Subcommands:
-  discover    Discover test suites and output JSON metadata
-  prepare     Generate overlay and start shared fixtures for debug (blocks until SIGTERM)
-  generate    Run code generation only (no test execution)
-  clean       Remove orphaned generated files
-  spec        Render behavioral specification from test suites
-  watch       Watch for file changes and re-run tests
-  scaffold    Generate test suite skeleton from a type or file
-  migrate     Convert testify/suite tests to go-test format
-  refactor    Source code refactoring tools (toggle-focus)
-  lint        Run gotest-specific linter checks
-  version     Print version information
-  help        Show this help message
-
-Flags (gotest):
-  --ci                      Enable focus guard (fail on F_ prefixes)
-  --debug                   Keep generated overlay for inspection
-  --spec                    Append spec view after normal test output
-  --update-snapshots        Regenerate snapshot files
-  --min=<pct>               Fail if coverage below threshold (enables -coverprofile)
-  --setup-timeout=<dur>     Shared fixture setup deadline (default 1m)
-  --debounce=<dur>          Watch mode debounce interval (default 200ms)
-
-gotest flags use --double-dash; go test flags use -single-dash.
-Use a bare "--" to pass unrecognized flags to go test without validation.
-`, about.ShortInfo())
-}

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -1,0 +1,400 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mvrahden/go-test/about"
+)
+
+func containsHelpFlag(args []string) bool {
+	for _, a := range args {
+		if a == "--" {
+			return false
+		}
+		if a == "--help" || a == "-h" || a == "-help" {
+			return true
+		}
+	}
+	return false
+}
+
+func showHelp(topic string) {
+	switch topic {
+	case "", "help":
+		printUsage()
+	case "test":
+		printTestHelp()
+	case "spec":
+		printSpecHelp()
+	case "watch":
+		printWatchHelp()
+	case "discover":
+		printDiscoverHelp()
+	case "scaffold":
+		printScaffoldHelp()
+	case "lint":
+		printLintHelp()
+	case "migrate":
+		printMigrateHelp()
+	case "refactor":
+		printRefactorHelp()
+	case "generate":
+		printGenerateHelp()
+	case "prepare":
+		printPrepareHelp()
+	case "clean":
+		printCleanHelp()
+	case "config":
+		printConfigHelp()
+	case "version":
+		fmt.Println(about.LongInfo())
+	default:
+		fmt.Fprintf(os.Stderr, "unknown help topic: %s\n\n", topic)
+		printUsage()
+	}
+}
+
+func printUsage() {
+	fmt.Printf(`%s — test suite runner for Go
+
+Usage:
+  gotest [flags] [--] [go-test-flags] [packages...]
+  gotest <subcommand> [flags] [packages...]
+
+Subcommands:
+  spec        Render behavioral specification from test output
+  watch       Watch for file changes and re-run tests
+  discover    Discover test suites and output JSON
+  scaffold    Generate test suite skeleton
+  lint        Run gotest-specific linter checks
+  migrate     Convert testify/suite tests to go-test format
+  refactor    Source code refactoring tools
+  generate    Run code generation only (no test execution)
+  prepare     Start shared fixtures for debug (blocks until SIGTERM)
+  clean       Remove orphaned generated files
+  version     Print version information
+
+Run "gotest help <subcommand>" for subcommand-specific help.
+
+Flags (gotest — use --double-dash):
+  --ci                    Fail on focused tests (F_ prefixes)
+  --debug                 Keep generated overlay for inspection
+  --spec                  Render spec view instead of default output
+  --update-snapshots      Regenerate snapshot files
+  --min=<pct>             Fail if coverage < pct%% (0-100)
+  --setup-timeout=<dur>   Shared fixture deadline (default: 1m)
+
+Flags (go test — use -single-dash, forwarded automatically):
+  -v                      Verbose output
+  -run=<regexp>           Run only matching tests
+  -count=<n>              Run each test n times (default: cached)
+  -race                   Enable data race detector
+  -timeout=<dur>          Per-test timeout (default: 10m)
+  -coverprofile=<file>    Write coverage profile
+  -tags=<tags>            Build tags (comma-separated)
+  -json                   Machine-readable JSON event stream
+
+Use a bare "--" to separate gotest flags from go test flags,
+or to pass unrecognized flags to go test without validation.
+
+Configuration:
+  Place a .gotest.yml in your project root. Run "gotest help config" for details.
+
+Examples:
+  gotest ./...                              Run all test suites
+  gotest --ci --min=80 ./... -race          CI with coverage gate and race detection
+  gotest spec --no-color -count=1 ./...     Spec report for CI artifacts
+  gotest watch ./pkg/auth/...               Re-run on file changes
+  gotest scaffold ./pkg/auth.ServiceImpl    Generate test suite skeleton
+  gotest lint ./...                         Check for common suite mistakes
+`, about.ShortInfo())
+}
+
+func printTestHelp() {
+	fmt.Print(`gotest test — run test suites (default subcommand)
+
+Usage:
+  gotest [flags] [--] [go-test-flags] [packages...]
+
+When no subcommand is given, gotest discovers test suites in the target
+packages, generates an overlay with lifecycle wiring, and runs "go test".
+
+Flags:
+  --ci                    Fail on focused tests (F_ prefixes)
+  --debug                 Keep generated overlay for inspection
+  --spec                  Render spec view instead of default output
+  --update-snapshots      Regenerate snapshot files
+  --min=<pct>             Fail if coverage < pct% (0-100, enables -coverprofile)
+  --setup-timeout=<dur>   Shared fixture deadline (default: 1m)
+
+All standard go test flags (-single-dash) are forwarded automatically.
+Use a bare "--" to pass unrecognized flags without validation.
+
+Examples:
+  gotest ./...                              Run all suites
+  gotest ./pkg/auth/... -v                  Verbose output for one package
+  gotest --ci --min=80 ./... -race          CI pipeline with coverage gate
+  gotest --debug ./pkg/auth/...             Keep overlay for inspection
+  gotest -- -customflag ./...               Escape hatch for custom flags
+`)
+}
+
+func printSpecHelp() {
+	fmt.Print(`gotest spec — render behavioral specification from test suites
+
+Usage:
+  gotest spec [flags] [--] [go-test-flags] [packages...]
+  gotest spec --input=<file> [--format=<fmt>] [--output=<file>]
+
+Runs test suites and renders a BDD-style specification tree showing
+pass/fail/skip status for each suite, method, and subtest.
+
+Flags:
+  --format=<fmt>          Output format: terminal (default), md, json
+  --output=<file>         Write to file instead of stdout
+  --input=<file>          Render from saved JSON ("-" for stdin)
+  --no-color              Disable ANSI color codes
+  --ci                    Fail on focused tests (F_ prefixes)
+  --debug                 Keep generated overlay
+  --update-snapshots      Regenerate snapshot files
+  --min=<pct>             Fail if coverage < pct% (0-100)
+  --setup-timeout=<dur>   Shared fixture deadline (default: 1m)
+
+Examples:
+  gotest spec ./...                                Run and render spec
+  gotest spec --format=md --output=spec.md ./...   Markdown report to file
+  gotest spec --no-color --output=spec.txt ./...   Plain text for CI artifacts
+  gotest spec --input=- < events.json              Render from piped JSON input
+  gotest spec --format=json ./... -count=1         JSON tree, no caching
+`)
+}
+
+func printWatchHelp() {
+	fmt.Print(`gotest watch — watch for file changes and re-run tests
+
+Usage:
+  gotest watch [flags] [--] [go-test-flags] [packages...]
+
+Watches .go files under the target packages and re-runs affected tests
+on every change. The initial run covers all target packages; subsequent
+runs are scoped to the packages containing changed files.
+
+Flags:
+  --debounce=<dur>        Re-run delay after change (default: 200ms)
+  --ci                    Fail on focused tests (F_ prefixes)
+  --debug                 Keep generated overlay
+  --update-snapshots      Regenerate snapshot files
+  --setup-timeout=<dur>   Shared fixture deadline (default: 1m)
+
+Examples:
+  gotest watch ./...                         Watch all packages
+  gotest watch ./pkg/auth/... -v             Watch with verbose output
+  gotest watch --debounce=500ms ./...        Slower debounce for large projects
+`)
+}
+
+func printDiscoverHelp() {
+	fmt.Print(`gotest discover — discover test suites and output JSON metadata
+
+Usage:
+  gotest discover [packages...]
+
+Loads test packages, discovers suite types and their methods, and outputs
+structured JSON. Used by IDE extensions for test explorer integration.
+
+Output schema:
+  {
+    "packages": [{
+      "importPath": "example.com/pkg",
+      "dir":        "/absolute/path",
+      "suites": [{
+        "name":     "UserTestSuite",
+        "file":     "user_test.go",
+        "line":     10,
+        "col":      1,
+        "focused":  false,
+        "excluded": false,
+        "guarded":  false,
+        "methods": [{
+          "name": "TestCreate",
+          "file": "user_test.go",
+          "line": 15,
+          "col":  1,
+          "focused":  false,
+          "excluded": false,
+          "parallel": false
+        }]
+      }]
+    }],
+    "warnings": [{"importPath": "...", "message": "..."}]
+  }
+
+Examples:
+  gotest discover ./...                      All packages
+  gotest discover ./pkg/auth/...             Single package tree
+`)
+}
+
+func printScaffoldHelp() {
+	fmt.Print(`gotest scaffold — generate test suite skeleton
+
+Usage:
+  gotest scaffold <target>
+
+Target is one of:
+  ./pkg/path.TypeName      Generate suite for a specific type
+  ./pkg/path/file.go       Generate suites for all types in a file
+
+Creates a new _test.go file with a suite struct, a runner function,
+and stub methods for each exported method on the target type.
+
+Examples:
+  gotest scaffold ./pkg/auth.UserService        Suite for UserService type
+  gotest scaffold ./pkg/auth/service.go         Suites for all types in file
+`)
+}
+
+func printLintHelp() {
+	fmt.Print(`gotest lint — run gotest-specific linter checks
+
+Usage:
+  gotest lint [flags] [packages...]
+
+Checks for common mistakes in gotest test suites. Defaults to ./... if
+no packages are specified.
+
+Rules:
+  focus           Focused (F_) suites/methods should not be committed
+  receiver        Suite methods should use pointer receivers
+  lifecycle-typo  Methods similar to lifecycle hooks (likely typos)
+  lifecycle-pair  BeforeAll without matching AfterAll (resource leak)
+  generated-file  Generated overlay files should not be in version control
+  stdlib-test     Stdlib test functions — consider using gotest suites
+  testify         testify imports — consider migrating to gotest
+
+Flags:
+  -skip-stdlib-test       Disable the stdlib-test rule
+  -skip-testify           Disable the testify rule
+  -fix                    Apply suggested fixes
+
+Suppress individual diagnostics with //nolint comments:
+  //nolint:stdlib-test             Suppress on same line or line above
+  package foo //nolint:stdlib-test  Suppress for entire file
+
+Examples:
+  gotest lint ./...                          Lint all packages
+  gotest lint -skip-testify ./...            Skip testify rule
+  gotest lint -fix ./...                     Auto-fix where possible
+`)
+}
+
+func printMigrateHelp() {
+	fmt.Print(`gotest migrate — convert testify/suite tests to go-test format
+
+Usage:
+  gotest migrate [packages...]
+
+Scans for testify/suite patterns and rewrites them into gotest suite
+format. Defaults to the current package if no patterns are given.
+
+Examples:
+  gotest migrate ./...                       Migrate all packages
+  gotest migrate ./pkg/auth                  Migrate one package
+`)
+}
+
+func printRefactorHelp() {
+	fmt.Print(`gotest refactor — source code refactoring tools
+
+Usage:
+  gotest refactor <command> [args]
+
+Commands:
+  toggle-focus <file> <identifier>
+
+    Toggle the F_ prefix on a suite type or method. The identifier is
+    either "SuiteName" (toggles the suite) or "SuiteName.MethodName"
+    (toggles a single method).
+
+Examples:
+  gotest refactor toggle-focus user_test.go UserTestSuite
+  gotest refactor toggle-focus user_test.go UserTestSuite.TestCreate
+`)
+}
+
+func printGenerateHelp() {
+	fmt.Print(`gotest generate — run code generation only
+
+Usage:
+  gotest generate [-tags=<tags>] [packages...]
+
+Generates the overlay files that gotest normally creates transparently
+during test runs. Useful for inspecting generated code or integrating
+with custom build pipelines.
+
+Examples:
+  gotest generate ./...                      Generate for all packages
+  gotest generate -tags=integration ./...    With build tags
+`)
+}
+
+func printPrepareHelp() {
+	fmt.Print(`gotest prepare — prepare debug session
+
+Usage:
+  gotest prepare [packages...]
+
+Generates the test overlay and starts shared fixtures, then blocks until
+SIGTERM. Used by IDE extensions to prepare Delve debug sessions.
+
+Outputs JSON to stdout:
+  {"overlayFile": "...", "dir": "...", "stateFile": "..."}
+
+Examples:
+  gotest prepare ./pkg/auth/...              Prepare auth package for debug
+`)
+}
+
+func printCleanHelp() {
+	fmt.Print(`gotest clean — remove orphaned generated files
+
+Usage:
+  gotest clean [packages...]
+
+Removes generated overlay files (ƒƒ_*_test.go) that are no longer
+needed. These files are normally ephemeral but may be left behind
+by --debug runs or interrupted processes.
+
+Examples:
+  gotest clean ./...                         Clean all packages
+`)
+}
+
+func printConfigHelp() {
+	fmt.Print(`gotest configuration — .gotest.yml project settings
+
+gotest reads project settings from a .gotest.yml file. The file is found
+by walking up from the working directory, stopping at the first match or
+at a go.mod boundary. CLI flags override config values.
+
+Fields:
+  tags: <string>            Build tags, comma-separated (e.g., "integration,e2e")
+  setup-timeout: <duration> Shared fixture deadline (e.g., "2m", default: 1m)
+  min-coverage: <int>       Minimum coverage percentage, 0-100
+  debounce: <duration>      Watch mode re-run delay (e.g., "500ms", default: 200ms)
+  lint:
+    skip: [<rule>, ...]     Lint rules to disable globally
+
+Skippable lint rules: stdlib-test, testify
+
+Example .gotest.yml:
+
+  tags: integration
+  setup-timeout: 2m
+  min-coverage: 80
+  lint:
+    skip:
+      - testify
+`)
+}

--- a/cmd/gotest/watch.go
+++ b/cmd/gotest/watch.go
@@ -41,6 +41,9 @@ func parseDebounceFlag(args []string) (time.Duration, error) {
 
 func runWatch(inv Invocation) int {
 	args := inv.DefaultArgs()
+	if inv.Config.Debounce.Duration() > 0 && !hasFlag(args, "--debounce") {
+		args = append([]string{"--debounce=" + inv.Config.Debounce.Duration().String()}, args...)
+	}
 	ownArgs, goTestArgs, err := SplitArgs(args, watchAllowed)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)

--- a/vscode-gotest/package.json
+++ b/vscode-gotest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gotest",
-  "displayName": "gotest — Go Suite Testing",
+  "displayName": "Go - Test Suites",
   "description": "Test Explorer, CodeLens, and debug integration for go-test suites",
   "version": "0.1.0",
   "publisher": "mvrahden",

--- a/vscode-gotest/src/cli.ts
+++ b/vscode-gotest/src/cli.ts
@@ -96,7 +96,13 @@ export async function buildCliCommand(
             log?.debug(`[cli] using go.mod (replace): ${bin}`);
             return { bin, args: subcommandArgs };
           }
-          log?.debug(`[cli] replace build failed, falling back to go run`);
+          log?.debug(
+            `[cli] replace build failed, using go run with module resolution`,
+          );
+          return {
+            bin: goBin,
+            args: ["run", modulePath, "--", ...subcommandArgs],
+          };
         }
 
         const qualified = `${modulePath}@${version}`;

--- a/vscode-gotest/src/cli.ts
+++ b/vscode-gotest/src/cli.ts
@@ -1,20 +1,10 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
-import * as os from "node:os";
-import {
-  readFile,
-  readdir,
-  stat,
-  access,
-  mkdir,
-  constants,
-} from "node:fs/promises";
-import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import {
   resolveGoBinary,
-  findInstalledGotest,
   fileExists,
   clearGoBinaryCache,
 } from "./goBinary.js";
@@ -23,14 +13,13 @@ export { resolveGoBinary } from "./goBinary.js";
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_MODULE_PATH = "github.com/mvrahden/go-test/cmd/gotest";
-const MIN_CLI_VERSION = "v1.3.0";
+const MIN_CLI_VERSION = "v1.13.0";
 
 export interface CliCommand {
   bin: string;
   args: string[];
 }
 
-const replaceBinaryCache = new Map<string, { hash: string; binPath: string }>();
 let versionWarningShown = false;
 
 export async function validateGoBinary(
@@ -64,60 +53,37 @@ export async function buildCliCommand(
     subcommandArgs = [...subcommandArgs, `-tags=${buildTags}`];
   }
 
-  // 1. Explicit cliPath override (highest priority)
+  const modulePath = config.get<string>("modulePath") ?? DEFAULT_MODULE_PATH;
+  const effectiveDir =
+    workspaceDir ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+
+  // 1. Explicit cliPath override — only trusted when user-provided and version-valid
   const cliPath = config.get<string>("cliPath", "").trim();
   if (cliPath) {
     const resolved = resolveCliPath(cliPath, workspaceDir);
     if (await fileExists(resolved)) {
-      log?.debug(`[cli] cliPath override: ${resolved}`);
-      return { bin: resolved, args: subcommandArgs };
-    }
-    log?.debug(`[cli] cliPath "${resolved}" not found, probing alternatives`);
-  }
-
-  // 2. Project-pinned version from go.mod
-  const modulePath = config.get<string>("modulePath") ?? DEFAULT_MODULE_PATH;
-  const effectiveDir =
-    workspaceDir ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-  if (effectiveDir && !modulePath.includes("@")) {
-    const version = await extractVersionFromGoMod(effectiveDir, modulePath);
-    if (version !== "latest") {
-      if (compareVersions(version, MIN_CLI_VERSION) >= 0) {
-        const goBin = await resolveGoBinary(log, workspaceDir);
-
-        if (await hasReplaceDirective(effectiveDir, modulePath)) {
-          const bin = await buildCachedBinary(
-            goBin,
-            effectiveDir,
-            modulePath,
-            log,
-          );
-          if (bin) {
-            log?.debug(`[cli] using go.mod (replace): ${bin}`);
-            return { bin, args: subcommandArgs };
-          }
-          log?.debug(
-            `[cli] replace build failed, using go run with module resolution`,
-          );
-          return {
-            bin: goBin,
-            args: ["run", modulePath, "--", ...subcommandArgs],
-          };
-        }
-
-        const qualified = `${modulePath}@${version}`;
-        log?.debug(`[cli] using go.mod: ${goBin} run ${qualified}`);
-        return {
-          bin: goBin,
-          args: ["run", qualified, "--", ...subcommandArgs],
-        };
+      const version = await queryBinaryVersion(resolved, log);
+      if (version && compareVersions(version, MIN_CLI_VERSION) >= 0) {
+        log?.debug(`[cli] cliPath override: ${resolved} (${version})`);
+        return { bin: resolved, args: subcommandArgs };
       }
-      log?.warn(`[cli] go.mod pins ${version}, requires >= ${MIN_CLI_VERSION}`);
-      showVersionWarning(version, effectiveDir, log);
+      if (version) {
+        log?.warn(
+          `[cli] cliPath "${resolved}" is ${version}, requires >= ${MIN_CLI_VERSION} — falling back to go run`,
+        );
+      } else {
+        log?.warn(
+          `[cli] cliPath "${resolved}" failed version check — falling back to go run`,
+        );
+      }
+    } else {
+      log?.debug(
+        `[cli] cliPath "${resolved}" not found, probing alternatives`,
+      );
     }
   }
 
-  // 2b. Workspace IS the gotest module (development / go.work overlap)
+  // 2. Workspace IS the gotest module (development / go.work overlap)
   if (effectiveDir) {
     const declaredModule = await readModuleDeclaration(effectiveDir);
     if (
@@ -126,23 +92,47 @@ export async function buildCliCommand(
         modulePath.startsWith(declaredModule + "/"))
     ) {
       const goBin = await resolveGoBinary(log, workspaceDir);
-      const bin = await buildCachedBinary(goBin, effectiveDir, modulePath, log);
-      if (bin) {
-        log?.debug(`[cli] using local module: ${bin}`);
-        return { bin, args: subcommandArgs };
-      }
-      log?.debug(`[cli] local module build failed, continuing`);
+      const relPath = "./" + modulePath.slice(declaredModule.length + 1);
+      log?.debug(`[cli] workspace is gotest module: ${goBin} run ${relPath}`);
+      return {
+        bin: goBin,
+        args: ["run", relPath, ...subcommandArgs],
+      };
     }
   }
 
-  // 3. Globally installed binary
-  const gotest = await findInstalledGotest(workspaceDir, log);
-  if (gotest) {
-    log?.debug(`[cli] using installed binary: ${gotest}`);
-    return { bin: gotest, args: subcommandArgs };
+  // 3–4. Project-pinned version from go.mod
+  if (effectiveDir && !modulePath.includes("@")) {
+    const version = await extractVersionFromGoMod(effectiveDir, modulePath);
+    if (version !== "latest") {
+      if (compareVersions(version, MIN_CLI_VERSION) >= 0) {
+        const goBin = await resolveGoBinary(log, workspaceDir);
+
+        // 3. Replace directive → go run without version (respects go.mod resolution)
+        if (await hasReplaceDirective(effectiveDir, modulePath)) {
+          log?.debug(
+            `[cli] go.mod has replace directive: ${goBin} run ${modulePath}`,
+          );
+          return {
+            bin: goBin,
+            args: ["run", modulePath, ...subcommandArgs],
+          };
+        }
+
+        // 4. Pinned version → go run module@version
+        const qualified = `${modulePath}@${version}`;
+        log?.debug(`[cli] using go.mod: ${goBin} run ${qualified}`);
+        return {
+          bin: goBin,
+          args: ["run", qualified, ...subcommandArgs],
+        };
+      }
+      log?.warn(`[cli] go.mod pins ${version}, requires >= ${MIN_CLI_VERSION}`);
+      showVersionWarning(version, effectiveDir, log);
+    }
   }
 
-  // 4. Fallback: go run @latest
+  // 5. Fallback: go run @latest
   const goBin = await resolveGoBinary(log, workspaceDir);
   const qualified = modulePath.includes("@")
     ? modulePath
@@ -214,6 +204,26 @@ function showVersionWarning(
     });
 }
 
+async function queryBinaryVersion(
+  binPath: string,
+  log?: vscode.LogOutputChannel,
+): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync(binPath, ["version"], {
+      timeout: 5_000,
+    });
+    const match = /^gotest\s+(v\S+)/m.exec(stdout);
+    if (match) {
+      return match[1];
+    }
+    log?.debug(`[cli] unexpected version output from ${binPath}: ${stdout.trim()}`);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log?.debug(`[cli] version check failed for ${binPath}: ${msg}`);
+  }
+  return undefined;
+}
+
 async function hasReplaceDirective(
   workspaceDir: string,
   modulePath: string,
@@ -237,136 +247,6 @@ async function hasReplaceDirective(
     // go.mod not found
   }
   return false;
-}
-
-async function collectGoFileMtimes(dir: string): Promise<number[]> {
-  const mtimes: number[] = [];
-  const entries = await readdir(dir, { withFileTypes: true, recursive: true });
-  for (const entry of entries) {
-    if (!entry.isFile()) continue;
-    if (!entry.name.endsWith(".go")) continue;
-    const rel = entry.parentPath ?? entry.path ?? "";
-    // skip vendor, testdata, hidden dirs
-    if (
-      rel.includes("/vendor/") ||
-      rel.includes("/testdata/") ||
-      /\/\./.test(rel)
-    )
-      continue;
-    const fullPath = path.join(rel, entry.name);
-    try {
-      const s = await stat(fullPath);
-      mtimes.push(s.mtimeMs);
-    } catch {
-      // skip unreadable files
-    }
-  }
-  return mtimes.sort();
-}
-
-function extractLocalReplacePath(
-  goModContent: string,
-  modulePath: string,
-): string | undefined {
-  let candidate = modulePath;
-  while (candidate) {
-    const pattern = new RegExp(
-      `^\\s*replace\\s+${escapeRegExp(candidate)}\\s+\\S*\\s*=>\\s*(\\S+)`,
-      "m",
-    );
-    const match = pattern.exec(goModContent);
-    if (match) {
-      const target = match[1];
-      if (target.startsWith(".") || target.startsWith("/")) {
-        return target;
-      }
-      return undefined; // remote replace, no local path
-    }
-    const lastSlash = candidate.lastIndexOf("/");
-    if (lastSlash <= 0) break;
-    candidate = candidate.substring(0, lastSlash);
-  }
-  return undefined;
-}
-
-async function buildCachedBinary(
-  goBin: string,
-  workspaceDir: string,
-  modulePath: string,
-  log?: vscode.LogOutputChannel,
-): Promise<string | undefined> {
-  const goModPath = path.join(workspaceDir, "go.mod");
-  let goModContent: string;
-  try {
-    goModContent = await readFile(goModPath, "utf-8");
-  } catch {
-    return undefined;
-  }
-
-  const h = createHash("sha256").update(goModContent).update(modulePath);
-  try {
-    const goSumContent = await readFile(
-      path.join(workspaceDir, "go.sum"),
-      "utf-8",
-    );
-    h.update(goSumContent);
-  } catch {
-    // go.sum may not exist
-  }
-
-  const localReplace = extractLocalReplacePath(goModContent, modulePath);
-  if (localReplace) {
-    const resolvedReplace = path.isAbsolute(localReplace)
-      ? localReplace
-      : path.resolve(workspaceDir, localReplace);
-    try {
-      const mtimes = await collectGoFileMtimes(resolvedReplace);
-      for (const mt of mtimes) {
-        h.update(String(mt));
-      }
-    } catch {
-      // if we can't read the replace dir, don't cache at all
-      h.update(String(Date.now()));
-    }
-  }
-
-  const hash = h.digest("hex").substring(0, 16);
-  const cached = replaceBinaryCache.get(workspaceDir);
-  if (cached?.hash === hash) {
-    try {
-      await access(cached.binPath, constants.X_OK);
-      return cached.binPath;
-    } catch {
-      // binary removed, rebuild
-    }
-  }
-
-  const cacheDir = path.join(os.tmpdir(), "gotest");
-  try {
-    await mkdir(cacheDir, { recursive: true });
-  } catch {
-    return undefined;
-  }
-
-  const dirHash = createHash("sha256")
-    .update(workspaceDir)
-    .digest("hex")
-    .substring(0, 12);
-  const binPath = path.join(cacheDir, `gotest-${dirHash}`);
-
-  try {
-    log?.debug(`[cli] building gotest from replace directive...`);
-    await execFileAsync(goBin, ["build", "-o", binPath, modulePath], {
-      cwd: workspaceDir,
-      timeout: 60_000,
-    });
-    replaceBinaryCache.set(workspaceDir, { hash, binPath });
-    return binPath;
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log?.warn(`[cli] replace build error: ${msg}`);
-    return undefined;
-  }
 }
 
 async function extractVersionFromGoMod(
@@ -427,6 +307,5 @@ export function scopedConfig(
 
 export function clearBinaryCache(): void {
   clearGoBinaryCache();
-  replaceBinaryCache.clear();
   versionWarningShown = false;
 }

--- a/vscode-gotest/src/cli.ts
+++ b/vscode-gotest/src/cli.ts
@@ -3,11 +3,7 @@ import * as path from "node:path";
 import { readFile } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import {
-  resolveGoBinary,
-  fileExists,
-  clearGoBinaryCache,
-} from "./goBinary.js";
+import { resolveGoBinary, fileExists, clearGoBinaryCache } from "./goBinary.js";
 
 export { resolveGoBinary } from "./goBinary.js";
 
@@ -77,9 +73,7 @@ export async function buildCliCommand(
         );
       }
     } else {
-      log?.debug(
-        `[cli] cliPath "${resolved}" not found, probing alternatives`,
-      );
+      log?.debug(`[cli] cliPath "${resolved}" not found, probing alternatives`);
     }
   }
 
@@ -216,7 +210,9 @@ async function queryBinaryVersion(
     if (match) {
       return match[1];
     }
-    log?.debug(`[cli] unexpected version output from ${binPath}: ${stdout.trim()}`);
+    log?.debug(
+      `[cli] unexpected version output from ${binPath}: ${stdout.trim()}`,
+    );
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     log?.debug(`[cli] version check failed for ${binPath}: ${msg}`);

--- a/vscode-gotest/src/discovery.ts
+++ b/vscode-gotest/src/discovery.ts
@@ -212,7 +212,9 @@ export class DiscoveryService {
         timeout: 30_000,
       });
 
-      const output: DiscoverOutput = JSON.parse(stdout);
+      const jsonStart = stdout.indexOf("{");
+      const json = jsonStart > 0 ? stdout.substring(jsonStart) : stdout;
+      const output: DiscoverOutput = JSON.parse(json);
       const fullScan = effectivePatterns.some((p) => p.includes("..."));
       const warnings = output.warnings ?? [];
       const packages = output.packages ?? [];

--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -24,7 +24,7 @@ import { copyCoverageSummary, copyTestResults } from "./reporting.js";
 let flushOnDeactivate: (() => Promise<void>) | undefined;
 
 export function activate(context: vscode.ExtensionContext): void {
-  const outputChannel = vscode.window.createOutputChannel("gotest", {
+  const outputChannel = vscode.window.createOutputChannel("Go - Test Suites", {
     log: true,
   });
   outputChannel.info("[activate] extension activated");

--- a/vscode-gotest/src/goBinary.ts
+++ b/vscode-gotest/src/goBinary.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
-import * as os from "node:os";
 import { readFile, readdir, access, constants } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
@@ -8,11 +7,9 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 const goBinaryCache = new Map<string, string>();
-let cachedGotestBinary: string | undefined;
 
 export function clearGoBinaryCache(): void {
   goBinaryCache.clear();
-  cachedGotestBinary = undefined;
 }
 
 export async function resolveGoBinary(
@@ -125,73 +122,6 @@ async function readGoVersionFromMod(
   } catch {
     return undefined;
   }
-}
-
-export async function findInstalledGotest(
-  workspaceDir?: string,
-  log?: vscode.LogOutputChannel,
-): Promise<string | undefined> {
-  if (cachedGotestBinary) {
-    if (await fileExists(cachedGotestBinary)) {
-      return cachedGotestBinary;
-    }
-    cachedGotestBinary = undefined;
-  }
-
-  const gobin = process.env.GOBIN;
-  if (gobin) {
-    const p = path.join(gobin, "gotest");
-    if (await fileExists(p)) {
-      cachedGotestBinary = p;
-      return p;
-    }
-  }
-
-  const gopath = process.env.GOPATH ?? path.join(process.env.HOME ?? "", "go");
-  const gopathBin = path.join(gopath, "bin", "gotest");
-  if (await fileExists(gopathBin)) {
-    cachedGotestBinary = gopathBin;
-    return gopathBin;
-  }
-
-  try {
-    const goBin = await resolveGoBinary(undefined, workspaceDir);
-    const { stdout } = await execFileAsync(goBin, ["env", "GOBIN"], {
-      cwd: workspaceDir,
-      timeout: 5_000,
-    });
-    const envGobin = stdout.trim();
-    if (envGobin) {
-      const p = path.join(envGobin, "gotest");
-      if (await fileExists(p)) {
-        cachedGotestBinary = p;
-        return p;
-      }
-    }
-
-    const { stdout: gpOut } = await execFileAsync(goBin, ["env", "GOPATH"], {
-      cwd: workspaceDir,
-      timeout: 5_000,
-    });
-    const envGopath = gpOut.trim();
-    if (envGopath) {
-      const p = path.join(envGopath, "bin", "gotest");
-      if (await fileExists(p)) {
-        cachedGotestBinary = p;
-        return p;
-      }
-    }
-  } catch {
-    log?.debug("[cli] failed to query go env for gotest location");
-  }
-
-  const whichGotest = await which("gotest");
-  if (whichGotest) {
-    cachedGotestBinary = whichGotest;
-    return whichGotest;
-  }
-
-  return undefined;
 }
 
 export async function fileExists(p: string): Promise<boolean> {

--- a/vscode-gotest/src/specView.ts
+++ b/vscode-gotest/src/specView.ts
@@ -313,9 +313,15 @@ ${SCRIPT}
   }
 
   private async runSpecFromInput(jsonInput: string): Promise<string> {
-    const cmd = await buildCliCommand(["spec", "--input=-", "--format=json"]);
+    const workspaceDir =
+      vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    const cmd = await buildCliCommand(
+      ["spec", "--input=-", "--format=json"],
+      workspaceDir,
+      this.outputChannel,
+    );
     return new Promise<string>((resolve, reject) => {
-      const child = spawn(cmd.bin, cmd.args);
+      const child = spawn(cmd.bin, cmd.args, { cwd: workspaceDir });
       let stdout = "";
       let stderr = "";
 

--- a/vscode-gotest/src/specView.ts
+++ b/vscode-gotest/src/specView.ts
@@ -313,8 +313,7 @@ ${SCRIPT}
   }
 
   private async runSpecFromInput(jsonInput: string): Promise<string> {
-    const workspaceDir =
-      vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     const cmd = await buildCliCommand(
       ["spec", "--input=-", "--format=json"],
       workspaceDir,


### PR DESCRIPTION
- Add structured --help output for all CLI subcommands with flag descriptions and usage examples
- Replace binary caching and global binary scanning with pure go run resolution — validates user-provided binaries by version, respects replace directives without custom build logic
- Fix go run argument passing (-- was intercepted by CLI escape hatch), specView missing workspace context, debounce config leaking to non-watch subcommands, and discovery JSON parsing