### PR TITLE
suppress spurious "exit status" lines from test output

### DIFF
--- a/vscode-gotest/src/batchRunner.ts
+++ b/vscode-gotest/src/batchRunner.ts
@@ -188,10 +188,14 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
     }
 
     if (result.exitCode !== 0) {
-      const stderrTrimmed = result.stderr.trim();
+      const stderrFiltered = result.stderr
+        .split("\n")
+        .filter((line) => !/^exit status \d+$/.test(line.trim()))
+        .join("\n")
+        .trim();
 
-      if (stderrTrimmed) {
-        run.appendOutput(stderrTrimmed.replace(/\n/g, "\r\n") + "\r\n");
+      if (stderrFiltered) {
+        run.appendOutput(stderrFiltered.replace(/\n/g, "\r\n") + "\r\n");
       }
 
       for (const info of pkgInfos) {
@@ -200,7 +204,7 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
         }
 
         const diagnostic = [
-          stderrTrimmed,
+          stderrFiltered,
           result.stdout.trim(),
           `exit code ${result.exitCode}`,
         ]

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -204,6 +204,9 @@ export function applyResults(
 
   for (const event of events) {
     if (event.Action === "output" && event.Output) {
+      if (!event.Test && /^exit status \d+\n?$/.test(event.Output)) {
+        continue;
+      }
       const line = event.Output.replace(/\n$/, "\r\n");
       const testItem = event.Test
         ? resolveTestItem(controller, event.Test, importPath)


### PR DESCRIPTION
Remove noise lines from test output that caused passing tests to appear as failed in the sidebar.