### PR TITLE
Fix setup-timeout and improve configuration docs

### DIFF
--- a/cmd/gotest/cli.go
+++ b/cmd/gotest/cli.go
@@ -186,12 +186,12 @@ func parseSetupTimeoutFlag(args []string) (time.Duration, error) {
 		if err != nil {
 			return 0, fmt.Errorf("invalid --setup-timeout value %q: %w", raw, err)
 		}
-		if d <= 0 {
-			return 0, fmt.Errorf("invalid --setup-timeout value %q: must be positive", raw)
+		if d < -1 || d == 0 {
+			return 0, fmt.Errorf("invalid --setup-timeout value %q: must be positive or -1 to disable", raw)
 		}
 		return d, nil
 	}
-	return time.Minute, nil
+	return 0, nil
 }
 
 func readCoverageTotal(profilePath string) (float64, error) {

--- a/cmd/gotest/cli.go
+++ b/cmd/gotest/cli.go
@@ -186,8 +186,8 @@ func parseSetupTimeoutFlag(args []string) (time.Duration, error) {
 		if err != nil {
 			return 0, fmt.Errorf("invalid --setup-timeout value %q: %w", raw, err)
 		}
-		if d < -1 || d == 0 {
-			return 0, fmt.Errorf("invalid --setup-timeout value %q: must be positive or -1 to disable", raw)
+		if d == 0 {
+			return 0, fmt.Errorf("invalid --setup-timeout value %q: must be positive or negative to disable", raw)
 		}
 		return d, nil
 	}

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -83,7 +83,7 @@ Flags (gotest — use --double-dash):
   --spec                  Render spec view instead of default output
   --update-snapshots      Regenerate snapshot files
   --min=<pct>             Fail if coverage < pct%% (0-100)
-  --setup-timeout=<dur>   Total budget for shared fixture setup (-1 to disable)
+  --setup-timeout=<dur>   Total budget for shared fixture setup (-1s to disable)
 
 Flags (go test — use -single-dash, forwarded automatically):
   -v                      Verbose output
@@ -126,7 +126,7 @@ Flags:
   --spec                  Render spec view instead of default output
   --update-snapshots      Regenerate snapshot files
   --min=<pct>             Fail if coverage < pct% (0-100, enables -coverprofile)
-  --setup-timeout=<dur>   Total budget for shared fixture setup (-1 to disable)
+  --setup-timeout=<dur>   Total budget for shared fixture setup (-1s to disable)
 
 All standard go test flags (-single-dash) are forwarded automatically.
 Use a bare "--" to pass unrecognized flags without validation.
@@ -159,7 +159,7 @@ Flags:
   --debug                 Keep generated overlay
   --update-snapshots      Regenerate snapshot files
   --min=<pct>             Fail if coverage < pct% (0-100)
-  --setup-timeout=<dur>   Total budget for shared fixture setup (-1 to disable)
+  --setup-timeout=<dur>   Total budget for shared fixture setup (-1s to disable)
 
 Examples:
   gotest spec ./...                                Run and render spec
@@ -185,7 +185,7 @@ Flags:
   --ci                    Fail on focused tests (F_ prefixes)
   --debug                 Keep generated overlay
   --update-snapshots      Regenerate snapshot files
-  --setup-timeout=<dur>   Total budget for shared fixture setup (-1 to disable)
+  --setup-timeout=<dur>   Total budget for shared fixture setup (-1s to disable)
 
 Examples:
   gotest watch ./...                         Watch all packages
@@ -380,7 +380,7 @@ at a go.mod boundary. CLI flags override config values.
 
 Fields:
   tags: <string>            Build tags, comma-separated (e.g., "integration,e2e")
-  setup-timeout: <duration> Total budget for all shared fixture setup (e.g., "2m", -1 to disable)
+  setup-timeout: <duration> Total budget for all shared fixture setup (e.g., "2m", "-1s" to disable)
   min-coverage: <int>       Minimum coverage percentage, 0-100
   debounce: <duration>      Watch mode re-run delay (e.g., "500ms", default: 200ms)
   lint:

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -83,7 +83,7 @@ Flags (gotest — use --double-dash):
   --spec                  Render spec view instead of default output
   --update-snapshots      Regenerate snapshot files
   --min=<pct>             Fail if coverage < pct%% (0-100)
-  --setup-timeout=<dur>   Shared fixture deadline (default: 1m)
+  --setup-timeout=<dur>   Shared fixture deadline (-1 to disable)
 
 Flags (go test — use -single-dash, forwarded automatically):
   -v                      Verbose output
@@ -126,7 +126,7 @@ Flags:
   --spec                  Render spec view instead of default output
   --update-snapshots      Regenerate snapshot files
   --min=<pct>             Fail if coverage < pct% (0-100, enables -coverprofile)
-  --setup-timeout=<dur>   Shared fixture deadline (default: 1m)
+  --setup-timeout=<dur>   Shared fixture deadline (-1 to disable)
 
 All standard go test flags (-single-dash) are forwarded automatically.
 Use a bare "--" to pass unrecognized flags without validation.
@@ -159,7 +159,7 @@ Flags:
   --debug                 Keep generated overlay
   --update-snapshots      Regenerate snapshot files
   --min=<pct>             Fail if coverage < pct% (0-100)
-  --setup-timeout=<dur>   Shared fixture deadline (default: 1m)
+  --setup-timeout=<dur>   Shared fixture deadline (-1 to disable)
 
 Examples:
   gotest spec ./...                                Run and render spec
@@ -185,7 +185,7 @@ Flags:
   --ci                    Fail on focused tests (F_ prefixes)
   --debug                 Keep generated overlay
   --update-snapshots      Regenerate snapshot files
-  --setup-timeout=<dur>   Shared fixture deadline (default: 1m)
+  --setup-timeout=<dur>   Shared fixture deadline (-1 to disable)
 
 Examples:
   gotest watch ./...                         Watch all packages
@@ -380,7 +380,7 @@ at a go.mod boundary. CLI flags override config values.
 
 Fields:
   tags: <string>            Build tags, comma-separated (e.g., "integration,e2e")
-  setup-timeout: <duration> Shared fixture deadline (e.g., "2m", default: 1m)
+  setup-timeout: <duration> Shared fixture deadline (e.g., "2m", -1 to disable)
   min-coverage: <int>       Minimum coverage percentage, 0-100
   debounce: <duration>      Watch mode re-run delay (e.g., "500ms", default: 200ms)
   lint:

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -83,7 +83,7 @@ Flags (gotest — use --double-dash):
   --spec                  Render spec view instead of default output
   --update-snapshots      Regenerate snapshot files
   --min=<pct>             Fail if coverage < pct%% (0-100)
-  --setup-timeout=<dur>   Shared fixture deadline (-1 to disable)
+  --setup-timeout=<dur>   Total budget for shared fixture setup (-1 to disable)
 
 Flags (go test — use -single-dash, forwarded automatically):
   -v                      Verbose output
@@ -126,7 +126,7 @@ Flags:
   --spec                  Render spec view instead of default output
   --update-snapshots      Regenerate snapshot files
   --min=<pct>             Fail if coverage < pct% (0-100, enables -coverprofile)
-  --setup-timeout=<dur>   Shared fixture deadline (-1 to disable)
+  --setup-timeout=<dur>   Total budget for shared fixture setup (-1 to disable)
 
 All standard go test flags (-single-dash) are forwarded automatically.
 Use a bare "--" to pass unrecognized flags without validation.
@@ -159,7 +159,7 @@ Flags:
   --debug                 Keep generated overlay
   --update-snapshots      Regenerate snapshot files
   --min=<pct>             Fail if coverage < pct% (0-100)
-  --setup-timeout=<dur>   Shared fixture deadline (-1 to disable)
+  --setup-timeout=<dur>   Total budget for shared fixture setup (-1 to disable)
 
 Examples:
   gotest spec ./...                                Run and render spec
@@ -185,7 +185,7 @@ Flags:
   --ci                    Fail on focused tests (F_ prefixes)
   --debug                 Keep generated overlay
   --update-snapshots      Regenerate snapshot files
-  --setup-timeout=<dur>   Shared fixture deadline (-1 to disable)
+  --setup-timeout=<dur>   Total budget for shared fixture setup (-1 to disable)
 
 Examples:
   gotest watch ./...                         Watch all packages
@@ -380,7 +380,7 @@ at a go.mod boundary. CLI flags override config values.
 
 Fields:
   tags: <string>            Build tags, comma-separated (e.g., "integration,e2e")
-  setup-timeout: <duration> Shared fixture deadline (e.g., "2m", -1 to disable)
+  setup-timeout: <duration> Total budget for all shared fixture setup (e.g., "2m", -1 to disable)
   min-coverage: <int>       Minimum coverage percentage, 0-100
   debounce: <duration>      Watch mode re-run delay (e.g., "500ms", default: 200ms)
   lint:

--- a/cmd/gotest/prepare.go
+++ b/cmd/gotest/prepare.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"github.com/mvrahden/go-test/internal/gotestgen"
 )
@@ -46,7 +45,7 @@ func runPrepare(inv Invocation) int {
 
 	var setupProc *SharedFixtureProcess
 	if len(overlay.sharedFixtures) > 0 {
-		setupProc, err = startSharedFixtures(ctx, overlay.tmpDir, overlay.sharedFixtures, time.Minute)
+		setupProc, err = startSharedFixtures(ctx, overlay.tmpDir, overlay.sharedFixtures, 0)
 		if err != nil {
 			stop()
 			cleanup()

--- a/cmd/gotest/sharedfixture.go
+++ b/cmd/gotest/sharedfixture.go
@@ -51,8 +51,8 @@ func (p *SharedFixtureProcess) Teardown() error {
 // starts it as a subprocess, reads JSON state from stdout, writes it to a state
 // file, and returns a SharedFixtureProcess. setupTimeout is a total budget for
 // all shared fixtures to complete setup; 0 means no external deadline (each
-// fixture's own SharedFixtureConfig().Timeout governs); -1 explicitly disables
-// the deadline.
+// fixture's own SharedFixtureConfig().Timeout governs); any negative value
+// explicitly disables the deadline.
 func startSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestgen.SharedFixtureInfo, setupTimeout time.Duration) (*SharedFixtureProcess, error) {
 	src, err := gotestgen.GenerateSharedSetup(fixtures)
 	if err != nil {

--- a/cmd/gotest/sharedfixture.go
+++ b/cmd/gotest/sharedfixture.go
@@ -49,7 +49,10 @@ func (p *SharedFixtureProcess) Teardown() error {
 
 // startSharedFixtures generates a shared setup binary in the overlay temp dir,
 // starts it as a subprocess, reads JSON state from stdout, writes it to a state
-// file, and returns a SharedFixtureProcess.
+// file, and returns a SharedFixtureProcess. setupTimeout is a total budget for
+// all shared fixtures to complete setup; 0 means no external deadline (each
+// fixture's own SharedFixtureConfig().Timeout governs); -1 explicitly disables
+// the deadline.
 func startSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestgen.SharedFixtureInfo, setupTimeout time.Duration) (*SharedFixtureProcess, error) {
 	src, err := gotestgen.GenerateSharedSetup(fixtures)
 	if err != nil {

--- a/cmd/gotest/sharedfixture.go
+++ b/cmd/gotest/sharedfixture.go
@@ -101,20 +101,34 @@ func startSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestge
 	}()
 
 	var state map[string]json.RawMessage
-	select {
-	case res := <-decoded:
-		if res.err != nil {
+	if setupTimeout > 0 {
+		select {
+		case res := <-decoded:
+			if res.err != nil {
+				cmd.Process.Kill()
+				return nil, fmt.Errorf("read shared fixture state: %w", res.err)
+			}
+			state = res.state
+		case <-ctx.Done():
 			cmd.Process.Kill()
-			return nil, fmt.Errorf("read shared fixture state: %w", res.err)
+			return nil, fmt.Errorf("cancelled: %w", ctx.Err())
+		case <-time.After(setupTimeout):
+			cmd.Process.Kill()
+			io.Copy(io.Discard, stdout)
+			return nil, fmt.Errorf("timed out after %v", setupTimeout)
 		}
-		state = res.state
-	case <-ctx.Done():
-		cmd.Process.Kill()
-		return nil, fmt.Errorf("cancelled: %w", ctx.Err())
-	case <-time.After(setupTimeout):
-		cmd.Process.Kill()
-		io.Copy(io.Discard, stdout)
-		return nil, fmt.Errorf("timed out after %v", setupTimeout)
+	} else {
+		select {
+		case res := <-decoded:
+			if res.err != nil {
+				cmd.Process.Kill()
+				return nil, fmt.Errorf("read shared fixture state: %w", res.err)
+			}
+			state = res.state
+		case <-ctx.Done():
+			cmd.Process.Kill()
+			return nil, fmt.Errorf("cancelled: %w", ctx.Err())
+		}
 	}
 
 	teardownTimeout := setupTimeout

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -779,7 +779,38 @@ InfraFixture.AfterAll</div>
     <!-- 6. Configuration -->
     <section class="ref-section" id="configuration">
       <h2>Configuration</h2>
-      <p class="lead">Sensible defaults. Override only what you need via marker methods.</p>
+      <p class="lead">Sensible defaults. Override only what you need — via project file, marker methods, or CLI flags.</p>
+
+      <h3>Precedence</h3>
+      <p>Configuration is resolved in layers. Each layer can override the one below it:</p>
+      <div class="diagram">1. CLI flags            <span class="d">--setup-timeout=2m, --min=80, --debounce=500ms</span>
+2. Project file         <span class="d">.gotest.yml — checked into the repo</span>
+3. In-code config       <span class="d">SuiteConfig(), FixtureConfig(), SharedFixtureConfig()</span>
+4. Built-in defaults    <span class="d">DefaultSuiteConfig(), DefaultFixtureConfig()</span></div>
+      <p>CLI flags take precedence over the project file. The project file sets team-wide defaults; CLI flags allow per-invocation overrides. In-code config and built-in defaults operate at the suite/fixture level — independent of the project-level settings.</p>
+
+      <h3>Project file — <code>.gotest.yml</code></h3>
+      <p>Place a <code>.gotest.yml</code> in your project root. gotest finds it by walking up from the working directory, stopping at the first match or at a <code>go.mod</code> boundary.</p>
+      <table class="ref-table">
+        <thead><tr><th>Field</th><th>Type</th><th>Default</th><th>Effect</th></tr></thead>
+        <tbody>
+          <tr><td><code>tags</code></td><td>string</td><td><em>none</em></td><td>Build tags, comma-separated (e.g. <code>"integration,e2e"</code>).</td></tr>
+          <tr><td><code>setup-timeout</code></td><td>duration</td><td>1m</td><td>Shared fixture setup deadline (<code>--setup-timeout</code>).</td></tr>
+          <tr><td><code>min-coverage</code></td><td>int</td><td>0 (off)</td><td>Minimum coverage percentage, 0–100 (<code>--min</code>).</td></tr>
+          <tr><td><code>debounce</code></td><td>duration</td><td>200ms</td><td>Watch mode re-run delay (<code>--debounce</code>).</td></tr>
+          <tr><td><code>lint.skip</code></td><td>[string]</td><td><em>none</em></td><td>Lint rules to disable: <code>stdlib-test</code>, <code>testify</code>.</td></tr>
+        </tbody>
+      </table>
+      <div class="code-block">
+        <div class="code-label">.gotest.yml</div>
+        <pre>tags: integration
+setup-timeout: 2m
+min-coverage: 80
+debounce: 500ms
+lint:
+  skip:
+    - testify</pre>
+      </div>
 
       <h3>Suite configuration</h3>
       <table class="ref-table">

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -795,7 +795,7 @@ InfraFixture.AfterAll</div>
         <thead><tr><th>Field</th><th>Type</th><th>Default</th><th>Effect</th></tr></thead>
         <tbody>
           <tr><td><code>tags</code></td><td>string</td><td><em>none</em></td><td>Build tags, comma-separated (e.g. <code>"integration,e2e"</code>).</td></tr>
-          <tr><td><code>setup-timeout</code></td><td>duration</td><td>1m</td><td>Shared fixture setup deadline (<code>--setup-timeout</code>).</td></tr>
+          <tr><td><code>setup-timeout</code></td><td>duration</td><td><em>none</em></td><td>Shared fixture setup deadline. Omit to let the fixture's own config govern. Use <code>-1</code> to disable (<code>--setup-timeout</code>).</td></tr>
           <tr><td><code>min-coverage</code></td><td>int</td><td>0 (off)</td><td>Minimum coverage percentage, 0–100 (<code>--min</code>).</td></tr>
           <tr><td><code>debounce</code></td><td>duration</td><td>200ms</td><td>Watch mode re-run delay (<code>--debounce</code>).</td></tr>
           <tr><td><code>lint.skip</code></td><td>[string]</td><td><em>none</em></td><td>Lint rules to disable: <code>stdlib-test</code>, <code>testify</code>.</td></tr>
@@ -910,7 +910,7 @@ percentage = covered / total</div>
           <tr><td><code>--output=&lt;path&gt;</code></td><td>Write formatted output to file.</td></tr>
           <tr><td><code>--no-color</code></td><td>Strip ANSI codes from output.</td></tr>
           <tr><td><code>--debug</code></td><td>Preserve overlays after the run for inspection.</td></tr>
-          <tr><td><code>--setup-timeout=&lt;dur&gt;</code></td><td>Shared fixture setup deadline (default 1m).</td></tr>
+          <tr><td><code>--setup-timeout=&lt;dur&gt;</code></td><td>Shared fixture setup deadline. Omit to let the fixture's own config govern. Use <code>-1</code> to disable.</td></tr>
           <tr><td><code>--debounce=&lt;dur&gt;</code></td><td>Watch mode debounce interval (default 200ms).</td></tr>
           <tr><td><code>--input=&lt;path&gt;</code></td><td>Read test output from file instead of running tests (<code>spec</code> command).</td></tr>
         </tbody>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -795,7 +795,7 @@ InfraFixture.AfterAll</div>
         <thead><tr><th>Field</th><th>Type</th><th>Default</th><th>Effect</th></tr></thead>
         <tbody>
           <tr><td><code>tags</code></td><td>string</td><td><em>none</em></td><td>Build tags, comma-separated (e.g. <code>"integration,e2e"</code>).</td></tr>
-          <tr><td><code>setup-timeout</code></td><td>duration</td><td><em>none</em></td><td>Shared fixture setup deadline. Omit to let the fixture's own config govern. Use <code>-1</code> to disable (<code>--setup-timeout</code>).</td></tr>
+          <tr><td><code>setup-timeout</code></td><td>duration</td><td><em>none</em></td><td>Total budget for all shared fixture setup. Omit to let each fixture's own config govern. Use <code>-1</code> to disable (<code>--setup-timeout</code>).</td></tr>
           <tr><td><code>min-coverage</code></td><td>int</td><td>0 (off)</td><td>Minimum coverage percentage, 0–100 (<code>--min</code>).</td></tr>
           <tr><td><code>debounce</code></td><td>duration</td><td>200ms</td><td>Watch mode re-run delay (<code>--debounce</code>).</td></tr>
           <tr><td><code>lint.skip</code></td><td>[string]</td><td><em>none</em></td><td>Lint rules to disable: <code>stdlib-test</code>, <code>testify</code>.</td></tr>
@@ -910,7 +910,7 @@ percentage = covered / total</div>
           <tr><td><code>--output=&lt;path&gt;</code></td><td>Write formatted output to file.</td></tr>
           <tr><td><code>--no-color</code></td><td>Strip ANSI codes from output.</td></tr>
           <tr><td><code>--debug</code></td><td>Preserve overlays after the run for inspection.</td></tr>
-          <tr><td><code>--setup-timeout=&lt;dur&gt;</code></td><td>Shared fixture setup deadline. Omit to let the fixture's own config govern. Use <code>-1</code> to disable.</td></tr>
+          <tr><td><code>--setup-timeout=&lt;dur&gt;</code></td><td>Total budget for all shared fixture setup. Omit to let each fixture's own config govern. Use <code>-1</code> to disable.</td></tr>
           <tr><td><code>--debounce=&lt;dur&gt;</code></td><td>Watch mode debounce interval (default 200ms).</td></tr>
           <tr><td><code>--input=&lt;path&gt;</code></td><td>Read test output from file instead of running tests (<code>spec</code> command).</td></tr>
         </tbody>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -797,7 +797,7 @@ InfraFixture.AfterAll</div>
         <thead><tr><th>Field</th><th>Type</th><th>Default</th><th>Effect</th></tr></thead>
         <tbody>
           <tr><td><code>tags</code></td><td>string</td><td><em>none</em></td><td>Build tags, comma-separated (e.g. <code>"integration,e2e"</code>).</td></tr>
-          <tr><td><code>setup-timeout</code></td><td>duration</td><td><em>none</em></td><td>Total budget for all shared fixture setup. Omit to let each fixture's own config govern. Use <code>-1</code> to disable (<code>--setup-timeout</code>).</td></tr>
+          <tr><td><code>setup-timeout</code></td><td>duration</td><td><em>none</em></td><td>Total budget for all shared fixture setup. Omit to let each fixture's own config govern. Use a negative value (e.g. <code>-1s</code>) to disable (<code>--setup-timeout</code>).</td></tr>
           <tr><td><code>min-coverage</code></td><td>int</td><td>0 (off)</td><td>Minimum coverage percentage, 0–100 (<code>--min</code>).</td></tr>
           <tr><td><code>debounce</code></td><td>duration</td><td>200ms</td><td>Watch mode re-run delay (<code>--debounce</code>).</td></tr>
           <tr><td><code>lint.skip</code></td><td>[string]</td><td><em>none</em></td><td>Lint rules to disable: <code>stdlib-test</code>, <code>testify</code>.</td></tr>
@@ -912,7 +912,7 @@ percentage = covered / total</div>
           <tr><td><code>--output=&lt;path&gt;</code></td><td>Write formatted output to file.</td></tr>
           <tr><td><code>--no-color</code></td><td>Strip ANSI codes from output.</td></tr>
           <tr><td><code>--debug</code></td><td>Preserve overlays after the run for inspection.</td></tr>
-          <tr><td><code>--setup-timeout=&lt;dur&gt;</code></td><td>Total budget for all shared fixture setup. Omit to let each fixture's own config govern. Use <code>-1</code> to disable.</td></tr>
+          <tr><td><code>--setup-timeout=&lt;dur&gt;</code></td><td>Total budget for all shared fixture setup. Omit to let each fixture's own config govern. Use a negative value (e.g. <code>-1s</code>) to disable.</td></tr>
           <tr><td><code>--debounce=&lt;dur&gt;</code></td><td>Watch mode debounce interval (default 200ms).</td></tr>
           <tr><td><code>--input=&lt;path&gt;</code></td><td>Read test output from file instead of running tests (<code>spec</code> command).</td></tr>
         </tbody>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -782,12 +782,14 @@ InfraFixture.AfterAll</div>
       <p class="lead">Sensible defaults. Override only what you need — via project file, marker methods, or CLI flags.</p>
 
       <h3>Precedence</h3>
-      <p>Configuration is resolved in layers. Each layer can override the one below it:</p>
+      <p>There are two independent configuration scopes:</p>
+      <p><strong>Project scope</strong> — CLI flags override the project file. These control the test runner itself:</p>
       <div class="diagram">1. CLI flags            <span class="d">--setup-timeout=2m, --min=80, --debounce=500ms</span>
-2. Project file         <span class="d">.gotest.yml — checked into the repo</span>
-3. In-code config       <span class="d">SuiteConfig(), FixtureConfig(), SharedFixtureConfig()</span>
-4. Built-in defaults    <span class="d">DefaultSuiteConfig(), DefaultFixtureConfig()</span></div>
-      <p>CLI flags take precedence over the project file. The project file sets team-wide defaults; CLI flags allow per-invocation overrides. In-code config and built-in defaults operate at the suite/fixture level — independent of the project-level settings.</p>
+2. Project file         <span class="d">.gotest.yml — checked into the repo</span></div>
+      <p><strong>Code scope</strong> — marker methods override built-in presets. These control individual suites and fixtures:</p>
+      <div class="diagram">1. In-code config       <span class="d">SuiteConfig(), FixtureConfig(), SharedFixtureConfig()</span>
+2. Built-in defaults    <span class="d">DefaultSuiteConfig(), DefaultFixtureConfig()</span></div>
+      <p>The two scopes are independent — they don't override each other. For shared fixture timeouts specifically, <code>--setup-timeout</code> is an outer wall-clock budget on the entire setup phase, while <code>SharedFixtureConfig().Timeout</code> is an inner per-fixture deadline. Both run concurrently — whichever fires first wins. When <code>--setup-timeout</code> is omitted, only the per-fixture timeouts apply.</p>
 
       <h3>Project file — <code>.gotest.yml</code></h3>
       <p>Place a <code>.gotest.yml</code> in your project root. gotest finds it by walking up from the working directory, stopping at the first match or at a <code>go.mod</code> boundary.</p>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,8 @@ const FileName = ".gotest.yml"
 type ProjectConfig struct {
 	// Tags is a comma-separated list of build tags passed to go test (e.g. "integration,e2e").
 	Tags string `yaml:"tags"`
-	// SetupTimeout is the deadline for shared fixture setup. Overrides the CLI default (1m).
+	// SetupTimeout is the total budget for all shared fixture setup.
+	// When omitted, each fixture's own SharedFixtureConfig().Timeout governs.
 	SetupTimeout Duration `yaml:"setup-timeout"`
 	// MinCoverage is the minimum coverage percentage (0-100). The run fails if coverage is below.
 	MinCoverage int `yaml:"min-coverage"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,15 +12,24 @@ import (
 
 const FileName = ".gotest.yml"
 
+// ProjectConfig holds settings loaded from .gotest.yml.
+// CLI flags take precedence over these values; zero values are ignored.
 type ProjectConfig struct {
-	Tags         string     `yaml:"tags"`
-	SetupTimeout Duration   `yaml:"setup-timeout"`
-	MinCoverage  int        `yaml:"min-coverage"`
-	Debounce     Duration   `yaml:"debounce"`
-	Lint         LintConfig `yaml:"lint"`
+	// Tags is a comma-separated list of build tags passed to go test (e.g. "integration,e2e").
+	Tags string `yaml:"tags"`
+	// SetupTimeout is the deadline for shared fixture setup. Overrides the CLI default (1m).
+	SetupTimeout Duration `yaml:"setup-timeout"`
+	// MinCoverage is the minimum coverage percentage (0-100). The run fails if coverage is below.
+	MinCoverage int `yaml:"min-coverage"`
+	// Debounce is the delay before re-running tests in watch mode. Overrides the CLI default (200ms).
+	Debounce Duration `yaml:"debounce"`
+	// Lint holds lint-specific configuration.
+	Lint LintConfig `yaml:"lint"`
 }
 
+// LintConfig controls which lint rules are disabled project-wide.
 type LintConfig struct {
+	// Skip lists lint rule names to disable (e.g. "stdlib-test", "testify").
 	Skip []string `yaml:"skip"`
 }
 

--- a/pkg/gotest/config.go
+++ b/pkg/gotest/config.go
@@ -2,36 +2,64 @@ package gotest
 
 import "time"
 
+// FixtureConfig controls timeout and retry behavior for package fixtures and
+// shared fixtures. Returned by the optional FixtureConfig() or
+// SharedFixtureConfig() marker method on a fixture struct.
+// A zero value means "keep the default."
 type FixtureConfig struct {
-	Timeout    time.Duration
-	Retries    int
+	// Timeout is the deadline for each lifecycle operation (BeforeAll/AfterAll).
+	// Use -1 to disable. Default: 2m (DefaultFixtureConfig).
+	Timeout time.Duration
+	// Retries is how many times to retry BeforeAll on failure. Default: 0.
+	Retries int
+	// RetryDelay is the pause between retry attempts. Default: 0.
 	RetryDelay time.Duration
 }
 
+// SuiteConfig controls timeout, parallelism, and failure behavior for a test
+// suite. Returned by the optional SuiteConfig() marker method on a suite struct.
+// A zero value means "keep the default"; booleans latch to true and cannot be
+// reset to false via overlay.
 type SuiteConfig struct {
-	Timeout      time.Duration
+	// Timeout is the per-test-method deadline. Use -1 to disable. Default: 30s.
+	Timeout time.Duration
+	// SetupTimeout is the deadline for BeforeAll/AfterAll. Use -1 to disable. Default: 30s.
 	SetupTimeout time.Duration
-	Retries      int
-	FailFast     bool
-	Parallel     bool
+	// Retries is how many times to retry a failed test method. Default: 0.
+	Retries int
+	// FailFast stops the suite after the first test failure. Default: false.
+	FailFast bool
+	// Parallel runs test methods concurrently. Requires a returning BeforeEach
+	// so each parallel test gets its own isolated state. Default: false.
+	Parallel bool
 }
 
+// DefaultFixtureConfig returns a baseline configuration for package fixtures:
+// 2-minute timeout, no retries.
 func DefaultFixtureConfig() FixtureConfig {
 	return FixtureConfig{Timeout: 2 * time.Minute}
 }
 
+// ContainerFixtureConfig returns a configuration tuned for container-based
+// fixtures (e.g. testcontainers): 5-minute timeout, 1 retry with 5s delay.
 func ContainerFixtureConfig() FixtureConfig {
 	return FixtureConfig{Timeout: 5 * time.Minute, Retries: 1, RetryDelay: 5 * time.Second}
 }
 
+// DefaultSuiteConfig returns a baseline suite configuration: 30s test timeout,
+// 30s setup timeout, no retries, sequential execution.
 func DefaultSuiteConfig() SuiteConfig {
 	return SuiteConfig{Timeout: 30 * time.Second, SetupTimeout: 30 * time.Second}
 }
 
+// IntegrationSuiteConfig returns a configuration for heavier integration suites:
+// 2-minute test timeout, 5-minute setup timeout.
 func IntegrationSuiteConfig() SuiteConfig {
 	return SuiteConfig{Timeout: 2 * time.Minute, SetupTimeout: 5 * time.Minute}
 }
 
+// OverlayFixtureConfig merges overlay into base: non-zero fields in overlay
+// replace the corresponding base field; zero fields are preserved.
 func OverlayFixtureConfig(base *FixtureConfig, overlay FixtureConfig) {
 	if overlay.Timeout != 0 {
 		base.Timeout = overlay.Timeout
@@ -44,6 +72,9 @@ func OverlayFixtureConfig(base *FixtureConfig, overlay FixtureConfig) {
 	}
 }
 
+// OverlaySuiteConfig merges overlay into base: non-zero fields replace the
+// corresponding base field. FailFast and Parallel are one-way latches — once
+// true, an overlay with false will not reset them.
 func OverlaySuiteConfig(base *SuiteConfig, overlay SuiteConfig) {
 	if overlay.Timeout != 0 {
 		base.Timeout = overlay.Timeout

--- a/pkg/gotest/helpers_test.go
+++ b/pkg/gotest/helpers_test.go
@@ -1,1 +1,0 @@
-package gotest_test

--- a/pkg/gotest/r_test.go
+++ b/pkg/gotest/r_test.go
@@ -1,0 +1,49 @@
+package gotest //nolint:stdlib-test
+
+import (
+	"testing"
+)
+
+func TestRecord_Pass(t *testing.T) {
+	rec := Record(func(r *R) {
+		// no assertions fail
+	})
+	if rec.Failed() {
+		t.Errorf("expected pass, got failed with message: %s", rec.Message())
+	}
+}
+
+func TestRecord_Errorf(t *testing.T) {
+	rec := Record(func(r *R) {
+		r.Errorf("expected %d, got %d", 1, 2)
+	})
+	if !rec.Failed() {
+		t.Error("expected failure")
+	}
+	if rec.Message() != "expected 1, got 2" {
+		t.Errorf("message = %q, want %q", rec.Message(), "expected 1, got 2")
+	}
+}
+
+func TestRecord_FailNow(t *testing.T) {
+	rec := Record(func(r *R) {
+		r.FailNow()
+		t.Error("should not reach here after FailNow")
+	})
+	if !rec.Failed() {
+		t.Error("expected failure from FailNow")
+	}
+}
+
+func TestRecord_ErrorfThenFailNow(t *testing.T) {
+	rec := Record(func(r *R) {
+		r.Errorf("first error")
+		r.FailNow()
+	})
+	if !rec.Failed() {
+		t.Error("expected failure")
+	}
+	if rec.Message() != "first error" {
+		t.Errorf("message = %q, want %q", rec.Message(), "first error")
+	}
+}

--- a/pkg/gotest/snapshot_internal_test.go
+++ b/pkg/gotest/snapshot_internal_test.go
@@ -41,7 +41,7 @@ func TestIsExternalPackage(t *testing.T) {
 	})
 
 	t.Run("result is cached", func(t *testing.T) {
-		path := filepath.Join(dir, "collecting_test.go")
+		path := filepath.Join(dir, "r_test.go")
 		pkgCache.Delete(path)
 		isExternalPackage(path)
 		_, ok := pkgCache.Load(path)

--- a/pkg/gotest/t_test.go
+++ b/pkg/gotest/t_test.go
@@ -5,50 +5,6 @@ import (
 	"time"
 )
 
-func TestRecord_Pass(t *testing.T) {
-	rec := Record(func(r *R) {
-		// no assertions fail
-	})
-	if rec.Failed() {
-		t.Errorf("expected pass, got failed with message: %s", rec.Message())
-	}
-}
-
-func TestRecord_Errorf(t *testing.T) {
-	rec := Record(func(r *R) {
-		r.Errorf("expected %d, got %d", 1, 2)
-	})
-	if !rec.Failed() {
-		t.Error("expected failure")
-	}
-	if rec.Message() != "expected 1, got 2" {
-		t.Errorf("message = %q, want %q", rec.Message(), "expected 1, got 2")
-	}
-}
-
-func TestRecord_FailNow(t *testing.T) {
-	rec := Record(func(r *R) {
-		r.FailNow()
-		t.Error("should not reach here after FailNow")
-	})
-	if !rec.Failed() {
-		t.Error("expected failure from FailNow")
-	}
-}
-
-func TestRecord_ErrorfThenFailNow(t *testing.T) {
-	rec := Record(func(r *R) {
-		r.Errorf("first error")
-		r.FailNow()
-	})
-	if !rec.Failed() {
-		t.Error("expected failure")
-	}
-	if rec.Message() != "first error" {
-		t.Errorf("message = %q, want %q", rec.Message(), "first error")
-	}
-}
-
 func TestNewTWithDeadline_SetsContextDeadline(t *testing.T) {
 	tt := NewTWithDeadline(t, 5*time.Second)
 	deadline, ok := tt.Context().Deadline()


### PR DESCRIPTION
Setup-timeout wasn't behaving as documented. Fix the default handling, accept negative values as "disable", and clarify how config options interact.