### PR TITLE
fix: propagate cancellation through process trees

### DIFF
--- a/cmd/gotest/exec.go
+++ b/cmd/gotest/exec.go
@@ -221,6 +221,10 @@ func executeTests(ctx context.Context, cfg ExecConfig, overlay *overlayResult) (
 		return 0, nil
 	}
 
+	for j := range targets {
+		targets[j].BudgetFile = targets[j].BinaryPath + ".budget"
+	}
+
 	setupCoverage(targets, overlay, pf.userCoverProfile)
 	if pf.userCoverProfile != "" {
 		defer mergeCoverProfiles(targets, pf.userCoverProfile)
@@ -305,11 +309,16 @@ func executeTestsStreaming(ctx context.Context, cfg ExecConfig, overlay *overlay
 	}
 
 loop:
-	for cr := range compileCh {
+	for {
+		var cr gotestrunner.CompileResult
+		var ok bool
 		select {
+		case cr, ok = <-compileCh:
+			if !ok {
+				break loop
+			}
 		case <-streamCtx.Done():
 			break loop
-		default:
 		}
 
 		singleCompiled := []gotestrunner.CompileResult{cr}
@@ -320,6 +329,10 @@ loop:
 			continue
 		}
 		anyTargets = true
+
+		for j := range targets {
+			targets[j].BudgetFile = targets[j].BinaryPath + ".budget"
+		}
 
 		if pf.userCoverProfile != "" {
 			baseIdx := len(allTargets)
@@ -352,15 +365,12 @@ loop:
 					env = baseEnv
 				}
 
-				sem <- struct{}{}
-				defer func() { <-sem }()
-
-				mu.Lock()
-				if streamCtx.Err() != nil {
-					mu.Unlock()
+				select {
+				case sem <- struct{}{}:
+				case <-streamCtx.Done():
 					return
 				}
-				mu.Unlock()
+				defer func() { <-sem }()
 
 				r := gotestrunner.RunSingleSuite(streamCtx, t, env, cfg.JSON)
 				mu.Lock()
@@ -423,6 +433,10 @@ func executeTestsCaptured(ctx context.Context, cfg ExecConfig, overlay *overlayR
 
 	if len(targets) == 0 {
 		return nil, 0, nil
+	}
+
+	for j := range targets {
+		targets[j].BudgetFile = targets[j].BinaryPath + ".budget"
 	}
 
 	if pf.userCoverProfile != "" {

--- a/cmd/gotest/sharedfixture.go
+++ b/cmd/gotest/sharedfixture.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/mvrahden/go-test/internal/gotestgen"
+	"github.com/mvrahden/go-test/internal/gotestrunner"
 )
 
 // SharedFixtureProcess manages a running shared fixture setup subprocess.
@@ -33,11 +34,11 @@ func (p *SharedFixtureProcess) Teardown() error {
 	if p.cmd == nil || p.cmd.Process == nil {
 		return nil
 	}
-	p.cmd.Process.Signal(syscall.SIGTERM)
+	syscall.Kill(-p.cmd.Process.Pid, syscall.SIGTERM)
 	select {
 	case <-p.done:
 	case <-time.After(30 * time.Second):
-		p.cmd.Process.Kill()
+		syscall.Kill(-p.cmd.Process.Pid, syscall.SIGKILL)
 	}
 	return nil
 }
@@ -64,12 +65,14 @@ func startSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestge
 	setupBin := filepath.Join(sharedDir, "setup")
 	buildCmd := exec.CommandContext(ctx, "go", "build", "-o", setupBin, setupFile)
 	buildCmd.Stderr = os.Stderr
+	gotestrunner.SetProcessGroup(buildCmd)
 	if err := buildCmd.Run(); err != nil {
 		return nil, fmt.Errorf("build shared fixture setup: %w", err)
 	}
 
 	cmd := exec.CommandContext(ctx, setupBin)
 	cmd.Stderr = os.Stderr
+	gotestrunner.SetProcessGroup(cmd)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/cmd/gotest/sharedfixture.go
+++ b/cmd/gotest/sharedfixture.go
@@ -19,9 +19,10 @@ import (
 // The subprocess starts shared fixtures, writes JSON state to stdout,
 // then blocks until SIGTERM/SIGINT triggers teardown.
 type SharedFixtureProcess struct {
-	cmd       *exec.Cmd
-	stateFile string
-	done      chan struct{}
+	cmd              *exec.Cmd
+	stateFile        string
+	done             chan struct{}
+	teardownTimeout  time.Duration
 }
 
 // StateFile returns the path to the shared fixture state JSON file.
@@ -34,10 +35,14 @@ func (p *SharedFixtureProcess) Teardown() error {
 	if p.cmd == nil || p.cmd.Process == nil {
 		return nil
 	}
+	timeout := p.teardownTimeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
 	syscall.Kill(-p.cmd.Process.Pid, syscall.SIGTERM)
 	select {
 	case <-p.done:
-	case <-time.After(30 * time.Second):
+	case <-time.After(timeout):
 		syscall.Kill(-p.cmd.Process.Pid, syscall.SIGKILL)
 	}
 	return nil
@@ -66,6 +71,7 @@ func startSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestge
 	buildCmd := exec.CommandContext(ctx, "go", "build", "-o", setupBin, setupFile)
 	buildCmd.Stderr = os.Stderr
 	gotestrunner.SetProcessGroup(buildCmd)
+	buildCmd.WaitDelay = gotestrunner.BuildShutdownDelay
 	if err := buildCmd.Run(); err != nil {
 		return nil, fmt.Errorf("build shared fixture setup: %w", err)
 	}
@@ -73,6 +79,7 @@ func startSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestge
 	cmd := exec.CommandContext(ctx, setupBin)
 	cmd.Stderr = os.Stderr
 	gotestrunner.SetProcessGroup(cmd)
+	cmd.WaitDelay = 0 // Teardown() manages lifecycle via explicit SIGTERM/SIGKILL
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -111,6 +118,17 @@ func startSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestge
 		return nil, fmt.Errorf("timed out after %v", setupTimeout)
 	}
 
+	teardownTimeout := setupTimeout
+	if budgetRaw, ok := state["_teardownBudget"]; ok {
+		var budgetStr string
+		if err := json.Unmarshal(budgetRaw, &budgetStr); err == nil {
+			if d, err := time.ParseDuration(budgetStr); err == nil && d > 0 {
+				teardownTimeout = d
+			}
+		}
+		delete(state, "_teardownBudget")
+	}
+
 	stateBytes, err := json.Marshal(state)
 	if err != nil {
 		cmd.Process.Kill()
@@ -129,5 +147,5 @@ func startSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestge
 		close(done)
 	}()
 
-	return &SharedFixtureProcess{cmd: cmd, stateFile: stateFile, done: done}, nil
+	return &SharedFixtureProcess{cmd: cmd, stateFile: stateFile, done: done, teardownTimeout: teardownTimeout}, nil
 }

--- a/internal/gotestgen/renderer.go
+++ b/internal/gotestgen/renderer.go
@@ -110,7 +110,7 @@ func (r *renderer) renderFileHeader(buf *bytes.Buffer, pkg *packages.Package, sp
 		imports = append(imports, headerImport{Path: "fmt"})
 		imports = append(imports, headerImport{Path: "time"})
 	}
-	if slices.Any(spec.EffectiveTestSuites, func(v *gotestast.TestSuiteSpec, idx int) bool {
+	if hasFixtures || slices.Any(spec.EffectiveTestSuites, func(v *gotestast.TestSuiteSpec, idx int) bool {
 		return v.IsMethodParallel()
 	}) {
 		imports = append(imports, headerImport{Path: "sync"})

--- a/internal/gotestgen/renderer_test.go
+++ b/internal/gotestgen/renderer_test.go
@@ -571,10 +571,10 @@ func (s *CFGTestSuite) TestOne(t *gotest.T) {}
 	output, _ := renderTestPkg(t, pkg)
 
 	gotest.Contains(t, output, "gotest.DefaultFixtureConfig()")
-	gotest.Contains(t, output, "gotest.OverlayFixtureConfig(&ƒcfg, ƒ_CFGFixture.FixtureConfig())")
-	gotest.Contains(t, output, "ƒattempts := 1 + ƒcfg.Retries")
+	gotest.Contains(t, output, "gotest.OverlayFixtureConfig(&ƒcfg_CFGFixture, ƒ_CFGFixture.FixtureConfig())")
+	gotest.Contains(t, output, "ƒattempts := 1 + ƒcfg_CFGFixture.Retries")
 	gotest.Contains(t, output, "ƒ_CFGFixture.BeforeAll(ctx)")
-	gotest.Contains(t, output, "context.WithTimeout(ctx, ƒcfg.Timeout)")
+	gotest.Contains(t, output, "context.WithTimeout(ƒctx, ƒcfg_CFGFixture.Timeout)")
 }
 
 func TestRenderer_FixtureWithoutConfig_UsesDefault(t *testing.T) {

--- a/internal/gotestgen/static/gotest.fixture.tpl
+++ b/internal/gotestgen/static/gotest.fixture.tpl
@@ -28,143 +28,270 @@ func TestMain(m *testing.M) { os.Exit(ƒƒ_GOTEST_main(m)) }
 
 func ƒƒ_GOTEST_main(m *testing.M) (ƒcode int) {
 {{ range $f := .RootFixtures }}
-{
-{{- /* Resolve shared fixture embeddings from JSON state */ -}}
-{{ if $f.SharedFixtures }}
-    ƒsharedFile := os.Getenv("GOTEST_SHARED_STATE_FILE")
-    if ƒsharedFile == "" {
-        fmt.Fprintln(os.Stderr, "FAIL: GOTEST_SHARED_STATE_FILE not set — run via gotest CLI")
-        return 2
-    }
-    ƒsharedRaw, ƒsharedErr := os.ReadFile(ƒsharedFile)
-    if ƒsharedErr != nil {
-        fmt.Fprintf(os.Stderr, "FAIL: read shared state file: %v\n", ƒsharedErr)
-        return 2
-    }
-    ƒsharedState := map[string]json.RawMessage{}
-    if err := json.Unmarshal(ƒsharedRaw, &ƒsharedState); err != nil {
-        fmt.Fprintf(os.Stderr, "FAIL: unmarshal shared state: %v\n", err)
-        return 2
-    }
-{{ range $sf := $f.SharedFixtures }}
-    {{ $sf.LocalVar }} := &{{ $sf.QualifiedType }}{}
-    if ƒb, ok := ƒsharedState["{{ $sf.StateKey }}"]; ok {
-        if err := json.Unmarshal(ƒb, {{ $sf.LocalVar }}); err != nil {
-            fmt.Fprintf(os.Stderr, "FAIL: unmarshal {{ $sf.FieldName }} state: %v\n", err)
-            return 2
-        }
-    }
-{{- if $sf.HasHydrate }}
-    if err := {{ $sf.LocalVar }}.Hydrate(context.Background()); err != nil {
-        fmt.Fprintf(os.Stderr, "FAIL: {{ $sf.FieldName }}.Hydrate: %v\n", err)
-        return 2
-    }
-{{- end }}
-{{- if $sf.HasDehydrate }}
-    defer {{ $sf.LocalVar }}.Dehydrate(context.Background())
-{{- end }}
-{{ end }}
-{{ end }}
-
-    ƒ_{{ $f.Identifier }} = &{{ $f.QualifiedIdentifier }}{}
-{{- range $sf := $f.SharedFixtures }}
-    ƒ_{{ $f.Identifier }}.{{ $sf.FieldName }} = {{ $sf.LocalVar }}
-{{- end }}
-    ƒcfg := gotest.DefaultFixtureConfig()
-{{- if $f.HasConfig }}
-    gotest.OverlayFixtureConfig(&ƒcfg, ƒ_{{ $f.Identifier }}.FixtureConfig())
-{{- end }}
-    var ƒerr error
-    ƒattempts := 1 + ƒcfg.Retries
-    for ƒi := range ƒattempts {
-        ctx := context.Background()
-        if ƒcfg.Timeout > 0 {
-            var cancel context.CancelFunc
-            ctx, cancel = context.WithTimeout(ctx, ƒcfg.Timeout)
-            defer cancel()
-        }
-        ƒerr = ƒ_{{ $f.Identifier }}.BeforeAll(ctx)
-        if ƒerr == nil {
-            break
-        }
-        if ƒi < ƒattempts-1 {
-            fmt.Fprintf(os.Stderr, "{{ $f.Identifier }}.BeforeAll attempt %d/%d failed: %v\n", ƒi+1, ƒattempts, ƒerr)
-            if ƒcfg.RetryDelay > 0 {
-                time.Sleep(ƒcfg.RetryDelay)
-            }
-        }
-    }
-    if ƒerr != nil {
-        fmt.Fprintf(os.Stderr, "FAIL: {{ $f.Identifier }}.BeforeAll failed after %d attempt(s): %v\n", ƒattempts, ƒerr)
-        return 2
-    }
-{{- if $f.AfterAll }}
-    defer func() {
-        ctx := context.Background()
-        if ƒcfg.Timeout > 0 {
-            var cancel context.CancelFunc
-            ctx, cancel = context.WithTimeout(ctx, ƒcfg.Timeout)
-            defer cancel()
-        }
-        if err := ƒ_{{ $f.Identifier }}.AfterAll(ctx); err != nil {
-            fmt.Fprintf(os.Stderr, "{{ $f.Identifier }}.AfterAll failed: %v\n", err)
-            if ƒcode == 0 { ƒcode = 1 }
-        }
-    }()
-{{- end }}
-}
-
-{{- /* Setup child fixtures */ -}}
+    var ƒcfg_{{ $f.Identifier }} gotest.FixtureConfig
+    var ƒok_{{ $f.Identifier }} bool
 {{ range $cf := $f.ChildFixtures }}
-{
-    ƒ_{{ $cf.Identifier }} = &{{ $cf.QualifiedIdentifier }}{
-        {{ $cf.ParentFieldName }}: ƒ_{{ $f.Identifier }},
-    }
-    ƒcfg := gotest.DefaultFixtureConfig()
-{{- if $cf.HasConfig }}
-    gotest.OverlayFixtureConfig(&ƒcfg, ƒ_{{ $cf.Identifier }}.FixtureConfig())
-{{- end }}
-    var ƒerr error
-    ƒattempts := 1 + ƒcfg.Retries
-    for ƒi := range ƒattempts {
-        ctx := context.Background()
-        if ƒcfg.Timeout > 0 {
-            var cancel context.CancelFunc
-            ctx, cancel = context.WithTimeout(ctx, ƒcfg.Timeout)
-            defer cancel()
-        }
-        ƒerr = ƒ_{{ $cf.Identifier }}.BeforeAll(ctx)
-        if ƒerr == nil {
-            break
-        }
-        if ƒi < ƒattempts-1 {
-            fmt.Fprintf(os.Stderr, "{{ $cf.Identifier }}.BeforeAll attempt %d/%d failed: %v\n", ƒi+1, ƒattempts, ƒerr)
-            if ƒcfg.RetryDelay > 0 {
-                time.Sleep(ƒcfg.RetryDelay)
-            }
-        }
-    }
-    if ƒerr != nil {
-        fmt.Fprintf(os.Stderr, "FAIL: {{ $cf.Identifier }}.BeforeAll failed after %d attempt(s): %v\n", ƒattempts, ƒerr)
-        return 2
-    }
-{{- if $cf.AfterAll }}
+    var ƒcfg_{{ $cf.Identifier }} gotest.FixtureConfig
+    var ƒok_{{ $cf.Identifier }} bool
+{{ end }}
+{{ end }}
+
     defer func() {
-        ctx := context.Background()
-        if ƒcfg.Timeout > 0 {
-            var cancel context.CancelFunc
-            ctx, cancel = context.WithTimeout(ctx, ƒcfg.Timeout)
-            defer cancel()
-        }
-        if err := ƒ_{{ $cf.Identifier }}.AfterAll(ctx); err != nil {
-            fmt.Fprintf(os.Stderr, "{{ $cf.Identifier }}.AfterAll failed: %v\n", err)
-            if ƒcode == 0 { ƒcode = 1 }
+        var ƒtwg sync.WaitGroup
+        ƒtdfails := make([]bool, {{ len .RootFixtures }})
+{{ range $i, $f := .RootFixtures }}
+        ƒtwg.Add(1)
+        go func() {
+            defer ƒtwg.Done()
+{{ if $f.ChildFixtures }}
+            var ƒcwg sync.WaitGroup
+            ƒcdfails := make([]bool, {{ len $f.ChildFixtures }})
+{{ range $j, $cf := $f.ChildFixtures }}
+{{- if $cf.AfterAll }}
+            if ƒok_{{ $cf.Identifier }} {
+                ƒcwg.Add(1)
+                go func() {
+                    defer ƒcwg.Done()
+                    ctx := context.Background()
+                    if ƒcfg_{{ $cf.Identifier }}.Timeout > 0 {
+                        var cancel context.CancelFunc
+                        ctx, cancel = context.WithTimeout(ctx, ƒcfg_{{ $cf.Identifier }}.Timeout)
+                        defer cancel()
+                    }
+                    if err := ƒ_{{ $cf.Identifier }}.AfterAll(ctx); err != nil {
+                        fmt.Fprintf(os.Stderr, "{{ $cf.Identifier }}.AfterAll failed: %v\n", err)
+                        ƒcdfails[{{ $j }}] = true
+                    }
+                }()
+            }
+{{- end }}
+{{ end }}
+            ƒcwg.Wait()
+            for _, ƒf := range ƒcdfails {
+                if ƒf { ƒtdfails[{{ $i }}] = true; break }
+            }
+{{ end }}
+{{- if $f.AfterAll }}
+            if ƒok_{{ $f.Identifier }} {
+                ctx := context.Background()
+                if ƒcfg_{{ $f.Identifier }}.Timeout > 0 {
+                    var cancel context.CancelFunc
+                    ctx, cancel = context.WithTimeout(ctx, ƒcfg_{{ $f.Identifier }}.Timeout)
+                    defer cancel()
+                }
+                if err := ƒ_{{ $f.Identifier }}.AfterAll(ctx); err != nil {
+                    fmt.Fprintf(os.Stderr, "{{ $f.Identifier }}.AfterAll failed: %v\n", err)
+                    ƒtdfails[{{ $i }}] = true
+                }
+            }
+{{- end }}
+{{- range $sf := $f.SharedFixtures }}
+{{- if $sf.HasDehydrate }}
+            if ƒok_{{ $f.Identifier }} {
+                ƒ_{{ $f.Identifier }}.{{ $sf.FieldName }}.Dehydrate(context.Background())
+            }
+{{- end }}
+{{- end }}
+        }()
+{{ end }}
+        ƒtwg.Wait()
+        for _, ƒf := range ƒtdfails {
+            if ƒf && ƒcode == 0 { ƒcode = 1; break }
         }
     }()
+
+    ƒctx, ƒcancel := context.WithCancel(context.Background())
+    defer ƒcancel()
+
+    {
+        var ƒswg sync.WaitGroup
+        ƒtfails := make([]bool, {{ len .RootFixtures }})
+{{ range $i, $f := .RootFixtures }}
+        ƒswg.Add(1)
+        go func() {
+            defer ƒswg.Done()
+{{ if $f.SharedFixtures }}
+            ƒsharedFile := os.Getenv("GOTEST_SHARED_STATE_FILE")
+            if ƒsharedFile == "" {
+                fmt.Fprintln(os.Stderr, "FAIL: GOTEST_SHARED_STATE_FILE not set — run via gotest CLI")
+                ƒtfails[{{ $i }}] = true
+                ƒcancel()
+                return
+            }
+            ƒsharedRaw, ƒsharedErr := os.ReadFile(ƒsharedFile)
+            if ƒsharedErr != nil {
+                fmt.Fprintf(os.Stderr, "FAIL: read shared state file: %v\n", ƒsharedErr)
+                ƒtfails[{{ $i }}] = true
+                ƒcancel()
+                return
+            }
+            ƒsharedState := map[string]json.RawMessage{}
+            if err := json.Unmarshal(ƒsharedRaw, &ƒsharedState); err != nil {
+                fmt.Fprintf(os.Stderr, "FAIL: unmarshal shared state: %v\n", err)
+                ƒtfails[{{ $i }}] = true
+                ƒcancel()
+                return
+            }
+{{ range $sf := $f.SharedFixtures }}
+            {{ $sf.LocalVar }} := &{{ $sf.QualifiedType }}{}
+            if ƒb, ok := ƒsharedState["{{ $sf.StateKey }}"]; ok {
+                if err := json.Unmarshal(ƒb, {{ $sf.LocalVar }}); err != nil {
+                    fmt.Fprintf(os.Stderr, "FAIL: unmarshal {{ $sf.FieldName }} state: %v\n", err)
+                    ƒtfails[{{ $i }}] = true
+                    ƒcancel()
+                    return
+                }
+            }
+{{- if $sf.HasHydrate }}
+            if err := {{ $sf.LocalVar }}.Hydrate(context.Background()); err != nil {
+                fmt.Fprintf(os.Stderr, "FAIL: {{ $sf.FieldName }}.Hydrate: %v\n", err)
+                ƒtfails[{{ $i }}] = true
+                ƒcancel()
+                return
+            }
 {{- end }}
-}
 {{ end }}
 {{ end }}
+            ƒ_{{ $f.Identifier }} = &{{ $f.QualifiedIdentifier }}{}
+{{- range $sf := $f.SharedFixtures }}
+            ƒ_{{ $f.Identifier }}.{{ $sf.FieldName }} = {{ $sf.LocalVar }}
+{{- end }}
+            ƒcfg_{{ $f.Identifier }} = gotest.DefaultFixtureConfig()
+{{- if $f.HasConfig }}
+            gotest.OverlayFixtureConfig(&ƒcfg_{{ $f.Identifier }}, ƒ_{{ $f.Identifier }}.FixtureConfig())
+{{- end }}
+            var ƒerr error
+            ƒattempts := 1 + ƒcfg_{{ $f.Identifier }}.Retries
+            for ƒi := range ƒattempts {
+                ctx := ƒctx
+                if ƒcfg_{{ $f.Identifier }}.Timeout > 0 {
+                    var cancel context.CancelFunc
+                    ctx, cancel = context.WithTimeout(ƒctx, ƒcfg_{{ $f.Identifier }}.Timeout)
+                    defer cancel()
+                }
+                ƒerr = ƒ_{{ $f.Identifier }}.BeforeAll(ctx)
+                if ƒerr == nil {
+                    break
+                }
+                if ƒctx.Err() != nil {
+                    break
+                }
+                if ƒi < ƒattempts-1 {
+                    fmt.Fprintf(os.Stderr, "{{ $f.Identifier }}.BeforeAll attempt %d/%d failed: %v\n", ƒi+1, ƒattempts, ƒerr)
+                    if ƒcfg_{{ $f.Identifier }}.RetryDelay > 0 {
+                        time.Sleep(ƒcfg_{{ $f.Identifier }}.RetryDelay)
+                    }
+                }
+            }
+            if ƒerr != nil {
+                fmt.Fprintf(os.Stderr, "FAIL: {{ $f.Identifier }}.BeforeAll failed after %d attempt(s): %v\n", ƒattempts, ƒerr)
+                ƒtfails[{{ $i }}] = true
+                ƒcancel()
+                return
+            }
+            ƒok_{{ $f.Identifier }} = true
+{{ if $f.ChildFixtures }}
+            {
+                ƒcfails := make([]bool, {{ len $f.ChildFixtures }})
+                var ƒcwg sync.WaitGroup
+{{ range $j, $cf := $f.ChildFixtures }}
+                ƒcwg.Add(1)
+                go func() {
+                    defer ƒcwg.Done()
+                    ƒ_{{ $cf.Identifier }} = &{{ $cf.QualifiedIdentifier }}{
+                        {{ $cf.ParentFieldName }}: ƒ_{{ $f.Identifier }},
+                    }
+                    ƒcfg_{{ $cf.Identifier }} = gotest.DefaultFixtureConfig()
+{{- if $cf.HasConfig }}
+                    gotest.OverlayFixtureConfig(&ƒcfg_{{ $cf.Identifier }}, ƒ_{{ $cf.Identifier }}.FixtureConfig())
+{{- end }}
+                    var ƒerr error
+                    ƒattempts := 1 + ƒcfg_{{ $cf.Identifier }}.Retries
+                    for ƒi := range ƒattempts {
+                        ctx := ƒctx
+                        if ƒcfg_{{ $cf.Identifier }}.Timeout > 0 {
+                            var cancel context.CancelFunc
+                            ctx, cancel = context.WithTimeout(ƒctx, ƒcfg_{{ $cf.Identifier }}.Timeout)
+                            defer cancel()
+                        }
+                        ƒerr = ƒ_{{ $cf.Identifier }}.BeforeAll(ctx)
+                        if ƒerr == nil {
+                            break
+                        }
+                        if ƒctx.Err() != nil {
+                            break
+                        }
+                        if ƒi < ƒattempts-1 {
+                            fmt.Fprintf(os.Stderr, "{{ $cf.Identifier }}.BeforeAll attempt %d/%d failed: %v\n", ƒi+1, ƒattempts, ƒerr)
+                            if ƒcfg_{{ $cf.Identifier }}.RetryDelay > 0 {
+                                time.Sleep(ƒcfg_{{ $cf.Identifier }}.RetryDelay)
+                            }
+                        }
+                    }
+                    if ƒerr != nil {
+                        fmt.Fprintf(os.Stderr, "FAIL: {{ $cf.Identifier }}.BeforeAll failed after %d attempt(s): %v\n", ƒattempts, ƒerr)
+                        ƒcfails[{{ $j }}] = true
+                        ƒcancel()
+                        return
+                    }
+                    ƒok_{{ $cf.Identifier }} = true
+                }()
+{{ end }}
+                ƒcwg.Wait()
+                for _, ƒf := range ƒcfails {
+                    if ƒf { ƒtfails[{{ $i }}] = true; break }
+                }
+            }
+{{ end }}
+        }()
+{{ end }}
+        ƒswg.Wait()
+        for _, ƒf := range ƒtfails {
+            if ƒf { return 2 }
+        }
+    }
+
+    {
+        var ƒmaxTreePath time.Duration
+        var ƒmaxSuiteSetup time.Duration
+{{ range $f := .RootFixtures }}
+        {
+{{- if $f.ChildFixtures }}
+            var ƒmaxChild time.Duration
+{{ range $cf := $f.ChildFixtures }}
+            if ƒcfg_{{ $cf.Identifier }}.Timeout > ƒmaxChild { ƒmaxChild = ƒcfg_{{ $cf.Identifier }}.Timeout }
+{{ end }}
+            ƒtreePath := ƒcfg_{{ $f.Identifier }}.Timeout + ƒmaxChild
+{{- else }}
+            ƒtreePath := ƒcfg_{{ $f.Identifier }}.Timeout
+{{- end }}
+            if ƒtreePath > ƒmaxTreePath { ƒmaxTreePath = ƒtreePath }
+        }
+{{ range $ts := $f.ChildSuites }}
+        {
+            ƒscfg := gotest.DefaultSuiteConfig()
+{{- if $ts.HasConfig }}
+            gotest.OverlaySuiteConfig(&ƒscfg, (&{{ $ts.Identifier }}{ {{ $ts.FixtureFieldName }}: ƒ_{{ $f.Identifier }} }).SuiteConfig())
+{{- end }}
+            if ƒscfg.SetupTimeout > ƒmaxSuiteSetup { ƒmaxSuiteSetup = ƒscfg.SetupTimeout }
+        }
+{{ end }}
+{{ range $cf := $f.ChildFixtures }}
+{{ range $ts := $cf.ChildSuites }}
+        {
+            ƒscfg := gotest.DefaultSuiteConfig()
+{{- if $ts.HasConfig }}
+            gotest.OverlaySuiteConfig(&ƒscfg, (&{{ $ts.Identifier }}{ {{ $ts.FixtureFieldName }}: ƒ_{{ $cf.Identifier }} }).SuiteConfig())
+{{- end }}
+            if ƒscfg.SetupTimeout > ƒmaxSuiteSetup { ƒmaxSuiteSetup = ƒscfg.SetupTimeout }
+        }
+{{ end }}
+{{ end }}
+{{ end }}
+        if ƒbudgetFile := os.Getenv("GOTEST_TEARDOWN_BUDGET_FILE"); ƒbudgetFile != "" {
+            os.WriteFile(ƒbudgetFile, []byte((ƒmaxTreePath + ƒmaxSuiteSetup + 30*time.Second).String()), 0644)
+        }
+    }
 
     ƒcode = m.Run()
     return

--- a/internal/gotestgen/static/sharedfixture.go.tpl
+++ b/internal/gotestgen/static/sharedfixture.go.tpl
@@ -102,6 +102,16 @@ func main() {
 	}
 {{- end }}
 {{ end }}
+	{
+		var ƒmaxTimeout time.Duration
+{{ range $f := .Fixtures }}
+		if ƒcfg_{{ $f.VarName }}.Timeout > ƒmaxTimeout {
+			ƒmaxTimeout = ƒcfg_{{ $f.VarName }}.Timeout
+		}
+{{ end }}
+		ƒbudgetBytes, _ := json.Marshal((ƒmaxTimeout + 30*time.Second).String())
+		state["_teardownBudget"] = ƒbudgetBytes
+	}
 	json.NewEncoder(os.Stdout).Encode(state)
 
 	sig := make(chan os.Signal, 1)

--- a/internal/gotestgen/testdata_e2e/fixture_lifecycle/ƒƒ_psuite_test.go.golden
+++ b/internal/gotestgen/testdata_e2e/fixture_lifecycle/ƒƒ_psuite_test.go.golden
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/mvrahden/go-test/pkg/gotest"
 	"os"
+	"sync"
 	"testing"
 	"time"
 )
@@ -29,49 +30,117 @@ func TestMain(m *testing.M) { os.Exit(ƒƒ_GOTEST_main(m)) }
 
 func ƒƒ_GOTEST_main(m *testing.M) (ƒcode int) {
 
-	{
+	var ƒcfg_AppFixture gotest.FixtureConfig
+	var ƒok_AppFixture bool
 
-		ƒ_AppFixture = &AppFixture{}
-		ƒcfg := gotest.DefaultFixtureConfig()
-		gotest.OverlayFixtureConfig(&ƒcfg, ƒ_AppFixture.FixtureConfig())
-		var ƒerr error
-		ƒattempts := 1 + ƒcfg.Retries
-		for ƒi := range ƒattempts {
-			ctx := context.Background()
-			if ƒcfg.Timeout > 0 {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(ctx, ƒcfg.Timeout)
-				defer cancel()
-			}
-			ƒerr = ƒ_AppFixture.BeforeAll(ctx)
-			if ƒerr == nil {
-				break
-			}
-			if ƒi < ƒattempts-1 {
-				fmt.Fprintf(os.Stderr, "AppFixture.BeforeAll attempt %d/%d failed: %v\n", ƒi+1, ƒattempts, ƒerr)
-				if ƒcfg.RetryDelay > 0 {
-					time.Sleep(ƒcfg.RetryDelay)
+	defer func() {
+		var ƒtwg sync.WaitGroup
+		ƒtdfails := make([]bool, 1)
+
+		ƒtwg.Add(1)
+		go func() {
+			defer ƒtwg.Done()
+
+			if ƒok_AppFixture {
+				ctx := context.Background()
+				if ƒcfg_AppFixture.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_AppFixture.Timeout)
+					defer cancel()
 				}
-			}
-		}
-		if ƒerr != nil {
-			fmt.Fprintf(os.Stderr, "FAIL: AppFixture.BeforeAll failed after %d attempt(s): %v\n", ƒattempts, ƒerr)
-			return 2
-		}
-		defer func() {
-			ctx := context.Background()
-			if ƒcfg.Timeout > 0 {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(ctx, ƒcfg.Timeout)
-				defer cancel()
-			}
-			if err := ƒ_AppFixture.AfterAll(ctx); err != nil {
-				fmt.Fprintf(os.Stderr, "AppFixture.AfterAll failed: %v\n", err)
-				if ƒcode == 0 {
-					ƒcode = 1
+				if err := ƒ_AppFixture.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "AppFixture.AfterAll failed: %v\n", err)
+					ƒtdfails[0] = true
 				}
 			}
 		}()
+
+		ƒtwg.Wait()
+		for _, ƒf := range ƒtdfails {
+			if ƒf && ƒcode == 0 {
+				ƒcode = 1
+				break
+			}
+		}
+	}()
+
+	ƒctx, ƒcancel := context.WithCancel(context.Background())
+	defer ƒcancel()
+
+	{
+		var ƒswg sync.WaitGroup
+		ƒtfails := make([]bool, 1)
+
+		ƒswg.Add(1)
+		go func() {
+			defer ƒswg.Done()
+
+			ƒ_AppFixture = &AppFixture{}
+			ƒcfg_AppFixture = gotest.DefaultFixtureConfig()
+			gotest.OverlayFixtureConfig(&ƒcfg_AppFixture, ƒ_AppFixture.FixtureConfig())
+			var ƒerr error
+			ƒattempts := 1 + ƒcfg_AppFixture.Retries
+			for ƒi := range ƒattempts {
+				ctx := ƒctx
+				if ƒcfg_AppFixture.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ƒctx, ƒcfg_AppFixture.Timeout)
+					defer cancel()
+				}
+				ƒerr = ƒ_AppFixture.BeforeAll(ctx)
+				if ƒerr == nil {
+					break
+				}
+				if ƒctx.Err() != nil {
+					break
+				}
+				if ƒi < ƒattempts-1 {
+					fmt.Fprintf(os.Stderr, "AppFixture.BeforeAll attempt %d/%d failed: %v\n", ƒi+1, ƒattempts, ƒerr)
+					if ƒcfg_AppFixture.RetryDelay > 0 {
+						time.Sleep(ƒcfg_AppFixture.RetryDelay)
+					}
+				}
+			}
+			if ƒerr != nil {
+				fmt.Fprintf(os.Stderr, "FAIL: AppFixture.BeforeAll failed after %d attempt(s): %v\n", ƒattempts, ƒerr)
+				ƒtfails[0] = true
+				ƒcancel()
+				return
+			}
+			ƒok_AppFixture = true
+
+		}()
+
+		ƒswg.Wait()
+		for _, ƒf := range ƒtfails {
+			if ƒf {
+				return 2
+			}
+		}
+	}
+
+	{
+		var ƒmaxTreePath time.Duration
+		var ƒmaxSuiteSetup time.Duration
+
+		{
+			ƒtreePath := ƒcfg_AppFixture.Timeout
+			if ƒtreePath > ƒmaxTreePath {
+				ƒmaxTreePath = ƒtreePath
+			}
+		}
+
+		{
+			ƒscfg := gotest.DefaultSuiteConfig()
+			gotest.OverlaySuiteConfig(&ƒscfg, (&AppTestSuite{App: ƒ_AppFixture}).SuiteConfig())
+			if ƒscfg.SetupTimeout > ƒmaxSuiteSetup {
+				ƒmaxSuiteSetup = ƒscfg.SetupTimeout
+			}
+		}
+
+		if ƒbudgetFile := os.Getenv("GOTEST_TEARDOWN_BUDGET_FILE"); ƒbudgetFile != "" {
+			os.WriteFile(ƒbudgetFile, []byte((ƒmaxTreePath + ƒmaxSuiteSetup + 30*time.Second).String()), 0644)
+		}
 	}
 
 	ƒcode = m.Run()

--- a/internal/gotestrunner/compile.go
+++ b/internal/gotestrunner/compile.go
@@ -41,7 +41,11 @@ func CompilePackages(ctx context.Context, packages []string, overlayFlag string,
 		wg.Add(1)
 		go func(idx int, pkgPath string) {
 			defer wg.Done()
-			sem <- struct{}{}
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
 			defer func() { <-sem }()
 
 			binaryName := sanitizePkgName(pkgPath) + ".test"
@@ -54,6 +58,7 @@ func CompilePackages(ctx context.Context, packages []string, overlayFlag string,
 			cmd := exec.CommandContext(ctx, "go", args...)
 			cmd.Stderr = os.Stderr
 			SetProcessGroup(cmd)
+			cmd.WaitDelay = BuildShutdownDelay
 
 			if err := cmd.Run(); err != nil {
 				results[idx] = result{err: fmt.Errorf("compile %s: %w", pkgPath, err)}
@@ -98,7 +103,11 @@ func CompilePackagesStream(ctx context.Context, packages []string, overlayFlag s
 			wg.Add(1)
 			go func(pkgPath string) {
 				defer wg.Done()
-				sem <- struct{}{}
+				select {
+				case sem <- struct{}{}:
+				case <-ctx.Done():
+					return
+				}
 				defer func() { <-sem }()
 
 				binaryName := sanitizePkgName(pkgPath) + ".test"
@@ -111,6 +120,7 @@ func CompilePackagesStream(ctx context.Context, packages []string, overlayFlag s
 				cmd := exec.CommandContext(ctx, "go", args...)
 				cmd.Stderr = os.Stderr
 				SetProcessGroup(cmd)
+				cmd.WaitDelay = BuildShutdownDelay
 
 				if err := cmd.Run(); err != nil {
 					fmt.Fprintf(os.Stderr, "compile %s: %s\n", pkgPath, err)

--- a/internal/gotestrunner/compile.go
+++ b/internal/gotestrunner/compile.go
@@ -53,6 +53,7 @@ func CompilePackages(ctx context.Context, packages []string, overlayFlag string,
 
 			cmd := exec.CommandContext(ctx, "go", args...)
 			cmd.Stderr = os.Stderr
+			SetProcessGroup(cmd)
 
 			if err := cmd.Run(); err != nil {
 				results[idx] = result{err: fmt.Errorf("compile %s: %w", pkgPath, err)}
@@ -109,6 +110,7 @@ func CompilePackagesStream(ctx context.Context, packages []string, overlayFlag s
 
 				cmd := exec.CommandContext(ctx, "go", args...)
 				cmd.Stderr = os.Stderr
+				SetProcessGroup(cmd)
 
 				if err := cmd.Run(); err != nil {
 					fmt.Fprintf(os.Stderr, "compile %s: %s\n", pkgPath, err)

--- a/internal/gotestrunner/json.go
+++ b/internal/gotestrunner/json.go
@@ -16,6 +16,7 @@ func StdlibRunTestsJSON(ctx context.Context, args []string, extraEnv ...map[stri
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = os.Stderr
+	SetProcessGroup(cmd)
 
 	if len(extraEnv) > 0 && len(extraEnv[0]) > 0 {
 		cmd.Env = os.Environ()

--- a/internal/gotestrunner/process.go
+++ b/internal/gotestrunner/process.go
@@ -1,0 +1,25 @@
+package gotestrunner
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// GracefulShutdownDelay is the time a child process has to exit after
+// receiving SIGTERM before it is forcibly killed.
+const GracefulShutdownDelay = 3 * time.Second
+
+// SetProcessGroup configures cmd to run in its own process group and
+// to receive SIGTERM (then SIGKILL after GracefulShutdownDelay) when
+// its associated context is cancelled.
+func SetProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	}
+	cmd.WaitDelay = GracefulShutdownDelay
+}

--- a/internal/gotestrunner/process.go
+++ b/internal/gotestrunner/process.go
@@ -6,9 +6,17 @@ import (
 	"time"
 )
 
-// GracefulShutdownDelay is the time a child process has to exit after
-// receiving SIGTERM before it is forcibly killed.
-const GracefulShutdownDelay = 3 * time.Second
+const (
+	// GracefulShutdownDelay is the time a test process has to exit after
+	// receiving SIGTERM before it is forcibly killed. Must cover the
+	// longest fixture teardown (FixtureConfig.Timeout up to 5 min for
+	// container fixtures, SuiteConfig.SetupTimeout up to 5 min for AfterAll).
+	GracefulShutdownDelay = 5*time.Minute + 30*time.Second
+
+	// BuildShutdownDelay is the WaitDelay for build/compile commands that
+	// have no teardown work.
+	BuildShutdownDelay = 10 * time.Second
+)
 
 // SetProcessGroup configures cmd to run in its own process group and
 // to receive SIGTERM (then SIGKILL after GracefulShutdownDelay) when

--- a/internal/gotestrunner/process_test.go
+++ b/internal/gotestrunner/process_test.go
@@ -1,0 +1,228 @@
+package gotestrunner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestSetProcessGroup(t *testing.T) {
+	cmd := exec.Command("echo")
+	SetProcessGroup(cmd)
+
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+		t.Fatal("expected Setpgid to be true")
+	}
+	if cmd.Cancel == nil {
+		t.Fatal("expected Cancel to be set")
+	}
+	if cmd.WaitDelay != GracefulShutdownDelay {
+		t.Errorf("WaitDelay = %v, want %v", cmd.WaitDelay, GracefulShutdownDelay)
+	}
+}
+
+func TestSetProcessGroup_KillsProcessTree(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Spawn a shell that starts a background child, then waits.
+	// The shell and its child form a process tree we need to kill.
+	cmd := exec.CommandContext(ctx, "sh", "-c", `
+		sleep 300 &
+		CHILD=$!
+		echo "child=$CHILD"
+		sleep 300
+	`)
+	SetProcessGroup(cmd)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the child PID from stdout.
+	buf := make([]byte, 256)
+	n, err := stdout.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := strings.TrimSpace(string(buf[:n]))
+	if !strings.HasPrefix(line, "child=") {
+		t.Fatalf("unexpected output: %q", line)
+	}
+	childPID, err := strconv.Atoi(strings.TrimPrefix(line, "child="))
+	if err != nil {
+		t.Fatalf("parse child PID: %v", err)
+	}
+
+	// Cancel the context — SetProcessGroup's Cancel sends SIGTERM to the group.
+	cancel()
+
+	// Wait for the command to finish (killed by context cancellation).
+	cmd.Wait()
+
+	// Give the OS a moment to reap.
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify the grandchild (sleep 300) is also dead.
+	proc, err := os.FindProcess(childPID)
+	if err != nil {
+		return // can't find it — already gone
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		t.Errorf("grandchild process %d is still alive after context cancellation", childPID)
+		// Clean up.
+		proc.Kill()
+	}
+}
+
+func TestBuildSuiteCmd_SetsProcessGroup(t *testing.T) {
+	ctx := context.Background()
+	env := []string{"PATH=/usr/bin"}
+
+	for _, test2json := range []bool{false, true} {
+		name := "plain"
+		if test2json {
+			name = "test2json"
+		}
+		t.Run(name, func(t *testing.T) {
+			target := SuiteTarget{
+				Package:    "example.com/pkg",
+				BinaryPath: "/tmp/pkg.test",
+				SuiteName:  "TestFoo",
+			}
+			cmd := buildSuiteCmd(ctx, target, env, test2json)
+
+			if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setpgid {
+				t.Fatal("expected Setpgid to be true")
+			}
+			if cmd.Cancel == nil {
+				t.Fatal("expected Cancel to be set")
+			}
+			if cmd.WaitDelay != GracefulShutdownDelay {
+				t.Errorf("WaitDelay = %v, want %v", cmd.WaitDelay, GracefulShutdownDelay)
+			}
+		})
+	}
+}
+
+func TestSetProcessGroup_Cancel_SendsSIGTERMToGroup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sleep", "300")
+	SetProcessGroup(cmd)
+
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := cmd.Process.Pid
+
+	// Verify the process is in its own group (PGID == PID).
+	pgid, err := syscall.Getpgid(pid)
+	if err != nil {
+		t.Fatalf("Getpgid: %v", err)
+	}
+	if pgid != pid {
+		t.Fatalf("expected PGID %d == PID %d", pgid, pid)
+	}
+
+	// Call Cancel directly and verify it sends SIGTERM to the group.
+	err = cmd.Cancel()
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("process did not exit after Cancel")
+		cmd.Process.Kill()
+	}
+
+	// Process should be gone.
+	err = syscall.Kill(pid, 0)
+	if err == nil {
+		t.Errorf("process %d still alive after Cancel", pid)
+	}
+}
+
+func TestSetProcessGroup_Cancel_NilProcess(t *testing.T) {
+	cmd := exec.Command("sleep", "300")
+	SetProcessGroup(cmd)
+
+	// Cancel before Start — Process is nil, should not panic.
+	err := cmd.Cancel()
+	if err != nil {
+		t.Errorf("Cancel with nil Process returned error: %v", err)
+	}
+}
+
+func TestSetProcessGroup_WaitDelay_ForceKills(t *testing.T) {
+	if os.Getenv("GOTEST_TRAP_SIGTERM") == "1" {
+		// Child: trap SIGTERM and ignore it, then sleep.
+		fmt.Println("ready")
+		// Block by reading stdin (never gets data).
+		buf := make([]byte, 1)
+		os.Stdin.Read(buf)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestSetProcessGroup_WaitDelay_ForceKills$")
+	cmd.Env = append(os.Environ(), "GOTEST_TRAP_SIGTERM=1")
+	SetProcessGroup(cmd)
+	// Override WaitDelay to a short value for the test.
+	cmd.WaitDelay = 500 * time.Millisecond
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the child to be ready.
+	buf := make([]byte, 64)
+	n, _ := stdout.Read(buf)
+	if !strings.Contains(string(buf[:n]), "ready") {
+		t.Fatalf("child not ready: %q", string(buf[:n]))
+	}
+
+	pid := cmd.Process.Pid
+	cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("process not killed after WaitDelay")
+		cmd.Process.Kill()
+	}
+
+	// Process should be dead.
+	time.Sleep(50 * time.Millisecond)
+	err = syscall.Kill(pid, 0)
+	if err == nil {
+		t.Errorf("process %d still alive after WaitDelay force-kill", pid)
+		syscall.Kill(-pid, syscall.SIGKILL)
+	}
+}

--- a/internal/gotestrunner/process_test.go
+++ b/internal/gotestrunner/process_test.go
@@ -1,4 +1,4 @@
-package gotestrunner
+package gotestrunner //nolint:stdlib-test
 
 import (
 	"context"

--- a/internal/gotestrunner/process_test.go
+++ b/internal/gotestrunner/process_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -109,8 +110,8 @@ func TestBuildSuiteCmd_SetsProcessGroup(t *testing.T) {
 			if cmd.Cancel == nil {
 				t.Fatal("expected Cancel to be set")
 			}
-			if cmd.WaitDelay != GracefulShutdownDelay {
-				t.Errorf("WaitDelay = %v, want %v", cmd.WaitDelay, GracefulShutdownDelay)
+			if cmd.WaitDelay != 0 {
+				t.Errorf("WaitDelay = %v, want 0 (manual kill timer)", cmd.WaitDelay)
 			}
 		})
 	}
@@ -169,6 +170,89 @@ func TestSetProcessGroup_Cancel_NilProcess(t *testing.T) {
 	if err != nil {
 		t.Errorf("Cancel with nil Process returned error: %v", err)
 	}
+}
+
+func TestReadTeardownBudget(t *testing.T) {
+	t.Run("empty path returns default", func(t *testing.T) {
+		got := readTeardownBudget("")
+		if got != GracefulShutdownDelay {
+			t.Errorf("got %v, want %v", got, GracefulShutdownDelay)
+		}
+	})
+
+	t.Run("missing file returns default", func(t *testing.T) {
+		got := readTeardownBudget("/nonexistent/budget")
+		if got != GracefulShutdownDelay {
+			t.Errorf("got %v, want %v", got, GracefulShutdownDelay)
+		}
+	})
+
+	t.Run("valid duration", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "budget")
+		os.WriteFile(f, []byte("2m30s\n"), 0644)
+		got := readTeardownBudget(f)
+		want := 2*time.Minute + 30*time.Second
+		if got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("invalid duration returns default", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "budget")
+		os.WriteFile(f, []byte("not-a-duration"), 0644)
+		got := readTeardownBudget(f)
+		if got != GracefulShutdownDelay {
+			t.Errorf("got %v, want %v", got, GracefulShutdownDelay)
+		}
+	})
+
+	t.Run("zero duration returns default", func(t *testing.T) {
+		f := filepath.Join(t.TempDir(), "budget")
+		os.WriteFile(f, []byte("0s"), 0644)
+		got := readTeardownBudget(f)
+		if got != GracefulShutdownDelay {
+			t.Errorf("got %v, want %v", got, GracefulShutdownDelay)
+		}
+	})
+}
+
+func TestBuildSuiteCmd_BudgetFileEnv(t *testing.T) {
+	ctx := context.Background()
+	env := []string{"PATH=/usr/bin"}
+
+	t.Run("sets GOTEST_TEARDOWN_BUDGET_FILE when BudgetFile is set", func(t *testing.T) {
+		target := SuiteTarget{
+			Package:    "example.com/pkg",
+			BinaryPath: "/tmp/pkg.test",
+			SuiteName:  "TestFoo",
+			BudgetFile: "/tmp/pkg.test.budget",
+		}
+		cmd := buildSuiteCmd(ctx, target, env, false)
+		found := false
+		for _, e := range cmd.Env {
+			if e == "GOTEST_TEARDOWN_BUDGET_FILE=/tmp/pkg.test.budget" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("GOTEST_TEARDOWN_BUDGET_FILE not found in cmd.Env")
+		}
+	})
+
+	t.Run("no GOTEST_TEARDOWN_BUDGET_FILE when BudgetFile is empty", func(t *testing.T) {
+		target := SuiteTarget{
+			Package:    "example.com/pkg",
+			BinaryPath: "/tmp/pkg.test",
+			SuiteName:  "TestFoo",
+		}
+		cmd := buildSuiteCmd(ctx, target, env, false)
+		for _, e := range cmd.Env {
+			if strings.HasPrefix(e, "GOTEST_TEARDOWN_BUDGET_FILE=") {
+				t.Errorf("unexpected GOTEST_TEARDOWN_BUDGET_FILE in env: %s", e)
+			}
+		}
+	})
 }
 
 func TestSetProcessGroup_WaitDelay_ForceKills(t *testing.T) {

--- a/internal/gotestrunner/stdlib.go
+++ b/internal/gotestrunner/stdlib.go
@@ -10,6 +10,7 @@ func StdlibRunTests(ctx context.Context, args []string, extraEnv ...map[string]s
 	cmd := exec.CommandContext(ctx, "go", append([]string{"test"}, args...)...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	SetProcessGroup(cmd)
 
 	if len(extraEnv) > 0 && len(extraEnv[0]) > 0 {
 		cmd.Env = os.Environ()

--- a/internal/gotestrunner/suiterun.go
+++ b/internal/gotestrunner/suiterun.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -23,6 +24,7 @@ type SuiteTarget struct {
 	RunFilter    string   // raw -test.run value (overrides SuiteName if set)
 	RunFlags     []string // test binary flags (with -test. prefix)
 	CoverProfile string   // per-suite cover profile path (empty if no -coverprofile)
+	BudgetFile   string   // sidecar path for teardown budget (empty = use default)
 }
 
 // SuiteResult holds the output from running a single suite subprocess.
@@ -147,7 +149,11 @@ func RunSuites(ctx context.Context, targets []SuiteTarget, extraEnv map[string]s
 		wg.Add(1)
 		go func(idx int, t SuiteTarget) {
 			defer wg.Done()
-			sem <- struct{}{}
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
 			defer func() { <-sem }()
 			r := RunSingleSuite(ctx, t, env, useTest2JSON)
 
@@ -208,20 +214,32 @@ func buildSuiteCmd(ctx context.Context, target SuiteTarget, env []string, test2j
 		args = append(args, testArgs...)
 		cmd := exec.CommandContext(ctx, "go", args...)
 		cmd.Env = env
+		if target.BudgetFile != "" {
+			cmd.Env = append(cmd.Env, "GOTEST_TEARDOWN_BUDGET_FILE="+target.BudgetFile)
+		}
 		cmd.Dir = target.Dir
 		SetProcessGroup(cmd)
+		cmd.WaitDelay = 0
 		return cmd
 	}
 
 	cmd := exec.CommandContext(ctx, target.BinaryPath, testArgs...)
 	cmd.Env = env
+	if target.BudgetFile != "" {
+		cmd.Env = append(cmd.Env, "GOTEST_TEARDOWN_BUDGET_FILE="+target.BudgetFile)
+	}
 	cmd.Dir = target.Dir
 	SetProcessGroup(cmd)
+	cmd.WaitDelay = 0
 	return cmd
 }
 
 // RunSingleSuite executes a single suite subprocess.
 // When test2json is true, the binary is wrapped with `go tool test2json`.
+//
+// On context cancellation, cmd.Cancel sends SIGTERM to the process group.
+// A per-process kill timer (from the teardown budget file) then governs
+// when SIGKILL is sent, rather than Go's built-in WaitDelay.
 func RunSingleSuite(ctx context.Context, target SuiteTarget, env []string, test2json bool) SuiteResult {
 	cmd := buildSuiteCmd(ctx, target, env, test2json)
 	var stdout, stderr bytes.Buffer
@@ -229,7 +247,27 @@ func RunSingleSuite(ctx context.Context, target SuiteTarget, env []string, test2
 	cmd.Stderr = &stderr
 
 	start := time.Now()
-	err := cmd.Run()
+
+	if err := cmd.Start(); err != nil {
+		return SuiteResult{Target: target, ExitCode: 2, Duration: time.Since(start)}
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	var err error
+	select {
+	case err = <-done:
+	case <-ctx.Done():
+		budget := readTeardownBudget(target.BudgetFile)
+		select {
+		case err = <-done:
+		case <-time.After(budget):
+			syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			err = <-done
+		}
+	}
+
 	duration := time.Since(start)
 
 	exitCode := 0
@@ -248,6 +286,21 @@ func RunSingleSuite(ctx context.Context, target SuiteTarget, env []string, test2
 		ExitCode: exitCode,
 		Duration: duration,
 	}
+}
+
+func readTeardownBudget(path string) time.Duration {
+	if path == "" {
+		return GracefulShutdownDelay
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return GracefulShutdownDelay
+	}
+	d, err := time.ParseDuration(strings.TrimSpace(string(data)))
+	if err != nil || d <= 0 {
+		return GracefulShutdownDelay
+	}
+	return d
 }
 
 func StripTrailingStatus(data []byte) []byte {

--- a/internal/gotestrunner/suiterun.go
+++ b/internal/gotestrunner/suiterun.go
@@ -209,12 +209,14 @@ func buildSuiteCmd(ctx context.Context, target SuiteTarget, env []string, test2j
 		cmd := exec.CommandContext(ctx, "go", args...)
 		cmd.Env = env
 		cmd.Dir = target.Dir
+		SetProcessGroup(cmd)
 		return cmd
 	}
 
 	cmd := exec.CommandContext(ctx, target.BinaryPath, testArgs...)
 	cmd.Env = env
 	cmd.Dir = target.Dir
+	SetProcessGroup(cmd)
 	return cmd
 }
 

--- a/tests/sharedfixture/sharedfixture_test.go
+++ b/tests/sharedfixture/sharedfixture_test.go
@@ -94,7 +94,7 @@ func TestSharedFixtureIntegration(t *testing.T) {
 		})
 
 		t.Run("StateContent", func(t *testing.T) {
-			gotest.Equal(t, 2, len(state), "expected entries for Alpha and Beta")
+			gotest.Equal(t, 3, len(state), "expected entries for Alpha, Beta, and _teardownBudget")
 
 			alphaKey := "github.com/mvrahden/go-test/tests/sharedfixture/fixtures.AlphaSharedFixture"
 			betaKey := "github.com/mvrahden/go-test/tests/sharedfixture/fixtures.BetaSharedFixture"
@@ -103,6 +103,8 @@ func TestSharedFixtureIntegration(t *testing.T) {
 			gotest.True(t, hasAlpha, "state should contain AlphaSharedFixture")
 			_, hasBeta := state[betaKey]
 			gotest.True(t, hasBeta, "state should contain BetaSharedFixture")
+			_, hasBudget := state["_teardownBudget"]
+			gotest.True(t, hasBudget, "state should contain _teardownBudget")
 
 			var alphaState struct{ DataPath string }
 			gotest.NoError(t, json.Unmarshal(state[alphaKey], &alphaState))

--- a/vscode-gotest/package.json
+++ b/vscode-gotest/package.json
@@ -212,6 +212,13 @@
           "default": "./...",
           "scope": "resource",
           "description": "Default package scope for watch mode"
+        },
+        "gotest.forceKillTimeout": {
+          "type": "number",
+          "default": 600,
+          "minimum": 10,
+          "scope": "resource",
+          "description": "Seconds to wait after SIGTERM before sending SIGKILL to a cancelled process"
         }
       }
     }

--- a/vscode-gotest/src/batchRunner.ts
+++ b/vscode-gotest/src/batchRunner.ts
@@ -169,8 +169,11 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
     }
 
     if (token.isCancellationRequested) {
-      for (const info of pkgInfos) {
-        if (streamedPkgs.has(info.importPath)) continue;
+      const skippedPkgs = pkgInfos.filter((i) => !streamedPkgs.has(i.importPath));
+      if (skippedPkgs.length > 0) {
+        outputChannel.info(`[${label}] cancelled, skipping ${skippedPkgs.length} remaining package(s)`);
+      }
+      for (const info of skippedPkgs) {
         for (const item of info.items) {
           run.skipped(item);
         }

--- a/vscode-gotest/src/batchRunner.ts
+++ b/vscode-gotest/src/batchRunner.ts
@@ -190,15 +190,6 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
 
       for (const info of pkgInfos) {
         if (streamedPkgs.has(info.importPath)) {
-          if (stderrTrimmed) {
-            for (const item of info.items) {
-              run.appendOutput(
-                stderrTrimmed.replace(/\n/g, "\r\n") + "\r\n",
-                undefined,
-                item,
-              );
-            }
-          }
           continue;
         }
 

--- a/vscode-gotest/src/batchRunner.ts
+++ b/vscode-gotest/src/batchRunner.ts
@@ -169,9 +169,13 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
     }
 
     if (token.isCancellationRequested) {
-      const skippedPkgs = pkgInfos.filter((i) => !streamedPkgs.has(i.importPath));
+      const skippedPkgs = pkgInfos.filter(
+        (i) => !streamedPkgs.has(i.importPath),
+      );
       if (skippedPkgs.length > 0) {
-        outputChannel.info(`[${label}] cancelled, skipping ${skippedPkgs.length} remaining package(s)`);
+        outputChannel.info(
+          `[${label}] cancelled, skipping ${skippedPkgs.length} remaining package(s)`,
+        );
       }
       for (const info of skippedPkgs) {
         for (const item of info.items) {

--- a/vscode-gotest/src/batchRunner.ts
+++ b/vscode-gotest/src/batchRunner.ts
@@ -60,10 +60,10 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
 
   const importPaths = pkgInfos.map((p) => p.importPath);
   const modulePath = await readModulePath(workspaceDir);
-  const wildcard = filter
+  const wildcards = filter
     ? undefined
     : computeWildcard(importPaths, modulePath);
-  const cliPkgArgs = wildcard ? [wildcard] : importPaths;
+  const cliPkgArgs = wildcards ?? importPaths;
   let coverFile: string | undefined;
 
   try {

--- a/vscode-gotest/src/coverOnSave.ts
+++ b/vscode-gotest/src/coverOnSave.ts
@@ -37,6 +37,7 @@ export class CoverOnSave implements vscode.Disposable {
 
   private async execute(importPath: string): Promise<void> {
     if (this.activeRun) {
+      this.outputChannel.info("[coverage:save] cancelling previous run");
       this.activeRun.cancel();
       if (this.activeRecordId) {
         this.registry.cancel(this.activeRecordId);

--- a/vscode-gotest/src/coverage.ts
+++ b/vscode-gotest/src/coverage.ts
@@ -268,9 +268,13 @@ export class CoverageRunner implements vscode.Disposable {
     }
     const cts = new vscode.CancellationTokenSource();
     this.activeRun = cts;
-    const cancelSub = token.onCancellationRequested(() => cts.cancel());
+    const cancelSub = token.onCancellationRequested(() => {
+      this.outputChannel.info("[coverage] stop requested");
+      cts.cancel();
+    });
     const effectiveToken = cts.token;
 
+    this.outputChannel.info("[coverage] run started");
     const run = this.controller.createTestRun(request, "Go Test Coverage");
 
     const items = collectItems(this.controller, request);
@@ -440,8 +444,13 @@ export class CoverageRunner implements vscode.Disposable {
         this.onJsonOutput(allJsonOutput);
       }
     } finally {
+      const wasCancelled = effectiveToken.isCancellationRequested;
       if (this.activeRecordId === recordId) {
-        this.registry.complete(recordId);
+        if (wasCancelled) {
+          this.registry.cancel(recordId);
+        } else {
+          this.registry.complete(recordId);
+        }
         this.activeRecordId = undefined;
       }
       resolveRun();
@@ -451,6 +460,7 @@ export class CoverageRunner implements vscode.Disposable {
       }
       cts.dispose();
       run.end();
+      this.outputChannel.info(`[coverage] run ${wasCancelled ? "cancelled" : "completed"}`);
     }
   }
 

--- a/vscode-gotest/src/coverage.ts
+++ b/vscode-gotest/src/coverage.ts
@@ -460,7 +460,9 @@ export class CoverageRunner implements vscode.Disposable {
       }
       cts.dispose();
       run.end();
-      this.outputChannel.info(`[coverage] run ${wasCancelled ? "cancelled" : "completed"}`);
+      this.outputChannel.info(
+        `[coverage] run ${wasCancelled ? "cancelled" : "completed"}`,
+      );
     }
   }
 

--- a/vscode-gotest/src/debug.ts
+++ b/vscode-gotest/src/debug.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { spawn, type ChildProcess } from "node:child_process";
 import type { PrepareOutput } from "./types.js";
 import { buildCliCommand, formatCliCommand, scopedConfig } from "./cli.js";
+import { killProcessTree } from "./runnerUtils.js";
 
 export class DebugLauncher implements vscode.Disposable {
   private readonly prepareProcesses = new Map<string, ChildProcess>();
@@ -130,7 +131,7 @@ export class DebugLauncher implements vscode.Disposable {
     token: vscode.CancellationToken,
   ): Promise<{ output: PrepareOutput; child: ChildProcess }> {
     return new Promise((resolve, reject) => {
-      const child = spawn(bin, args, { cwd });
+      const child = spawn(bin, args, { cwd, detached: true });
       let stdout = "";
       let settled = false;
       const settle = (fn: () => void) => {
@@ -144,14 +145,14 @@ export class DebugLauncher implements vscode.Disposable {
 
       const timer = setTimeout(() => {
         settle(() => {
-          child.kill("SIGTERM");
+          killProcessTree(child, "SIGTERM");
           reject(new Error(`timed out after ${timeoutSeconds}s`));
         });
       }, timeoutSeconds * 1000);
 
       const cancelListener = token.onCancellationRequested(() => {
         settle(() => {
-          child.kill("SIGTERM");
+          killProcessTree(child, "SIGTERM");
           reject(new Error("cancelled"));
         });
       });
@@ -164,7 +165,7 @@ export class DebugLauncher implements vscode.Disposable {
               const output = JSON.parse(stdout.split("\n")[0]) as PrepareOutput;
               resolve({ output, child });
             } catch {
-              child.kill("SIGTERM");
+              killProcessTree(child, "SIGTERM");
               reject(
                 new Error(`Failed to parse prepare output: ${stdout.trim()}`),
               );
@@ -195,7 +196,7 @@ export class DebugLauncher implements vscode.Disposable {
     const child = this.prepareProcesses.get(sessionName);
     if (child) {
       this.prepareProcesses.delete(sessionName);
-      child.kill("SIGTERM");
+      killProcessTree(child, "SIGTERM");
     }
   }
 }

--- a/vscode-gotest/src/runner.ts
+++ b/vscode-gotest/src/runner.ts
@@ -50,9 +50,13 @@ export class TestRunner {
     }
     const cts = new vscode.CancellationTokenSource();
     this.activeRun = cts;
-    const cancelSub = token.onCancellationRequested(() => cts.cancel());
+    const cancelSub = token.onCancellationRequested(() => {
+      this.outputChannel.info("[runner] stop requested");
+      cts.cancel();
+    });
     const effectiveToken = cts.token;
 
+    this.outputChannel.info("[runner] run started");
     const run = this.controller.createTestRun(request, "Go Test Run");
     this._lastJsonOutput = "";
     let anyCoverOnRun = false;
@@ -202,8 +206,13 @@ export class TestRunner {
       }
       this.controller.saveResults();
     } finally {
+      const wasCancelled = effectiveToken.isCancellationRequested;
       if (recordId !== undefined && this.activeRecordId === recordId) {
-        this.registry.complete(recordId);
+        if (wasCancelled) {
+          this.registry.cancel(recordId);
+        } else {
+          this.registry.complete(recordId);
+        }
         this.activeRecordId = undefined;
       }
       resolveRun();
@@ -216,6 +225,7 @@ export class TestRunner {
         this._onDidComplete.fire(this._lastJsonOutput);
       }
       run.end();
+      this.outputChannel.info(`[runner] run ${wasCancelled ? "cancelled" : "completed"}`);
     }
   }
 

--- a/vscode-gotest/src/runner.ts
+++ b/vscode-gotest/src/runner.ts
@@ -225,7 +225,9 @@ export class TestRunner {
         this._onDidComplete.fire(this._lastJsonOutput);
       }
       run.end();
-      this.outputChannel.info(`[runner] run ${wasCancelled ? "cancelled" : "completed"}`);
+      this.outputChannel.info(
+        `[runner] run ${wasCancelled ? "cancelled" : "completed"}`,
+      );
     }
   }
 

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -663,6 +663,24 @@ describe("computeWildcard", () => {
     ).toBeUndefined();
   });
 
+  it("includes module-root package alongside sub-directory wildcards", () => {
+    expect(
+      computeWildcard(
+        [
+          "example.com",
+          "example.com/pkg/a",
+          "example.com/pkg/b",
+          "example.com/internal/c",
+        ],
+        "example.com",
+      ),
+    ).toEqual([
+      "example.com",
+      "example.com/pkg/...",
+      "example.com/internal/c",
+    ]);
+  });
+
   it("allows wildcard deeper than module root", () => {
     expect(
       computeWildcard(

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -608,9 +608,9 @@ describe("computeWildcard", () => {
   });
 
   it("returns wildcard for two paths with common prefix", () => {
-    expect(computeWildcard(["example.com/pkg/a", "example.com/pkg/b"])).toBe(
-      "example.com/pkg/...",
-    );
+    expect(
+      computeWildcard(["example.com/pkg/a", "example.com/pkg/b"]),
+    ).toEqual(["example.com/pkg/..."]);
   });
 
   it("finds deep common prefix", () => {
@@ -620,19 +620,19 @@ describe("computeWildcard", () => {
         "example.com/pkg/platform/cluster",
         "example.com/pkg/platform/auth",
       ]),
-    ).toBe("example.com/pkg/platform/...");
+    ).toEqual(["example.com/pkg/platform/..."]);
   });
 
   it("stops at segment boundary", () => {
     expect(
       computeWildcard(["example.com/foo/bar", "example.com/foo/baz"]),
-    ).toBe("example.com/foo/...");
+    ).toEqual(["example.com/foo/..."]);
   });
 
   it("handles divergence at top level", () => {
     expect(
       computeWildcard(["example.com/pkg/a", "example.com/internal/b"]),
-    ).toBe("example.com/...");
+    ).toEqual(["example.com/..."]);
   });
 
   it("returns undefined when all paths are identical", () => {
@@ -641,7 +641,20 @@ describe("computeWildcard", () => {
     ).toBeUndefined();
   });
 
-  it("returns undefined when wildcard would equal modulePath/...", () => {
+  it("groups by sub-directory when prefix equals module root", () => {
+    expect(
+      computeWildcard(
+        [
+          "example.com/pkg/a",
+          "example.com/pkg/b",
+          "example.com/internal/c",
+        ],
+        "example.com",
+      ),
+    ).toEqual(["example.com/pkg/...", "example.com/internal/c"]);
+  });
+
+  it("returns undefined when sub-grouping does not reduce count", () => {
     expect(
       computeWildcard(
         ["example.com/pkg/a", "example.com/internal/b"],
@@ -656,7 +669,7 @@ describe("computeWildcard", () => {
         ["example.com/pkg/a", "example.com/pkg/b"],
         "example.com",
       ),
-    ).toBe("example.com/pkg/...");
+    ).toEqual(["example.com/pkg/..."]);
   });
 });
 

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -608,9 +608,9 @@ describe("computeWildcard", () => {
   });
 
   it("returns wildcard for two paths with common prefix", () => {
-    expect(
-      computeWildcard(["example.com/pkg/a", "example.com/pkg/b"]),
-    ).toEqual(["example.com/pkg/..."]);
+    expect(computeWildcard(["example.com/pkg/a", "example.com/pkg/b"])).toEqual(
+      ["example.com/pkg/..."],
+    );
   });
 
   it("finds deep common prefix", () => {
@@ -644,11 +644,7 @@ describe("computeWildcard", () => {
   it("groups by sub-directory when prefix equals module root", () => {
     expect(
       computeWildcard(
-        [
-          "example.com/pkg/a",
-          "example.com/pkg/b",
-          "example.com/internal/c",
-        ],
+        ["example.com/pkg/a", "example.com/pkg/b", "example.com/internal/c"],
         "example.com",
       ),
     ).toEqual(["example.com/pkg/...", "example.com/internal/c"]);
@@ -674,11 +670,7 @@ describe("computeWildcard", () => {
         ],
         "example.com",
       ),
-    ).toEqual([
-      "example.com",
-      "example.com/pkg/...",
-      "example.com/internal/c",
-    ]);
+    ).toEqual(["example.com", "example.com/pkg/...", "example.com/internal/c"]);
   });
 
   it("allows wildcard deeper than module root", () => {

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -442,7 +442,12 @@ export function computeWildcard(
   if (!modulePath || prefix !== modulePath) return [prefix + "/..."];
 
   const groups = new Map<string, string[]>();
+  const ungrouped: string[] = [];
   for (const p of importPaths) {
+    if (p === modulePath) {
+      ungrouped.push(p);
+      continue;
+    }
     const rest = p.slice(modulePath.length + 1);
     const seg = rest.split("/")[0];
     let group = groups.get(seg);
@@ -453,7 +458,7 @@ export function computeWildcard(
     group.push(p);
   }
 
-  const result: string[] = [];
+  const result: string[] = [...ungrouped];
   for (const [seg, paths] of groups) {
     if (paths.length === 1) {
       result.push(paths[0]);

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -273,6 +273,7 @@ export function spawnTestProcess(
     let stdout = "";
     let stderr = "";
     let lineBuffer = "";
+    let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
 
     child.stdout.on("data", (data: Buffer) => {
       const chunk = data.toString();
@@ -296,10 +297,16 @@ export function spawnTestProcess(
     });
 
     const cancelListener = token.onCancellationRequested(() => {
+      outputChannel.info(`[${label}] cancellation requested, sending SIGTERM (pid ${child.pid})`);
       child.kill("SIGTERM");
+      forceKillTimer = setTimeout(() => {
+        outputChannel.warn(`[${label}] process did not exit after SIGTERM, sending SIGKILL`);
+        child.kill("SIGKILL");
+      }, 5000);
     });
 
     child.on("close", (code) => {
+      if (forceKillTimer) clearTimeout(forceKillTimer);
       cancelListener.dispose();
       if (onStdoutLine) {
         const remaining = lineBuffer.trim();
@@ -318,6 +325,7 @@ export function spawnTestProcess(
     });
 
     child.on("error", (err: Error) => {
+      if (forceKillTimer) clearTimeout(forceKillTimer);
       cancelListener.dispose();
       outputChannel.error(`[${label}] ${err.message}`);
       reject(err);

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -422,7 +422,7 @@ export function buildRunFilter(items: vscode.TestItem[]): string | undefined {
 export function computeWildcard(
   importPaths: string[],
   modulePath?: string,
-): string | undefined {
+): string[] | undefined {
   if (importPaths.length <= 1) return undefined;
 
   const split = importPaths.map((p) => p.split("/"));
@@ -439,9 +439,30 @@ export function computeWildcard(
 
   const prefix = first.slice(0, prefixLen).join("/");
   if (importPaths.every((p) => p === prefix)) return undefined;
-  if (modulePath && prefix === modulePath) return undefined;
+  if (!modulePath || prefix !== modulePath) return [prefix + "/..."];
 
-  return prefix + "/...";
+  const groups = new Map<string, string[]>();
+  for (const p of importPaths) {
+    const rest = p.slice(modulePath.length + 1);
+    const seg = rest.split("/")[0];
+    let group = groups.get(seg);
+    if (!group) {
+      group = [];
+      groups.set(seg, group);
+    }
+    group.push(p);
+  }
+
+  const result: string[] = [];
+  for (const [seg, paths] of groups) {
+    if (paths.length === 1) {
+      result.push(paths[0]);
+    } else {
+      result.push(modulePath + "/" + seg + "/...");
+    }
+  }
+
+  return result.length < importPaths.length ? result : undefined;
 }
 
 export function getPackageDir(

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -313,11 +313,18 @@ export function spawnTestProcess(
     });
 
     const cancelListener = token.onCancellationRequested(() => {
-      outputChannel.info(`[${label}] cancellation requested, sending SIGTERM (pid ${child.pid})`);
+      outputChannel.info(
+        `[${label}] cancellation requested, sending SIGTERM (pid ${child.pid})`,
+      );
       killProcessTree(child, "SIGTERM");
-      const killTimeout = vscode.workspace.getConfiguration("gotest").get<number>("forceKillTimeout", 600) * 1000;
+      const killTimeout =
+        vscode.workspace
+          .getConfiguration("gotest")
+          .get<number>("forceKillTimeout", 600) * 1000;
       forceKillTimer = setTimeout(() => {
-        outputChannel.warn(`[${label}] process did not exit after SIGTERM, sending SIGKILL`);
+        outputChannel.warn(
+          `[${label}] process did not exit after SIGTERM, sending SIGKILL`,
+        );
         killProcessTree(child, "SIGKILL");
       }, killTimeout);
     });

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -1,8 +1,23 @@
 import * as vscode from "vscode";
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import type { GoTestController } from "./testController.js";
 import type { DiscoveryCache } from "./discovery.js";
 import { extractTestMessages, type TestEvent } from "./outputParser.js";
+
+export function killProcessTree(
+  child: ChildProcess,
+  signal: NodeJS.Signals = "SIGTERM",
+): void {
+  if (child.pid) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // process group already exited
+    }
+  }
+  child.kill(signal);
+}
 
 export function enqueueDescendants(
   run: vscode.TestRun,
@@ -269,6 +284,7 @@ export function spawnTestProcess(
     const child = spawn(bin, args, {
       cwd,
       env: env ? { ...process.env, ...env } : undefined,
+      detached: true,
     });
     let stdout = "";
     let stderr = "";
@@ -298,11 +314,12 @@ export function spawnTestProcess(
 
     const cancelListener = token.onCancellationRequested(() => {
       outputChannel.info(`[${label}] cancellation requested, sending SIGTERM (pid ${child.pid})`);
-      child.kill("SIGTERM");
+      killProcessTree(child, "SIGTERM");
+      const killTimeout = vscode.workspace.getConfiguration("gotest").get<number>("forceKillTimeout", 600) * 1000;
       forceKillTimer = setTimeout(() => {
         outputChannel.warn(`[${label}] process did not exit after SIGTERM, sending SIGKILL`);
-        child.kill("SIGKILL");
-      }, 5000);
+        killProcessTree(child, "SIGKILL");
+      }, killTimeout);
     });
 
     child.on("close", (code) => {

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -4,7 +4,7 @@ import type { GoTestController } from "./testController.js";
 import type { DiscoveryCache } from "./discovery.js";
 import { parseTestEvents, type TestEvent } from "./outputParser.js";
 import { buildCliCommand, formatCliCommand, type CliCommand } from "./cli.js";
-import { resolveTestItem, applyResults } from "./runnerUtils.js";
+import { resolveTestItem, applyResults, killProcessTree } from "./runnerUtils.js";
 import type { RunRegistry } from "./runRegistry.js";
 
 /**
@@ -41,7 +41,7 @@ class WatchProcess implements vscode.Disposable {
       `[watch] spawning: ${formatCliCommand(this.cmd)} (cwd: ${this.cwd})`,
     );
 
-    this.child = spawn(this.cmd.bin, this.cmd.args, { cwd: this.cwd });
+    this.child = spawn(this.cmd.bin, this.cmd.args, { cwd: this.cwd, detached: true });
     this.buffer = "";
     this.cycleBuffer = "";
 
@@ -165,13 +165,14 @@ class WatchProcess implements vscode.Disposable {
       this.child = undefined;
 
       this.outputChannel.info(`[watch] sending SIGTERM (pid ${child.pid})`);
-      child.kill("SIGTERM");
+      killProcessTree(child, "SIGTERM");
 
+      const killTimeout = vscode.workspace.getConfiguration("gotest").get<number>("forceKillTimeout", 600) * 1000;
       const forceKill = setTimeout(() => {
         if (!child.killed) {
-          child.kill("SIGKILL");
+          killProcessTree(child, "SIGKILL");
         }
-      }, 5000);
+      }, killTimeout);
 
       child.on("close", () => {
         clearTimeout(forceKill);

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -4,7 +4,11 @@ import type { GoTestController } from "./testController.js";
 import type { DiscoveryCache } from "./discovery.js";
 import { parseTestEvents, type TestEvent } from "./outputParser.js";
 import { buildCliCommand, formatCliCommand, type CliCommand } from "./cli.js";
-import { resolveTestItem, applyResults, killProcessTree } from "./runnerUtils.js";
+import {
+  resolveTestItem,
+  applyResults,
+  killProcessTree,
+} from "./runnerUtils.js";
 import type { RunRegistry } from "./runRegistry.js";
 
 /**
@@ -41,7 +45,10 @@ class WatchProcess implements vscode.Disposable {
       `[watch] spawning: ${formatCliCommand(this.cmd)} (cwd: ${this.cwd})`,
     );
 
-    this.child = spawn(this.cmd.bin, this.cmd.args, { cwd: this.cwd, detached: true });
+    this.child = spawn(this.cmd.bin, this.cmd.args, {
+      cwd: this.cwd,
+      detached: true,
+    });
     this.buffer = "";
     this.cycleBuffer = "";
 
@@ -167,7 +174,10 @@ class WatchProcess implements vscode.Disposable {
       this.outputChannel.info(`[watch] sending SIGTERM (pid ${child.pid})`);
       killProcessTree(child, "SIGTERM");
 
-      const killTimeout = vscode.workspace.getConfiguration("gotest").get<number>("forceKillTimeout", 600) * 1000;
+      const killTimeout =
+        vscode.workspace
+          .getConfiguration("gotest")
+          .get<number>("forceKillTimeout", 600) * 1000;
       const forceKill = setTimeout(() => {
         if (!child.killed) {
           killProcessTree(child, "SIGKILL");
@@ -324,7 +334,9 @@ export class WatchManager implements vscode.Disposable {
   }
 
   stopAll(): void {
-    this.outputChannel.info(`[watch] stopping all (${this.watchers.size} active)`);
+    this.outputChannel.info(
+      `[watch] stopping all (${this.watchers.size} active)`,
+    );
     for (const [scope, watcher] of this.watchers) {
       const recordId = this.watchRecordIds.get(scope);
       if (recordId) {

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -164,14 +164,14 @@ class WatchProcess implements vscode.Disposable {
       const child = this.child;
       this.child = undefined;
 
+      this.outputChannel.info(`[watch] sending SIGTERM (pid ${child.pid})`);
       child.kill("SIGTERM");
 
-      // Force kill after 2s if still alive
       const forceKill = setTimeout(() => {
         if (!child.killed) {
           child.kill("SIGKILL");
         }
-      }, 2000);
+      }, 5000);
 
       child.on("close", () => {
         clearTimeout(forceKill);
@@ -300,6 +300,7 @@ export class WatchManager implements vscode.Disposable {
   }
 
   stop(pkgScope: string): void {
+    this.outputChannel.info(`[watch] stop requested for ${pkgScope}`);
     const recordId = this.watchRecordIds.get(pkgScope);
     if (recordId) {
       this.registry.cancel(recordId);
@@ -322,6 +323,7 @@ export class WatchManager implements vscode.Disposable {
   }
 
   stopAll(): void {
+    this.outputChannel.info(`[watch] stopping all (${this.watchers.size} active)`);
     for (const [scope, watcher] of this.watchers) {
       const recordId = this.watchRecordIds.get(scope);
       if (recordId) {


### PR DESCRIPTION
SIGTERM/SIGKILL propagation to child process groups, context-aware semaphores, wildcard sub-grouping for top-level runs, and lifecycle logging.