### PR TITLE
feat(gen): capture fixture teardown coverage

### DIFF
--- a/cmd/gotest/exec.go
+++ b/cmd/gotest/exec.go
@@ -154,6 +154,7 @@ type parsedFlags struct {
 
 func parseExecFlags(goTestArgs []string) parsedFlags {
 	classified := gotestrunner.ClassifyGoTestArgs(goTestArgs)
+	classified.BuildFlags = gotestrunner.InjectChecklinkname(classified.BuildFlags)
 	userRunFilter := gotestrunner.ExtractRunFilter(classified.RunFlags)
 	runFlags := gotestrunner.StripRunFilter(classified.RunFlags)
 	userCoverProfile := gotestrunner.ExtractCoverProfile(runFlags)

--- a/internal/gotestgen/collector_test.go
+++ b/internal/gotestgen/collector_test.go
@@ -15,69 +15,90 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-var sharedMod struct {
-	once  sync.Once
-	goMod []byte
-	goSum []byte
-	err   error
+var sharedModRoot struct {
+	once sync.Once
+	dir  string
+	err  error
 }
 
-func initSharedMod() {
+func initSharedModRoot() {
 	modRoot, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {
-		sharedMod.err = err
+		sharedModRoot.err = err
 		return
 	}
 
-	dir, err := os.MkdirTemp("", "gotest-shared-mod-*")
+	// Bootstrap: run go mod tidy in a scratch dir to produce go.sum.
+	scratch, err := os.MkdirTemp("", "gotest-mod-init-*")
 	if err != nil {
-		sharedMod.err = err
+		sharedModRoot.err = err
 		return
 	}
-	defer os.RemoveAll(dir)
+	defer os.RemoveAll(scratch)
 
 	goMod := []byte("module testpkg\n\ngo 1.24\n\nrequire github.com/mvrahden/go-test v0.0.0\n\nreplace github.com/mvrahden/go-test => " + modRoot + "\n")
-	if err := os.WriteFile(filepath.Join(dir, "go.mod"), goMod, 0644); err != nil {
-		sharedMod.err = err
+	if err := os.WriteFile(filepath.Join(scratch, "go.mod"), goMod, 0644); err != nil {
+		sharedModRoot.err = err
 		return
 	}
-	if err := os.WriteFile(filepath.Join(dir, "stub.go"), []byte("package testpkg\n\nimport _ \"github.com/mvrahden/go-test/pkg/gotest\"\n"), 0644); err != nil {
-		sharedMod.err = err
+	if err := os.WriteFile(filepath.Join(scratch, "stub.go"), []byte("package testpkg\n\nimport _ \"github.com/mvrahden/go-test/pkg/gotest\"\n"), 0644); err != nil {
+		sharedModRoot.err = err
 		return
 	}
 
 	cmd := exec.Command("go", "mod", "tidy")
-	cmd.Dir = dir
+	cmd.Dir = scratch
 	cmd.Env = append(os.Environ(), "GOWORK=off")
 	if out, err := cmd.CombinedOutput(); err != nil {
-		sharedMod.err = fmt.Errorf("go mod tidy: %w\n%s", err, out)
+		sharedModRoot.err = fmt.Errorf("go mod tidy: %w\n%s", err, out)
 		return
 	}
 
-	sharedMod.goMod, _ = os.ReadFile(filepath.Join(dir, "go.mod"))
-	sharedMod.goSum, _ = os.ReadFile(filepath.Join(dir, "go.sum"))
+	// Persistent shared module root — all tests create sub-packages here.
+	dir, err := os.MkdirTemp("", "gotest-shared-root-*")
+	if err != nil {
+		sharedModRoot.err = err
+		return
+	}
+
+	tidiedMod, _ := os.ReadFile(filepath.Join(scratch, "go.mod"))
+	tidiedSum, _ := os.ReadFile(filepath.Join(scratch, "go.sum"))
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), tidiedMod, 0644); err != nil {
+		sharedModRoot.err = err
+		return
+	}
+	if len(tidiedSum) > 0 {
+		if err := os.WriteFile(filepath.Join(dir, "go.sum"), tidiedSum, 0644); err != nil {
+			sharedModRoot.err = err
+			return
+		}
+	}
+	sharedModRoot.dir = dir
 }
 
-// loadTestPkgWithGotest loads a package that imports gotest.T using the full
-// packages.Load machinery. Module resolution is cached across tests.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if sharedModRoot.dir != "" {
+		os.RemoveAll(sharedModRoot.dir)
+	}
+	os.Exit(code)
+}
+
 func loadTestPkgWithGotest(t *testing.T, src string) *packages.Package {
 	t.Helper()
 
-	sharedMod.once.Do(initSharedMod)
-	if sharedMod.err != nil {
-		t.Fatal(sharedMod.err)
+	sharedModRoot.once.Do(initSharedModRoot)
+	if sharedModRoot.err != nil {
+		t.Fatal(sharedModRoot.err)
 	}
 
-	dir := t.TempDir()
-	gotest.NoError(t, os.WriteFile(filepath.Join(dir, "test.go"), []byte(src), 0644))
-	gotest.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), sharedMod.goMod, 0644))
-	if len(sharedMod.goSum) > 0 {
-		gotest.NoError(t, os.WriteFile(filepath.Join(dir, "go.sum"), sharedMod.goSum, 0644))
-	}
+	subDir := filepath.Join(sharedModRoot.dir, t.Name())
+	gotest.NoError(t, os.MkdirAll(subDir, 0755))
+	gotest.NoError(t, os.WriteFile(filepath.Join(subDir, "test.go"), []byte(src), 0644))
 
 	pkgs, err := packages.Load(&packages.Config{
 		Mode: packageEvalMode,
-		Dir:  dir,
+		Dir:  subDir,
 		Env:  append(os.Environ(), "GOWORK=off"),
 	}, ".")
 	gotest.NoError(t, err)

--- a/internal/gotestgen/collector_test.go
+++ b/internal/gotestgen/collector_test.go
@@ -1,13 +1,15 @@
 package gotestgen //nolint:stdlib-test
 
 import (
+	"embed"
 	"fmt"
 	"go/token"
 	"go/types"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sync"
+	"strings"
 	"testing"
 
 	"github.com/mvrahden/go-test/internal/gotestast"
@@ -15,97 +17,119 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-var sharedModRoot struct {
-	once sync.Once
-	dir  string
-	err  error
+//go:embed testdata/sources
+var testSources embed.FS
+
+var (
+	testPkgIndex map[string]*packages.Package
+	testPkgDir   string
+	testPkgErr   error
+)
+
+func TestMain(m *testing.M) {
+	testPkgIndex, testPkgDir, testPkgErr = loadAllTestPkgs()
+	code := m.Run()
+	if testPkgDir != "" {
+		os.RemoveAll(testPkgDir)
+	}
+	os.Exit(code)
 }
 
-func initSharedModRoot() {
+func loadAllTestPkgs() (map[string]*packages.Package, string, error) {
 	modRoot, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {
-		sharedModRoot.err = err
-		return
+		return nil, "", err
 	}
 
-	// Bootstrap: run go mod tidy in a scratch dir to produce go.sum.
 	scratch, err := os.MkdirTemp("", "gotest-mod-init-*")
 	if err != nil {
-		sharedModRoot.err = err
-		return
+		return nil, "", err
 	}
 	defer os.RemoveAll(scratch)
 
 	goMod := []byte("module testpkg\n\ngo 1.24\n\nrequire github.com/mvrahden/go-test v0.0.0\n\nreplace github.com/mvrahden/go-test => " + modRoot + "\n")
 	if err := os.WriteFile(filepath.Join(scratch, "go.mod"), goMod, 0644); err != nil {
-		sharedModRoot.err = err
-		return
+		return nil, "", err
 	}
 	if err := os.WriteFile(filepath.Join(scratch, "stub.go"), []byte("package testpkg\n\nimport _ \"github.com/mvrahden/go-test/pkg/gotest\"\n"), 0644); err != nil {
-		sharedModRoot.err = err
-		return
+		return nil, "", err
 	}
 
 	cmd := exec.Command("go", "mod", "tidy")
 	cmd.Dir = scratch
 	cmd.Env = append(os.Environ(), "GOWORK=off")
 	if out, err := cmd.CombinedOutput(); err != nil {
-		sharedModRoot.err = fmt.Errorf("go mod tidy: %w\n%s", err, out)
-		return
+		return nil, "", fmt.Errorf("go mod tidy: %w\n%s", err, out)
 	}
 
-	// Persistent shared module root — all tests create sub-packages here.
-	dir, err := os.MkdirTemp("", "gotest-shared-root-*")
+	dir, err := os.MkdirTemp("", "gotest-batch-root-*")
 	if err != nil {
-		sharedModRoot.err = err
-		return
+		return nil, "", err
 	}
 
 	tidiedMod, _ := os.ReadFile(filepath.Join(scratch, "go.mod"))
 	tidiedSum, _ := os.ReadFile(filepath.Join(scratch, "go.sum"))
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), tidiedMod, 0644); err != nil {
-		sharedModRoot.err = err
-		return
+		return nil, dir, err
 	}
 	if len(tidiedSum) > 0 {
 		if err := os.WriteFile(filepath.Join(dir, "go.sum"), tidiedSum, 0644); err != nil {
-			sharedModRoot.err = err
-			return
+			return nil, dir, err
 		}
 	}
-	sharedModRoot.dir = dir
-}
 
-func TestMain(m *testing.M) {
-	code := m.Run()
-	if sharedModRoot.dir != "" {
-		os.RemoveAll(sharedModRoot.dir)
+	entries, err := fs.ReadDir(testSources, "testdata/sources")
+	if err != nil {
+		return nil, dir, err
 	}
-	os.Exit(code)
-}
-
-func loadTestPkgWithGotest(t *testing.T, src string) *packages.Package {
-	t.Helper()
-
-	sharedModRoot.once.Do(initSharedModRoot)
-	if sharedModRoot.err != nil {
-		t.Fatal(sharedModRoot.err)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		data, err := fs.ReadFile(testSources, "testdata/sources/"+name+"/test.go")
+		if err != nil {
+			return nil, dir, err
+		}
+		subDir := filepath.Join(dir, name)
+		if err := os.MkdirAll(subDir, 0755); err != nil {
+			return nil, dir, err
+		}
+		if err := os.WriteFile(filepath.Join(subDir, "test.go"), data, 0644); err != nil {
+			return nil, dir, err
+		}
 	}
-
-	subDir := filepath.Join(sharedModRoot.dir, t.Name())
-	gotest.NoError(t, os.MkdirAll(subDir, 0755))
-	gotest.NoError(t, os.WriteFile(filepath.Join(subDir, "test.go"), []byte(src), 0644))
 
 	pkgs, err := packages.Load(&packages.Config{
 		Mode: packageEvalMode,
-		Dir:  subDir,
+		Dir:  dir,
 		Env:  append(os.Environ(), "GOWORK=off"),
-	}, ".")
-	gotest.NoError(t, err)
-	gotest.True(t, len(pkgs) > 0, "expected at least one package loaded")
+	}, "./...")
+	if err != nil {
+		return nil, dir, err
+	}
 
-	pkg := pkgs[0]
-	gotest.True(t, len(pkg.Errors) == 0, "expected no package errors, got: %v", pkg.Errors)
+	index := make(map[string]*packages.Package, len(pkgs))
+	for _, pkg := range pkgs {
+		parts := strings.Split(pkg.PkgPath, "/")
+		key := parts[len(parts)-1]
+		index[key] = pkg
+	}
+	return index, dir, nil
+}
+
+func mustTestPkg(t *testing.T) *packages.Package {
+	t.Helper()
+	if testPkgErr != nil {
+		t.Fatal(testPkgErr)
+	}
+	pkg, ok := testPkgIndex[t.Name()]
+	if !ok {
+		t.Fatalf("no test package found for %s", t.Name())
+	}
+	if len(pkg.Errors) > 0 {
+		t.Fatalf("package errors: %v", pkg.Errors)
+	}
 	return pkg
 }
 
@@ -113,17 +137,7 @@ func loadTestPkgWithGotest(t *testing.T, src string) *packages.Package {
 
 func TestCollector_FixtureCollection_PackageFixture(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "context"
-
-type DBFixture struct {
-	Conn string
-}
-
-func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -136,20 +150,7 @@ func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
 
 func TestCollector_FixtureCollection_PackageFixtureAllMethods(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "context"
-
-type DBFixture struct {
-	Conn string
-}
-
-func (f *DBFixture) BeforeAll(ctx context.Context) error  { return nil }
-func (f *DBFixture) AfterAll(ctx context.Context) error   { return nil }
-func (f *DBFixture) BeforeEach(ctx context.Context) error { return nil }
-func (f *DBFixture) AfterEach(ctx context.Context) error  { return nil }
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -164,17 +165,7 @@ func (f *DBFixture) AfterEach(ctx context.Context) error  { return nil }
 
 func TestCollector_FixtureCollection_SharedFixture(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "context"
-
-type RedisSharedFixture struct {
-	Addr string
-}
-
-func (f *RedisSharedFixture) BeforeAll(ctx context.Context) error { return nil }
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -185,18 +176,7 @@ func (f *RedisSharedFixture) BeforeAll(ctx context.Context) error { return nil }
 
 func TestCollector_FixtureCollection_SharedFixtureWithAfterAll(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "context"
-
-type RedisSharedFixture struct {
-	Addr string
-}
-
-func (f *RedisSharedFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *RedisSharedFixture) AfterAll(ctx context.Context) error  { return nil }
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -211,27 +191,7 @@ func (f *RedisSharedFixture) AfterAll(ctx context.Context) error  { return nil }
 
 func TestCollector_FixtureEmbeddingInTestSuite(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type DBFixture struct {
-	Conn string
-}
-
-func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type MyTestSuite struct {
-	*DBFixture
-}
-
-func (s *MyTestSuite) TestSomething(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -242,15 +202,7 @@ func (s *MyTestSuite) TestSomething(t *gotest.T) {}
 
 func TestCollector_NoFixtureEmbedding(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) TestSomething(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -262,21 +214,7 @@ func (s *MyTestSuite) TestSomething(t *gotest.T) {}
 
 func TestCollector_FixtureToFixtureEmbedding(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "context"
-
-type BaseFixture struct{}
-
-func (f *BaseFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type DBFixture struct {
-	*BaseFixture
-}
-
-func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	// Note: this will error because there are 2 package fixtures
@@ -290,16 +228,7 @@ func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
 
 func TestCollector_SharedFixture_BeforeEachDisallowed(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "context"
-
-type RedisSharedFixture struct{}
-
-func (f *RedisSharedFixture) BeforeAll(ctx context.Context) error    { return nil }
-func (f *RedisSharedFixture) BeforeEach(ctx context.Context) error   { return nil }
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.True(t, len(result.Errs) > 0, "expected error for BeforeEach on shared fixture")
@@ -308,16 +237,7 @@ func (f *RedisSharedFixture) BeforeEach(ctx context.Context) error   { return ni
 
 func TestCollector_SharedFixture_AfterEachDisallowed(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "context"
-
-type RedisSharedFixture struct{}
-
-func (f *RedisSharedFixture) BeforeAll(ctx context.Context) error  { return nil }
-func (f *RedisSharedFixture) AfterEach(ctx context.Context) error  { return nil }
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.True(t, len(result.Errs) > 0, "expected error for AfterEach on shared fixture")
@@ -326,15 +246,7 @@ func (f *RedisSharedFixture) AfterEach(ctx context.Context) error  { return nil 
 
 func TestCollector_SharedFixture_WrongBeforeAllSignature(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type RedisSharedFixture struct{}
-
-func (f *RedisSharedFixture) BeforeAll(t *gotest.T) {} // wrong: should be (ctx context.Context) error
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.True(t, len(result.Errs) > 0, "expected error for wrong BeforeAll signature on shared fixture")
@@ -358,15 +270,7 @@ func TestApplyTestSuiteSpecs_OK(t *testing.T) {
 
 func TestCollector_PackageFixture_WrongBeforeAllSignature(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type DBFixture struct{}
-
-func (f *DBFixture) BeforeAll(t *gotest.T) {} // wrong: should be (ctx context.Context) error
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.True(t, len(result.Errs) > 0, "expected error for wrong BeforeAll signature on package fixture")
@@ -377,15 +281,7 @@ func (f *DBFixture) BeforeAll(t *gotest.T) {} // wrong: should be (ctx context.C
 
 func TestCollector_StdlibT_SuiteDetected(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "testing"
-
-type PlainTestSuite struct{}
-
-func (s *PlainTestSuite) TestFoo(t *testing.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -397,19 +293,7 @@ func (s *PlainTestSuite) TestFoo(t *testing.T) {}
 
 func TestCollector_StdlibT_LifecycleHooks(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "testing"
-
-type HookTestSuite struct{}
-
-func (s *HookTestSuite) BeforeAll(t *testing.T)  {}
-func (s *HookTestSuite) AfterAll(t *testing.T)   {}
-func (s *HookTestSuite) BeforeEach(t *testing.T) {}
-func (s *HookTestSuite) AfterEach(t *testing.T)  {}
-func (s *HookTestSuite) TestOne(t *testing.T)    {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -428,20 +312,7 @@ func (s *HookTestSuite) TestOne(t *testing.T)    {}
 
 func TestCollector_StdlibT_MixedMethodSignatures(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"testing"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type MixedTestSuite struct{}
-
-func (s *MixedTestSuite) TestStdlib(t *testing.T) {}
-func (s *MixedTestSuite) TestGotest(t *gotest.T)  {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -457,15 +328,7 @@ func (s *MixedTestSuite) TestGotest(t *gotest.T)  {}
 
 func TestCollector_StdlibT_WrongParamType(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "fmt"
-
-type BadTestSuite struct{}
-
-func (s *BadTestSuite) TestBad(f fmt.Stringer) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.True(t, len(result.Errs) > 0, "expected error for unsupported param type")
@@ -474,15 +337,7 @@ func (s *BadTestSuite) TestBad(f fmt.Stringer) {}
 
 func TestCollector_GotestT_NotUsesStdlibT(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type GotestTestSuite struct{}
-
-func (s *GotestTestSuite) TestFoo(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -504,25 +359,7 @@ func TestCollector_NilPackage(t *testing.T) {
 
 func TestCollector_SharedFixtureNotTreatedAsParent(t *testing.T) {
 	t.Parallel()
-	src := "package testpkg\n\n" +
-		"import (\n" +
-		"\t\"context\"\n\n" +
-		"\t\"github.com/mvrahden/go-test/pkg/gotest\"\n" +
-		")\n\n" +
-		"type PGSharedFixture struct {\n" +
-		"\tDSN string `gotest:\"env=PG_DSN\"`\n" +
-		"}\n\n" +
-		"func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }\n\n" +
-		"type E2EFixture struct {\n" +
-		"\t*PGSharedFixture\n" +
-		"}\n\n" +
-		"func (f *E2EFixture) BeforeAll(ctx context.Context) error { return nil }\n\n" +
-		"type QueryTestSuite struct {\n" +
-		"\t*E2EFixture\n" +
-		"}\n\n" +
-		"func (s *QueryTestSuite) TestInsert(t *gotest.T) {}\n"
-
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs), "expected no errors, got: %v", result.Errs)
@@ -542,22 +379,7 @@ func TestCollector_SharedFixtureNotTreatedAsParent(t *testing.T) {
 
 func TestCollector_FixtureConfig_Detected(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type DBFixture struct{}
-
-func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *DBFixture) FixtureConfig() gotest.FixtureConfig {
-	return gotest.DefaultFixtureConfig()
-}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -567,22 +389,7 @@ func (f *DBFixture) FixtureConfig() gotest.FixtureConfig {
 
 func TestCollector_SharedFixtureConfig_Detected(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type PGSharedFixture struct{}
-
-func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *PGSharedFixture) SharedFixtureConfig() gotest.FixtureConfig {
-	return gotest.ContainerFixtureConfig()
-}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs), "expected no errors, got: %v", result.Errs)
@@ -592,15 +399,7 @@ func (f *PGSharedFixture) SharedFixtureConfig() gotest.FixtureConfig {
 
 func TestCollector_FixtureConfig_AbsentIsNil(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "context"
-
-type PlainFixture struct{}
-
-func (f *PlainFixture) BeforeAll(ctx context.Context) error { return nil }
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -610,18 +409,7 @@ func (f *PlainFixture) BeforeAll(ctx context.Context) error { return nil }
 
 func TestCollector_SuiteConfig_Detected(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
-	return gotest.SuiteConfig{}
-}
-func (s *MyTestSuite) TestFoo(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -631,15 +419,7 @@ func (s *MyTestSuite) TestFoo(t *gotest.T) {}
 
 func TestCollector_SuiteConfig_AbsentIsFalse(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type PlainTestSuite struct{}
-
-func (s *PlainTestSuite) TestFoo(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -649,22 +429,7 @@ func (s *PlainTestSuite) TestFoo(t *gotest.T) {}
 
 func TestCollector_FixtureConfig_InvalidSignature_WithParams(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type BadFixture struct{}
-
-func (f *BadFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *BadFixture) FixtureConfig(x int) gotest.FixtureConfig {
-	return gotest.DefaultFixtureConfig()
-}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error for invalid FixtureConfig signature")
@@ -673,16 +438,7 @@ func (f *BadFixture) FixtureConfig(x int) gotest.FixtureConfig {
 
 func TestCollector_FixtureConfig_InvalidSignature_WrongReturnType(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "context"
-
-type BadFixture struct{}
-
-func (f *BadFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *BadFixture) FixtureConfig() string { return "" }
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error for wrong FixtureConfig return type")
@@ -691,18 +447,7 @@ func (f *BadFixture) FixtureConfig() string { return "" }
 
 func TestCollector_SuiteConfig_InvalidSignature_WithParams(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type BadTestSuite struct{}
-
-func (s *BadTestSuite) SuiteConfig(x int) gotest.SuiteConfig {
-	return gotest.DefaultSuiteConfig()
-}
-func (s *BadTestSuite) TestFoo(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error for invalid SuiteConfig signature")
@@ -711,16 +456,7 @@ func (s *BadTestSuite) TestFoo(t *gotest.T) {}
 
 func TestCollector_SuiteConfig_InvalidSignature_WrongReturnType(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type BadTestSuite struct{}
-
-func (s *BadTestSuite) SuiteConfig() int { return 0 }
-func (s *BadTestSuite) TestFoo(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error for wrong SuiteConfig return type")
@@ -729,16 +465,7 @@ func (s *BadTestSuite) TestFoo(t *gotest.T) {}
 
 func TestCollector_SuiteGuard_Detected(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) SuiteGuard() string { return "" }
-func (s *MyTestSuite) TestFoo(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -748,15 +475,7 @@ func (s *MyTestSuite) TestFoo(t *gotest.T) {}
 
 func TestCollector_SuiteGuard_AbsentIsFalse(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type PlainTestSuite struct{}
-
-func (s *PlainTestSuite) TestFoo(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -766,16 +485,7 @@ func (s *PlainTestSuite) TestFoo(t *gotest.T) {}
 
 func TestCollector_SuiteGuard_InvalidSignature_WithParams(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type BadTestSuite struct{}
-
-func (s *BadTestSuite) SuiteGuard(x int) string { return "" }
-func (s *BadTestSuite) TestFoo(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error for invalid SuiteGuard signature")
@@ -784,16 +494,7 @@ func (s *BadTestSuite) TestFoo(t *gotest.T) {}
 
 func TestCollector_SuiteGuard_InvalidSignature_WrongReturnType(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type BadTestSuite struct{}
-
-func (s *BadTestSuite) SuiteGuard() int { return 0 }
-func (s *BadTestSuite) TestFoo(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error for wrong SuiteGuard return type")
@@ -804,18 +505,7 @@ func (s *BadTestSuite) TestFoo(t *gotest.T) {}
 
 func TestCollector_BeforeEach_ReturningForm(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{ val string }
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
-func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs), "expected no errors, got: %v", result.Errs)
@@ -828,18 +518,7 @@ func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
 
 func TestCollector_BeforeEach_TooManyReturns(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{}
-
-type BadTestSuite struct{}
-
-func (s *BadTestSuite) BeforeEach(t *gotest.T) (*myCtx, error) { return nil, nil }
-func (s *BadTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error for 2 return values")
@@ -848,19 +527,7 @@ func (s *BadTestSuite) TestOne(t *gotest.T) {}
 
 func TestCollector_AfterEach_WithContextParam(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{ val string }
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
-func (s *MyTestSuite) AfterEach(t *gotest.T, ctx *myCtx) {}
-func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs), "expected no errors, got: %v", result.Errs)
@@ -872,18 +539,7 @@ func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
 
 func TestCollector_AfterEach_TooManyParams(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{}
-
-type BadTestSuite struct{}
-
-func (s *BadTestSuite) AfterEach(t *gotest.T, ctx *myCtx, extra int) {}
-func (s *BadTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error for 3 params")
@@ -891,19 +547,7 @@ func (s *BadTestSuite) TestOne(t *gotest.T) {}
 
 func TestCollector_TestMethod_WithContextParam(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{}
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
-func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
-func (s *MyTestSuite) TestTwo(t *gotest.T, _ *myCtx) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs), "expected no errors, got: %v", result.Errs)
@@ -914,18 +558,7 @@ func (s *MyTestSuite) TestTwo(t *gotest.T, _ *myCtx) {}
 
 func TestCollector_TestMethod_AsyncWithContext(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{}
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
-func (s *MyTestSuite) TestOneAsync(t *gotest.T, ctx *myCtx, done func()) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs), "expected no errors, got: %v", result.Errs)
@@ -935,21 +568,7 @@ func (s *MyTestSuite) TestOneAsync(t *gotest.T, ctx *myCtx, done func()) {}
 
 func TestCollector_SuiteConfig_ParallelParsed(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{}
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
-	return gotest.SuiteConfig{Parallel: true}
-}
-func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
-func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs), "expected no errors, got: %v", result.Errs)
@@ -958,20 +577,7 @@ func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
 
 func TestCollector_SuiteConfig_NonLiteralBody_Error(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type MyTestSuite struct{}
-
-var cfg = gotest.SuiteConfig{Parallel: true}
-
-func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
-	return cfg
-}
-func (s *MyTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error for non-literal SuiteConfig body")
@@ -979,19 +585,7 @@ func (s *MyTestSuite) TestOne(t *gotest.T) {}
 
 func TestCollector_Validation_ParallelRequiresReturningBeforeEach(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
-	return gotest.SuiteConfig{Parallel: true}
-}
-func (s *MyTestSuite) BeforeEach(t *gotest.T) {}
-func (s *MyTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error: parallel requires returning BeforeEach")
@@ -1000,18 +594,7 @@ func (s *MyTestSuite) TestOne(t *gotest.T) {}
 
 func TestCollector_Validation_ParallelWithoutBeforeEach_Allowed(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
-	return gotest.SuiteConfig{Parallel: true}
-}
-func (s *MyTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs), "parallel with no BeforeEach should be allowed")
@@ -1019,19 +602,7 @@ func (s *MyTestSuite) TestOne(t *gotest.T) {}
 
 func TestCollector_Validation_MethodMissingContextParam(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{}
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
-func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
-func (s *MyTestSuite) TestTwo(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error: TestTwo missing context param")
@@ -1040,19 +611,7 @@ func (s *MyTestSuite) TestTwo(t *gotest.T) {}
 
 func TestCollector_Validation_AfterEachMissingContextParam(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{}
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
-func (s *MyTestSuite) AfterEach(t *gotest.T) {}
-func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error: AfterEach missing context param")
@@ -1061,18 +620,7 @@ func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
 
 func TestCollector_Validation_OrphanContextAfterEach(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{}
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) AfterEach(t *gotest.T, ctx *myCtx) {}
-func (s *MyTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error: orphan context AfterEach")
@@ -1080,19 +628,7 @@ func (s *MyTestSuite) TestOne(t *gotest.T) {}
 
 func TestCollector_Validation_TypeMismatch(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{}
-type otherCtx struct{}
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
-func (s *MyTestSuite) TestOne(t *gotest.T, ctx *otherCtx) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.NotEmpty(t, result.Errs, "expected error: type mismatch")
@@ -1101,20 +637,7 @@ func (s *MyTestSuite) TestOne(t *gotest.T, ctx *otherCtx) {}
 
 func TestCollector_Validation_ReturningBeforeEach_FullyConsistent_OK(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{}
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
-func (s *MyTestSuite) AfterEach(t *gotest.T, ctx *myCtx) {}
-func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
-func (s *MyTestSuite) TestTwo(t *gotest.T, _ *myCtx) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs), "expected no errors, got: %v", result.Errs)

--- a/internal/gotestgen/linkname_compat_test.go
+++ b/internal/gotestgen/linkname_compat_test.go
@@ -1,0 +1,79 @@
+package gotestgen //nolint:stdlib-test
+
+import (
+	"go/types"
+	"testing"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+	"golang.org/x/tools/go/packages"
+)
+
+func loadTestingScope(t *testing.T) *types.Scope {
+	t.Helper()
+	cfg := &packages.Config{Mode: packages.NeedTypes | packages.NeedSyntax}
+	pkgs, err := packages.Load(cfg, "testing")
+	gotest.NoError(t, err)
+	gotest.True(t, len(pkgs) > 0)
+	return pkgs[0].Types.Scope()
+}
+
+func TestLinknameCompat_CoverStructLayout(t *testing.T) {
+	scope := loadTestingScope(t)
+
+	// Go 1.25+ uses "cover", Go 1.24 uses "cover2".
+	varName := "cover"
+	if scope.Lookup("cover2") != nil {
+		varName = "cover2"
+	}
+
+	obj := scope.Lookup(varName)
+	if obj == nil {
+		t.Fatalf("testing.%s variable not found", varName)
+	}
+	st, ok := obj.Type().Underlying().(*types.Struct)
+	if !ok {
+		t.Fatalf("testing.%s is %s, expected struct", varName, obj.Type())
+	}
+
+	type field struct {
+		name string
+		typ  string
+	}
+	want := []field{
+		{"mode", "string"},
+		{"tearDown", "func(coverprofile string, gocoverdir string) (string, error)"},
+		{"snapshotcov", "func() float64"},
+	}
+
+	if st.NumFields() != len(want) {
+		t.Fatalf("testing.%s has %d fields, expected %d", varName, st.NumFields(), len(want))
+	}
+	for i, w := range want {
+		f := st.Field(i)
+		if f.Name() != w.name {
+			t.Errorf("field %d: name = %q, want %q", i, f.Name(), w.name)
+		}
+		if f.Type().String() != w.typ {
+			t.Errorf("field %d (%s): type = %q, want %q", i, w.name, f.Type().String(), w.typ)
+		}
+	}
+}
+
+func TestLinknameCompat_CoverReportSignature(t *testing.T) {
+	scope := loadTestingScope(t)
+
+	obj := scope.Lookup("coverReport")
+	if obj == nil {
+		t.Fatal("testing.coverReport function not found — may have been renamed or removed")
+	}
+	sig, ok := obj.Type().(*types.Signature)
+	if !ok {
+		t.Fatalf("testing.coverReport is %s, expected function", obj.Type())
+	}
+	if sig.Params().Len() != 0 {
+		t.Errorf("testing.coverReport has %d params, expected 0", sig.Params().Len())
+	}
+	if sig.Results().Len() != 0 {
+		t.Errorf("testing.coverReport has %d results, expected 0", sig.Results().Len())
+	}
+}

--- a/internal/gotestgen/renderer.go
+++ b/internal/gotestgen/renderer.go
@@ -76,7 +76,7 @@ func (r renderer) RenderTestSuiteSpec(pkg *packages.Package, spec SpecOutcome, r
 	}
 
 	if len(fixtureBound) > 0 {
-		if err := r.renderFixtures(buf, fixtureBound, viewModels); err != nil {
+		if err := r.renderFixtures(buf, pkg, fixtureBound, viewModels); err != nil {
 			return nil, fmt.Errorf("failed rendering fixture suites. err: %w", err)
 		}
 	}
@@ -109,6 +109,7 @@ func (r *renderer) renderFileHeader(buf *bytes.Buffer, pkg *packages.Package, sp
 	if hasFixtures {
 		imports = append(imports, headerImport{Path: "fmt"})
 		imports = append(imports, headerImport{Path: "time"})
+		imports = append(imports, headerImport{Name: "_", Path: "unsafe"})
 	}
 	if hasFixtures || slices.Any(spec.EffectiveTestSuites, func(v *gotestast.TestSuiteSpec, idx int) bool {
 		return v.IsMethodParallel()
@@ -177,7 +178,7 @@ func (r *renderer) renderTestSuites(buf *bytes.Buffer, spec SpecOutcome, suiteSh
 	})
 }
 
-func (r *renderer) renderFixtures(buf *bytes.Buffer, fixtureBound []*gotestast.TestSuiteSpec, viewModels []*FixtureViewModel) error {
+func (r *renderer) renderFixtures(buf *bytes.Buffer, pkg *packages.Package, fixtureBound []*gotestast.TestSuiteSpec, viewModels []*FixtureViewModel) error {
 	if len(viewModels) == 0 {
 		return nil
 	}
@@ -185,7 +186,17 @@ func (r *renderer) renderFixtures(buf *bytes.Buffer, fixtureBound []*gotestast.T
 	return gotestTpl.ExecuteTemplate(buf, "gotest.fixture.tpl", map[string]any{
 		"RootFixtures":       viewModels,
 		"FixtureBoundSuites": fixtureBound,
+		"CoverVarName":       detectCoverVarName(pkg),
 	})
+}
+
+func detectCoverVarName(pkg *packages.Package) string {
+	if tp := pkg.Imports["testing"]; tp != nil && tp.Types != nil {
+		if tp.Types.Scope().Lookup("cover2") != nil {
+			return "cover2"
+		}
+	}
+	return "cover"
 }
 
 func (renderer) formatOutput(buf *bytes.Buffer) ([]byte, error) {

--- a/internal/gotestgen/renderer_test.go
+++ b/internal/gotestgen/renderer_test.go
@@ -540,7 +540,7 @@ func TestBuildFixtureViewModels_SharedFixtureDetection(t *testing.T) {
 	gotest.Equal(t, "PGSharedFixture", sf.QualifiedType)
 	gotest.Equal(t, "PGSharedFixture", sf.FieldName)
 	gotest.Equal(t, "", sf.PkgPath, "same-package shared fixture should have empty PkgPath")
-	gotest.Equal(t, "testpkg.PGSharedFixture", sf.StateKey)
+	gotest.Equal(t, pkg.PkgPath+".PGSharedFixture", sf.StateKey)
 }
 
 func TestRenderer_FixtureWithConfig(t *testing.T) {

--- a/internal/gotestgen/renderer_test.go
+++ b/internal/gotestgen/renderer_test.go
@@ -31,31 +31,7 @@ func renderTestPkg(t *testing.T, pkg *packages.Package) (string, SpecOutcome) {
 
 func TestRenderer_FixtureWithChildSuite(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type DBFixture struct {
-	Conn string
-}
-
-func (f *DBFixture) BeforeAll(ctx context.Context) error  { return nil }
-func (f *DBFixture) AfterAll(ctx context.Context) error   { return nil }
-
-type QueryTestSuite struct {
-	*DBFixture
-}
-
-func (s *QueryTestSuite) BeforeEach(t *gotest.T) {}
-func (s *QueryTestSuite) AfterEach(t *gotest.T)  {}
-func (s *QueryTestSuite) TestInsert(t *gotest.T) {}
-func (s *QueryTestSuite) TestSelect(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 	gotest.True(t, len(output) > 0, "expected non-empty output")
 
@@ -87,25 +63,7 @@ func (s *QueryTestSuite) TestSelect(t *gotest.T) {}
 
 func TestRenderer_FixtureWithoutAfterAll(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type SimpleFixture struct {}
-
-func (f *SimpleFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type BasicTestSuite struct {
-	*SimpleFixture
-}
-
-func (s *BasicTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	// AfterAll should NOT be in the cleanup since the fixture has no AfterAll
@@ -115,29 +73,7 @@ func (s *BasicTestSuite) TestOne(t *gotest.T) {}
 
 func TestRenderer_MixedFixtureBoundAndStandalone(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type AppFixture struct {}
-
-func (f *AppFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type BoundTestSuite struct {
-	*AppFixture
-}
-
-func (s *BoundTestSuite) TestBound(t *gotest.T) {}
-
-type StandaloneTestSuite struct {}
-
-func (s *StandaloneTestSuite) TestFree(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	// Should have both fixture-bound and standalone
@@ -149,32 +85,7 @@ func (s *StandaloneTestSuite) TestFree(t *gotest.T) {}
 
 func TestRenderer_FixtureWithBeforeAfterEach(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type EachFixture struct {}
-
-func (f *EachFixture) BeforeAll(ctx context.Context) error  { return nil }
-func (f *EachFixture) AfterAll(ctx context.Context) error   { return nil }
-func (f *EachFixture) BeforeEach(ctx context.Context) error { return nil }
-func (f *EachFixture) AfterEach(ctx context.Context) error  { return nil }
-
-type EachTestSuite struct {
-	*EachFixture
-}
-
-func (s *EachTestSuite) BeforeAll(t *gotest.T)  {}
-func (s *EachTestSuite) AfterAll(t *gotest.T)   {}
-func (s *EachTestSuite) BeforeEach(t *gotest.T) {}
-func (s *EachTestSuite) AfterEach(t *gotest.T)  {}
-func (s *EachTestSuite) TestCase(t *gotest.T)   {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 	gotest.True(t, len(output) > 0, "expected non-empty output")
 
@@ -202,25 +113,7 @@ func (s *EachTestSuite) TestCase(t *gotest.T)   {}
 
 func TestRenderer_FixtureWithoutBeforeAfterEach(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type MinimalFixture struct {}
-
-func (f *MinimalFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type MinimalTestSuite struct {
-	*MinimalFixture
-}
-
-func (s *MinimalTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	// Fixture without BeforeEach/AfterEach should NOT emit those calls
@@ -230,37 +123,7 @@ func (s *MinimalTestSuite) TestOne(t *gotest.T) {}
 
 func TestRenderer_NestedFixtureWithBeforeAfterEach(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type InfraFixture struct {}
-
-func (f *InfraFixture) BeforeAll(ctx context.Context) error  { return nil }
-func (f *InfraFixture) BeforeEach(ctx context.Context) error { return nil }
-func (f *InfraFixture) AfterEach(ctx context.Context) error  { return nil }
-
-type APIFixture struct {
-	*InfraFixture
-}
-
-func (f *APIFixture) BeforeAll(ctx context.Context) error  { return nil }
-func (f *APIFixture) BeforeEach(ctx context.Context) error { return nil }
-func (f *APIFixture) AfterEach(ctx context.Context) error  { return nil }
-
-type HandlerTestSuite struct {
-	*APIFixture
-}
-
-func (s *HandlerTestSuite) BeforeEach(t *gotest.T) {}
-func (s *HandlerTestSuite) AfterEach(t *gotest.T)  {}
-func (s *HandlerTestSuite) TestGet(t *gotest.T)    {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	// Nested fixture: parent (fixture) and child hooks should both appear with error handling
@@ -289,26 +152,7 @@ func (s *HandlerTestSuite) TestGet(t *gotest.T)    {}
 
 func TestBuildFixtureViewModels_RootFixtureOnly(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type MyFixture struct {}
-
-func (f *MyFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *MyFixture) AfterAll(ctx context.Context) error  { return nil }
-
-type MyTestSuite struct {
-	*MyFixture
-}
-
-func (s *MyTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -333,18 +177,7 @@ func (s *MyTestSuite) TestOne(t *gotest.T) {}
 
 func TestRenderer_StdlibT_StandaloneSuite(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "testing"
-
-type PlainTestSuite struct{}
-
-func (s *PlainTestSuite) BeforeEach(t *testing.T) {}
-func (s *PlainTestSuite) AfterEach(t *testing.T)  {}
-func (s *PlainTestSuite) TestFoo(t *testing.T)    {}
-func (s *PlainTestSuite) TestBar(t *testing.T)    {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	// Wrapper lifecycle methods should unwrap via .T()
@@ -358,21 +191,7 @@ func (s *PlainTestSuite) TestBar(t *testing.T)    {}
 
 func TestRenderer_StdlibT_MixedSuite(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"testing"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type MixedTestSuite struct{}
-
-func (s *MixedTestSuite) BeforeEach(t *testing.T) {}
-func (s *MixedTestSuite) TestStdlib(t *testing.T)  {}
-func (s *MixedTestSuite) TestGotest(t *gotest.T)   {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	// BeforeEach uses *testing.T → unwrap
@@ -388,26 +207,7 @@ func (s *MixedTestSuite) TestGotest(t *gotest.T)   {}
 
 func TestRenderer_StdlibT_FixtureBoundSuite(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"testing"
-)
-
-type DBFixture struct{}
-
-func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type StdlibTestSuite struct {
-	*DBFixture
-}
-
-func (s *StdlibTestSuite) BeforeAll(t *testing.T)  {}
-func (s *StdlibTestSuite) AfterEach(t *testing.T)  {}
-func (s *StdlibTestSuite) TestQuery(t *testing.T)  {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	// Wrapper lifecycle should unwrap
@@ -420,27 +220,7 @@ func (s *StdlibTestSuite) TestQuery(t *testing.T)  {}
 
 func TestRenderer_SharedFixtureEmbedding(t *testing.T) {
 	t.Parallel()
-	src := "package testpkg\n\n" +
-		"import (\n" +
-		"\t\"context\"\n\n" +
-		"\t\"github.com/mvrahden/go-test/pkg/gotest\"\n" +
-		")\n\n" +
-		"type PostgresSharedFixture struct {\n" +
-		"\tDSN string\n" +
-		"}\n\n" +
-		"func (f *PostgresSharedFixture) BeforeAll(ctx context.Context) error { return nil }\n\n" +
-		"type E2EFixture struct {\n" +
-		"\t*PostgresSharedFixture\n" +
-		"\tPool string\n" +
-		"}\n\n" +
-		"func (f *E2EFixture) BeforeAll(ctx context.Context) error { return nil }\n" +
-		"func (f *E2EFixture) AfterAll(ctx context.Context) error  { return nil }\n\n" +
-		"type QueryTestSuite struct {\n" +
-		"\t*E2EFixture\n" +
-		"}\n\n" +
-		"func (s *QueryTestSuite) TestInsert(t *gotest.T) {}\n"
-
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 	gotest.True(t, len(output) > 0, "expected non-empty output")
 
@@ -471,23 +251,7 @@ func TestRenderer_SharedFixtureEmbedding(t *testing.T) {
 
 func TestRenderer_SharedFixtureEmptyStruct(t *testing.T) {
 	t.Parallel()
-	src := "package testpkg\n\n" +
-		"import (\n" +
-		"\t\"context\"\n\n" +
-		"\t\"github.com/mvrahden/go-test/pkg/gotest\"\n" +
-		")\n\n" +
-		"type SetupSharedFixture struct{}\n\n" +
-		"func (f *SetupSharedFixture) BeforeAll(ctx context.Context) error { return nil }\n\n" +
-		"type AppFixture struct {\n" +
-		"\t*SetupSharedFixture\n" +
-		"}\n\n" +
-		"func (f *AppFixture) BeforeAll(ctx context.Context) error { return nil }\n\n" +
-		"type AppTestSuite struct {\n" +
-		"\t*AppFixture\n" +
-		"}\n\n" +
-		"func (s *AppTestSuite) TestRun(t *gotest.T) {}\n"
-
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	// Shared fixture should be created and assigned via JSON state
@@ -498,26 +262,7 @@ func TestRenderer_SharedFixtureEmptyStruct(t *testing.T) {
 
 func TestBuildFixtureViewModels_SharedFixtureDetection(t *testing.T) {
 	t.Parallel()
-	src := "package testpkg\n\n" +
-		"import (\n" +
-		"\t\"context\"\n\n" +
-		"\t\"github.com/mvrahden/go-test/pkg/gotest\"\n" +
-		")\n\n" +
-		"type PGSharedFixture struct {\n" +
-		"\tDSN  string\n" +
-		"\tHost string\n" +
-		"}\n\n" +
-		"func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }\n\n" +
-		"type DBFixture struct {\n" +
-		"\t*PGSharedFixture\n" +
-		"}\n\n" +
-		"func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }\n\n" +
-		"type DBTestSuite struct {\n" +
-		"\t*DBFixture\n" +
-		"}\n\n" +
-		"func (s *DBTestSuite) TestQuery(t *gotest.T) {}\n"
-
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -545,29 +290,7 @@ func TestBuildFixtureViewModels_SharedFixtureDetection(t *testing.T) {
 
 func TestRenderer_FixtureWithConfig(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type CFGFixture struct{}
-
-func (f *CFGFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *CFGFixture) AfterAll(ctx context.Context) error  { return nil }
-func (f *CFGFixture) FixtureConfig() gotest.FixtureConfig {
-	return gotest.ContainerFixtureConfig()
-}
-
-type CFGTestSuite struct {
-	*CFGFixture
-}
-
-func (s *CFGTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	gotest.Contains(t, output, "gotest.DefaultFixtureConfig()")
@@ -579,25 +302,7 @@ func (s *CFGTestSuite) TestOne(t *gotest.T) {}
 
 func TestRenderer_FixtureWithoutConfig_UsesDefault(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type PlainFixture struct{}
-
-func (f *PlainFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type PlainTestSuite struct {
-	*PlainFixture
-}
-
-func (s *PlainTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	gotest.Contains(t, output, "gotest.DefaultFixtureConfig()")
@@ -606,18 +311,7 @@ func (s *PlainTestSuite) TestOne(t *gotest.T) {}
 
 func TestRenderer_SuiteWithConfig(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type ConfiguredTestSuite struct{}
-
-func (s *ConfiguredTestSuite) SuiteConfig() gotest.SuiteConfig {
-	return gotest.SuiteConfig{Timeout: 10_000_000_000, FailFast: true}
-}
-func (s *ConfiguredTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	gotest.Contains(t, output, "gotest.DefaultSuiteConfig()")
@@ -628,15 +322,7 @@ func (s *ConfiguredTestSuite) TestOne(t *gotest.T) {}
 
 func TestRenderer_SuiteWithoutConfig_UsesDefault(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type PlainTestSuite struct{}
-
-func (s *PlainTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	gotest.Contains(t, output, "gotest.DefaultSuiteConfig()")
@@ -645,20 +331,7 @@ func (s *PlainTestSuite) TestOne(t *gotest.T) {}
 
 func TestRenderer_NamedField_SuiteToFixture(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type DBFixture struct{ Conn string }
-func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type QueryTestSuite struct { db *DBFixture }
-func (s *QueryTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	gotest.Contains(t, output, "db: ƒ_DBFixture", "suite struct literal should use named field")
@@ -667,26 +340,7 @@ func (s *QueryTestSuite) TestOne(t *gotest.T) {}
 
 func TestRenderer_NamedField_ChildToParentFixture(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type InfraFixture struct{ Val string }
-func (f *InfraFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type APIFixture struct { infra *InfraFixture }
-func (f *APIFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type LightTestSuite struct { *InfraFixture }
-func (s *LightTestSuite) TestOne(t *gotest.T) {}
-
-type FullTestSuite struct { *APIFixture }
-func (s *FullTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	gotest.Contains(t, output, "infra: ƒ_InfraFixture", "child fixture struct literal should use named parent field")
@@ -694,24 +348,7 @@ func (s *FullTestSuite) TestOne(t *gotest.T) {}
 
 func TestRenderer_NamedField_SharedFixtureInFixture(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type PGSharedFixture struct{ ConnStr string }
-func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
-
-type AppFixture struct { pg *PGSharedFixture }
-func (f *AppFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type UserTestSuite struct { *AppFixture }
-func (s *UserTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	gotest.Contains(t, output, "ƒ_AppFixture.pg = sf0", "shared fixture injection should use named field")
@@ -720,23 +357,7 @@ func (s *UserTestSuite) TestOne(t *gotest.T) {}
 
 func TestRenderer_MixedFieldStyles_SameFixture(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type DBFixture struct{ Conn string }
-func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type EmbeddedTestSuite struct { *DBFixture }
-func (s *EmbeddedTestSuite) TestOne(t *gotest.T) {}
-
-type NamedTestSuite struct { db *DBFixture }
-func (s *NamedTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	gotest.Contains(t, output, "DBFixture: ƒ_DBFixture", "embedded suite should use type name")
@@ -745,17 +366,7 @@ func (s *NamedTestSuite) TestOne(t *gotest.T) {}
 
 func TestRenderer_VoidBeforeEach_Sequential(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type OrderTestSuite struct{}
-
-func (s *OrderTestSuite) BeforeEach(t *gotest.T) {}
-func (s *OrderTestSuite) AfterEach(t *gotest.T)  {}
-func (s *OrderTestSuite) TestOne(t *gotest.T)    {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	gotest.True(t, !strings.Contains(output, "t.Parallel()"), "suite-level t.Parallel() should not be emitted — isolation is subprocess-level")
@@ -767,20 +378,7 @@ func (s *OrderTestSuite) TestOne(t *gotest.T)    {}
 
 func TestRenderer_ReturningBeforeEach_Sequential(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{ val string }
-
-type OrderTestSuite struct{}
-
-func (s *OrderTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
-func (s *OrderTestSuite) AfterEach(t *gotest.T, ctx *myCtx) {}
-func (s *OrderTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
-func (s *OrderTestSuite) TestTwo(t *gotest.T, _ *myCtx)   {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	gotest.True(t, !strings.Contains(output, "t.Parallel()"), "suite-level t.Parallel() should not be emitted")
@@ -794,22 +392,7 @@ func (s *OrderTestSuite) TestTwo(t *gotest.T, _ *myCtx)   {}
 
 func TestRenderer_ReturningBeforeEach_Parallel(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type myCtx struct{ val string }
-
-type OrderTestSuite struct{}
-
-func (s *OrderTestSuite) SuiteConfig() gotest.SuiteConfig {
-	return gotest.SuiteConfig{Parallel: true}
-}
-func (s *OrderTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
-func (s *OrderTestSuite) AfterEach(t *gotest.T, ctx *myCtx) {}
-func (s *OrderTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	stripped := strings.ReplaceAll(output, "it.Parallel()", "")
@@ -825,29 +408,7 @@ func (s *OrderTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
 
 func TestRenderer_FixtureBound_ReturningBeforeEach(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type DBFixture struct{ Conn string }
-
-func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type myCtx struct{ pool string }
-
-type QueryTestSuite struct {
-	*DBFixture
-}
-
-func (s *QueryTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
-func (s *QueryTestSuite) AfterEach(t *gotest.T, ctx *myCtx) {}
-func (s *QueryTestSuite) TestInsert(t *gotest.T, ctx *myCtx) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	output, _ := renderTestPkg(t, pkg)
 
 	gotest.True(t, !strings.Contains(output, "t.Parallel()"), "suite-level t.Parallel() should not be emitted")

--- a/internal/gotestgen/resolver_test.go
+++ b/internal/gotestgen/resolver_test.go
@@ -25,20 +25,7 @@ func TestIsInternalPkgPath(t *testing.T) {
 
 func TestResolve_Embedding_SuiteToFixture(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type DBFixture struct{ Conn string }
-func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type QueryTestSuite struct { *DBFixture }
-func (s *QueryTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -59,20 +46,7 @@ func (s *QueryTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_NamedField_SuiteToFixture(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type DBFixture struct{ Conn string }
-func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type QueryTestSuite struct { db *DBFixture }
-func (s *QueryTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -93,24 +67,7 @@ func (s *QueryTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_Embedding_ChildToParentFixture(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type InfraFixture struct{ Val string }
-func (f *InfraFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *InfraFixture) AfterAll(ctx context.Context) error  { return nil }
-
-type APIFixture struct { *InfraFixture }
-func (f *APIFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type FullTestSuite struct { *APIFixture }
-func (s *FullTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -132,23 +89,7 @@ func (s *FullTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_NamedField_ChildToParentFixture(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type InfraFixture struct{ Val string }
-func (f *InfraFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type APIFixture struct { infra *InfraFixture }
-func (f *APIFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type FullTestSuite struct { *APIFixture }
-func (s *FullTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -170,24 +111,7 @@ func (s *FullTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_NamedField_FixtureToSharedFixture(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type PGSharedFixture struct{ ConnStr string }
-func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
-
-type AppFixture struct { pg *PGSharedFixture }
-func (f *AppFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type UserTestSuite struct { *AppFixture }
-func (s *UserTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -210,21 +134,7 @@ func (s *UserTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_DirectSharedFixture_Embedded(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type PGSharedFixture struct{ ConnStr string }
-func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
-
-type UserTestSuite struct { *PGSharedFixture }
-func (s *UserTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -253,21 +163,7 @@ func (s *UserTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_DirectSharedFixture_NamedField(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type PGSharedFixture struct{ ConnStr string }
-func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
-
-type UserTestSuite struct { pg *PGSharedFixture }
-func (s *UserTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -288,27 +184,7 @@ func (s *UserTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_SuiteWithFixtureAndDirectSharedFixture(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type PGSharedFixture struct{ ConnStr string }
-func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
-
-type AppFixture struct{ Val string }
-func (f *AppFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type UserTestSuite struct {
-	*AppFixture
-	*PGSharedFixture
-}
-func (s *UserTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -332,23 +208,7 @@ func (s *UserTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_MixedFieldStyles_SameFixture(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type DBFixture struct{ Conn string }
-func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type EmbeddedTestSuite struct { *DBFixture }
-func (s *EmbeddedTestSuite) TestOne(t *gotest.T) {}
-
-type NamedTestSuite struct { db *DBFixture }
-func (s *NamedTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -372,23 +232,7 @@ func (s *NamedTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_CycleDetection(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type AFixture struct { *BFixture }
-func (f *AFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type BFixture struct { *AFixture }
-func (f *BFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type SomeTestSuite struct { *AFixture }
-func (s *SomeTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -403,26 +247,7 @@ func (s *SomeTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_MultipleFixturesPerSuite(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type AFixture struct{}
-func (f *AFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type BFixture struct{}
-func (f *BFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type BadTestSuite struct {
-	*AFixture
-	*BFixture
-}
-func (s *BadTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -437,16 +262,7 @@ func (s *BadTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_MissingBeforeAll(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type NoSetupFixture struct{ Val string }
-
-type SomeTestSuite struct { *NoSetupFixture }
-func (s *SomeTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -461,14 +277,7 @@ func (s *SomeTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_NoFixture_Standalone(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import "github.com/mvrahden/go-test/pkg/gotest"
-
-type PlainTestSuite struct{ val string }
-func (s *PlainTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -487,29 +296,7 @@ func (s *PlainTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_MultipleParentFixtures_Error(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type AFixture struct{}
-func (f *AFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type BFixture struct{}
-func (f *BFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type ChildFixture struct {
-	*AFixture
-	*BFixture
-}
-func (f *ChildFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type SomeTestSuite struct { *ChildFixture }
-func (s *SomeTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -524,27 +311,7 @@ func (s *SomeTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_SharedFixture_TransferFields(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type PGSharedFixture struct {
-	ConnStr string
-	Port    int
-}
-func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
-
-type AppFixture struct { *PGSharedFixture }
-func (f *AppFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type UserTestSuite struct { *AppFixture }
-func (s *UserTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -566,23 +333,7 @@ func (s *UserTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_LifecycleMethods_Detection(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type FullFixture struct{ Val string }
-func (f *FullFixture) BeforeAll(ctx context.Context) error  { return nil }
-func (f *FullFixture) AfterAll(ctx context.Context) error   { return nil }
-func (f *FullFixture) BeforeEach(ctx context.Context) error { return nil }
-func (f *FullFixture) AfterEach(ctx context.Context) error  { return nil }
-
-type SomeTestSuite struct { *FullFixture }
-func (s *SomeTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -603,23 +354,7 @@ func (s *SomeTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_UnreferencedFixture_NotInOutput(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type UsedFixture struct{}
-func (f *UsedFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type UnusedFixture struct{}
-func (f *UnusedFixture) BeforeAll(ctx context.Context) error { return nil }
-
-type MyTestSuite struct { *UsedFixture }
-func (s *MyTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))
@@ -636,28 +371,7 @@ func (s *MyTestSuite) TestOne(t *gotest.T) {}
 
 func TestResolve_DirectMultipleSharedFixtures_OnSuite(t *testing.T) {
 	t.Parallel()
-	src := `package testpkg
-
-import (
-	"context"
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
-
-type PGSharedFixture struct{ ConnStr string }
-func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
-
-type RedisSharedFixture struct{ Addr string }
-func (f *RedisSharedFixture) BeforeAll(ctx context.Context) error { return nil }
-func (f *RedisSharedFixture) AfterAll(ctx context.Context) error  { return nil }
-
-type FullTestSuite struct {
-	pg    *PGSharedFixture
-	redis *RedisSharedFixture
-}
-func (s *FullTestSuite) TestOne(t *gotest.T) {}
-`
-	pkg := loadTestPkgWithGotest(t, src)
+	pkg := mustTestPkg(t)
 	c := collector{}
 	result := c.CollectSuiteSpecs(pkg)
 	gotest.Equal(t, 0, len(result.Errs))

--- a/internal/gotestgen/static/gotest.fixture.tpl
+++ b/internal/gotestgen/static/gotest.fixture.tpl
@@ -24,6 +24,23 @@ var ƒ_{{ $cf.Identifier }} *{{ $cf.QualifiedIdentifier }}
 {{ end }}
 {{ end }}
 
+{{- /*
+Go flushes coverage counters inside m.Run(), before fixture AfterAll runs.
+We swap tearDown with a no-op so counters survive, then flush after teardown.
+The linkname struct layout is guarded by TestLinknameCompat tests.
+*/}}
+// ƒflushCoverage triggers coverage report writing.
+//go:linkname ƒflushCoverage testing.coverReport
+func ƒflushCoverage()
+
+// ƒtestingCover exposes the stdlib coverage state for tearDown interception.
+//go:linkname ƒtestingCover testing.{{ .CoverVarName }}
+var ƒtestingCover struct {
+    mode        string
+    tearDown    func(coverprofile string, gocoverdir string) (string, error)
+    snapshotcov func() float64
+}
+
 func TestMain(m *testing.M) { os.Exit(ƒƒ_GOTEST_main(m)) }
 
 func ƒƒ_GOTEST_main(m *testing.M) (ƒcode int) {
@@ -35,6 +52,12 @@ func ƒƒ_GOTEST_main(m *testing.M) (ƒcode int) {
     var ƒok_{{ $cf.Identifier }} bool
 {{ end }}
 {{ end }}
+
+    var ƒorigTearDown func(string, string) (string, error)
+    if testing.CoverMode() != "" {
+        ƒorigTearDown = ƒtestingCover.tearDown
+        ƒtestingCover.tearDown = func(string, string) (string, error) { return "", nil }
+    }
 
     defer func() {
         var ƒtwg sync.WaitGroup
@@ -97,6 +120,10 @@ func ƒƒ_GOTEST_main(m *testing.M) (ƒcode int) {
         ƒtwg.Wait()
         for _, ƒf := range ƒtdfails {
             if ƒf && ƒcode == 0 { ƒcode = 1; break }
+        }
+        if ƒorigTearDown != nil {
+            ƒtestingCover.tearDown = ƒorigTearDown
+            ƒflushCoverage()
         }
     }()
 

--- a/internal/gotestgen/testdata/sources/TestBuildFixtureViewModels_RootFixtureOnly/test.go
+++ b/internal/gotestgen/testdata/sources/TestBuildFixtureViewModels_RootFixtureOnly/test.go
@@ -1,0 +1,18 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type MyFixture struct {}
+
+func (f *MyFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *MyFixture) AfterAll(ctx context.Context) error  { return nil }
+
+type MyTestSuite struct {
+	*MyFixture
+}
+
+func (s *MyTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestBuildFixtureViewModels_SharedFixtureDetection/test.go
+++ b/internal/gotestgen/testdata/sources/TestBuildFixtureViewModels_SharedFixtureDetection/test.go
@@ -1,0 +1,26 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type PGSharedFixture struct {
+	DSN  string
+	Host string
+}
+
+func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type DBFixture struct {
+	*PGSharedFixture
+}
+
+func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type DBTestSuite struct {
+	*DBFixture
+}
+
+func (s *DBTestSuite) TestQuery(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_AfterEach_TooManyParams/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_AfterEach_TooManyParams/test.go
@@ -1,0 +1,10 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{}
+
+type BadTestSuite struct{}
+
+func (s *BadTestSuite) AfterEach(t *gotest.T, ctx *myCtx, extra int) {}
+func (s *BadTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_AfterEach_WithContextParam/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_AfterEach_WithContextParam/test.go
@@ -1,0 +1,11 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{ val string }
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
+func (s *MyTestSuite) AfterEach(t *gotest.T, ctx *myCtx) {}
+func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_BeforeEach_ReturningForm/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_BeforeEach_ReturningForm/test.go
@@ -1,0 +1,10 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{ val string }
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
+func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_BeforeEach_TooManyReturns/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_BeforeEach_TooManyReturns/test.go
@@ -1,0 +1,10 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{}
+
+type BadTestSuite struct{}
+
+func (s *BadTestSuite) BeforeEach(t *gotest.T) (*myCtx, error) { return nil, nil }
+func (s *BadTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_FixtureCollection_PackageFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_FixtureCollection_PackageFixture/test.go
@@ -1,0 +1,9 @@
+package testpkg
+
+import "context"
+
+type DBFixture struct {
+	Conn string
+}
+
+func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }

--- a/internal/gotestgen/testdata/sources/TestCollector_FixtureCollection_PackageFixtureAllMethods/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_FixtureCollection_PackageFixtureAllMethods/test.go
@@ -1,0 +1,12 @@
+package testpkg
+
+import "context"
+
+type DBFixture struct {
+	Conn string
+}
+
+func (f *DBFixture) BeforeAll(ctx context.Context) error  { return nil }
+func (f *DBFixture) AfterAll(ctx context.Context) error   { return nil }
+func (f *DBFixture) BeforeEach(ctx context.Context) error { return nil }
+func (f *DBFixture) AfterEach(ctx context.Context) error  { return nil }

--- a/internal/gotestgen/testdata/sources/TestCollector_FixtureCollection_SharedFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_FixtureCollection_SharedFixture/test.go
@@ -1,0 +1,9 @@
+package testpkg
+
+import "context"
+
+type RedisSharedFixture struct {
+	Addr string
+}
+
+func (f *RedisSharedFixture) BeforeAll(ctx context.Context) error { return nil }

--- a/internal/gotestgen/testdata/sources/TestCollector_FixtureCollection_SharedFixtureWithAfterAll/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_FixtureCollection_SharedFixtureWithAfterAll/test.go
@@ -1,0 +1,10 @@
+package testpkg
+
+import "context"
+
+type RedisSharedFixture struct {
+	Addr string
+}
+
+func (f *RedisSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *RedisSharedFixture) AfterAll(ctx context.Context) error  { return nil }

--- a/internal/gotestgen/testdata/sources/TestCollector_FixtureConfig_AbsentIsNil/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_FixtureConfig_AbsentIsNil/test.go
@@ -1,0 +1,7 @@
+package testpkg
+
+import "context"
+
+type PlainFixture struct{}
+
+func (f *PlainFixture) BeforeAll(ctx context.Context) error { return nil }

--- a/internal/gotestgen/testdata/sources/TestCollector_FixtureConfig_Detected/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_FixtureConfig_Detected/test.go
@@ -1,0 +1,14 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type DBFixture struct{}
+
+func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *DBFixture) FixtureConfig() gotest.FixtureConfig {
+	return gotest.DefaultFixtureConfig()
+}

--- a/internal/gotestgen/testdata/sources/TestCollector_FixtureConfig_InvalidSignature_WithParams/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_FixtureConfig_InvalidSignature_WithParams/test.go
@@ -1,0 +1,14 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type BadFixture struct{}
+
+func (f *BadFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *BadFixture) FixtureConfig(x int) gotest.FixtureConfig {
+	return gotest.DefaultFixtureConfig()
+}

--- a/internal/gotestgen/testdata/sources/TestCollector_FixtureConfig_InvalidSignature_WrongReturnType/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_FixtureConfig_InvalidSignature_WrongReturnType/test.go
@@ -1,0 +1,8 @@
+package testpkg
+
+import "context"
+
+type BadFixture struct{}
+
+func (f *BadFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *BadFixture) FixtureConfig() string { return "" }

--- a/internal/gotestgen/testdata/sources/TestCollector_FixtureEmbeddingInTestSuite/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_FixtureEmbeddingInTestSuite/test.go
@@ -1,0 +1,19 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type DBFixture struct {
+	Conn string
+}
+
+func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type MyTestSuite struct {
+	*DBFixture
+}
+
+func (s *MyTestSuite) TestSomething(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_FixtureToFixtureEmbedding/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_FixtureToFixtureEmbedding/test.go
@@ -1,0 +1,13 @@
+package testpkg
+
+import "context"
+
+type BaseFixture struct{}
+
+func (f *BaseFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type DBFixture struct {
+	*BaseFixture
+}
+
+func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }

--- a/internal/gotestgen/testdata/sources/TestCollector_GotestT_NotUsesStdlibT/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_GotestT_NotUsesStdlibT/test.go
@@ -1,0 +1,7 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type GotestTestSuite struct{}
+
+func (s *GotestTestSuite) TestFoo(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_NoFixtureEmbedding/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_NoFixtureEmbedding/test.go
@@ -1,0 +1,7 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) TestSomething(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_PackageFixture_WrongBeforeAllSignature/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_PackageFixture_WrongBeforeAllSignature/test.go
@@ -1,0 +1,7 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type DBFixture struct{}
+
+func (f *DBFixture) BeforeAll(t *gotest.T) {} // wrong: should be (ctx context.Context) error

--- a/internal/gotestgen/testdata/sources/TestCollector_SharedFixtureConfig_Detected/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SharedFixtureConfig_Detected/test.go
@@ -1,0 +1,14 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type PGSharedFixture struct{}
+
+func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *PGSharedFixture) SharedFixtureConfig() gotest.FixtureConfig {
+	return gotest.ContainerFixtureConfig()
+}

--- a/internal/gotestgen/testdata/sources/TestCollector_SharedFixtureNotTreatedAsParent/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SharedFixtureNotTreatedAsParent/test.go
@@ -1,0 +1,25 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type PGSharedFixture struct {
+	DSN string `gotest:"env=PG_DSN"`
+}
+
+func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type E2EFixture struct {
+	*PGSharedFixture
+}
+
+func (f *E2EFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type QueryTestSuite struct {
+	*E2EFixture
+}
+
+func (s *QueryTestSuite) TestInsert(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_SharedFixture_AfterEachDisallowed/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SharedFixture_AfterEachDisallowed/test.go
@@ -1,0 +1,8 @@
+package testpkg
+
+import "context"
+
+type RedisSharedFixture struct{}
+
+func (f *RedisSharedFixture) BeforeAll(ctx context.Context) error  { return nil }
+func (f *RedisSharedFixture) AfterEach(ctx context.Context) error  { return nil }

--- a/internal/gotestgen/testdata/sources/TestCollector_SharedFixture_BeforeEachDisallowed/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SharedFixture_BeforeEachDisallowed/test.go
@@ -1,0 +1,8 @@
+package testpkg
+
+import "context"
+
+type RedisSharedFixture struct{}
+
+func (f *RedisSharedFixture) BeforeAll(ctx context.Context) error    { return nil }
+func (f *RedisSharedFixture) BeforeEach(ctx context.Context) error   { return nil }

--- a/internal/gotestgen/testdata/sources/TestCollector_SharedFixture_WrongBeforeAllSignature/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SharedFixture_WrongBeforeAllSignature/test.go
@@ -1,0 +1,7 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type RedisSharedFixture struct{}
+
+func (f *RedisSharedFixture) BeforeAll(t *gotest.T) {} // wrong: should be (ctx context.Context) error

--- a/internal/gotestgen/testdata/sources/TestCollector_StdlibT_LifecycleHooks/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_StdlibT_LifecycleHooks/test.go
@@ -1,0 +1,11 @@
+package testpkg
+
+import "testing"
+
+type HookTestSuite struct{}
+
+func (s *HookTestSuite) BeforeAll(t *testing.T)  {}
+func (s *HookTestSuite) AfterAll(t *testing.T)   {}
+func (s *HookTestSuite) BeforeEach(t *testing.T) {}
+func (s *HookTestSuite) AfterEach(t *testing.T)  {}
+func (s *HookTestSuite) TestOne(t *testing.T)    {}

--- a/internal/gotestgen/testdata/sources/TestCollector_StdlibT_MixedMethodSignatures/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_StdlibT_MixedMethodSignatures/test.go
@@ -1,0 +1,12 @@
+package testpkg
+
+import (
+	"testing"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type MixedTestSuite struct{}
+
+func (s *MixedTestSuite) TestStdlib(t *testing.T) {}
+func (s *MixedTestSuite) TestGotest(t *gotest.T)  {}

--- a/internal/gotestgen/testdata/sources/TestCollector_StdlibT_SuiteDetected/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_StdlibT_SuiteDetected/test.go
@@ -1,0 +1,7 @@
+package testpkg
+
+import "testing"
+
+type PlainTestSuite struct{}
+
+func (s *PlainTestSuite) TestFoo(t *testing.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_StdlibT_WrongParamType/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_StdlibT_WrongParamType/test.go
@@ -1,0 +1,7 @@
+package testpkg
+
+import "fmt"
+
+type BadTestSuite struct{}
+
+func (s *BadTestSuite) TestBad(f fmt.Stringer) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_AbsentIsFalse/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_AbsentIsFalse/test.go
@@ -1,0 +1,7 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type PlainTestSuite struct{}
+
+func (s *PlainTestSuite) TestFoo(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_Detected/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_Detected/test.go
@@ -1,0 +1,10 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{}
+}
+func (s *MyTestSuite) TestFoo(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_InvalidSignature_WithParams/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_InvalidSignature_WithParams/test.go
@@ -1,0 +1,10 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type BadTestSuite struct{}
+
+func (s *BadTestSuite) SuiteConfig(x int) gotest.SuiteConfig {
+	return gotest.DefaultSuiteConfig()
+}
+func (s *BadTestSuite) TestFoo(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_InvalidSignature_WrongReturnType/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_InvalidSignature_WrongReturnType/test.go
@@ -1,0 +1,8 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type BadTestSuite struct{}
+
+func (s *BadTestSuite) SuiteConfig() int { return 0 }
+func (s *BadTestSuite) TestFoo(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_NonLiteralBody_Error/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_NonLiteralBody_Error/test.go
@@ -1,0 +1,12 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type MyTestSuite struct{}
+
+var cfg = gotest.SuiteConfig{Parallel: true}
+
+func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return cfg
+}
+func (s *MyTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_ParallelParsed/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_ParallelParsed/test.go
@@ -1,0 +1,13 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{}
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{Parallel: true}
+}
+func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
+func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_SuiteGuard_AbsentIsFalse/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SuiteGuard_AbsentIsFalse/test.go
@@ -1,0 +1,7 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type PlainTestSuite struct{}
+
+func (s *PlainTestSuite) TestFoo(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_SuiteGuard_Detected/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SuiteGuard_Detected/test.go
@@ -1,0 +1,8 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) SuiteGuard() string { return "" }
+func (s *MyTestSuite) TestFoo(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_SuiteGuard_InvalidSignature_WithParams/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SuiteGuard_InvalidSignature_WithParams/test.go
@@ -1,0 +1,8 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type BadTestSuite struct{}
+
+func (s *BadTestSuite) SuiteGuard(x int) string { return "" }
+func (s *BadTestSuite) TestFoo(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_SuiteGuard_InvalidSignature_WrongReturnType/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SuiteGuard_InvalidSignature_WrongReturnType/test.go
@@ -1,0 +1,8 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type BadTestSuite struct{}
+
+func (s *BadTestSuite) SuiteGuard() int { return 0 }
+func (s *BadTestSuite) TestFoo(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_TestMethod_AsyncWithContext/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_TestMethod_AsyncWithContext/test.go
@@ -1,0 +1,10 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{}
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
+func (s *MyTestSuite) TestOneAsync(t *gotest.T, ctx *myCtx, done func()) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_TestMethod_WithContextParam/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_TestMethod_WithContextParam/test.go
@@ -1,0 +1,11 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{}
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
+func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
+func (s *MyTestSuite) TestTwo(t *gotest.T, _ *myCtx) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_Validation_AfterEachMissingContextParam/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_Validation_AfterEachMissingContextParam/test.go
@@ -1,0 +1,11 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{}
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
+func (s *MyTestSuite) AfterEach(t *gotest.T) {}
+func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_Validation_MethodMissingContextParam/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_Validation_MethodMissingContextParam/test.go
@@ -1,0 +1,11 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{}
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
+func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
+func (s *MyTestSuite) TestTwo(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_Validation_OrphanContextAfterEach/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_Validation_OrphanContextAfterEach/test.go
@@ -1,0 +1,10 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{}
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) AfterEach(t *gotest.T, ctx *myCtx) {}
+func (s *MyTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_Validation_ParallelRequiresReturningBeforeEach/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_Validation_ParallelRequiresReturningBeforeEach/test.go
@@ -1,0 +1,11 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{Parallel: true}
+}
+func (s *MyTestSuite) BeforeEach(t *gotest.T) {}
+func (s *MyTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_Validation_ParallelWithoutBeforeEach_Allowed/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_Validation_ParallelWithoutBeforeEach_Allowed/test.go
@@ -1,0 +1,10 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{Parallel: true}
+}
+func (s *MyTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_Validation_ReturningBeforeEach_FullyConsistent_OK/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_Validation_ReturningBeforeEach_FullyConsistent_OK/test.go
@@ -1,0 +1,12 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{}
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
+func (s *MyTestSuite) AfterEach(t *gotest.T, ctx *myCtx) {}
+func (s *MyTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
+func (s *MyTestSuite) TestTwo(t *gotest.T, _ *myCtx) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_Validation_TypeMismatch/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_Validation_TypeMismatch/test.go
@@ -1,0 +1,11 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{}
+type otherCtx struct{}
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
+func (s *MyTestSuite) TestOne(t *gotest.T, ctx *otherCtx) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_FixtureBound_ReturningBeforeEach/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_FixtureBound_ReturningBeforeEach/test.go
@@ -1,0 +1,21 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type DBFixture struct{ Conn string }
+
+func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type myCtx struct{ pool string }
+
+type QueryTestSuite struct {
+	*DBFixture
+}
+
+func (s *QueryTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
+func (s *QueryTestSuite) AfterEach(t *gotest.T, ctx *myCtx) {}
+func (s *QueryTestSuite) TestInsert(t *gotest.T, ctx *myCtx) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_FixtureWithBeforeAfterEach/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_FixtureWithBeforeAfterEach/test.go
@@ -1,0 +1,24 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type EachFixture struct {}
+
+func (f *EachFixture) BeforeAll(ctx context.Context) error  { return nil }
+func (f *EachFixture) AfterAll(ctx context.Context) error   { return nil }
+func (f *EachFixture) BeforeEach(ctx context.Context) error { return nil }
+func (f *EachFixture) AfterEach(ctx context.Context) error  { return nil }
+
+type EachTestSuite struct {
+	*EachFixture
+}
+
+func (s *EachTestSuite) BeforeAll(t *gotest.T)  {}
+func (s *EachTestSuite) AfterAll(t *gotest.T)   {}
+func (s *EachTestSuite) BeforeEach(t *gotest.T) {}
+func (s *EachTestSuite) AfterEach(t *gotest.T)  {}
+func (s *EachTestSuite) TestCase(t *gotest.T)   {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_FixtureWithChildSuite/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_FixtureWithChildSuite/test.go
@@ -1,0 +1,23 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type DBFixture struct {
+	Conn string
+}
+
+func (f *DBFixture) BeforeAll(ctx context.Context) error  { return nil }
+func (f *DBFixture) AfterAll(ctx context.Context) error   { return nil }
+
+type QueryTestSuite struct {
+	*DBFixture
+}
+
+func (s *QueryTestSuite) BeforeEach(t *gotest.T) {}
+func (s *QueryTestSuite) AfterEach(t *gotest.T)  {}
+func (s *QueryTestSuite) TestInsert(t *gotest.T) {}
+func (s *QueryTestSuite) TestSelect(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_FixtureWithConfig/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_FixtureWithConfig/test.go
@@ -1,0 +1,21 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type CFGFixture struct{}
+
+func (f *CFGFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *CFGFixture) AfterAll(ctx context.Context) error  { return nil }
+func (f *CFGFixture) FixtureConfig() gotest.FixtureConfig {
+	return gotest.ContainerFixtureConfig()
+}
+
+type CFGTestSuite struct {
+	*CFGFixture
+}
+
+func (s *CFGTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_FixtureWithoutAfterAll/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_FixtureWithoutAfterAll/test.go
@@ -1,0 +1,17 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type SimpleFixture struct {}
+
+func (f *SimpleFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type BasicTestSuite struct {
+	*SimpleFixture
+}
+
+func (s *BasicTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_FixtureWithoutBeforeAfterEach/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_FixtureWithoutBeforeAfterEach/test.go
@@ -1,0 +1,17 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type MinimalFixture struct {}
+
+func (f *MinimalFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type MinimalTestSuite struct {
+	*MinimalFixture
+}
+
+func (s *MinimalTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_FixtureWithoutConfig_UsesDefault/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_FixtureWithoutConfig_UsesDefault/test.go
@@ -1,0 +1,17 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type PlainFixture struct{}
+
+func (f *PlainFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type PlainTestSuite struct {
+	*PlainFixture
+}
+
+func (s *PlainTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_MixedFieldStyles_SameFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_MixedFieldStyles_SameFixture/test.go
@@ -1,0 +1,15 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type DBFixture struct{ Conn string }
+func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type EmbeddedTestSuite struct { *DBFixture }
+func (s *EmbeddedTestSuite) TestOne(t *gotest.T) {}
+
+type NamedTestSuite struct { db *DBFixture }
+func (s *NamedTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_MixedFixtureBoundAndStandalone/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_MixedFixtureBoundAndStandalone/test.go
@@ -1,0 +1,21 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type AppFixture struct {}
+
+func (f *AppFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type BoundTestSuite struct {
+	*AppFixture
+}
+
+func (s *BoundTestSuite) TestBound(t *gotest.T) {}
+
+type StandaloneTestSuite struct {}
+
+func (s *StandaloneTestSuite) TestFree(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_NamedField_ChildToParentFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_NamedField_ChildToParentFixture/test.go
@@ -1,0 +1,18 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type InfraFixture struct{ Val string }
+func (f *InfraFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type APIFixture struct { infra *InfraFixture }
+func (f *APIFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type LightTestSuite struct { *InfraFixture }
+func (s *LightTestSuite) TestOne(t *gotest.T) {}
+
+type FullTestSuite struct { *APIFixture }
+func (s *FullTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_NamedField_SharedFixtureInFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_NamedField_SharedFixtureInFixture/test.go
@@ -1,0 +1,16 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type PGSharedFixture struct{ ConnStr string }
+func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
+
+type AppFixture struct { pg *PGSharedFixture }
+func (f *AppFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type UserTestSuite struct { *AppFixture }
+func (s *UserTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_NamedField_SuiteToFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_NamedField_SuiteToFixture/test.go
@@ -1,0 +1,12 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type DBFixture struct{ Conn string }
+func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type QueryTestSuite struct { db *DBFixture }
+func (s *QueryTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_NestedFixtureWithBeforeAfterEach/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_NestedFixtureWithBeforeAfterEach/test.go
@@ -1,0 +1,29 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type InfraFixture struct {}
+
+func (f *InfraFixture) BeforeAll(ctx context.Context) error  { return nil }
+func (f *InfraFixture) BeforeEach(ctx context.Context) error { return nil }
+func (f *InfraFixture) AfterEach(ctx context.Context) error  { return nil }
+
+type APIFixture struct {
+	*InfraFixture
+}
+
+func (f *APIFixture) BeforeAll(ctx context.Context) error  { return nil }
+func (f *APIFixture) BeforeEach(ctx context.Context) error { return nil }
+func (f *APIFixture) AfterEach(ctx context.Context) error  { return nil }
+
+type HandlerTestSuite struct {
+	*APIFixture
+}
+
+func (s *HandlerTestSuite) BeforeEach(t *gotest.T) {}
+func (s *HandlerTestSuite) AfterEach(t *gotest.T)  {}
+func (s *HandlerTestSuite) TestGet(t *gotest.T)    {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_ReturningBeforeEach_Parallel/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_ReturningBeforeEach_Parallel/test.go
@@ -1,0 +1,14 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{ val string }
+
+type OrderTestSuite struct{}
+
+func (s *OrderTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{Parallel: true}
+}
+func (s *OrderTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
+func (s *OrderTestSuite) AfterEach(t *gotest.T, ctx *myCtx) {}
+func (s *OrderTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_ReturningBeforeEach_Sequential/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_ReturningBeforeEach_Sequential/test.go
@@ -1,0 +1,12 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type myCtx struct{ val string }
+
+type OrderTestSuite struct{}
+
+func (s *OrderTestSuite) BeforeEach(t *gotest.T) *myCtx { return &myCtx{} }
+func (s *OrderTestSuite) AfterEach(t *gotest.T, ctx *myCtx) {}
+func (s *OrderTestSuite) TestOne(t *gotest.T, ctx *myCtx) {}
+func (s *OrderTestSuite) TestTwo(t *gotest.T, _ *myCtx)   {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_SharedFixtureEmbedding/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_SharedFixtureEmbedding/test.go
@@ -1,0 +1,27 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type PostgresSharedFixture struct {
+	DSN string
+}
+
+func (f *PostgresSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type E2EFixture struct {
+	*PostgresSharedFixture
+	Pool string
+}
+
+func (f *E2EFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *E2EFixture) AfterAll(ctx context.Context) error  { return nil }
+
+type QueryTestSuite struct {
+	*E2EFixture
+}
+
+func (s *QueryTestSuite) TestInsert(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_SharedFixtureEmptyStruct/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_SharedFixtureEmptyStruct/test.go
@@ -1,0 +1,23 @@
+package testpkg
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type SetupSharedFixture struct{}
+
+func (f *SetupSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type AppFixture struct {
+	*SetupSharedFixture
+}
+
+func (f *AppFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type AppTestSuite struct {
+	*AppFixture
+}
+
+func (s *AppTestSuite) TestRun(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_StdlibT_FixtureBoundSuite/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_StdlibT_FixtureBoundSuite/test.go
@@ -1,0 +1,18 @@
+package testpkg
+
+import (
+	"context"
+	"testing"
+)
+
+type DBFixture struct{}
+
+func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type StdlibTestSuite struct {
+	*DBFixture
+}
+
+func (s *StdlibTestSuite) BeforeAll(t *testing.T)  {}
+func (s *StdlibTestSuite) AfterEach(t *testing.T)  {}
+func (s *StdlibTestSuite) TestQuery(t *testing.T)  {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_StdlibT_MixedSuite/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_StdlibT_MixedSuite/test.go
@@ -1,0 +1,13 @@
+package testpkg
+
+import (
+	"testing"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type MixedTestSuite struct{}
+
+func (s *MixedTestSuite) BeforeEach(t *testing.T) {}
+func (s *MixedTestSuite) TestStdlib(t *testing.T)  {}
+func (s *MixedTestSuite) TestGotest(t *gotest.T)   {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_StdlibT_StandaloneSuite/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_StdlibT_StandaloneSuite/test.go
@@ -1,0 +1,10 @@
+package testpkg
+
+import "testing"
+
+type PlainTestSuite struct{}
+
+func (s *PlainTestSuite) BeforeEach(t *testing.T) {}
+func (s *PlainTestSuite) AfterEach(t *testing.T)  {}
+func (s *PlainTestSuite) TestFoo(t *testing.T)    {}
+func (s *PlainTestSuite) TestBar(t *testing.T)    {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_SuiteWithConfig/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_SuiteWithConfig/test.go
@@ -1,0 +1,10 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type ConfiguredTestSuite struct{}
+
+func (s *ConfiguredTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{Timeout: 10_000_000_000, FailFast: true}
+}
+func (s *ConfiguredTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_SuiteWithoutConfig_UsesDefault/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_SuiteWithoutConfig_UsesDefault/test.go
@@ -1,0 +1,7 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type PlainTestSuite struct{}
+
+func (s *PlainTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestRenderer_VoidBeforeEach_Sequential/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_VoidBeforeEach_Sequential/test.go
@@ -1,0 +1,9 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type OrderTestSuite struct{}
+
+func (s *OrderTestSuite) BeforeEach(t *gotest.T) {}
+func (s *OrderTestSuite) AfterEach(t *gotest.T)  {}
+func (s *OrderTestSuite) TestOne(t *gotest.T)    {}

--- a/internal/gotestgen/testdata/sources/TestResolve_CycleDetection/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_CycleDetection/test.go
@@ -1,0 +1,15 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type AFixture struct { *BFixture }
+func (f *AFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type BFixture struct { *AFixture }
+func (f *BFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type SomeTestSuite struct { *AFixture }
+func (s *SomeTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_DirectMultipleSharedFixtures_OnSuite/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_DirectMultipleSharedFixtures_OnSuite/test.go
@@ -1,0 +1,20 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type PGSharedFixture struct{ ConnStr string }
+func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
+
+type RedisSharedFixture struct{ Addr string }
+func (f *RedisSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *RedisSharedFixture) AfterAll(ctx context.Context) error  { return nil }
+
+type FullTestSuite struct {
+	pg    *PGSharedFixture
+	redis *RedisSharedFixture
+}
+func (s *FullTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_DirectSharedFixture_Embedded/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_DirectSharedFixture_Embedded/test.go
@@ -1,0 +1,13 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type PGSharedFixture struct{ ConnStr string }
+func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
+
+type UserTestSuite struct { *PGSharedFixture }
+func (s *UserTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_DirectSharedFixture_NamedField/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_DirectSharedFixture_NamedField/test.go
@@ -1,0 +1,13 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type PGSharedFixture struct{ ConnStr string }
+func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
+
+type UserTestSuite struct { pg *PGSharedFixture }
+func (s *UserTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_Embedding_ChildToParentFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_Embedding_ChildToParentFixture/test.go
@@ -1,0 +1,16 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type InfraFixture struct{ Val string }
+func (f *InfraFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *InfraFixture) AfterAll(ctx context.Context) error  { return nil }
+
+type APIFixture struct { *InfraFixture }
+func (f *APIFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type FullTestSuite struct { *APIFixture }
+func (s *FullTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_Embedding_SuiteToFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_Embedding_SuiteToFixture/test.go
@@ -1,0 +1,12 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type DBFixture struct{ Conn string }
+func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type QueryTestSuite struct { *DBFixture }
+func (s *QueryTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_LifecycleMethods_Detection/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_LifecycleMethods_Detection/test.go
@@ -1,0 +1,15 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type FullFixture struct{ Val string }
+func (f *FullFixture) BeforeAll(ctx context.Context) error  { return nil }
+func (f *FullFixture) AfterAll(ctx context.Context) error   { return nil }
+func (f *FullFixture) BeforeEach(ctx context.Context) error { return nil }
+func (f *FullFixture) AfterEach(ctx context.Context) error  { return nil }
+
+type SomeTestSuite struct { *FullFixture }
+func (s *SomeTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_MissingBeforeAll/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_MissingBeforeAll/test.go
@@ -1,0 +1,8 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type NoSetupFixture struct{ Val string }
+
+type SomeTestSuite struct { *NoSetupFixture }
+func (s *SomeTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_MixedFieldStyles_SameFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_MixedFieldStyles_SameFixture/test.go
@@ -1,0 +1,15 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type DBFixture struct{ Conn string }
+func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type EmbeddedTestSuite struct { *DBFixture }
+func (s *EmbeddedTestSuite) TestOne(t *gotest.T) {}
+
+type NamedTestSuite struct { db *DBFixture }
+func (s *NamedTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_MultipleFixturesPerSuite/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_MultipleFixturesPerSuite/test.go
@@ -1,0 +1,18 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type AFixture struct{}
+func (f *AFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type BFixture struct{}
+func (f *BFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type BadTestSuite struct {
+	*AFixture
+	*BFixture
+}
+func (s *BadTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_MultipleParentFixtures_Error/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_MultipleParentFixtures_Error/test.go
@@ -1,0 +1,21 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type AFixture struct{}
+func (f *AFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type BFixture struct{}
+func (f *BFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type ChildFixture struct {
+	*AFixture
+	*BFixture
+}
+func (f *ChildFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type SomeTestSuite struct { *ChildFixture }
+func (s *SomeTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_NamedField_ChildToParentFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_NamedField_ChildToParentFixture/test.go
@@ -1,0 +1,15 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type InfraFixture struct{ Val string }
+func (f *InfraFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type APIFixture struct { infra *InfraFixture }
+func (f *APIFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type FullTestSuite struct { *APIFixture }
+func (s *FullTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_NamedField_FixtureToSharedFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_NamedField_FixtureToSharedFixture/test.go
@@ -1,0 +1,16 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type PGSharedFixture struct{ ConnStr string }
+func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
+
+type AppFixture struct { pg *PGSharedFixture }
+func (f *AppFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type UserTestSuite struct { *AppFixture }
+func (s *UserTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_NamedField_SuiteToFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_NamedField_SuiteToFixture/test.go
@@ -1,0 +1,12 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type DBFixture struct{ Conn string }
+func (f *DBFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type QueryTestSuite struct { db *DBFixture }
+func (s *QueryTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_NoFixture_Standalone/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_NoFixture_Standalone/test.go
@@ -1,0 +1,6 @@
+package testpkg
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type PlainTestSuite struct{ val string }
+func (s *PlainTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_SharedFixture_TransferFields/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_SharedFixture_TransferFields/test.go
@@ -1,0 +1,19 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type PGSharedFixture struct {
+	ConnStr string
+	Port    int
+}
+func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
+
+type AppFixture struct { *PGSharedFixture }
+func (f *AppFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type UserTestSuite struct { *AppFixture }
+func (s *UserTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_SuiteWithFixtureAndDirectSharedFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_SuiteWithFixtureAndDirectSharedFixture/test.go
@@ -1,0 +1,19 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type PGSharedFixture struct{ ConnStr string }
+func (f *PGSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *PGSharedFixture) AfterAll(ctx context.Context) error  { return nil }
+
+type AppFixture struct{ Val string }
+func (f *AppFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type UserTestSuite struct {
+	*AppFixture
+	*PGSharedFixture
+}
+func (s *UserTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestResolve_UnreferencedFixture_NotInOutput/test.go
+++ b/internal/gotestgen/testdata/sources/TestResolve_UnreferencedFixture_NotInOutput/test.go
@@ -1,0 +1,15 @@
+package testpkg
+
+import (
+	"context"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type UsedFixture struct{}
+func (f *UsedFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type UnusedFixture struct{}
+func (f *UnusedFixture) BeforeAll(ctx context.Context) error { return nil }
+
+type MyTestSuite struct { *UsedFixture }
+func (s *MyTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata_e2e/fixture_lifecycle/ƒƒ_psuite_test.go.golden
+++ b/internal/gotestgen/testdata_e2e/fixture_lifecycle/ƒƒ_psuite_test.go.golden
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	_ "unsafe"
 )
 
 //go:noinline
@@ -26,12 +27,32 @@ func (ts *ƒƒ_GOTEST_AppTestSuite) AfterEach(it *gotest.T)  { ts.AppTestSuite.A
 
 var ƒ_AppFixture *AppFixture
 
+// ƒflushCoverage triggers coverage report writing.
+//
+//go:linkname ƒflushCoverage testing.coverReport
+func ƒflushCoverage()
+
+// ƒtestingCover exposes the stdlib coverage state for tearDown interception.
+//
+//go:linkname ƒtestingCover testing.cover
+var ƒtestingCover struct {
+	mode        string
+	tearDown    func(coverprofile string, gocoverdir string) (string, error)
+	snapshotcov func() float64
+}
+
 func TestMain(m *testing.M) { os.Exit(ƒƒ_GOTEST_main(m)) }
 
 func ƒƒ_GOTEST_main(m *testing.M) (ƒcode int) {
 
 	var ƒcfg_AppFixture gotest.FixtureConfig
 	var ƒok_AppFixture bool
+
+	var ƒorigTearDown func(string, string) (string, error)
+	if testing.CoverMode() != "" {
+		ƒorigTearDown = ƒtestingCover.tearDown
+		ƒtestingCover.tearDown = func(string, string) (string, error) { return "", nil }
+	}
 
 	defer func() {
 		var ƒtwg sync.WaitGroup
@@ -61,6 +82,10 @@ func ƒƒ_GOTEST_main(m *testing.M) (ƒcode int) {
 				ƒcode = 1
 				break
 			}
+		}
+		if ƒorigTearDown != nil {
+			ƒtestingCover.tearDown = ƒorigTearDown
+			ƒflushCoverage()
 		}
 	}()
 

--- a/internal/gotestrunner/args.go
+++ b/internal/gotestrunner/args.go
@@ -299,6 +299,24 @@ func StripCoverBuildFlags(flags []string) []string {
 	return out
 }
 
+// InjectChecklinkname ensures -ldflags includes -checklinkname=0 so that
+// linkname references in generated overlay code can link correctly
+// (required for Go 1.23+ which restricts linkname to stdlib symbols).
+func InjectChecklinkname(buildFlags []string) []string {
+	const ldflag = "-checklinkname=0"
+	for i, f := range buildFlags {
+		if strings.HasPrefix(f, "-ldflags=") {
+			buildFlags[i] = f + " " + ldflag
+			return buildFlags
+		}
+		if f == "-ldflags" && i+1 < len(buildFlags) {
+			buildFlags[i+1] = buildFlags[i+1] + " " + ldflag
+			return buildFlags
+		}
+	}
+	return append(buildFlags, "-ldflags="+ldflag)
+}
+
 // IsGoTestFlag reports whether name (the flag name without any =value suffix)
 // is a recognized go test flag. It returns whether the flag takes a value
 // argument and whether it is known at all.

--- a/internal/gotestrunner/json.go
+++ b/internal/gotestrunner/json.go
@@ -8,8 +8,8 @@ import (
 )
 
 func StdlibRunTestsJSON(ctx context.Context, args []string, extraEnv ...map[string]string) ([]byte, int, error) {
-	jsonArgs := make([]string, 0, len(args)+2)
-	jsonArgs = append(jsonArgs, "test", "-json")
+	jsonArgs := make([]string, 0, len(args)+3)
+	jsonArgs = append(jsonArgs, "test", "-json", "-ldflags=-checklinkname=0")
 	jsonArgs = append(jsonArgs, args...)
 
 	cmd := exec.CommandContext(ctx, "go", jsonArgs...)

--- a/internal/gotestrunner/stdlib.go
+++ b/internal/gotestrunner/stdlib.go
@@ -7,7 +7,7 @@ import (
 )
 
 func StdlibRunTests(ctx context.Context, args []string, extraEnv ...map[string]string) (int, error) {
-	cmd := exec.CommandContext(ctx, "go", append([]string{"test"}, args...)...)
+	cmd := exec.CommandContext(ctx, "go", append([]string{"test", "-ldflags=-checklinkname=0"}, args...)...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	SetProcessGroup(cmd)


### PR DESCRIPTION
Fixture AfterAll teardown code now correctly appears as covered in coverage reports. Includes CI guard tests that detect stdlib changes across Go versions.