### PR TITLE
Simplify ext CLI resolution and reposition around AI-assisted development

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Test output is standard — but the mechanism behind it isn't.
 The generated code is deleted after tests run.
 What remains is standard `go test` output, zero runtime dependencies, and no lock-in — `gotest clean` removes all traces, and your test structs still compile.
 
-**AI-assisted development** — BDD-style suites double as behavioral specifications that AI agents consume natively. Every CLI command produces structured JSON. Define what the system should do, let AI implement, tests verify. The `gotest spec` output gives you a human-readable and machine-readable contract in one artifact.
+**AI-assisted development** — BDD-style suites double as behavioral specifications. `gotest spec` renders your test structure as a readable contract with structured JSON output. Your tests are the documentation — always in sync, never stale.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Go tests that write themselves, organize themselves, and explain themselves.
+Specification-driven test suites for AI-assisted Go development.
 
 `gotest` closes the gap between `func TestX(t *testing.T)` and a well-organized test suite through code generation.
 You write structs, name them well, and the tool handles the rest.
@@ -31,6 +32,8 @@ Test output is standard — but the mechanism behind it isn't.
 **gotest** takes a different approach: you write structs with naming conventions, and a code generator produces the `func Test*` wrappers, lifecycle wiring, and `t.Run` nesting that you'd write by hand.
 The generated code is deleted after tests run.
 What remains is standard `go test` output, zero runtime dependencies, and no lock-in — `gotest clean` removes all traces, and your test structs still compile.
+
+**AI-assisted development** — BDD-style suites double as behavioral specifications that AI agents consume natively. Every CLI command produces structured JSON. Define what the system should do, let AI implement, tests verify. The `gotest spec` output gives you a human-readable and machine-readable contract in one artifact.
 
 ## Install
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>gotest — Go Test Framework with Code Generation &amp; BDD</title>
-  <meta name="description" content="Go test suite framework powered by code generation — BDD vocabulary, lifecycle hooks, fixtures, snapshot testing, type-safe assertions. Zero reflection, zero runtime deps.">
-  <meta name="keywords" content="go, golang, testing, test framework, bdd, code generation, test suite, assertions, snapshot testing, testify alternative">
+  <title>gotest — Specification-Driven Test Suites for AI-Assisted Go Development</title>
+  <meta name="description" content="Go test suites that double as behavioral specifications. Powered by code generation with structured output for AI-assisted development. Zero reflection, zero runtime deps.">
+  <meta name="keywords" content="go, golang, testing, test framework, bdd, code generation, test suite, assertions, snapshot testing, testify alternative, specification, behavioral specification, ai-assisted, ai">
 
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://mvrahden.github.io/go-test/">
-  <meta property="og:title" content="gotest — Go Test Framework with Code Generation &amp; BDD">
-  <meta property="og:description" content="Write structs. Name them well. The tool handles the rest. Zero runtime dependencies, no reflection, no lock-in.">
+  <meta property="og:title" content="gotest — Specification-Driven Test Suites for AI-Assisted Go Development">
+  <meta property="og:description" content="Test suites that double as behavioral specifications with structured output. Zero reflection, zero runtime deps, zero lock-in.">
   <meta property="og:image" content="https://mvrahden.github.io/go-test/gopher.png">
   <meta property="og:image:width" content="1024">
   <meta property="og:image:height" content="572">
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="gotest — Go Test Framework for Go">
-  <meta name="twitter:description" content="Code-generated test suites with BDD vocabulary, lifecycle hooks, and type-safe assertions.">
+  <meta name="twitter:title" content="gotest — Specification-Driven Test Suites for Go">
+  <meta name="twitter:description" content="Test suites that double as behavioral specifications with structured output. Zero reflection, zero runtime deps, zero lock-in.">
   <meta name="twitter:image" content="https://mvrahden.github.io/go-test/gopher.png">
 
   <link rel="icon" type="image/png" href="logo.png">
@@ -28,7 +28,7 @@
     "@context": "https://schema.org",
     "@type": "SoftwareSourceCode",
     "name": "gotest",
-    "description": "Go test suite framework powered by code generation — BDD vocabulary, lifecycle hooks, fixtures, snapshot testing, type-safe assertions.",
+    "description": "Go test suites that double as behavioral specifications. Powered by code generation with structured output for AI-assisted development.",
     "url": "https://mvrahden.github.io/go-test/",
     "codeRepository": "https://github.com/mvrahden/go-test",
     "programmingLanguage": "Go",
@@ -523,7 +523,7 @@
     <section class="hero">
       <div class="container">
         <h1>gotest</h1>
-        <p class="tagline">Go test suite framework powered by code generation.</p>
+        <p class="tagline">Specification-driven test suites for AI-assisted Go development.</p>
         <div class="pills">
           <span class="pill">No runtime deps</span>
           <span class="pill">No reflection</span>
@@ -568,12 +568,12 @@
     <!-- Features -->
     <section class="features">
       <div class="container">
-        <h2>Everything you need for Go tests</h2>
-        <p class="subtitle">Convention-driven. No configuration files, struct tags, or annotations.</p>
+        <h2>Tests that verify. Specifications that document.</h2>
+        <p class="subtitle">Convention-driven suites that read as documentation. Structured output for AI-assisted workflows.</p>
         <div class="feature-grid">
           <div class="feature-card">
-            <h3><span class="check">&#10003;</span> BDD Vocabulary</h3>
-            <p><code>When</code> groups context, <code>It</code> specifies behavior. Your tests read like documentation and run like tests.</p>
+            <h3><span class="check">&#10003;</span> Behavioral Specifications</h3>
+            <p><code>When</code> groups context, <code>It</code> specifies behavior. Your tests are the documentation — always in sync, never stale.</p>
           </div>
           <div class="feature-card">
             <h3><span class="check">&#10003;</span> Lifecycle Hooks</h3>
@@ -603,7 +603,7 @@
     <section class="code-section">
       <div class="container">
         <h2>Write structs. Get tests.</h2>
-        <p class="subtitle">The naming conventions are the API. The generated code is what you'd write by hand.</p>
+        <p class="subtitle">The naming conventions are the API. Your test structure is the specification.</p>
         <div class="code-block">
           <div class="code-header">user_service_suite_test.go</div>
           <pre class="code-body"><span class="kw">type</span> <span class="tp">UserServiceTestSuite</span> <span class="kw">struct</span> {
@@ -713,7 +713,7 @@
           <div class="eco-item">
             <strong>VS Code</strong>
             <code>mvrahden.gotest</code>
-            <p>Test Explorer, CodeLens, coverage gutters, watch mode</p>
+            <p>Spec View, Test Explorer, coverage, debug</p>
           </div>
           <div class="eco-item">
             <strong>CI</strong>
@@ -733,7 +733,7 @@
       <a href="reference.html">Reference</a>
       <a href="https://github.com/mvrahden/go-test/blob/main/LICENSE">MIT License</a>
     </div>
-    <p class="footer-copy">Built for Go developers who want organized tests without the ceremony.</p>
+    <p class="footer-copy">Built for Go developers who want tests that explain themselves.</p>
   </footer>
 </body>
 </html>

--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -6,14 +6,14 @@
 
 Specification-driven test suites for AI-assisted Go development.
 
-[go-test](https://github.com/mvrahden/go-test) turns your tests into behavioral specifications — BDD-style suites that read as documentation, with structured output that AI agents consume natively.
+[go-test](https://github.com/mvrahden/go-test) turns your tests into behavioral specifications — BDD-style suites that read as documentation, with structured output for AI-assisted workflows.
 This extension brings that workflow into VS Code: run, debug, watch, and verify your specifications without leaving the editor.
 
 ## Why this extension?
 
 AI writes code fast. The bottleneck is verification — you can't review AI-generated code line by line at the rate it's produced.
 
-[go-test](https://github.com/mvrahden/go-test) closes that gap. Test suites become formal behavioral specifications. Every CLI command produces structured JSON. The Spec View renders your specification as an interactive tree. Coverage shows implementation progress. You define what the system should do — AI implements, tests verify.
+[go-test](https://github.com/mvrahden/go-test) closes that gap. Test suites become behavioral specifications. The Spec View renders your specification as an interactive tree with structured output. Coverage shows implementation progress. You define what the system should do — tests verify.
 
 - **Spec View** — Your quality dashboard. BDD-formatted specification tree with pass/fail/skip indicators, go-to-source navigation, and clipboard export. Paste specs into AI conversations as context.
 - **Suite-aware Test Explorer** — Navigate tests as Package > Suite > Method > Subtest, not a flat list of functions.

--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -1,26 +1,25 @@
-# gotest — Go Suite Testing
+# Go - Test Suites
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/mvrahden/go-test/main/static/gopher.png" alt="gotest gopher" width="360" />
 </p>
 
-First-class VS Code integration for [go-test](https://github.com/mvrahden/go-test) — suite-based, BDD-style testing for Go.
+Specification-driven test suites for AI-assisted Go development.
 
-Run, debug, and watch your test suites directly from the editor.
-See structured results in Test Explorer, get coverage gutters, and scaffold new suites without leaving VS Code.
+[go-test](https://github.com/mvrahden/go-test) turns your tests into behavioral specifications — BDD-style suites that read as documentation, with structured output that AI agents consume natively.
+This extension brings that workflow into VS Code: run, debug, watch, and verify your specifications without leaving the editor.
 
 ## Why this extension?
 
-Go's standard `testing` package gives you `func TestX(t *testing.T)` and nothing more.
-[go-test](https://github.com/mvrahden/go-test) adds suite-based organization with lifecycle hooks, fixtures, focus/exclude, and BDD-style output — all through naming conventions, zero runtime dependencies.
+AI writes code fast. The bottleneck is verification — you can't review AI-generated code line by line at the rate it's produced.
 
-This extension makes that workflow native to VS Code:
+[go-test](https://github.com/mvrahden/go-test) closes that gap. Test suites become formal behavioral specifications. Every CLI command produces structured JSON. The Spec View renders your specification as an interactive tree. Coverage shows implementation progress. You define what the system should do — AI implements, tests verify.
 
+- **Spec View** — Your quality dashboard. BDD-formatted specification tree with pass/fail/skip indicators, go-to-source navigation, and clipboard export. Paste specs into AI conversations as context.
 - **Suite-aware Test Explorer** — Navigate tests as Package > Suite > Method > Subtest, not a flat list of functions.
+- **Coverage gutters** — Track implementation progress with native VS Code coverage integration, per-statement highlighting, and persistent results across sessions.
 - **One-click Run and Debug** — CodeLens buttons above every suite and method. Debug with Delve, breakpoints included.
-- **Coverage gutters** — Native VS Code coverage integration with per-statement highlighting and persistent results across sessions.
-- **Watch mode** — Continuous testing on file changes with streaming results and a status bar indicator.
-- **Spec View** — BDD-formatted output rendered in a side panel after every test run.
+- **Watch mode** — Continuous verification on file changes with streaming results and a status bar indicator.
 - **Focus/Exclude management** — Toggle `F_`/`X_` prefixes via Quick Fix actions. Diagnostic warnings prevent focused tests from reaching CI.
 - **Scaffold generation** — Generate test suite skeletons from types and files via code actions or the command palette.
 
@@ -28,7 +27,7 @@ This extension makes that workflow native to VS Code:
 
 ### Prerequisites
 
-- **Go** (1.21+)
+- **Go** (1.24+)
 - **VS Code** (1.101+)
 - **[Delve](https://github.com/go-delve/delve)** (for debugging only)
 
@@ -192,12 +191,13 @@ These can be set in `.vscode/settings.json` per workspace folder:
 
 ### Gotest CLI resolution
 
-The extension resolves the gotest binary in this order:
+The extension resolves the gotest CLI in this order:
 
-1. **`gotest.cliPath`** — Explicit path to a binary. Highest priority; always used when set.
-2. **`go.mod` version** — If your project's `go.mod` references the gotest module, the pinned version is used via `go run pkg@version`.
-3. **Installed binary** — A `gotest` binary found in `GOBIN`, `GOPATH/bin`, or on `PATH`.
-4. **`go run @latest`** — Fallback when none of the above apply.
+1. **`gotest.cliPath`** — Explicit path to a binary. Highest priority; version-validated against the minimum required version.
+2. **Workspace is gotest module** — If the workspace's `go.mod` declares the gotest module itself (development or `go.work` overlap), uses `go run ./cmd/gotest`.
+3. **`go.mod` + replace directive** — If `go.mod` has a `replace` directive for the gotest module, uses `go run modulePath` (no version, respects replace resolution).
+4. **`go.mod` pinned version** — If `go.mod` references the gotest module, uses `go run modulePath@version` with the pinned version.
+5. **`go run @latest`** — Fallback when none of the above apply.
 
 ### Go binary resolution
 
@@ -211,7 +211,7 @@ The extension resolves the Go toolchain per workspace folder:
 ## Requirements
 
 - VS Code 1.101 or later
-- Go 1.21 or later
+- Go 1.24 or later
 - A Go project using [go-test](https://github.com/mvrahden/go-test) suites
 - [Delve](https://github.com/go-delve/delve) for debug support
 

--- a/vscode-gotest/package.json
+++ b/vscode-gotest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gotest",
   "displayName": "Go - Test Suites",
-  "description": "Test Explorer, CodeLens, and debug integration for go-test suites",
+  "description": "Specification-driven test suites for AI-assisted Go development — Spec View, Test Explorer, coverage, and debug integration",
   "version": "0.1.0",
   "publisher": "mvrahden",
   "license": "MIT",
@@ -17,7 +17,10 @@
     "test",
     "testing",
     "suite",
-    "bdd"
+    "bdd",
+    "specification",
+    "coverage",
+    "ai"
   ],
   "engines": {
     "vscode": "^1.101.0"

--- a/vscode-gotest/package.json
+++ b/vscode-gotest/package.json
@@ -26,7 +26,8 @@
     "vscode": "^1.101.0"
   },
   "categories": [
-    "Testing"
+    "Testing",
+    "Programming Languages"
   ],
   "activationEvents": [
     "workspaceContains:go.mod",

--- a/vscode-gotest/src/cli.ts
+++ b/vscode-gotest/src/cli.ts
@@ -9,7 +9,7 @@ export { resolveGoBinary } from "./goBinary.js";
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_MODULE_PATH = "github.com/mvrahden/go-test/cmd/gotest";
-const MIN_CLI_VERSION = "v1.13.0";
+const MIN_CLI_VERSION = "v1.14.0";
 
 export interface CliCommand {
   bin: string;


### PR DESCRIPTION
- Simplify CLI resolution to pure go run (remove binary caching, -- separator, installed-binary probe)
- Fix specView workspace context, output channel name, and discovery JSON parsing
- Reposition docs, landing page, and extension metadata around "specification-driven test suites for AI-assisted development"