### PR TITLE
fix: overlay race protection and process lifecycle tracking

### DIFF
--- a/cmd/gotest/exec.go
+++ b/cmd/gotest/exec.go
@@ -31,6 +31,8 @@ func generateOverlayFromLoaded(loaded []*gotestgen.LoadResult, debug bool) (*ove
 		return nil, nil, err
 	}
 
+	gotestrunner.CleanStaleOverlays()
+
 	tmpDir, err := gotestrunner.WriteOverlay(allResults)
 	if err != nil {
 		return nil, nil, err

--- a/internal/gotestrunner/overlay.go
+++ b/internal/gotestrunner/overlay.go
@@ -22,12 +22,15 @@ func WriteOverlay(results gotestgen.GenerateResults) (string, error) {
 		return "", fmt.Errorf("get working directory: %w", err)
 	}
 	h := sha256.Sum256([]byte(cwd))
-	dirName := fmt.Sprintf("gotest-overlay-%x", h[:8])
-	tmpDir := filepath.Join(os.TempDir(), dirName)
-
-	os.RemoveAll(tmpDir)
-	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+	prefix := fmt.Sprintf("gotest-overlay-%x-", h[:8])
+	tmpDir, err := os.MkdirTemp(os.TempDir(), prefix)
+	if err != nil {
 		return "", fmt.Errorf("create overlay dir: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(tmpDir, ".pid"), []byte(strconv.Itoa(os.Getpid())), 0644); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", fmt.Errorf("write pid file: %w", err)
 	}
 
 	overlay := overlayJSON{Replace: map[string]string{}}

--- a/internal/gotestrunner/overlay_cleanup.go
+++ b/internal/gotestrunner/overlay_cleanup.go
@@ -1,0 +1,48 @@
+package gotestrunner
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+func CleanStaleOverlays() {
+	pattern := filepath.Join(os.TempDir(), "gotest-overlay-*")
+	dirs, err := filepath.Glob(pattern)
+	if err != nil {
+		return
+	}
+	for _, dir := range dirs {
+		info, err := os.Stat(dir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		if isOverlayAlive(dir) {
+			continue
+		}
+		os.RemoveAll(dir)
+	}
+}
+
+func isOverlayAlive(dir string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, ".pid"))
+	if err != nil {
+		return false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return false
+	}
+	return processAlive(pid)
+}
+
+func processAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil
+}

--- a/internal/gotestrunner/overlay_cleanup.go
+++ b/internal/gotestrunner/overlay_cleanup.go
@@ -1,6 +1,7 @@
 package gotestrunner
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -44,5 +45,5 @@ func processAlive(pid int) bool {
 		return false
 	}
 	err = proc.Signal(syscall.Signal(0))
-	return err == nil
+	return err == nil || errors.Is(err, syscall.EPERM)
 }

--- a/internal/gotestrunner/overlay_cleanup_test.go
+++ b/internal/gotestrunner/overlay_cleanup_test.go
@@ -1,0 +1,69 @@
+package gotestrunner //nolint:stdlib-test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestCleanStaleOverlays_RemovesDeadPID(t *testing.T) {
+	dir, err := os.MkdirTemp(os.TempDir(), "gotest-overlay-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Write a PID that doesn't exist (PID 2 is typically kthreadd on Linux, use a very high PID)
+	os.WriteFile(filepath.Join(dir, ".pid"), []byte("999999999"), 0644)
+
+	CleanStaleOverlays()
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		os.RemoveAll(dir)
+		t.Fatal("expected stale overlay to be removed")
+	}
+}
+
+func TestCleanStaleOverlays_KeepsLivePID(t *testing.T) {
+	dir, err := os.MkdirTemp(os.TempDir(), "gotest-overlay-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	// Write our own PID — guaranteed alive
+	os.WriteFile(filepath.Join(dir, ".pid"), []byte(strconv.Itoa(os.Getpid())), 0644)
+
+	CleanStaleOverlays()
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		t.Fatal("expected live overlay to be kept")
+	}
+}
+
+func TestCleanStaleOverlays_RemovesNoPIDFile(t *testing.T) {
+	dir, err := os.MkdirTemp(os.TempDir(), "gotest-overlay-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	CleanStaleOverlays()
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		os.RemoveAll(dir)
+		t.Fatal("expected overlay without PID file to be removed")
+	}
+}
+
+func TestCleanStaleOverlays_IgnoresNonOverlayDirs(t *testing.T) {
+	dir, err := os.MkdirTemp(os.TempDir(), "unrelated-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	CleanStaleOverlays()
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		t.Fatal("expected non-overlay dir to be untouched")
+	}
+}

--- a/internal/gotestrunner/overlay_test.go
+++ b/internal/gotestrunner/overlay_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/mvrahden/go-test/about"
@@ -51,6 +53,53 @@ func TestWriteOverlay(t *testing.T) {
 	bPXSuite := filepath.Join("/fake/pkg/b", about.PXSuite)
 	if _, ok := ov.Replace[bPXSuite]; ok {
 		t.Error("pkg/b should not have PXSuite mapping (empty PXTest)")
+	}
+}
+
+func TestWriteOverlay_UniquePaths(t *testing.T) {
+	results := gotestgen.GenerateResults{
+		{AbsPath: "/fake/pkg/a", PTest: []byte("package a\n")},
+	}
+
+	dir1, err := WriteOverlay(results)
+	if err != nil {
+		t.Fatalf("first WriteOverlay: %v", err)
+	}
+	defer os.RemoveAll(dir1)
+
+	dir2, err := WriteOverlay(results)
+	if err != nil {
+		t.Fatalf("second WriteOverlay: %v", err)
+	}
+	defer os.RemoveAll(dir2)
+
+	if dir1 == dir2 {
+		t.Fatalf("expected unique overlay dirs, both are %s", dir1)
+	}
+}
+
+func TestWriteOverlay_PIDFile(t *testing.T) {
+	results := gotestgen.GenerateResults{
+		{AbsPath: "/fake/pkg/a", PTest: []byte("package a\n")},
+	}
+
+	tmpDir, err := WriteOverlay(results)
+	if err != nil {
+		t.Fatalf("WriteOverlay: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, ".pid"))
+	if err != nil {
+		t.Fatalf("read .pid: %v", err)
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("parse .pid: %v", err)
+	}
+	if pid != os.Getpid() {
+		t.Fatalf("expected PID %d, got %d", os.Getpid(), pid)
 	}
 }
 

--- a/vscode-gotest/src/coverOnSave.ts
+++ b/vscode-gotest/src/coverOnSave.ts
@@ -8,6 +8,7 @@ import type { CoverageStore } from "./coverageStore.js";
 import { buildCliCommand, formatCliCommand, scopedConfig } from "./cli.js";
 import { spawnTestProcess } from "./runnerUtils.js";
 import { runGoToolCoverFunc } from "./coverageUtils.js";
+import type { RunRegistry } from "./runRegistry.js";
 
 export class CoverOnSave implements vscode.Disposable {
   private activeRun: vscode.CancellationTokenSource | undefined;
@@ -19,6 +20,7 @@ export class CoverOnSave implements vscode.Disposable {
     private readonly cache: DiscoveryCache,
     private readonly store: CoverageStore,
     private readonly outputChannel: vscode.LogOutputChannel,
+    private readonly registry: RunRegistry,
   ) {}
 
   run(importPath: string): Promise<void> {

--- a/vscode-gotest/src/coverOnSave.ts
+++ b/vscode-gotest/src/coverOnSave.ts
@@ -59,7 +59,9 @@ export class CoverOnSave implements vscode.Disposable {
     this.activeRecordId = recordId;
 
     let resolveRun!: () => void;
-    this.previousRunPromise = new Promise<void>((r) => { resolveRun = r; });
+    this.previousRunPromise = new Promise<void>((r) => {
+      resolveRun = r;
+    });
 
     const config = scopedConfig(workspaceDir);
     const testFlags = config.get<string[]>("testFlags") ?? [];

--- a/vscode-gotest/src/coverOnSave.ts
+++ b/vscode-gotest/src/coverOnSave.ts
@@ -12,6 +12,8 @@ import type { RunRegistry } from "./runRegistry.js";
 
 export class CoverOnSave implements vscode.Disposable {
   private activeRun: vscode.CancellationTokenSource | undefined;
+  private activeRecordId: string | undefined;
+  private previousRunPromise: Promise<void> = Promise.resolve();
   private runQueue = Promise.resolve();
   private pendingPackages = new Set<string>();
 
@@ -34,7 +36,14 @@ export class CoverOnSave implements vscode.Disposable {
   }
 
   private async execute(importPath: string): Promise<void> {
-    this.activeRun?.cancel();
+    if (this.activeRun) {
+      this.activeRun.cancel();
+      if (this.activeRecordId) {
+        this.registry.cancel(this.activeRecordId);
+        this.activeRecordId = undefined;
+      }
+      await this.previousRunPromise;
+    }
     const cts = new vscode.CancellationTokenSource();
     this.activeRun = cts;
 
@@ -42,6 +51,15 @@ export class CoverOnSave implements vscode.Disposable {
     if (!pkg) return;
     const workspaceDir = this.cache.getWorkspaceDir(importPath);
     if (!workspaceDir) return;
+
+    const recordId = this.registry.register({
+      kind: "coverage",
+      packages: [importPath],
+    }).id;
+    this.activeRecordId = recordId;
+
+    let resolveRun!: () => void;
+    this.previousRunPromise = new Promise<void>((r) => { resolveRun = r; });
 
     const config = scopedConfig(workspaceDir);
     const testFlags = config.get<string[]>("testFlags") ?? [];
@@ -98,6 +116,11 @@ export class CoverOnSave implements vscode.Disposable {
       this.outputChannel.error(`[coverage:save] ${message}`);
       return;
     } finally {
+      if (this.activeRecordId === recordId) {
+        this.registry.complete(recordId);
+        this.activeRecordId = undefined;
+      }
+      resolveRun();
       if (this.activeRun === cts) this.activeRun = undefined;
       cts.dispose();
       if (coverFile)

--- a/vscode-gotest/src/coverage.ts
+++ b/vscode-gotest/src/coverage.ts
@@ -241,6 +241,8 @@ export function parseFuncCoverage(
 
 export class CoverageRunner implements vscode.Disposable {
   private activeRun: vscode.CancellationTokenSource | undefined;
+  private activeRecordId: string | undefined;
+  private previousRunPromise: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly controller: GoTestController,
@@ -258,6 +260,11 @@ export class CoverageRunner implements vscode.Disposable {
     if (this.activeRun) {
       this.outputChannel.info("[coverage] cancelling previous run");
       this.activeRun.cancel();
+      if (this.activeRecordId) {
+        this.registry.cancel(this.activeRecordId);
+        this.activeRecordId = undefined;
+      }
+      await this.previousRunPromise;
     }
     const cts = new vscode.CancellationTokenSource();
     this.activeRun = cts;
@@ -266,12 +273,22 @@ export class CoverageRunner implements vscode.Disposable {
 
     const run = this.controller.createTestRun(request, "Go Test Coverage");
 
-    try {
-      const items = collectItems(this.controller, request);
-      if (items.length === 0) {
-        return;
-      }
+    const items = collectItems(this.controller, request);
+    if (items.length === 0) {
+      run.end();
+      return;
+    }
 
+    const recordId = this.registry.register({
+      kind: "coverage",
+      packages: items.map((i) => i.id),
+    }).id;
+    this.activeRecordId = recordId;
+
+    let resolveRun!: () => void;
+    this.previousRunPromise = new Promise<void>((r) => { resolveRun = r; });
+
+    try {
       for (const item of items) {
         this.controller.clearResults(item);
         run.started(item);
@@ -418,6 +435,11 @@ export class CoverageRunner implements vscode.Disposable {
         this.onJsonOutput(allJsonOutput);
       }
     } finally {
+      if (this.activeRecordId === recordId) {
+        this.registry.complete(recordId);
+        this.activeRecordId = undefined;
+      }
+      resolveRun();
       cancelSub.dispose();
       if (this.activeRun === cts) {
         this.activeRun = undefined;

--- a/vscode-gotest/src/coverage.ts
+++ b/vscode-gotest/src/coverage.ts
@@ -276,6 +276,9 @@ export class CoverageRunner implements vscode.Disposable {
     const items = collectItems(this.controller, request);
     if (items.length === 0) {
       run.end();
+      cancelSub.dispose();
+      if (this.activeRun === cts) this.activeRun = undefined;
+      cts.dispose();
       return;
     }
 

--- a/vscode-gotest/src/coverage.ts
+++ b/vscode-gotest/src/coverage.ts
@@ -12,6 +12,7 @@ import {
   resolvePackageItems,
 } from "./runnerUtils.js";
 import { executeBatch } from "./batchRunner.js";
+import type { RunRegistry } from "./runRegistry.js";
 
 export interface ParsedFileCoverage {
   absPath: string;
@@ -247,6 +248,7 @@ export class CoverageRunner implements vscode.Disposable {
     private readonly store: CoverageStore,
     private readonly outputChannel: vscode.LogOutputChannel,
     private readonly onJsonOutput: (json: string) => void,
+    private readonly registry: RunRegistry,
   ) {}
 
   async run(

--- a/vscode-gotest/src/coverage.ts
+++ b/vscode-gotest/src/coverage.ts
@@ -289,7 +289,9 @@ export class CoverageRunner implements vscode.Disposable {
     this.activeRecordId = recordId;
 
     let resolveRun!: () => void;
-    this.previousRunPromise = new Promise<void>((r) => { resolveRun = r; });
+    this.previousRunPromise = new Promise<void>((r) => {
+      resolveRun = r;
+    });
 
     try {
       for (const item of items) {

--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -171,9 +171,11 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 
   flushOnDeactivate = async () => {
-    await runRegistry.save();
-    await coverageStore.flush();
-    await testResultStore.flush();
+    await Promise.allSettled([
+      runRegistry.save(),
+      coverageStore.flush(),
+      testResultStore.flush(),
+    ]);
   };
 
   initializeAsync({
@@ -553,9 +555,11 @@ async function initializeAsync(deps: {
   runRegistry.sweep();
   await runRegistry.save();
 
-  const registrySaveInterval = setInterval(async () => {
+  const registrySaveInterval = setInterval(() => {
     runRegistry.sweep();
-    await runRegistry.save();
+    runRegistry.save().catch((err) => {
+      outputChannel.error(`[registry] periodic save failed: ${err}`);
+    });
   }, 60_000);
   context.subscriptions.push({
     dispose() {

--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -17,6 +17,7 @@ import { CoverageRunner } from "./coverage.js";
 import { CoverOnSave } from "./coverOnSave.js";
 import { CoverageStore } from "./coverageStore.js";
 import { TestResultStore } from "./testResultStore.js";
+import { RunRegistry } from "./runRegistry.js";
 import { validateGoBinary, scopedConfig } from "./cli.js";
 import { buildRunFilter, getPackageDir } from "./runnerUtils.js";
 import { copyCoverageSummary, copyTestResults } from "./reporting.js";
@@ -40,6 +41,8 @@ export function activate(context: vscode.ExtensionContext): void {
   const discoveryService = new DiscoveryService(cache, outputChannel);
   const debugLauncher = new DebugLauncher(outputChannel);
   const testResultStore = new TestResultStore(context.storageUri);
+  const registryDir = context.storageUri?.fsPath ?? context.globalStorageUri.fsPath;
+  const runRegistry = new RunRegistry(registryDir);
 
   let runner!: TestRunner;
   let coverageRunner!: CoverageRunner;
@@ -74,6 +77,7 @@ export function activate(context: vscode.ExtensionContext): void {
     cache,
     coverageStore,
     outputChannel,
+    runRegistry,
   );
   const specView = new SpecViewPanel(outputChannel, cache);
   specView.setExtensionUri(context.extensionUri);
@@ -98,13 +102,14 @@ export function activate(context: vscode.ExtensionContext): void {
     (jsonOutput) => {
       specView.refresh(jsonOutput, "coverage");
     },
+    runRegistry,
   );
 
   controller.setCoverageDetailProvider((uri) =>
     coverageStore.getDetails(uri.fsPath),
   );
 
-  runner = new TestRunner(controller, cache, outputChannel, coverageStore);
+  runner = new TestRunner(controller, cache, outputChannel, runRegistry, coverageStore);
 
   const specViewRefreshDisposable = runner.onDidComplete((jsonOutput) => {
     specView.refresh(jsonOutput, "run");
@@ -117,6 +122,7 @@ export function activate(context: vscode.ExtensionContext): void {
     (jsonOutput, scope, cwd) => {
       specView.refresh(jsonOutput, `watch:${scope}@${cwd}`);
     },
+    runRegistry,
   );
 
   const diagnostics = new FocusDiagnostics(cache);
@@ -165,6 +171,7 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 
   flushOnDeactivate = async () => {
+    await runRegistry.save();
     await coverageStore.flush();
     await testResultStore.flush();
   };
@@ -177,6 +184,7 @@ export function activate(context: vscode.ExtensionContext): void {
     testResultStore,
     controller,
     cache,
+    runRegistry,
   }).catch((err) => {
     outputChannel.error(`[activate] async initialization failed: ${err}`);
   });
@@ -509,6 +517,7 @@ async function initializeAsync(deps: {
   testResultStore: TestResultStore;
   controller: GoTestController;
   cache: DiscoveryCache;
+  runRegistry: RunRegistry;
 }): Promise<void> {
   const {
     workspaceFolders,
@@ -518,6 +527,7 @@ async function initializeAsync(deps: {
     testResultStore,
     controller,
     cache,
+    runRegistry,
   } = deps;
 
   const firstDir = workspaceFolders[0].uri.fsPath;
@@ -531,6 +541,14 @@ async function initializeAsync(deps: {
     if (choice === "Open Output") outputChannel.show();
     return;
   }
+
+  await runRegistry.load();
+  const crashed = runRegistry.sweepStale();
+  if (crashed.length > 0) {
+    outputChannel.info(`[registry] marked ${crashed.length} stale run(s) as crashed`);
+  }
+  runRegistry.sweep();
+  await runRegistry.save();
 
   for (const folder of workspaceFolders) {
     await discoveryService.discover(folder.uri.fsPath);

--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -185,6 +185,7 @@ export function activate(context: vscode.ExtensionContext): void {
     controller,
     cache,
     runRegistry,
+    context,
   }).catch((err) => {
     outputChannel.error(`[activate] async initialization failed: ${err}`);
   });
@@ -518,6 +519,7 @@ async function initializeAsync(deps: {
   controller: GoTestController;
   cache: DiscoveryCache;
   runRegistry: RunRegistry;
+  context: vscode.ExtensionContext;
 }): Promise<void> {
   const {
     workspaceFolders,
@@ -528,6 +530,7 @@ async function initializeAsync(deps: {
     controller,
     cache,
     runRegistry,
+    context,
   } = deps;
 
   const firstDir = workspaceFolders[0].uri.fsPath;
@@ -549,6 +552,16 @@ async function initializeAsync(deps: {
   }
   runRegistry.sweep();
   await runRegistry.save();
+
+  const registrySaveInterval = setInterval(async () => {
+    runRegistry.sweep();
+    await runRegistry.save();
+  }, 60_000);
+  context.subscriptions.push({
+    dispose() {
+      clearInterval(registrySaveInterval);
+    },
+  });
 
   for (const folder of workspaceFolders) {
     await discoveryService.discover(folder.uri.fsPath);

--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -41,7 +41,8 @@ export function activate(context: vscode.ExtensionContext): void {
   const discoveryService = new DiscoveryService(cache, outputChannel);
   const debugLauncher = new DebugLauncher(outputChannel);
   const testResultStore = new TestResultStore(context.storageUri);
-  const registryDir = context.storageUri?.fsPath ?? context.globalStorageUri.fsPath;
+  const registryDir =
+    context.storageUri?.fsPath ?? context.globalStorageUri.fsPath;
   const runRegistry = new RunRegistry(registryDir);
 
   let runner!: TestRunner;
@@ -109,7 +110,13 @@ export function activate(context: vscode.ExtensionContext): void {
     coverageStore.getDetails(uri.fsPath),
   );
 
-  runner = new TestRunner(controller, cache, outputChannel, runRegistry, coverageStore);
+  runner = new TestRunner(
+    controller,
+    cache,
+    outputChannel,
+    runRegistry,
+    coverageStore,
+  );
 
   const specViewRefreshDisposable = runner.onDidComplete((jsonOutput) => {
     specView.refresh(jsonOutput, "run");
@@ -550,7 +557,9 @@ async function initializeAsync(deps: {
   await runRegistry.load();
   const crashed = runRegistry.sweepStale();
   if (crashed.length > 0) {
-    outputChannel.info(`[registry] marked ${crashed.length} stale run(s) as crashed`);
+    outputChannel.info(
+      `[registry] marked ${crashed.length} stale run(s) as crashed`,
+    );
   }
   runRegistry.sweep();
   await runRegistry.save();

--- a/vscode-gotest/src/runRegistry.test.ts
+++ b/vscode-gotest/src/runRegistry.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { RunRegistry } from "./runRegistry.js";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { tmpdir } from "node:os";
+
+describe("RunRegistry", () => {
+  let registry: RunRegistry;
+  let storageDir: string;
+
+  beforeEach(async () => {
+    storageDir = await fs.mkdtemp(path.join(tmpdir(), "gotest-reg-"));
+    registry = new RunRegistry(storageDir);
+  });
+
+  it("registers and retrieves a run", () => {
+    const record = registry.register({
+      kind: "test",
+      packages: ["./pkg/..."],
+    });
+
+    expect(record.id).toBeTruthy();
+    expect(record.status).toBe("running");
+
+    const found = registry.get(record.id);
+    expect(found).toEqual(record);
+  });
+
+  it("updates status to completed", () => {
+    const record = registry.register({
+      kind: "coverage",
+      packages: [],
+    });
+
+    registry.complete(record.id);
+
+    const updated = registry.get(record.id);
+    expect(updated?.status).toBe("completed");
+    expect(updated?.endedAt).toBeGreaterThan(0);
+  });
+
+  it("updates status to cancelled", () => {
+    const record = registry.register({
+      kind: "test",
+      packages: [],
+    });
+
+    registry.cancel(record.id);
+
+    expect(registry.get(record.id)?.status).toBe("cancelled");
+  });
+
+  it("lists active runs", () => {
+    const r1 = registry.register({ kind: "test", packages: [] });
+    const r2 = registry.register({ kind: "coverage", packages: [] });
+    registry.complete(r1.id);
+
+    const active = registry.active();
+    expect(active).toHaveLength(1);
+    expect(active[0].id).toBe(r2.id);
+  });
+
+  it("expires terminal records after TTL", () => {
+    const record = registry.register({
+      kind: "test",
+      packages: [],
+    });
+
+    registry.complete(record.id);
+
+    // Backdate endedAt to 16 minutes ago
+    const updated = registry.get(record.id)!;
+    (updated as { endedAt: number }).endedAt = Date.now() - 16 * 60 * 1000;
+
+    registry.sweep();
+
+    expect(registry.get(record.id)).toBeUndefined();
+  });
+
+  it("keeps terminal records within TTL", () => {
+    const record = registry.register({ kind: "test", packages: [] });
+    registry.complete(record.id);
+
+    registry.sweep();
+
+    expect(registry.get(record.id)).toBeDefined();
+  });
+
+  it("sweepStale marks all running records as crashed", () => {
+    const r1 = registry.register({ kind: "test", packages: [] });
+    const r2 = registry.register({ kind: "coverage", packages: [] });
+    registry.complete(r2.id);
+
+    const crashed = registry.sweepStale();
+
+    expect(crashed).toHaveLength(1);
+    expect(crashed[0].id).toBe(r1.id);
+    expect(registry.get(r1.id)?.status).toBe("crashed");
+    expect(registry.get(r2.id)?.status).toBe("completed");
+  });
+
+  it("persists and loads from disk", async () => {
+    registry.register({
+      kind: "watch",
+      packages: ["./..."],
+    });
+
+    await registry.save();
+
+    const loaded = new RunRegistry(storageDir);
+    await loaded.load();
+
+    expect(loaded.all()).toHaveLength(1);
+    expect(loaded.all()[0].kind).toBe("watch");
+  });
+
+  it("load with no file starts empty", async () => {
+    const fresh = new RunRegistry(storageDir + "/nonexistent");
+    await fresh.load();
+
+    expect(fresh.all()).toHaveLength(0);
+  });
+});

--- a/vscode-gotest/src/runRegistry.ts
+++ b/vscode-gotest/src/runRegistry.ts
@@ -1,0 +1,111 @@
+import * as path from "node:path";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+
+export type RunKind = "test" | "coverage" | "watch" | "prepare";
+export type RunStatus = "running" | "completed" | "cancelled" | "crashed";
+
+export interface RunRecord {
+  id: string;
+  kind: RunKind;
+  status: RunStatus;
+  startedAt: number;
+  endedAt?: number;
+  packages: string[];
+}
+
+export interface RegisterInput {
+  kind: RunKind;
+  packages: string[];
+}
+
+const TTL_MS = 15 * 60 * 1000;
+const REGISTRY_FILE = "run-registry.json";
+
+export class RunRegistry {
+  private records = new Map<string, RunRecord>();
+
+  constructor(private readonly storageDir: string) {}
+
+  register(input: RegisterInput): RunRecord {
+    const record: RunRecord = {
+      id: crypto.randomUUID(),
+      kind: input.kind,
+      status: "running",
+      startedAt: Date.now(),
+      packages: input.packages,
+    };
+    this.records.set(record.id, record);
+    return record;
+  }
+
+  get(id: string): RunRecord | undefined {
+    return this.records.get(id);
+  }
+
+  complete(id: string): void {
+    this.transition(id, "completed");
+  }
+
+  cancel(id: string): void {
+    this.transition(id, "cancelled");
+  }
+
+  crash(id: string): void {
+    this.transition(id, "crashed");
+  }
+
+  active(): RunRecord[] {
+    return [...this.records.values()].filter((r) => r.status === "running");
+  }
+
+  all(): RunRecord[] {
+    return [...this.records.values()];
+  }
+
+  sweepStale(): RunRecord[] {
+    const crashed: RunRecord[] = [];
+    for (const record of this.records.values()) {
+      if (record.status !== "running") continue;
+      record.status = "crashed";
+      record.endedAt = Date.now();
+      crashed.push(record);
+    }
+    return crashed;
+  }
+
+  sweep(): void {
+    const now = Date.now();
+    for (const [id, record] of this.records) {
+      if (record.status !== "running" && record.endedAt && now - record.endedAt > TTL_MS) {
+        this.records.delete(id);
+      }
+    }
+  }
+
+  async save(): Promise<void> {
+    await mkdir(this.storageDir, { recursive: true });
+    const data = JSON.stringify([...this.records.values()], null, 2);
+    await writeFile(path.join(this.storageDir, REGISTRY_FILE), data, "utf-8");
+  }
+
+  async load(): Promise<void> {
+    try {
+      const data = await readFile(path.join(this.storageDir, REGISTRY_FILE), "utf-8");
+      const records: RunRecord[] = JSON.parse(data);
+      this.records.clear();
+      for (const r of records) {
+        this.records.set(r.id, r);
+      }
+    } catch {
+      // No file or invalid — start fresh
+    }
+  }
+
+  private transition(id: string, status: RunStatus): void {
+    const record = this.records.get(id);
+    if (record) {
+      record.status = status;
+      record.endedAt = Date.now();
+    }
+  }
+}

--- a/vscode-gotest/src/runRegistry.ts
+++ b/vscode-gotest/src/runRegistry.ts
@@ -76,7 +76,11 @@ export class RunRegistry {
   sweep(): void {
     const now = Date.now();
     for (const [id, record] of this.records) {
-      if (record.status !== "running" && record.endedAt && now - record.endedAt > TTL_MS) {
+      if (
+        record.status !== "running" &&
+        record.endedAt &&
+        now - record.endedAt > TTL_MS
+      ) {
         this.records.delete(id);
       }
     }
@@ -90,7 +94,10 @@ export class RunRegistry {
 
   async load(): Promise<void> {
     try {
-      const data = await readFile(path.join(this.storageDir, REGISTRY_FILE), "utf-8");
+      const data = await readFile(
+        path.join(this.storageDir, REGISTRY_FILE),
+        "utf-8",
+      );
       const records: RunRecord[] = JSON.parse(data);
       this.records.clear();
       for (const r of records) {

--- a/vscode-gotest/src/runner.ts
+++ b/vscode-gotest/src/runner.ts
@@ -18,6 +18,8 @@ export class TestRunner {
   private readonly _onDidComplete = new vscode.EventEmitter<string>();
   readonly onDidComplete: vscode.Event<string> = this._onDidComplete.event;
   private activeRun: vscode.CancellationTokenSource | undefined;
+  private activeRecordId: string | undefined;
+  private previousRunPromise: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly controller: GoTestController,
@@ -40,6 +42,11 @@ export class TestRunner {
     if (this.activeRun) {
       this.outputChannel.info("[runner] cancelling previous run");
       this.activeRun.cancel();
+      if (this.activeRecordId) {
+        this.registry.cancel(this.activeRecordId);
+        this.activeRecordId = undefined;
+      }
+      await this.previousRunPromise;
     }
     const cts = new vscode.CancellationTokenSource();
     this.activeRun = cts;
@@ -50,11 +57,22 @@ export class TestRunner {
     this._lastJsonOutput = "";
     let anyCoverOnRun = false;
 
+    let resolveRun!: () => void;
+    this.previousRunPromise = new Promise<void>((r) => { resolveRun = r; });
+
+    let recordId: string | undefined;
+
     try {
       const items = collectItems(this.controller, request);
       if (items.length === 0) {
         return;
       }
+
+      recordId = this.registry.register({
+        kind: "test",
+        packages: items.map((i) => i.id),
+      }).id;
+      this.activeRecordId = recordId;
 
       for (const item of items) {
         this.controller.clearResults(item);
@@ -182,6 +200,11 @@ export class TestRunner {
       }
       this.controller.saveResults();
     } finally {
+      if (recordId !== undefined && this.activeRecordId === recordId) {
+        this.registry.complete(recordId);
+        this.activeRecordId = undefined;
+      }
+      resolveRun();
       cancelSub.dispose();
       if (this.activeRun === cts) {
         this.activeRun = undefined;

--- a/vscode-gotest/src/runner.ts
+++ b/vscode-gotest/src/runner.ts
@@ -58,7 +58,9 @@ export class TestRunner {
     let anyCoverOnRun = false;
 
     let resolveRun!: () => void;
-    this.previousRunPromise = new Promise<void>((r) => { resolveRun = r; });
+    this.previousRunPromise = new Promise<void>((r) => {
+      resolveRun = r;
+    });
 
     let recordId: string | undefined;
 

--- a/vscode-gotest/src/runner.ts
+++ b/vscode-gotest/src/runner.ts
@@ -11,6 +11,7 @@ import {
 } from "./runnerUtils.js";
 import type { CoverageStore } from "./coverageStore.js";
 import { executeBatch } from "./batchRunner.js";
+import type { RunRegistry } from "./runRegistry.js";
 
 export class TestRunner {
   private _lastJsonOutput = "";
@@ -22,6 +23,7 @@ export class TestRunner {
     private readonly controller: GoTestController,
     private readonly cache: DiscoveryCache,
     private readonly outputChannel: vscode.LogOutputChannel,
+    private readonly registry: RunRegistry,
     private readonly coverageStore?: CoverageStore,
   ) {}
 

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -188,6 +188,7 @@ class WatchProcess implements vscode.Disposable {
 export class WatchManager implements vscode.Disposable {
   private watchers = new Map<string, WatchProcess>();
   private activeRuns = new Map<string, vscode.TestRun>();
+  private watchRecordIds = new Map<string, string>();
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   readonly onDidChange: vscode.Event<void> = this._onDidChange.event;
   private readonly statusBar: vscode.StatusBarItem;
@@ -261,6 +262,11 @@ export class WatchManager implements vscode.Disposable {
       },
       // onExit
       () => {
+        const recordId = this.watchRecordIds.get(pkgScope);
+        if (recordId) {
+          this.registry.crash(recordId);
+          this.watchRecordIds.delete(pkgScope);
+        }
         const run = this.activeRuns.get(pkgScope);
         if (run) {
           run.appendOutput(
@@ -284,11 +290,21 @@ export class WatchManager implements vscode.Disposable {
     );
 
     this.watchers.set(pkgScope, watcher);
+    const recordId = this.registry.register({
+      kind: "watch",
+      packages: [pkgScope],
+    }).id;
+    this.watchRecordIds.set(pkgScope, recordId);
     this.updateStatusBar();
     this._onDidChange.fire();
   }
 
   stop(pkgScope: string): void {
+    const recordId = this.watchRecordIds.get(pkgScope);
+    if (recordId) {
+      this.registry.cancel(recordId);
+      this.watchRecordIds.delete(pkgScope);
+    }
     const watcher = this.watchers.get(pkgScope);
     if (watcher) {
       watcher.dispose();
@@ -307,12 +323,17 @@ export class WatchManager implements vscode.Disposable {
 
   stopAll(): void {
     for (const [scope, watcher] of this.watchers) {
+      const recordId = this.watchRecordIds.get(scope);
+      if (recordId) {
+        this.registry.cancel(recordId);
+      }
       watcher.dispose();
       const run = this.activeRuns.get(scope);
       if (run) {
         run.end();
       }
     }
+    this.watchRecordIds.clear();
     this.watchers.clear();
     this.activeRuns.clear();
     this.updateStatusBar();

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -5,6 +5,7 @@ import type { DiscoveryCache } from "./discovery.js";
 import { parseTestEvents, type TestEvent } from "./outputParser.js";
 import { buildCliCommand, formatCliCommand, type CliCommand } from "./cli.js";
 import { resolveTestItem, applyResults } from "./runnerUtils.js";
+import type { RunRegistry } from "./runRegistry.js";
 
 /**
  * Wraps a single `gotest watch -json <scope>` child process.
@@ -200,6 +201,7 @@ export class WatchManager implements vscode.Disposable {
       scope: string,
       cwd: string,
     ) => void,
+    private readonly registry: RunRegistry,
   ) {
     this.statusBar = vscode.window.createStatusBarItem(
       vscode.StatusBarAlignment.Left,


### PR DESCRIPTION
PID-scoped overlay paths with stale cleanup, plus a RunRegistry that tracks all spawned processes across test runs, coverage, and watch mode with periodic persistence and stale sweep.