### PR TITLE
fix: propagate tree states and show full inline errors

### DIFF
--- a/vscode-gotest/src/coverage.ts
+++ b/vscode-gotest/src/coverage.ts
@@ -10,6 +10,7 @@ import {
   groupByPackage,
   buildRunFilter,
   resolvePackageItems,
+  resolveAncestorItems,
 } from "./runnerUtils.js";
 import { executeBatch } from "./batchRunner.js";
 import type { RunRegistry } from "./runRegistry.js";
@@ -430,6 +431,7 @@ export class CoverageRunner implements vscode.Disposable {
       }
 
       resolvePackageItems(run, items, this.controller);
+      resolveAncestorItems(run, this.controller);
 
       const { coverages: allCoverages } = this.store.buildFileCoverages(
         this.cache,

--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -19,7 +19,11 @@ import { CoverageStore } from "./coverageStore.js";
 import { TestResultStore } from "./testResultStore.js";
 import { RunRegistry } from "./runRegistry.js";
 import { validateGoBinary, scopedConfig } from "./cli.js";
-import { buildRunFilter, getPackageDir } from "./runnerUtils.js";
+import {
+  buildRunFilter,
+  getPackageDir,
+  resolveAncestorItems,
+} from "./runnerUtils.js";
 import { copyCoverageSummary, copyTestResults } from "./reporting.js";
 import { execFile } from "node:child_process";
 
@@ -663,6 +667,7 @@ async function initializeAsync(deps: {
         );
       else if (result.status === "skip") resultRun.skipped(item);
     });
+    resolveAncestorItems(resultRun, controller);
     resultRun.end();
     outputChannel.info(
       `[results] restored ${testResultStore.size} result(s) from storage`,

--- a/vscode-gotest/src/outputParser.test.ts
+++ b/vscode-gotest/src/outputParser.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { parseTestEvents, extractTestMessages } from "./outputParser.js";
+import {
+  parseTestEvents,
+  extractTestMessages,
+  parseExpectedActual,
+} from "./outputParser.js";
 
 describe("parseTestEvents", () => {
   it("parses valid JSON lines into events", () => {
@@ -83,5 +87,100 @@ describe("extractTestMessages", () => {
 
   it("returns empty array for empty input", () => {
     expect(extractTestMessages("", "/pkg")).toHaveLength(0);
+  });
+
+  it("collects continuation lines into the message", () => {
+    const output = [
+      "    config_suite_test.go:14: Equal failed:",
+      "          expected: 720000000000",
+      "          actual:   120000000000",
+    ].join("\n");
+
+    const messages = extractTestMessages(output, "/pkg");
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toBe(
+      "Equal failed:\n          expected: 720000000000\n          actual:   120000000000",
+    );
+  });
+
+  it("stops continuation at the next file:line: match", () => {
+    const output = [
+      "    a_test.go:10: Equal failed:",
+      "          expected: 1",
+      "          actual:   2",
+      "    a_test.go:15: NotEqual failed:",
+      "          expected: 3",
+      "          actual:   3",
+    ].join("\n");
+
+    const messages = extractTestMessages(output, "/pkg");
+    expect(messages).toHaveLength(2);
+    expect(messages[0].message).toBe(
+      "Equal failed:\n          expected: 1\n          actual:   2",
+    );
+    expect(messages[1].message).toBe(
+      "NotEqual failed:\n          expected: 3\n          actual:   3",
+    );
+  });
+
+  it("stops continuation at === RUN and --- FAIL lines", () => {
+    const output = [
+      "    a_test.go:10: Equal failed:",
+      "          expected: 1",
+      "          actual:   2",
+      "--- FAIL: TestFoo (0.00s)",
+    ].join("\n");
+
+    const messages = extractTestMessages(output, "/pkg");
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toBe(
+      "Equal failed:\n          expected: 1\n          actual:   2",
+    );
+  });
+
+  it("collects diff blocks in continuation", () => {
+    const output = [
+      "    a_test.go:10: Equal failed:",
+      '          expected: map[string]int{"a":1, "b":2}',
+      '          actual:   map[string]int{"a":1, "b":3}',
+      "          diff:",
+      '            - "b": 2',
+      '            + "b": 3',
+    ].join("\n");
+
+    const messages = extractTestMessages(output, "/pkg");
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain("diff:");
+    expect(messages[0].message).toContain('+ "b": 3');
+  });
+});
+
+describe("parseExpectedActual", () => {
+  it("extracts expected and actual values", () => {
+    const message =
+      "Equal failed:\n          expected: 720000000000\n          actual:   120000000000";
+    const result = parseExpectedActual(message);
+    expect(result).toEqual({
+      expected: "720000000000",
+      actual: "120000000000",
+    });
+  });
+
+  it("returns undefined when no expected/actual present", () => {
+    expect(parseExpectedActual("some error message")).toBeUndefined();
+  });
+
+  it("returns undefined when only expected is present", () => {
+    expect(parseExpectedActual("Equal failed:\n  expected: 1")).toBeUndefined();
+  });
+
+  it("handles complex values", () => {
+    const message =
+      'Equal failed:\n  expected: map[string]int{"a":1, "b":2}\n  actual:   map[string]int{"a":1, "b":3}';
+    const result = parseExpectedActual(message);
+    expect(result).toEqual({
+      expected: 'map[string]int{"a":1, "b":2}',
+      actual: 'map[string]int{"a":1, "b":3}',
+    });
   });
 });

--- a/vscode-gotest/src/outputParser.ts
+++ b/vscode-gotest/src/outputParser.ts
@@ -69,20 +69,39 @@ export function extractTestMessages(
   const pattern = /^\s*(.+?):(\d+):\s*(.+)$/;
   const lines = output.split("\n");
 
-  for (const line of lines) {
-    const match = pattern.exec(line);
-    if (match) {
-      let file = match[1];
-      const lineNum = parseInt(match[2], 10);
-      const message = match[3];
+  for (let i = 0; i < lines.length; i++) {
+    const match = pattern.exec(lines[i]);
+    if (!match) continue;
 
-      if (!path.isAbsolute(file)) {
-        file = path.join(pkgDir, file);
-      }
+    let file = match[1];
+    const lineNum = parseInt(match[2], 10);
+    let message = match[3];
 
-      messages.push({ file, line: lineNum, message });
+    if (!path.isAbsolute(file)) {
+      file = path.join(pkgDir, file);
     }
+
+    while (i + 1 < lines.length) {
+      const next = lines[i + 1];
+      const trimmed = next.trim();
+      if (!trimmed || pattern.test(next) || /^(===\s|---\s)/.test(trimmed))
+        break;
+      if (!/^\s/.test(next)) break;
+      message += "\n" + next;
+      i++;
+    }
+
+    messages.push({ file, line: lineNum, message });
   }
 
   return messages;
+}
+
+export function parseExpectedActual(
+  message: string,
+): { expected: string; actual: string } | undefined {
+  const expectedMatch = /^\s*expected:\s*(.+)$/m.exec(message);
+  const actualMatch = /^\s*actual:\s*(.+)$/m.exec(message);
+  if (!expectedMatch || !actualMatch) return undefined;
+  return { expected: expectedMatch[1], actual: actualMatch[1] };
 }

--- a/vscode-gotest/src/runner.ts
+++ b/vscode-gotest/src/runner.ts
@@ -8,6 +8,7 @@ import {
   groupByPackage,
   buildRunFilter,
   resolvePackageItems,
+  resolveAncestorItems,
 } from "./runnerUtils.js";
 import type { CoverageStore } from "./coverageStore.js";
 import { executeBatch } from "./batchRunner.js";
@@ -206,6 +207,7 @@ export class TestRunner {
       }
 
       resolvePackageItems(run, items, this.controller);
+      resolveAncestorItems(run, this.controller);
 
       if (anyCoverOnRun) {
         const { coverages: allCoverages } =

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -17,7 +17,15 @@ vi.mock("vscode", () => {
   }
   class TestMessage {
     location?: unknown;
+    expectedOutput?: string;
+    actualOutput?: string;
     constructor(public readonly message: string) {}
+    static diff(message: string, expected: string, actual: string) {
+      const msg = new TestMessage(message);
+      msg.expectedOutput = expected;
+      msg.actualOutput = actual;
+      return msg;
+    }
   }
   class Location {
     constructor(
@@ -596,6 +604,66 @@ describe("applyResults", () => {
       status: "fail",
       duration: 2300,
     });
+  });
+
+  it("creates TestMessage.diff with expected/actual from assertion output", () => {
+    const { controller, run, failItem } = makeApplyResultsFixture();
+
+    const events = [
+      {
+        Action: "output" as const,
+        Test: "MySuite/TestFail",
+        Package: "example.com/pkg",
+        Output: "=== RUN   MySuite/TestFail\n",
+      },
+      {
+        Action: "output" as const,
+        Test: "MySuite/TestFail",
+        Package: "example.com/pkg",
+        Output: "    fail_test.go:14: Equal failed:\n",
+      },
+      {
+        Action: "output" as const,
+        Test: "MySuite/TestFail",
+        Package: "example.com/pkg",
+        Output: "          expected: 720000000000\n",
+      },
+      {
+        Action: "output" as const,
+        Test: "MySuite/TestFail",
+        Package: "example.com/pkg",
+        Output: "          actual:   120000000000\n",
+      },
+      {
+        Action: "output" as const,
+        Test: "MySuite/TestFail",
+        Package: "example.com/pkg",
+        Output: "--- FAIL: MySuite/TestFail (0.00s)\n",
+      },
+      {
+        Action: "fail" as const,
+        Test: "MySuite/TestFail",
+        Package: "example.com/pkg",
+        Elapsed: 0,
+      },
+    ];
+
+    applyResults(
+      controller as any,
+      run as any,
+      events as any,
+      "example.com/pkg",
+      "/some/dir",
+    );
+
+    expect(run.failed).toHaveBeenCalledTimes(1);
+    const messages = run.failed.mock.calls[0][1];
+    expect(messages).toHaveLength(1);
+    expect(messages[0].expectedOutput).toBe("720000000000");
+    expect(messages[0].actualOutput).toBe("120000000000");
+    expect(messages[0].message).toBe(
+      "Equal failed: expected 720000000000, actual 120000000000",
+    );
   });
 });
 

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -40,6 +40,7 @@ import {
   applyResults,
   enqueueDescendants,
   resolvePackageItems,
+  resolveAncestorItems,
 } from "./runnerUtils.js";
 import { buildPathTrie, collapsePathTrie, type PathNode } from "./pathTrie.js";
 
@@ -783,5 +784,167 @@ describe("resolvePackageItems", () => {
     resolvePackageItems(run as any, [pkg as any], controller as any);
     expect(run.passed).not.toHaveBeenCalled();
     expect(run.failed).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveAncestorItems", () => {
+  function makeAncestorFixture() {
+    const dir = createItem("dir:internal", "internal", undefined);
+    const pkg = createItem("example.com/internal/auth", "auth", dir, [
+      { id: "package" },
+    ]);
+    const suite = createItem(
+      "example.com/internal/auth/AuthSuite",
+      "AuthSuite",
+      pkg,
+    );
+    const method = createItem(
+      "example.com/internal/auth/AuthSuite/TestLogin",
+      "TestLogin",
+      suite,
+    );
+
+    const run = {
+      passed: vi.fn(),
+      failed: vi.fn(),
+    };
+
+    const controller = {
+      getResult: vi.fn((_id: string) => undefined as any),
+      testController: {
+        items: new Map<string, MockTestItem>([["dir:internal", dir]]),
+      },
+    };
+
+    return { dir, pkg, suite, method, run, controller };
+  }
+
+  it("marks dir passed when all packages passed", () => {
+    const { dir, run, controller } = makeAncestorFixture();
+    controller.getResult.mockImplementation((id: string) => {
+      if (id === "example.com/internal/auth")
+        return { status: "pass" as const, duration: 500 };
+      return undefined;
+    });
+
+    resolveAncestorItems(run as any, controller as any);
+
+    expect(run.passed).toHaveBeenCalledTimes(1);
+    expect(run.passed).toHaveBeenCalledWith(dir);
+    expect(run.failed).not.toHaveBeenCalled();
+  });
+
+  it("marks dir failed when any package failed", () => {
+    const { dir, run, controller } = makeAncestorFixture();
+    controller.getResult.mockImplementation((id: string) => {
+      if (id === "example.com/internal/auth")
+        return { status: "fail" as const, duration: 500 };
+      return undefined;
+    });
+
+    resolveAncestorItems(run as any, controller as any);
+
+    expect(run.failed).toHaveBeenCalledWith(dir, []);
+    expect(run.passed).not.toHaveBeenCalled();
+  });
+
+  it("marks dir failed when one of multiple packages failed", () => {
+    const dir = createItem("dir:pkg", "pkg", undefined);
+    const pkgA = createItem("example.com/pkg/a", "a", dir, [{ id: "package" }]);
+    const pkgB = createItem("example.com/pkg/b", "b", dir, [{ id: "package" }]);
+
+    const run = { passed: vi.fn(), failed: vi.fn() };
+    const controller = {
+      getResult: vi.fn((id: string) => {
+        if (id === "example.com/pkg/a")
+          return { status: "pass" as const, duration: 100 };
+        if (id === "example.com/pkg/b")
+          return { status: "fail" as const, duration: 200 };
+        return undefined;
+      }),
+      testController: {
+        items: new Map<string, MockTestItem>([["dir:pkg", dir]]),
+      },
+    };
+
+    resolveAncestorItems(run as any, controller as any);
+
+    expect(run.failed).toHaveBeenCalledWith(dir, []);
+    expect(run.passed).not.toHaveBeenCalled();
+  });
+
+  it("propagates through nested directory levels", () => {
+    const root = createItem("dir:src", "src", undefined);
+    const sub = createItem("dir:src/internal", "internal", root);
+    const pkg = createItem("example.com/src/internal/svc", "svc", sub, [
+      { id: "package" },
+    ]);
+
+    const run = { passed: vi.fn(), failed: vi.fn() };
+    const controller = {
+      getResult: vi.fn((id: string) => {
+        if (id === "example.com/src/internal/svc")
+          return { status: "fail" as const, duration: 300 };
+        return undefined;
+      }),
+      testController: {
+        items: new Map<string, MockTestItem>([["dir:src", root]]),
+      },
+    };
+
+    resolveAncestorItems(run as any, controller as any);
+
+    expect(run.failed).toHaveBeenCalledTimes(2);
+    expect(run.failed).toHaveBeenCalledWith(root, []);
+    expect(run.failed).toHaveBeenCalledWith(sub, []);
+  });
+
+  it("propagates through wsFolder items", () => {
+    const wsFolder = createItem("wsFolder:myproject", "myproject", undefined);
+    const pkg = createItem("example.com/root", "root", wsFolder, [
+      { id: "package" },
+    ]);
+
+    const run = { passed: vi.fn(), failed: vi.fn() };
+    const controller = {
+      getResult: vi.fn((id: string) => {
+        if (id === "example.com/root")
+          return { status: "pass" as const, duration: 100 };
+        return undefined;
+      }),
+      testController: {
+        items: new Map<string, MockTestItem>([
+          ["wsFolder:myproject", wsFolder],
+        ]),
+      },
+    };
+
+    resolveAncestorItems(run as any, controller as any);
+
+    expect(run.passed).toHaveBeenCalledWith(wsFolder);
+  });
+
+  it("does not set state when no descendants have results", () => {
+    const { dir, run, controller } = makeAncestorFixture();
+
+    resolveAncestorItems(run as any, controller as any);
+
+    expect(run.passed).not.toHaveBeenCalled();
+    expect(run.failed).not.toHaveBeenCalled();
+  });
+
+  it("derives dir state from suite/method results when package has no result", () => {
+    const { dir, run, controller } = makeAncestorFixture();
+    controller.getResult.mockImplementation((id: string) => {
+      if (id === "example.com/internal/auth/AuthSuite/TestLogin")
+        return { status: "fail" as const, duration: 50 };
+      return undefined;
+    });
+
+    resolveAncestorItems(run as any, controller as any);
+
+    expect(run.failed).toHaveBeenCalledTimes(1);
+    expect(run.failed).toHaveBeenCalledWith(dir, []);
+    expect(run.passed).not.toHaveBeenCalled();
   });
 });

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -2,7 +2,11 @@ import * as vscode from "vscode";
 import { spawn, type ChildProcess } from "node:child_process";
 import type { GoTestController } from "./testController.js";
 import type { DiscoveryCache } from "./discovery.js";
-import { extractTestMessages, type TestEvent } from "./outputParser.js";
+import {
+  extractTestMessages,
+  parseExpectedActual,
+  type TestEvent,
+} from "./outputParser.js";
 
 export function killProcessTree(
   child: ChildProcess,
@@ -237,7 +241,16 @@ export function applyResults(
         const output = outputMap.get(event.Test) ?? "";
         const testMessages = extractTestMessages(output, pkgDir);
         const vscodeMessages = testMessages.map((msg) => {
-          const message = new vscode.TestMessage(msg.message);
+          const parsed = parseExpectedActual(msg.message);
+          const message = new vscode.TestMessage(
+            parsed
+              ? `${msg.message.split("\n")[0].replace(/:\s*$/, "")}: expected ${parsed.expected}, actual ${parsed.actual}`
+              : msg.message,
+          );
+          if (parsed) {
+            message.expectedOutput = parsed.expected;
+            message.actualOutput = parsed.actual;
+          }
           message.location = new vscode.Location(
             vscode.Uri.file(msg.file),
             new vscode.Position(msg.line - 1, 0),

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -522,3 +522,62 @@ export function resolvePackageItems(
     }
   }
 }
+
+export function resolveAncestorItems(
+  run: vscode.TestRun,
+  controller: GoTestController,
+): void {
+  controller.testController.items.forEach((item) => {
+    resolveItemRecursive(run, item, controller);
+  });
+}
+
+function resolveItemRecursive(
+  run: vscode.TestRun,
+  item: vscode.TestItem,
+  controller: GoTestController,
+): { anyFailed: boolean; anyResolved: boolean } {
+  if (item.tags.some((t) => t.id === "package")) {
+    const result = controller.getResult(item.id);
+    if (result) {
+      return { anyFailed: result.status === "fail", anyResolved: true };
+    }
+    return checkSubtreeResults(item, controller);
+  }
+
+  let anyFailed = false;
+  let anyResolved = false;
+  item.children.forEach((child) => {
+    const r = resolveItemRecursive(run, child, controller);
+    if (r.anyResolved) anyResolved = true;
+    if (r.anyFailed) anyFailed = true;
+  });
+
+  if (anyResolved) {
+    if (anyFailed) {
+      run.failed(item, []);
+    } else {
+      run.passed(item);
+    }
+  }
+
+  return { anyFailed, anyResolved };
+}
+
+function checkSubtreeResults(
+  item: vscode.TestItem,
+  controller: GoTestController,
+): { anyFailed: boolean; anyResolved: boolean } {
+  const result = controller.getResult(item.id);
+  if (result) {
+    return { anyFailed: result.status === "fail", anyResolved: true };
+  }
+  let anyFailed = false;
+  let anyResolved = false;
+  item.children.forEach((child) => {
+    const r = checkSubtreeResults(child, controller);
+    if (r.anyResolved) anyResolved = true;
+    if (r.anyFailed) anyFailed = true;
+  });
+  return { anyFailed, anyResolved };
+}

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -8,6 +8,8 @@ import {
   resolveTestItem,
   applyResults,
   killProcessTree,
+  resolvePackageItems,
+  resolveAncestorItems,
 } from "./runnerUtils.js";
 import type { RunRegistry } from "./runRegistry.js";
 
@@ -407,6 +409,16 @@ export class WatchManager implements vscode.Disposable {
           this.controller.recordResult(r.itemId, r.status, r.duration);
         }
       }
+    }
+
+    const pkgItems: vscode.TestItem[] = [];
+    for (const importPath of byPackage.keys()) {
+      const item = this.controller.findItem(importPath);
+      if (item) pkgItems.push(item);
+    }
+    if (pkgItems.length > 0) {
+      resolvePackageItems(run, pkgItems, this.controller);
+      resolveAncestorItems(run, this.controller);
     }
   }
 }


### PR DESCRIPTION
- Propagate failed/passed states upward from leaf tests through suites, packages, and directories so the Test Explorer tree reflects actual results
- Extract expected/actual values from assertion output and surface them in inline error decorations instead of truncated messages