### PR TITLE
fix: Windows build support and cross-platform CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+      - run: go build ./...
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/cmd/gotest/sharedfixture.go
+++ b/cmd/gotest/sharedfixture.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/mvrahden/go-test/internal/gotestgen"
@@ -39,11 +38,11 @@ func (p *SharedFixtureProcess) Teardown() error {
 	if timeout <= 0 {
 		timeout = 30 * time.Second
 	}
-	syscall.Kill(-p.cmd.Process.Pid, syscall.SIGTERM)
+	gotestrunner.TerminateProcessGroup(p.cmd.Process.Pid)
 	select {
 	case <-p.done:
 	case <-time.After(timeout):
-		syscall.Kill(-p.cmd.Process.Pid, syscall.SIGKILL)
+		gotestrunner.ForceKillProcessGroup(p.cmd.Process.Pid)
 	}
 	return nil
 }

--- a/internal/gotestrunner/overlay_cleanup.go
+++ b/internal/gotestrunner/overlay_cleanup.go
@@ -1,12 +1,10 @@
 package gotestrunner
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 func CleanStaleOverlays() {
@@ -37,13 +35,4 @@ func isOverlayAlive(dir string) bool {
 		return false
 	}
 	return processAlive(pid)
-}
-
-func processAlive(pid int) bool {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	err = proc.Signal(syscall.Signal(0))
-	return err == nil || errors.Is(err, syscall.EPERM)
 }

--- a/internal/gotestrunner/overlay_cleanup_unix.go
+++ b/internal/gotestrunner/overlay_cleanup_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package gotestrunner
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func processAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/internal/gotestrunner/overlay_cleanup_windows.go
+++ b/internal/gotestrunner/overlay_cleanup_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package gotestrunner
+
+func processAlive(_ int) bool {
+	// On Windows, there is no reliable equivalent to Unix signal-zero probing
+	// without pulling in additional dependencies. Conservatively assume alive;
+	// stale overlays get overwritten on the next run that owns the directory.
+	return true
+}

--- a/internal/gotestrunner/process.go
+++ b/internal/gotestrunner/process.go
@@ -2,7 +2,6 @@ package gotestrunner
 
 import (
 	"os/exec"
-	"syscall"
 	"time"
 )
 
@@ -22,12 +21,12 @@ const (
 // to receive SIGTERM (then SIGKILL after GracefulShutdownDelay) when
 // its associated context is cancelled.
 func SetProcessGroup(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setProcessGroupAttr(cmd)
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return nil
 		}
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+		return TerminateProcessGroup(cmd.Process.Pid)
 	}
 	cmd.WaitDelay = GracefulShutdownDelay
 }

--- a/internal/gotestrunner/process_test.go
+++ b/internal/gotestrunner/process_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package gotestrunner //nolint:stdlib-test
 
 import (

--- a/internal/gotestrunner/process_unix.go
+++ b/internal/gotestrunner/process_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package gotestrunner
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func setProcessGroupAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// TerminateProcessGroup sends SIGTERM to the process group led by pid.
+func TerminateProcessGroup(pid int) error {
+	return syscall.Kill(-pid, syscall.SIGTERM)
+}
+
+// ForceKillProcessGroup sends SIGKILL to the process group led by pid.
+func ForceKillProcessGroup(pid int) error {
+	return syscall.Kill(-pid, syscall.SIGKILL)
+}

--- a/internal/gotestrunner/process_windows.go
+++ b/internal/gotestrunner/process_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package gotestrunner
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func setProcessGroupAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}
+
+// TerminateProcessGroup kills the process group led by pid.
+// On Windows there is no SIGTERM, so the process is killed directly.
+func TerminateProcessGroup(pid int) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return p.Kill()
+}
+
+// ForceKillProcessGroup forcibly kills the process group led by pid.
+func ForceKillProcessGroup(pid int) error {
+	return TerminateProcessGroup(pid)
+}

--- a/internal/gotestrunner/suiterun.go
+++ b/internal/gotestrunner/suiterun.go
@@ -10,7 +10,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -263,7 +262,7 @@ func RunSingleSuite(ctx context.Context, target SuiteTarget, env []string, test2
 		select {
 		case err = <-done:
 		case <-time.After(budget):
-			syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			ForceKillProcessGroup(cmd.Process.Pid)
 			err = <-done
 		}
 	}

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -244,20 +244,11 @@ func toPascalCase(s string) string {
 }
 
 func determinePkgDir(pkg *packages.Package) string {
-	// Use the directory from GoFiles if available
 	if len(pkg.GoFiles) > 0 {
-		// GoFiles contains absolute paths; extract directory from first file
-		lastSlash := strings.LastIndex(pkg.GoFiles[0], "/")
-		if lastSlash >= 0 {
-			return pkg.GoFiles[0][:lastSlash]
-		}
+		return filepath.Dir(pkg.GoFiles[0])
 	}
-	// Fallback: try CompiledGoFiles
 	if len(pkg.CompiledGoFiles) > 0 {
-		lastSlash := strings.LastIndex(pkg.CompiledGoFiles[0], "/")
-		if lastSlash >= 0 {
-			return pkg.CompiledGoFiles[0][:lastSlash]
-		}
+		return filepath.Dir(pkg.CompiledGoFiles[0])
 	}
 	return ""
 }

--- a/vscode-gotest/src/debug.ts
+++ b/vscode-gotest/src/debug.ts
@@ -162,7 +162,9 @@ export class DebugLauncher implements vscode.Disposable {
         if (!settled && stdout.includes("\n")) {
           settle(() => {
             try {
-              const output = JSON.parse(stdout.split("\n")[0]) as PrepareOutput;
+              const output = JSON.parse(
+                stdout.split("\n")[0].trim(),
+              ) as PrepareOutput;
               resolve({ output, child });
             } catch {
               killProcessTree(child, "SIGTERM");

--- a/vscode-gotest/src/goBinary.ts
+++ b/vscode-gotest/src/goBinary.ts
@@ -48,9 +48,9 @@ async function resolveProjectGoBinary(
 
   log?.debug(`[go] go.mod declares go ${goVersion}`);
 
-  // ~/sdk/go1.26.2/bin/go
-  const home = process.env.HOME ?? "";
-  const sdkBin = path.join(home, "sdk", `go${goVersion}`, "bin", "go");
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+  const goBin = process.platform === "win32" ? "go.exe" : "go";
+  const sdkBin = path.join(home, "sdk", `go${goVersion}`, "bin", goBin);
   if (await fileExists(sdkBin)) {
     log?.debug(`[go] resolved go ${goVersion} via SDK: ${sdkBin}`);
     return sdkBin;
@@ -81,7 +81,8 @@ async function resolveGenericGoBinary(
 ): Promise<string> {
   const goroot = process.env.GOROOT;
   if (goroot) {
-    const goBin = path.join(goroot, "bin", "go");
+    const goExe = process.platform === "win32" ? "go.exe" : "go";
+    const goBin = path.join(goroot, "bin", goExe);
     if (await fileExists(goBin)) {
       log?.debug(`[go] resolved via GOROOT: ${goBin}`);
       return goBin;
@@ -126,7 +127,10 @@ async function readGoVersionFromMod(
 
 export async function fileExists(p: string): Promise<boolean> {
   try {
-    await access(p, constants.X_OK);
+    await access(
+      p,
+      process.platform === "win32" ? constants.F_OK : constants.X_OK,
+    );
     return true;
   } catch {
     return false;
@@ -134,9 +138,10 @@ export async function fileExists(p: string): Promise<boolean> {
 }
 
 async function which(name: string): Promise<string | undefined> {
+  const cmd = process.platform === "win32" ? "where" : "which";
   try {
-    const { stdout } = await execFileAsync("which", [name], { timeout: 3_000 });
-    const resolved = stdout.trim();
+    const { stdout } = await execFileAsync(cmd, [name], { timeout: 3_000 });
+    const resolved = stdout.trim().split(/\r?\n/)[0];
     return resolved || undefined;
   } catch {
     return undefined;
@@ -144,6 +149,9 @@ async function which(name: string): Promise<string | undefined> {
 }
 
 async function whichFromShell(name: string): Promise<string | undefined> {
+  if (process.platform === "win32") {
+    return undefined;
+  }
   const shell = process.env.SHELL ?? "/bin/bash";
   try {
     const { stdout } = await execFileAsync(
@@ -159,13 +167,20 @@ async function whichFromShell(name: string): Promise<string | undefined> {
 }
 
 async function commonGoPaths(): Promise<string[]> {
-  const home = process.env.HOME ?? "";
-  const paths = [
-    "/usr/local/go/bin/go",
-    path.join(home, "go", "bin", "go"),
-    "/usr/bin/go",
-    "/snap/bin/go",
-  ];
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+  const goBin = process.platform === "win32" ? "go.exe" : "go";
+  const paths: string[] = [];
+
+  if (process.platform === "win32") {
+    paths.push(path.join("C:\\Program Files\\Go\\bin", goBin));
+    paths.push(path.join(home, "go", "bin", goBin));
+    paths.push(path.join(home, "scoop", "apps", "go", "current", "bin", goBin));
+  } else {
+    paths.push("/usr/local/go/bin/go");
+    paths.push(path.join(home, "go", "bin", "go"));
+    paths.push("/usr/bin/go");
+    paths.push("/snap/bin/go");
+  }
 
   const sdkDir = path.join(home, "sdk");
   try {
@@ -175,7 +190,7 @@ async function commonGoPaths(): Promise<string[]> {
       .sort()
       .reverse();
     for (const dir of goDirs) {
-      paths.push(path.join(sdkDir, dir, "bin", "go"));
+      paths.push(path.join(sdkDir, dir, "bin", goBin));
     }
   } catch {
     // ~/sdk doesn't exist

--- a/vscode-gotest/src/outputParser.ts
+++ b/vscode-gotest/src/outputParser.ts
@@ -1,3 +1,5 @@
+import * as path from "node:path";
+
 export interface TestEvent {
   Time: string;
   Action: "run" | "pass" | "fail" | "skip" | "output" | "pause" | "cont";
@@ -74,9 +76,8 @@ export function extractTestMessages(
       const lineNum = parseInt(match[2], 10);
       const message = match[3];
 
-      // Prepend pkgDir to relative file paths
-      if (!file.startsWith("/")) {
-        file = `${pkgDir}/${file}`;
+      if (!path.isAbsolute(file)) {
+        file = path.join(pkgDir, file);
       }
 
       messages.push({ file, line: lineNum, message });

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -8,7 +8,7 @@ export function killProcessTree(
   child: ChildProcess,
   signal: NodeJS.Signals = "SIGTERM",
 ): void {
-  if (child.pid) {
+  if (child.pid && process.platform !== "win32") {
     try {
       process.kill(-child.pid, signal);
       return;


### PR DESCRIPTION
Extract platform-specific process group handling into `_unix.go/_windows.go` files and add a cross-platform build matrix to CI.