### PR TITLE
docs: rewrite and align documentation with implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,46 +147,34 @@ gotest.Panics(t, f func()) any  // asserts f panics, returns recovered value
 
 ## Eventually & Consistently
 
-Two forms exist for each:
-
-### Standalone (simple bool polling)
+Package-level functions for async polling. Both use `*gotest.R` — an assertion recorder that captures failures without propagating them.
 
 ```go
-gotest.Eventually(t, func() bool { return ready() }, 5*time.Second, 100*time.Millisecond)
-gotest.Consistently(t, func() bool { return stable() }, 2*time.Second, 100*time.Millisecond)
-```
-
-### Method form (full assertion support)
-
-```go
-t.Eventually(5*time.Second, 100*time.Millisecond, func(poll *gotest.T) {
+gotest.Eventually(t, 5*time.Second, 100*time.Millisecond, func(poll *gotest.R) {
     gotest.Equal(poll, "ready", getStatus())
 })
 
-t.Consistently(2*time.Second, 100*time.Millisecond, func(poll *gotest.T) {
+gotest.Consistently(t, 2*time.Second, 100*time.Millisecond, func(poll *gotest.R) {
     gotest.True(poll, isHealthy())
 })
 ```
 
-The method form creates a **collecting T** with `t: nil`.
-On each tick, the callback runs; if any assertion fails, it retries on the next tick.
-On timeout, the last failure is reported.
+There are no method forms on `*T`. Only package-level `gotest.Eventually()` and `gotest.Consistently()` exist.
 
-**Critical constraint:** Inside the callback, `poll.T()` panics.
-All code in the callback must use gotest assertions only.
+**Critical constraint:** Inside the callback, `poll` is a `*gotest.R`, not a `*gotest.T`.
+`poll` has no `T()` method. All code in the callback must use gotest assertions only.
 Any helper that calls `t.T()` will panic.
-This is by design — the collecting T intercepts failures without aborting, enabling retry semantics.
+This is by design — the recorder intercepts failures without aborting, enabling retry semantics.
 
 ## Suite Conventions
 
 ### Suite types
 
 ```go
-type MyServiceTestSuite struct { /* state */ }           // sequential suite
-type MyServiceTestSuiteParallel struct { /* state */ }   // runs parallel with other suites
+type MyServiceTestSuite struct { /* state */ }           // test suite
 ```
 
-- Name must end with `TestSuite` or `TestSuiteParallel`
+- Name must end with `TestSuite`
 - All methods must use pointer receivers
 - Must have at least one `Test*` method
 
@@ -194,7 +182,7 @@ type MyServiceTestSuiteParallel struct { /* state */ }   // runs parallel with o
 
 ```go
 func (s *MyTestSuite) TestCreate(t *gotest.T) {}                 // sequential
-func (s *MyTestSuite) TestParallelRead(t *gotest.T) {}           // parallel within suite (concurrent with other TestParallel* methods)
+func (s *MyTestSuite) TestRead(t *gotest.T) {}                   // standard test method
 func (s *MyTestSuite) TestLongPollAsync(t *gotest.T, done func()) {} // async (call done() when finished)
 ```
 
@@ -221,7 +209,7 @@ func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
 }
 ```
 
-Fields: `Timeout` (per-test deadline), `SetupTimeout`, `Retries`, `FailFast` (stop on first failure).
+Fields: `Timeout` (per-test deadline), `SetupTimeout`, `Retries`, `FailFast` (stop on first failure), `Parallel` (run methods concurrently).
 Presets: `DefaultSuiteConfig()` (30s/30s), `IntegrationSuiteConfig()` (2m/5m).
 
 ### SuiteGuard (optional)
@@ -255,16 +243,12 @@ Focus and exclude apply independently at both suite and test case levels.
 
 ## Parallel Semantics
 
-**Suite-level** (`*TestSuiteParallel` suffix): The entire suite runs concurrently with other top-level tests.
-Methods within the suite run sequentially relative to each other.
-Safe to share suite struct state `s` across methods.
+**Suite-level**: Each suite runs as a separate subprocess — full process isolation. This is automatic.
 
-**Method-level** (`TestParallel*` prefix): Individual test cases run concurrently within the same suite.
+**Method-level**: Opt-in via `SuiteConfig{Parallel: true}`.
+All test methods within the suite run concurrently.
 Suite struct state `s` is shared — writing to `s` fields from parallel methods is a data race.
-Use method-local variables or synchronization.
-
-These are independent.
-A `TestSuiteParallel` can also have `TestParallel*` methods (suite runs parallel with others AND methods run parallel within it).
+Use a returning `BeforeEach` to give each method its own isolated state.
 
 ## Other T Methods
 
@@ -273,12 +257,9 @@ t.T() *testing.T                                    // access underlying testing
 t.Context() context.Context                          // test context (respects deadline from SuiteConfig)
 t.It("description", func(it *gotest.T) { ... })     // BDD-style subtest
 t.When("condition", func(w *gotest.T) { ... })       // BDD-style subtest
-t.Each(entries, func(t *gotest.T, entry E) { ... })  // table-driven iteration (reflection-based)
-t.MatchSnapshot(value any, name ...string)           // snapshot testing (testdata/__snapshots__/)
-t.Assert(v any).Equal(expected)                      // fluent assertion chain (alternative style)
 ```
 
-Generic `Each` (preferred over method form):
+Table-driven tests with `Each`:
 ```go
 for t, entry := range gotest.Each(t, entries) {
     gotest.Equal(t, entry.Expected, Compute(entry.Input))

--- a/README.md
+++ b/README.md
@@ -10,29 +10,14 @@
 [![Go 1.24+](https://img.shields.io/badge/Go-1.24%2B-00ADD8?logo=go)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Specification-driven test suites for Go.
+Specification-driven test suites for Go with isolation and parallelism as first-class citizens.
 
-`gotest` closes the gap between `func TestX(t *testing.T)` and a well-organized test suite through code generation.
-You write structs, name them well, and the tool handles the rest.
-No runtime dependencies.
-No reflection.
-Pure code generation.
-Just standard Go tests with lifecycle management and structured organization.
+Write test suites as Go structs.
+`gotest` generates the lifecycle wiring, `t.Run` nesting, and process isolation that you'd write by hand — then cleans up after.
+What runs is standard `go test`.
+What you read back is a behavioral specification.
 
-## Why gotest?
-
-Go's `testing` package gives you `func TestX(t *testing.T)` and nothing more.
-Setup/teardown logic is copy-pasted or buried in `TestMain`.
-As test suites grow, organization becomes a discipline problem rather than a tooling one.
-
-**testify/suite** solves organization but adds runtime reflection, interface dispatch, and a `suite.Run(t, new(MySuite))` ceremony in every file.
-Test output is standard — but the mechanism behind it isn't.
-
-**gotest** takes a different approach: you write structs with naming conventions, and a code generator produces the `func Test*` wrappers, lifecycle wiring, and `t.Run` nesting that you'd write by hand.
-Generated wiring never touches your source tree — your project directory stays clean.
-What remains is standard `go test` output, zero runtime dependencies, and test structs that are plain Go.
-
-**Structured output** — BDD-style suites double as behavioral specifications. `gotest spec` renders your test structure as a readable contract with structured JSON output. Feed specs into AI conversations, CI reports, or documentation pipelines — always in sync, never stale.
+No runtime dependencies. No reflection. Pure code generation.
 
 ## Install
 
@@ -42,7 +27,7 @@ go install github.com/mvrahden/go-test/cmd/gotest@latest
 
 ## 30-Second Example
 
-Write a test suite struct:
+Write a test suite:
 
 ```go
 // user_service_suite_test.go
@@ -66,8 +51,9 @@ func (s *UserServiceTestSuite) TestCreate(t *gotest.T) {
 
     t.When("email already exists", func(w *gotest.T) {
         w.It("returns ErrDuplicate", func(it *gotest.T) {
-            s.svc.Create("alice@example.com")
             err := s.svc.Create("alice@example.com")
+            gotest.NoError(it, err)
+            err = s.svc.Create("alice@example.com")
             gotest.ErrorIs(it, err, ErrDuplicate)
         })
     })
@@ -80,7 +66,7 @@ Run:
 gotest ./... -v
 ```
 
-Output is standard `go test` output:
+Standard `go test` output:
 
 ```
 === RUN   TestUserServiceTestSuite
@@ -91,10 +77,119 @@ Output is standard `go test` output:
 --- PASS: TestUserServiceTestSuite (0.01s)
 ```
 
-No generated code leaks into your workflow.
-`gotest` generates it before tests run and cleans it up after.
+The same suites render as a behavioral specification:
 
-## Features
+```bash
+gotest spec ./pkg/user
+```
+
+```
+UserService
+  Create
+    ✓ creates a user with valid input
+    when email already exists
+      ✓ returns ErrDuplicate
+
+1 suite, 2 behaviors: 2 passed
+```
+
+No generated code leaks into your workflow.
+`gotest` creates it before tests run and cleans it up after.
+
+## Why gotest?
+
+Go's `testing` package gives you `func TestX(t *testing.T)` and nothing more.
+Setup/teardown logic is copy-pasted or buried in `TestMain`.
+As test suites grow, organization becomes a discipline problem rather than a tooling one.
+
+**testify/suite** solves organization but adds runtime reflection, interface dispatch, and a `suite.Run(t, new(MySuite))` ceremony in every file.
+Test output is standard — but the mechanism behind it isn't.
+
+**gotest** takes a different approach:
+
+- **Specification-driven.** BDD vocabulary (`When`/`It`) structures tests as readable behavioral contracts. `gotest spec` renders them as documentation — in the terminal, as markdown, or as structured JSON. Always in sync, never stale.
+- **Isolated by default.** Each suite runs in its own process. Each test gets fresh state through lifecycle hooks. Shared mutable state between tests isn't a discipline problem — it's structurally impossible.
+- **Safely parallel.** Suite-level parallelism is automatic. Method-level is opt-in. Because isolation is built in, parallel tests can't interfere with each other.
+
+Under the hood, `gotest` generates the same `t.Run`, `t.Cleanup`, and `defer` code you'd write by hand.
+Generated files never touch your source tree — they're created before tests run and cleaned up after.
+
+## How It Works
+
+```
+you write:          gotest generates:         go test runs:
+                    (hidden, auto-cleaned)
+
+MySuite struct      ƒƒ_psuite_test.go        func TestMySuite(t *testing.T)
+  BeforeAll()   →     lifecycle wiring    →     t.Cleanup(AfterAll)
+  TestFoo()           t.Run nesting              BeforeAll()
+  AfterAll()          process isolation          t.Run("TestFoo", ...)
+```
+
+The generated code is what a careful developer would write by hand: `t.Run`, `t.Cleanup`, `defer`, `sync.WaitGroup`.
+No reflection, no interface dispatch.
+
+## Specification
+
+Tests are structured as behavioral specifications using BDD vocabulary.
+`gotest spec` renders the structure as readable documentation — in the terminal, as markdown, or as structured JSON for CI reports, AI conversations, and documentation pipelines.
+
+### BDD Vocabulary
+
+```go
+func (s *Suite) TestCreate(t *gotest.T) {
+    t.When("input is valid", func(w *gotest.T) {
+        w.It("creates the record", func(it *gotest.T) {
+            // ...
+        })
+    })
+}
+```
+
+`When` groups context.
+`It` specifies behavior.
+Both map to `t.Run` under the hood.
+
+### Behavior Specification
+
+View test suites as a readable behavioral specification:
+
+```bash
+gotest spec ./pkg/user -v
+```
+
+```
+UserService
+  Create
+    when email is valid
+      ✓ creates the user (8ms)
+      ✓ sends a welcome email (120ms)
+    when email already exists
+      ✓ returns ErrDuplicate (<1ms)
+  Delete
+    ✓ soft-deletes the user (5ms)
+    ~ hard-deletes after 30 days — SKIPPED
+
+2 suites, 5 behaviors: 4 passed, 0 failed, 1 skipped
+```
+
+Generate a markdown specification document:
+
+```bash
+gotest spec ./... --format=md --output=docs/behavior-spec.md
+```
+
+Append spec view after normal test output:
+
+```bash
+gotest ./... -v --spec
+```
+
+## Isolation
+
+Each suite runs in its own process with zero shared state.
+Each test method gets fresh state through lifecycle hooks.
+Resources live as suite fields, managed through `BeforeEach`/`AfterEach` — never scattered across test methods with `defer` or `t.Cleanup`.
 
 ### Lifecycle Hooks
 
@@ -107,8 +202,9 @@ func (s *MySuite) BeforeEach(t *gotest.T) {} // before each test method
 func (s *MySuite) AfterEach(t *gotest.T)  {} // after each test method
 ```
 
-`*gotest.T` exposes `t.Context()` (mirrors Go 1.24's `testing.T.Context()`), plus the full DSL (`t.It()`, `t.When()`, `t.MatchSnapshot()`).
+`*gotest.T` exposes `t.Context()` (mirrors Go 1.24's `testing.T.Context()`), plus the BDD vocabulary (`t.It()`, `t.When()`).
 Use `*testing.T` for plain stdlib tests — the functional assertions (`gotest.Equal(t, ...)`) still work with either type.
+
 You can mix freely within a single suite:
 
 ```go
@@ -116,6 +212,10 @@ func (s *MySuite) BeforeEach(t *testing.T) {} // stdlib is fine here
 func (s *MySuite) TestPlain(t *testing.T)  {} // no gotest import needed
 func (s *MySuite) TestRich(t *gotest.T)    {} // full DSL available
 ```
+
+All hooks are optional.
+`AfterAll` runs via `t.Cleanup` (LIFO).
+`AfterEach` is deferred, so it runs even on `t.Fatal()`.
 
 **Resource management through suite fields.**
 Resources that need setup and teardown (database pools, caches, services) should be stored as suite fields and managed through `BeforeEach`/`AfterEach`.
@@ -154,23 +254,6 @@ func (s *AuthServiceTestSuite) TestPermissions(t *gotest.T) {
 When different test methods need fundamentally different service configurations, split them into separate suites — each with its own `BeforeEach`/`AfterEach`.
 This keeps resource management declarative and predictable.
 
-Fixture hooks receive `context.Context` and return `error` — the generated wrapper reports failures with automatic attribution:
-
-```go
-func (f *MyFixture) BeforeAll(ctx context.Context) error  { return nil }
-func (f *MyFixture) AfterAll(ctx context.Context) error   { return nil }
-func (f *MyFixture) BeforeEach(ctx context.Context) error { return nil }
-func (f *MyFixture) AfterEach(ctx context.Context) error  { return nil }
-```
-
-Setup hooks (`BeforeAll`, `BeforeEach`) receive `t.Context()` — cancelled when the test ends, carries the test deadline.
-Cleanup hooks (`AfterAll`, `AfterEach`) receive `context.Background()` — cleanup must proceed even after the test context is cancelled.
-Requires Go 1.24+.
-
-All hooks are optional.
-`AfterAll` runs via `t.Cleanup` (LIFO).
-`AfterEach` is deferred, so it runs even on `t.Fatal()`.
-
 ### Fixtures
 
 Fixtures replace `TestMain` + package-level singletons with convention-driven setup.
@@ -199,7 +282,11 @@ func (f *E2ESetupFixture) AfterAll(ctx context.Context) error {
 }
 ```
 
-Fixture hooks return `error` — the generated wrapper handles reporting with automatic attribution (e.g., `E2ESetupFixture.BeforeAll failed: start postgres: connection refused`).
+Fixture hooks receive `context.Context` and return `error` — the generated wrapper reports failures with automatic attribution (e.g., `E2ESetupFixture.BeforeAll failed: start postgres: connection refused`).
+
+Setup hooks (`BeforeAll`, `BeforeEach`) receive `t.Context()` — cancelled when the test ends, carries the test deadline.
+Cleanup hooks (`AfterAll`, `AfterEach`) receive `context.Background()` — cleanup must proceed even after the test context is cancelled.
+Requires Go 1.24+.
 
 Test suites reference the fixture via a named pointer field:
 
@@ -248,11 +335,153 @@ InfraFixture.BeforeEach
 InfraFixture.AfterEach
 ```
 
-Output nests naturally: `Test_InfraFixture/APIFixture/BatchTestSuite/TestDispatch`.
+**Failure reporting.**
+Fixture hook failures are reported with automatic attribution.
+`BeforeEach`/`AfterEach` failures appear in test output — attributed to the fixture and the failing hook:
+
+```
+--- FAIL: TestBatchTestSuite/TestDispatch
+    E2ESetupFixture.BeforeEach failed: connection refused
+```
+
+`BeforeAll`/`AfterAll` run in `TestMain`, so failures are reported to stderr and abort the test binary:
+
+```
+FAIL: E2ESetupFixture.BeforeAll failed after 2 attempt(s): start postgres: connection refused
+```
 
 For cross-package shared state (e.g. a database container shared across integration test packages), use `*SharedFixture` suffix — see [docs/design/fixtures.md](docs/design/fixtures.md) for the full reference.
 
-### Configuration
+## Parallelism
+
+Isolation makes parallelism safe.
+Parallelism makes tests fast.
+`gotest` gives you both.
+
+**Suite-level parallelism** is automatic — the `gotest` runner executes each suite's test binary as a separate subprocess, giving full process isolation with zero shared state between suites.
+
+**Method-level parallelism** is opt-in via `SuiteConfig{Parallel: true}`.
+When enabled, each test method runs concurrently.
+Because the suite struct is shared, parallel methods can't safely mutate it — instead, `BeforeEach` returns a per-test context struct that each method receives as a second argument:
+
+```go
+type MethodParallelCtx struct {
+    Value int64
+}
+
+type MyTestSuite struct{}
+
+func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
+    return gotest.SuiteConfig{Parallel: true}
+}
+
+func (s *MyTestSuite) BeforeEach(t *gotest.T) *MethodParallelCtx {
+    return &MethodParallelCtx{Value: time.Now().UnixNano()}
+}
+
+func (s *MyTestSuite) TestOne(t *gotest.T, ctx *MethodParallelCtx) {
+    gotest.NotZero(t, ctx.Value)
+}
+
+func (s *MyTestSuite) TestTwo(t *gotest.T, ctx *MethodParallelCtx) {
+    gotest.NotZero(t, ctx.Value)
+}
+```
+
+The returning `BeforeEach` pattern ensures each parallel method operates on its own isolated state.
+
+## Testing Toolkit
+
+### Type-Safe Assertions
+
+Functional API with compile-time type safety:
+
+```go
+gotest.Equal(t, expected, actual)            // [T any] — cross-type comparison is a compile error
+gotest.NoError(t, err)
+gotest.ErrorIs(t, err, target)
+gotest.ErrorAs[*MyError](t, err)             // returns the matched error
+gotest.ErrorContains(t, err, "not found")
+gotest.Contains(t, haystack, needle)
+gotest.Greater(t, a, b)                      // [T cmp.Ordered]
+gotest.Len(t, collection, 3)
+gotest.True(t, condition)
+gotest.Panics(t, func() { ... })
+gotest.Regexp(t, `^start`, str)
+gotest.InDelta(t, 3.14, pi, 0.01)
+gotest.JSONEq(t, expected, actual)           // string, []byte, io.Reader, or any marshalable value
+gotest.Eventually(t, 5*time.Second, 100*time.Millisecond, func(poll *gotest.R) { ... })
+gotest.Consistently(t, 500*time.Millisecond, 50*time.Millisecond, func(poll *gotest.R) { ... })
+```
+
+Unwrap `(T, error)` or `(T, bool)` pairs in test setup:
+
+```go
+conn := gotest.Must(db.Connect(ctx))
+val  := gotest.Must(cache.Get(key))
+```
+
+All assertions work with `*gotest.T` (suites), `*testing.T` (standalone tests), and `*gotest.R` (polling callbacks).
+
+### Data-Driven Tests
+
+Iterator API with compile-time type safety (recommended):
+
+```go
+func (s *Suite) TestParsing(t *gotest.T) {
+    for it, tc := range gotest.Each(t, []struct {
+        Desc  string
+        Input string
+        Want  int
+    }{
+        {Desc: "single digit", Input: "5", Want: 5},
+        {Desc: "negative",     Input: "-3", Want: -3},
+    }) {
+        gotest.Equal(it, tc.Want, parse(tc.Input))
+    }
+}
+```
+
+Each entry becomes a subtest.
+Uses `Desc` or `Name` field for the test name, falls back to `#0`, `#1`, etc.
+
+### Async Assertions
+
+```go
+// Poll until condition is met (or timeout)
+gotest.Eventually(t, 5*time.Second, 100*time.Millisecond, func(poll *gotest.R) {
+    gotest.Equal(poll, "ready", getStatus())
+})
+
+// Assert condition holds for the full duration
+gotest.Consistently(t, 500*time.Millisecond, 50*time.Millisecond, func(poll *gotest.R) {
+    gotest.True(poll, cache.IsValid())
+})
+```
+
+Poll callbacks receive a `*gotest.R` — an assertion recorder that captures failures without propagating them to the test runner.
+The full assertion library works with `*R` just as it does with `*T` or `*testing.T`.
+Failures are collected until the timeout; only the final outcome is reported.
+
+### Snapshot Testing
+
+```go
+func (s *Suite) TestRender(t *gotest.T) {
+    gotest.MatchSnapshot(t, render(input))            // auto-named from test
+    gotest.MatchSnapshot(t, render(other), "variant") // custom snapshot name
+}
+```
+
+Snapshots are stored in `testdata/__snapshots__/`.
+On first run, the snapshot is created.
+On subsequent runs, the output is compared.
+Update all snapshots with:
+
+```bash
+gotest --update-snapshots ./...
+```
+
+## Configuration
 
 Every fixture and suite runs with sensible defaults — 2-minute fixture timeout, 30-second per-test timeout.
 Override with optional marker methods:
@@ -290,6 +519,8 @@ Preset constructors for common scenarios:
 | `DefaultSuiteConfig()` | 30 sec | 0 | Unit/integration tests |
 | `IntegrationSuiteConfig()` | 2 min | 0 | Heavier integration tests |
 
+## Test Selection
+
 ### Focus and Exclude
 
 ```go
@@ -322,150 +553,19 @@ func (s *IntegrationTestSuite) SuiteGuard() string {
 Returns a non-empty reason to skip the entire suite.
 Unlike `X_` (static exclude), `SuiteGuard` makes the decision at runtime — useful for integration tests that need external services.
 
-### BDD Vocabulary
+## Tooling
 
-```go
-func (s *Suite) TestCreate(t *gotest.T) {
-    t.When("input is valid", func(w *gotest.T) {
-        w.It("creates the record", func(it *gotest.T) {
-            // ...
-        })
-    })
-}
-```
+### Watch Mode
 
-`When` groups context.
-`It` specifies behavior.
-Both map to `t.Run` under the hood.
-
-### Parallel Tests
-
-**Suite-level parallelism** is automatic — the `gotest` runner executes each suite's test binary as a separate subprocess, giving full process isolation with zero shared state between suites.
-
-**Method-level parallelism** is opt-in via `SuiteConfig{Parallel: true}`.
-When enabled, each test method runs concurrently.
-Because the suite struct is shared, parallel methods can't safely mutate it — instead, `BeforeEach` returns a per-test context struct that each method receives as a second argument:
-
-```go
-type MethodParallelCtx struct {
-    Value int64
-}
-
-type MyTestSuite struct{}
-
-func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
-    return gotest.SuiteConfig{Parallel: true}
-}
-
-func (s *MyTestSuite) BeforeEach(t *gotest.T) *MethodParallelCtx {
-    return &MethodParallelCtx{Value: time.Now().UnixNano()}
-}
-
-func (s *MyTestSuite) TestOne(t *gotest.T, ctx *MethodParallelCtx) {
-    gotest.NotZero(t, ctx.Value)
-}
-
-func (s *MyTestSuite) TestTwo(t *gotest.T, ctx *MethodParallelCtx) {
-    gotest.NotZero(t, ctx.Value)
-}
-```
-
-The returning `BeforeEach` pattern ensures each parallel method operates on its own isolated state.
-
-### Type-Safe Assertions
-
-Functional API with compile-time type safety:
-
-```go
-gotest.Equal(t, expected, actual)            // [T any] — cross-type comparison is a compile error
-gotest.NoError(t, err)
-gotest.ErrorIs(t, err, target)
-gotest.ErrorAs[*MyError](t, err)             // returns the matched error
-gotest.ErrorContains(t, err, "not found")
-gotest.Contains(t, haystack, needle)
-gotest.Greater(t, a, b)                      // [T cmp.Ordered]
-gotest.Len(t, collection, 3)
-gotest.True(t, condition)
-gotest.Panics(t, func() { ... })
-gotest.Regexp(t, `^start`, str)
-gotest.InDelta(t, 3.14, pi, 0.01)
-gotest.JSONEq(t, expected, actual)           // string, []byte, io.Reader, or any marshalable value
-gotest.Eventually(t, func() bool { ... }, 5*time.Second, 100*time.Millisecond)
-```
-
-Unwrap `(T, error)` or `(T, bool)` pairs in test setup:
-
-```go
-conn := gotest.Must(db.Connect(ctx))
-val  := gotest.Must(cache.Get(key))
-```
-
-All assertions work with both `*gotest.T` (suites) and `*testing.T` (standalone tests).
-
-### Data-Driven Tests
-
-Iterator API with compile-time type safety (recommended):
-
-```go
-func (s *Suite) TestParsing(t *gotest.T) {
-    for it, tc := range gotest.Each(t, []struct {
-        Desc  string
-        Input string
-        Want  int
-    }{
-        {Desc: "single digit", Input: "5", Want: 5},
-        {Desc: "negative",     Input: "-3", Want: -3},
-    }) {
-        gotest.Equal(it, tc.Want, parse(tc.Input))
-    }
-}
-```
-
-Callback API also available via `t.Each(entries, fn)`:
-
-```go
-t.Each(cases, func(it *gotest.T, tc Case) {
-    gotest.Equal(it, tc.Want, parse(tc.Input))
-})
-```
-
-Each entry becomes a subtest.
-Uses `Desc` or `Name` field for the test name, falls back to `#0`, `#1`, etc.
-
-### Async Assertions
-
-```go
-// Poll until condition is met (or timeout)
-t.Eventually(5*time.Second, 100*time.Millisecond, func(poll *gotest.T) {
-    gotest.Equal(poll, "ready", getStatus())
-})
-
-// Assert condition holds for the full duration
-t.Consistently(500*time.Millisecond, 50*time.Millisecond, func(poll *gotest.T) {
-    gotest.True(poll, cache.IsValid())
-})
-```
-
-Poll callbacks receive a `*gotest.T` — use the full assertion library inside.
-Failures during polling are collected, not propagated, until the timeout.
-
-### Snapshot Testing
-
-```go
-func (s *Suite) TestRender(t *gotest.T) {
-    t.MatchSnapshot(render(input))           // auto-named from test
-    t.MatchSnapshot(render(other), "variant") // custom snapshot name
-}
-```
-
-Snapshots are stored in `testdata/__snapshots__/`.
-On first run, the snapshot is created.
-On subsequent runs, the output is compared.
-Update all snapshots with:
+Re-run tests on file changes with 200ms debounce:
 
 ```bash
-gotest --update-snapshots ./...
+gotest watch ./... -v
+gotest watch ./... --spec     # watch + spec view
 ```
+
+Only the affected package is re-run.
+Combine with `F_` prefix for a tight feedback loop — only focused tests run on each save.
 
 ### Scaffold
 
@@ -486,86 +586,16 @@ gotest migrate ./...
 
 Renames lifecycle methods, rewrites assertions, removes testify imports.
 
-## How It Works
+### Linter
 
-```
-you write:          gotest generates:         go test runs:
-                    (hidden, auto-cleaned)
-
-MySuite struct      ƒƒ_psuite_test.go        func TestMySuite(t *testing.T)
-  BeforeAll()   →     BeforeAll wrapper    →    t.Cleanup(AfterAll)
-  TestFoo()           TestFoo wrapper            BeforeAll()
-  AfterAll()          t.Run("TestFoo",...)       t.Run("TestFoo", ...)
-                                                 ...
-```
-
-The generated code is what a careful developer would write by hand: `t.Run`, `t.Cleanup`, `defer`, `sync.WaitGroup`.
-No reflection, no interface dispatch.
-
-## Naming Conventions
-
-| Convention | Meaning |
-|---|---|
-| `*TestSuite` suffix | Test suite struct |
-| `BeforeAll` / `AfterAll` | Suite-level lifecycle |
-| `BeforeEach` / `AfterEach` | Test-level lifecycle |
-| `Test*` method | Test case |
-| `F_` prefix | Focus (run only this) |
-| `X_` prefix | Exclude (skip this) |
-| `SuiteGuard()` method | Runtime-conditional suite skipping |
-| `*Fixture` suffix | Package-scoped fixture |
-| `*SharedFixture` suffix | Cross-package shared fixture |
-| `FixtureConfig()` method | Fixture timeout/retry config |
-| `SharedFixtureConfig()` method | Shared fixture timeout/retry config |
-| `SuiteConfig()` method | Suite timeout/failfast config |
-| `Hydrate` / `Dehydrate` | SharedFixture test-process resource reconstruction |
-
-## Behavior Specification
-
-View test suites as a readable behavioral specification:
+Catch common mistakes in test suites with static analysis:
 
 ```bash
-gotest spec ./pkg/user -v
+gotest lint ./...
 ```
 
-```
-UserService
-  Create
-    when email is valid
-      ✓ creates the user (8ms)
-      ✓ sends a welcome email (120ms)
-    when email already exists
-      ✓ returns ErrDuplicate (<1ms)
-  Delete
-    ✓ soft-deletes the user (5ms)
-    ~ hard-deletes after 30 days — SKIPPED
-
-2 suites, 5 behaviors: 4 passed, 0 failed, 1 skipped
-```
-
-Generate a markdown specification document:
-
-```bash
-gotest spec ./... --format=md --output=docs/behavior-spec.md
-```
-
-Append spec view after normal test output:
-
-```bash
-gotest ./... -v --spec
-```
-
-## Watch Mode
-
-Re-run tests on file changes with 200ms debounce:
-
-```bash
-gotest watch ./... -v
-gotest watch ./... --spec     # watch + spec view
-```
-
-Only the affected package is re-run.
-Combine with `F_` prefix for a tight feedback loop — only focused tests run on each save.
+Detects: lifecycle hook typos, value receivers on suite methods, missing `AfterAll` when `BeforeAll` exists, committed `F_` prefixes, and orphaned generated files.
+Also available as a standalone binary (`gotest-lint`) compatible with `golangci-lint` via `go/analysis`.
 
 ## Commands
 
@@ -585,16 +615,23 @@ gotest help                    # show help
 
 All `go test` flags work unchanged: `-race`, `-cover`, `-count`, `-run`, `-json`, `-short`, `-timeout`, `-v`.
 
-### Linter
+## Naming Conventions
 
-Catch common mistakes in test suites with static analysis:
-
-```bash
-gotest lint ./...
-```
-
-Detects: lifecycle hook typos, value receivers on suite methods, missing `AfterAll` when `BeforeAll` exists, committed `F_` prefixes, and orphaned generated files.
-Also available as a standalone binary (`gotest-lint`) compatible with `golangci-lint` via `go/analysis`.
+| Convention | Meaning |
+|---|---|
+| `*TestSuite` suffix | Test suite struct |
+| `BeforeAll` / `AfterAll` | Suite-level lifecycle |
+| `BeforeEach` / `AfterEach` | Test-level lifecycle |
+| `Test*` method | Test case |
+| `F_` prefix | Focus (run only this) |
+| `X_` prefix | Exclude (skip this) |
+| `SuiteGuard()` method | Runtime-conditional suite skipping |
+| `*Fixture` suffix | Package-scoped fixture |
+| `*SharedFixture` suffix | Cross-package shared fixture |
+| `FixtureConfig()` method | Fixture timeout/retry config |
+| `SharedFixtureConfig()` method | Shared fixture timeout/retry config |
+| `SuiteConfig()` method | Suite timeout/failfast config |
+| `Hydrate` / `Dehydrate` | SharedFixture test-process resource reconstruction |
 
 ## VS Code Extension
 

--- a/README.md
+++ b/README.md
@@ -397,19 +397,60 @@ The returning `BeforeEach` pattern ensures each parallel method operates on its 
 Functional API with compile-time type safety:
 
 ```go
-gotest.Equal(t, expected, actual)            // [T any] — cross-type comparison is a compile error
+// Equality
+gotest.Equal(t, expected, actual)            // [V any] — deep equality; cross-type = compile error
+gotest.NotEqual(t, expected, actual)         // [V any] — deep inequality
+
+// Boolean
+gotest.True(t, condition)
+gotest.False(t, condition)
+
+// Zero / nil
+gotest.Zero(t, value)                        // [V comparable] — value == zero value for type
+gotest.NotZero(t, value)                     // [V comparable] — also covers pointer/interface nil
+
+// Errors
 gotest.NoError(t, err)
+gotest.Error(t, err)                         // err != nil
 gotest.ErrorIs(t, err, target)
 gotest.ErrorAs[*MyError](t, err)             // returns the matched error
 gotest.ErrorContains(t, err, "not found")
-gotest.Contains(t, haystack, needle)
-gotest.Greater(t, a, b)                      // [T cmp.Ordered]
+
+// Collections
+gotest.Empty(t, object)                      // nil, or len == 0
+gotest.NotEmpty(t, object)
 gotest.Len(t, collection, 3)
-gotest.True(t, condition)
-gotest.Panics(t, func() { ... })
-gotest.Regexp(t, `^start`, str)
+gotest.Contains(t, haystack, needle)         // substring, element, or map key
+gotest.NotContains(t, haystack, needle)
+gotest.ElementsMatch(t, a, b)               // [V comparable] — same elements, any order
+gotest.Subset(t, list, subset)              // [V comparable] — all subset elements in list
+
+// Ordering
+gotest.Greater(t, a, b)                      // [V cmp.Ordered]
+gotest.GreaterOrEqual(t, a, b)               // [V cmp.Ordered]
+gotest.Less(t, a, b)                         // [V cmp.Ordered]
+gotest.LessOrEqual(t, a, b)                  // [V cmp.Ordered]
+
+// Numeric
 gotest.InDelta(t, 3.14, pi, 0.01)
+
+// Strings & patterns
+gotest.Regexp(t, `^start`, str)
+
+// JSON
 gotest.JSONEq(t, expected, actual)           // string, []byte, io.Reader, or any marshalable value
+
+// Time
+gotest.TimeWithin(t, expected, actual, tol)  // times within tolerance
+gotest.TimeIsNow(t, ts, tolerance)           // timestamp ≈ now
+
+// Panics
+gotest.Panics(t, func() { ... })             // returns recovered value
+
+// Failure
+gotest.Fail(t, "unreachable")                // immediate unconditional failure
+
+// Async polling
 gotest.Eventually(t, 5*time.Second, 100*time.Millisecond, func(poll *gotest.R) { ... })
 gotest.Consistently(t, 500*time.Millisecond, 50*time.Millisecond, func(poll *gotest.R) { ... })
 ```
@@ -481,6 +522,12 @@ Update all snapshots with:
 gotest --update-snapshots ./...
 ```
 
+Or when running `go test` directly:
+
+```bash
+GOTEST_UPDATE_SNAPSHOTS=1 go test ./...
+```
+
 ## Configuration
 
 Every fixture and suite runs with sensible defaults — 2-minute fixture timeout, 30-second per-test timeout.
@@ -501,8 +548,10 @@ func (f *PostgresSharedFixture) SharedFixtureConfig() gotest.FixtureConfig {
 
 func (s *BatchTestSuite) SuiteConfig() gotest.SuiteConfig {
     return gotest.SuiteConfig{
-        Timeout:  1 * time.Minute,
-        FailFast: true,
+        Timeout:      1 * time.Minute,
+        SetupTimeout: 2 * time.Minute,
+        FailFast:     true,
+        Parallel:     false,
     }
 }
 ```
@@ -512,12 +561,12 @@ Use negative duration to explicitly disable a timeout (`Timeout: -1`).
 
 Preset constructors for common scenarios:
 
-| Preset | Timeout | Retries | Use case |
-|--------|---------|---------|----------|
-| `DefaultFixtureConfig()` | 2 min | 0 | Standard fixtures |
-| `ContainerFixtureConfig()` | 5 min | 1 | Testcontainers, image pulls |
-| `DefaultSuiteConfig()` | 30 sec | 0 | Unit/integration tests |
-| `IntegrationSuiteConfig()` | 2 min | 0 | Heavier integration tests |
+| Preset | Timeout | SetupTimeout | Retries | RetryDelay | Use case |
+|--------|---------|--------------|---------|------------|----------|
+| `DefaultFixtureConfig()` | 2 min | — | 0 | — | Standard fixtures |
+| `ContainerFixtureConfig()` | 5 min | — | 1 | 5 sec | Testcontainers, image pulls |
+| `DefaultSuiteConfig()` | 30 sec | 30 sec | 0 | — | Unit/integration tests |
+| `IntegrationSuiteConfig()` | 2 min | 5 min | 0 | — | Heavier integration tests |
 
 ## Test Selection
 
@@ -630,7 +679,7 @@ All `go test` flags work unchanged: `-race`, `-cover`, `-count`, `-run`, `-json`
 | `*SharedFixture` suffix | Cross-package shared fixture |
 | `FixtureConfig()` method | Fixture timeout/retry config |
 | `SharedFixtureConfig()` method | Shared fixture timeout/retry config |
-| `SuiteConfig()` method | Suite timeout/failfast config |
+| `SuiteConfig()` method | Suite timeout/parallelism/failfast config |
 | `Hydrate` / `Dehydrate` | SharedFixture test-process resource reconstruction |
 
 ## VS Code Extension

--- a/docs/design/fixtures.md
+++ b/docs/design/fixtures.md
@@ -57,12 +57,15 @@ func (s *BatchTestSuite) TestDispatch(t *gotest.T) {
 
 ### Generated test output
 
+Fixture lifecycle runs through `TestMain` — fixture names do not appear in test paths.
+Suites bound to a fixture produce the same test names as standalone suites:
+
 ```
-Test_E2ESetupFixture/BatchTestSuite/TestDispatch        PASS
-Test_E2ESetupFixture/KeyTestSuite/TestCreate             PASS
+TestBatchTestSuite/TestDispatch        PASS
+TestKeyTestSuite/TestCreate            PASS
 ```
 
-Filter with `-run Test_E2ESetupFixture/BatchTestSuite` to run only batch tests.
+Filter with `-run TestBatchTestSuite` to run only batch tests.
 
 ## Nested Fixtures (Level 2)
 
@@ -95,11 +98,11 @@ type BatchTestSuite struct { API *APIFixture }            // needs full API
 ### Generated test output
 
 ```
-Test_InfraFixture/ReconcilerTestSuite/TestOrphan        PASS
-Test_InfraFixture/APIFixture/BatchTestSuite/TestDispatch PASS
+TestReconcilerTestSuite/TestOrphan  PASS
+TestBatchTestSuite/TestDispatch     PASS
 ```
 
-Filter with `-run Test_InfraFixture/ReconcilerTestSuite` to skip the API stack entirely.
+Filter with `-run TestReconcilerTestSuite` to run only reconciler tests.
 
 ## Shared Fixtures (Level 3, `*SharedFixture` suffix)
 

--- a/docs/design/fixtures.md
+++ b/docs/design/fixtures.md
@@ -50,7 +50,7 @@ func (s *BatchTestSuite) TestDispatch(t *gotest.T) {
 - One root `*Fixture` per package (nested child fixtures are allowed).
 - The fixture struct must have `BeforeAll(ctx context.Context) error`.
   `AfterAll(ctx context.Context) error` is optional.
-- `BeforeEach(t *gotest.T)` and `AfterEach(t *gotest.T)` are optional and run around every test case in all child suites.
+- `BeforeEach(ctx context.Context) error` and `AfterEach(ctx context.Context) error` are optional and run around every test case in all child suites.
 - TestSuites reference the fixture via a named pointer field (`Fixture *E2ESetupFixture`).
 - The code generator owns `TestMain` when a fixture is present.
   Remove any user-defined `TestMain`.

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -90,6 +90,8 @@ gotest [subcommand] [packages...] [go-test-flags...] [--gotest-flags...]
 | `spec` | Run tests and render behavioral specification |
 | `lint` | Run gotest-specific linter checks |
 | `refactor` | Source code refactoring tools (e.g. `toggle-focus`) |
+| `discover` | Discover test suites and output JSON metadata |
+| `prepare` | Start shared fixtures for debug (blocks until SIGTERM) |
 | `version` | Print version information |
 | `help` | Show help |
 
@@ -105,6 +107,9 @@ gotest [subcommand] [packages...] [go-test-flags...] [--gotest-flags...]
 | `--output=<path>` | Write formatted output to file |
 | `--no-color` | Strip ANSI codes from terminal output |
 | `--min=<pct>` | Fail if coverage below threshold (enables `-coverprofile`) |
+| `--setup-timeout=<dur>` | Override fixture setup timeout |
+| `--debounce=<dur>` | Debounce interval for watch mode (default 200ms) |
+| `--input=<path>` | Input file for `spec` subcommand |
 
 ### Disambiguation
 
@@ -371,7 +376,11 @@ Fixtures nest — a root fixture's hooks run first, wrapping the child's:
 InfraFixture.BeforeAll
   APIFixture.BeforeAll
     Suite.BeforeAll
-      Suite.BeforeEach → Test → Suite.AfterEach
+      InfraFixture.BeforeEach
+        APIFixture.BeforeEach
+          Suite.BeforeEach → Test → Suite.AfterEach
+        APIFixture.AfterEach
+      InfraFixture.AfterEach
     Suite.AfterAll
   APIFixture.AfterAll
 InfraFixture.AfterAll
@@ -593,16 +602,17 @@ Existing `NewT` callers are unaffected.
 ### Functional API
 
 Type-safe generics with compile-time safety.
-All functions accept any type implementing `testingT` (`Helper()` + `Errorf()` + `FailNow()`) — works with both `*gotest.T` and `*testing.T`.
+All functions accept any type implementing `testingT` (`Errorf()` + `FailNow()`) — works with `*gotest.T`, `*testing.T`, and `*gotest.R`.
+`Helper()` is optional: when present, failures include the caller's file:line.
 
 ```go
-// Equality — [T any] catches cross-type comparison at compile time
-gotest.Equal[T any](t, expected, actual T, msgAndArgs ...any)
-gotest.NotEqual[T any](t, expected, actual T, msgAndArgs ...any)
+// Equality — [V any] catches cross-type comparison at compile time
+gotest.Equal[V any](t, expected, actual V, msgAndArgs ...any)
+gotest.NotEqual[V any](t, expected, actual V, msgAndArgs ...any)
 
 // Zero / Empty
-gotest.Zero[T comparable](t, value T, msgAndArgs ...any)
-gotest.NotZero[T comparable](t, value T, msgAndArgs ...any)
+gotest.Zero[V comparable](t, value V, msgAndArgs ...any)
+gotest.NotZero[V comparable](t, value V, msgAndArgs ...any)
 gotest.Empty(t, object any, msgAndArgs ...any)
 gotest.NotEmpty(t, object any, msgAndArgs ...any)
 
@@ -621,20 +631,20 @@ gotest.ErrorContains(t, err error, contains string, msgAndArgs ...any)
 gotest.Contains(t, s, contains any, msgAndArgs ...any)
 gotest.NotContains(t, s, contains any, msgAndArgs ...any)
 gotest.Len(t, object any, length int, msgAndArgs ...any)
-gotest.ElementsMatch[T comparable](t, listA, listB []T, msgAndArgs ...any)
-gotest.Subset[T comparable](t, list, subset []T, msgAndArgs ...any)
+gotest.ElementsMatch[V comparable](t, listA, listB []V, msgAndArgs ...any)
+gotest.Subset[V comparable](t, list, subset []V, msgAndArgs ...any)
 
-// Comparison — [T cmp.Ordered] prevents comparing incomparable types
-gotest.Greater[T cmp.Ordered](t, a, b T, msgAndArgs ...any)
-gotest.GreaterOrEqual[T cmp.Ordered](t, a, b T, msgAndArgs ...any)
-gotest.Less[T cmp.Ordered](t, a, b T, msgAndArgs ...any)
-gotest.LessOrEqual[T cmp.Ordered](t, a, b T, msgAndArgs ...any)
+// Comparison — [V cmp.Ordered] prevents comparing incomparable types
+gotest.Greater[V cmp.Ordered](t, a, b V, msgAndArgs ...any)
+gotest.GreaterOrEqual[V cmp.Ordered](t, a, b V, msgAndArgs ...any)
+gotest.Less[V cmp.Ordered](t, a, b V, msgAndArgs ...any)
+gotest.LessOrEqual[V cmp.Ordered](t, a, b V, msgAndArgs ...any)
 
 // String / Regex
 gotest.Regexp[P regexpPattern](t, rx P, str string, msgAndArgs ...any)
 
 // Numeric
-gotest.InDelta[T numeric](t, expected, actual T, delta float64, msgAndArgs ...any)
+gotest.InDelta[V numeric](t, expected, actual V, delta float64, msgAndArgs ...any)
 
 // Serialization — accepts string, []byte, json.RawMessage, io.Reader, or marshalable
 gotest.JSONEq(t, expected, actual any, msgAndArgs ...any)
@@ -646,11 +656,20 @@ gotest.TimeIsNow(t, ts time.Time, tolerance time.Duration, msgAndArgs ...any)
 // Panic
 gotest.Panics(t, f func(), msgAndArgs ...any) any
 
+// Snapshot — auto-named from test path, or custom name
+gotest.MatchSnapshot(t, value any, name ...string)
+
+// Polling — see Async Assertions section
+gotest.Eventually(t, waitFor, tick time.Duration, fn func(poll *gotest.R))
+gotest.Consistently(t, waitFor, tick time.Duration, fn func(poll *gotest.R))
+
+// Explicit failure
+gotest.Fail(t, msgAndArgs ...any)
+
 // Unwrap — panics on failure (no t parameter, enables multi-return expansion)
-gotest.Must[T any](val T, ok any) T
+gotest.Must[V any](val V, ok any) V
 ```
 
-All functions call `t.Helper()` so failures report the caller's file:line.
 Equality failures include a diff:
 
 ```
@@ -695,7 +714,7 @@ func (s *UserServiceTestSuite) TestCreate(t *gotest.T) {
 }
 ```
 
-### t.Each()
+### gotest.Each()
 
 Table-driven tests with automatic subtest naming.
 
@@ -714,52 +733,56 @@ for it, tc := range gotest.Each(t, []struct {
 }
 ```
 
-Callback API:
-
-```go
-t.Each(cases, func(it *gotest.T, tc Case) {
-    gotest.Equal(it, tc.Want, parse(tc.Input))
-})
-```
-
 Uses `Desc` or `Name` field for the subtest name, falls back to `#0`, `#1`, etc.
 
 ---
 
 ## Async Assertions
 
-**Boolean polling** (functional API):
+### *gotest.R — Assertion Recorder
+
+`*R` is an assertion recorder that captures assertion outcomes without propagating them to the test runner.
+It satisfies the same `testingT` contract as `*testing.T` (`Errorf` + `FailNow`), making it the callback type for `Eventually` and `Consistently`.
+All assertion functions work with `*R` just as they do with `*T` or `*testing.T`.
 
 ```go
-gotest.Eventually(t, func() bool { return s.svc.IsReady() }, 5*time.Second, 100*time.Millisecond)
-gotest.Consistently(t, func() bool { return cache.IsValid() }, 2*time.Second, 50*time.Millisecond)
+type R struct { ... }
+func (r *R) Errorf(format string, args ...any)
+func (r *R) FailNow()
+func (r *R) Helper()
+func (r *R) Failed() bool
+func (r *R) Message() string
+
+func Record(fn func(*R)) *R
 ```
 
-**Rich assertion polling** (methods on `*gotest.T`):
+`Record` runs `fn` with a fresh `*R` in a dedicated goroutine (required because `FailNow` calls `runtime.Goexit`).
+
+### Polling
 
 ```go
-t.Eventually(5*time.Second, 100*time.Millisecond, func(poll *gotest.T) {
+gotest.Eventually(t, 5*time.Second, 100*time.Millisecond, func(poll *gotest.R) {
     result, err := s.store.Get("key")
     gotest.NoError(poll, err)
-    gotest.Equal(poll, result.Status, "completed")
+    gotest.Equal(poll, "completed", result.Status)
 })
 
-t.Consistently(2*time.Second, 100*time.Millisecond, func(poll *gotest.T) {
-    gotest.Equal(poll, s.counter.Value(), 0)
+gotest.Consistently(t, 2*time.Second, 100*time.Millisecond, func(poll *gotest.R) {
+    gotest.Equal(poll, 0, s.counter.Value())
 })
 ```
 
-The `poll *gotest.T` is a collecting wrapper — assertion failures during intermediate polls are captured but not propagated.
-On timeout, the last poll's assertion failures are reported.
-`Consistently` fails on first `false` poll and reports which poll failed.
+The `poll *gotest.R` captures assertion failures without propagating them to the test runner.
+On timeout, `Eventually` reports the last poll's assertion failures.
+`Consistently` fails on first assertion failure and reports which poll failed.
 
 ---
 
 ## Snapshot Testing
 
 ```go
-t.MatchSnapshot(result)               // auto-named from test
-t.MatchSnapshot(result, "variant")    // custom snapshot name
+gotest.MatchSnapshot(t, result)               // auto-named from test
+gotest.MatchSnapshot(t, result, "variant")    // custom snapshot name
 ```
 
 - Snapshots stored in `testdata/__snapshots__/<TestName>.snap`
@@ -937,6 +960,9 @@ Detects:
 - **Missing lifecycle pair:** `BeforeAll` without `AfterAll` — resources may leak
 - **Committed focus prefixes:** `F_` prefix on types or methods
 - **Orphaned generated files:** `ƒƒ_*` files checked into version control
+- **Stdlib test functions:** `func TestX(t *testing.T)` in packages with suites — likely meant to be a suite method
+- **Testify imports:** `testify/suite` imports in packages using gotest — migration incomplete
+- **Poll scope errors:** Assertions inside `Eventually`/`Consistently` callbacks using the outer `t` instead of the `poll` parameter
 
 ---
 
@@ -1102,19 +1128,21 @@ They add a layer on top; they never suppress or replace the underlying output.
 ```
 cmd/gotest/                  CLI entrypoint, subcommands, arg handling
   └── internal/gotestrunner/   Suite generation I/O, go test execution, overlay
-        └── internal/cmd/testgen/   Generation orchestration
-              └── internal/gotestgen/   Package loading, collection, fixture resolution, rendering
-                    └── internal/gotestast/   AST analysis, spec model, regex classification
+        └── internal/gotestgen/   Package loading, collection, fixture resolution, rendering
+              └── internal/gotestast/   AST analysis, spec model, regex classification
 
 cmd/gotest-lint/             Standalone linter binary (singlechecker)
   └── internal/lint/           go/analysis analyzer
 
+internal/config/             gotest.yaml configuration loading
 internal/gotestspec/         Spec tree builder and renderers (terminal, markdown)
 internal/scaffold/           Type-to-suite skeleton generator
 internal/migrate/            testify/suite AST transformer
+internal/refactor/           AST refactoring tools (focus/exclude toggle)
 
-pkg/gotest/                  User-facing API (T, Assert, It, When, Each, Eventually, MatchSnapshot)
-  └── internal/assert/         Core assertion implementation (~300 lines, pure stdlib)
+pkg/gotest/                  User-facing API (T, R, assertions, Each, Eventually, Consistently, MatchSnapshot)
+  └── internal/assert/         Core assertion implementation (pure stdlib)
+  └── internal/snapfile/       Snapshot file I/O and diffing
 
 about/                       Build metadata, file naming constants
 ```

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -563,12 +563,6 @@ AfterAll <span class="d">(via t.Cleanup — always runs)</span></div>
     gotest.Equal(it, tc.Want, parse(tc.Input))
 }</pre>
       </div>
-      <p><strong>Callback API</strong> — same semantics, different style:</p>
-      <div class="code-block">
-        <pre>t.Each(cases, <span class="kw">func</span>(it *gotest.T, tc Case) {
-    gotest.Equal(it, tc.Want, parse(tc.Input))
-})</pre>
-      </div>
       <div class="callout">
         Each entry becomes a subtest. Uses the <code>Desc</code> or <code>Name</code> field for the test name, falls back to <code>#0</code>, <code>#1</code>, etc.
       </div>
@@ -576,28 +570,28 @@ AfterAll <span class="d">(via t.Cleanup — always runs)</span></div>
       <h3>Snapshot testing</h3>
       <p>Capture expected output once, verify it on every subsequent run:</p>
       <div class="code-block">
-        <pre>t.MatchSnapshot(render(input))              <span class="cm">// auto-named from test path</span>
-t.MatchSnapshot(render(other), <span class="st">"variant"</span>)  <span class="cm">// explicit snapshot name</span></pre>
+        <pre>gotest.MatchSnapshot(t, render(input))              <span class="cm">// auto-named from test path</span>
+gotest.MatchSnapshot(t, render(other), <span class="st">"variant"</span>)  <span class="cm">// explicit snapshot name</span></pre>
       </div>
       <p>On first run, the snapshot is created. On subsequent runs, the output is compared and failures include a diff. Update all snapshots with <code>gotest --update-snapshots ./...</code>.</p>
 
       <h3>Async polling</h3>
-      <p>Two forms — a simple boolean check, or rich assertion polling with the full assertion library:</p>
+      <p>Package-level functions for polling conditions. Callbacks receive <code>*gotest.R</code> — an assertion recorder that captures failures without propagating them:</p>
       <div class="code-block">
-        <div class="code-label">Boolean polling (function)</div>
-        <pre>gotest.Eventually(t, <span class="kw">func</span>() <span class="tp">bool</span> {
-    <span class="kw">return</span> s.svc.IsReady()
-}, 5*time.Second, 100*time.Millisecond)</pre>
-      </div>
-      <div class="code-block">
-        <div class="code-label">Rich assertion polling (method on *T)</div>
-        <pre>t.Eventually(5*time.Second, 100*time.Millisecond, <span class="kw">func</span>(poll *gotest.T) {
+        <div class="code-label">Eventually — poll until assertions pass</div>
+        <pre>gotest.Eventually(t, 5*time.Second, 100*time.Millisecond, <span class="kw">func</span>(poll *gotest.R) {
     result, err := s.store.Get(<span class="st">"key"</span>)
     gotest.NoError(poll, err)
     gotest.Equal(poll, <span class="st">"completed"</span>, result.Status)
 })</pre>
       </div>
-      <p>The method form collects intermediate failures without propagating them. On timeout, the last poll's assertion failures are reported. <code>Consistently</code> works the same way — it asserts a condition holds for the full duration and fails on the first violation.</p>
+      <div class="code-block">
+        <div class="code-label">Consistently — assert condition holds for full duration</div>
+        <pre>gotest.Consistently(t, 2*time.Second, 100*time.Millisecond, <span class="kw">func</span>(poll *gotest.R) {
+    gotest.True(poll, s.cache.IsValid())
+})</pre>
+      </div>
+      <p>On each tick the callback runs; if any assertion fails, it retries on the next tick. On timeout, the last failure is reported. <code>Consistently</code> inverts the logic — it fails on the first assertion failure.</p>
 
       <h3>Helpers</h3>
       <table class="ref-table">
@@ -763,12 +757,12 @@ InfraFixture.AfterAll</div>
       <table class="ref-table">
         <thead><tr><th>Function</th><th>Description</th></tr></thead>
         <tbody>
-          <tr><td><code>Eventually(t, fn, timeout, tick)</code></td><td>Poll <code>func() bool</code> until true or timeout.</td></tr>
-          <tr><td><code>Consistently(t, fn, duration, tick)</code></td><td>Assert <code>func() bool</code> holds for the full duration.</td></tr>
+          <tr><td><code>Eventually(t, timeout, tick, fn)</code></td><td>Poll <code>func(poll *R)</code> until assertions pass or timeout.</td></tr>
+          <tr><td><code>Consistently(t, duration, tick, fn)</code></td><td>Assert <code>func(poll *R)</code> holds for the full duration.</td></tr>
         </tbody>
       </table>
       <div class="callout">
-        These are the standalone boolean-polling forms. For rich assertion polling with <code>func(poll *T)</code>, use the <a href="#test-dsl">method forms on *T</a>.
+        All assertions work inside polling callbacks — use <code>poll</code> (a <code>*gotest.R</code>) exactly as you would use <code>t</code>. Failures are collected, not propagated, enabling retry semantics.
       </div>
 
       <div class="callout">

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -10,4 +10,4 @@ Demonstrates error assertions, parameterized testing, and the exclude modifier u
 
 ## Features
 
-`ErrorIs` · `ErrorAs` · `ErrorContains` · `Panics` · `Must` · `Regexp` · `t.Each` · `gotest.Each` · `X_` exclude
+`ErrorIs` · `ErrorAs` · `ErrorContains` · `Panics` · `Must` · `Regexp` · `gotest.Each` · `X_` exclude

--- a/examples/notification/README.md
+++ b/examples/notification/README.md
@@ -9,4 +9,4 @@ Demonstrates async testing with temporal assertions, JSON comparison, and snapsh
 
 ## Features
 
-`t.Eventually` · `gotest.Eventually` · `t.Consistently` · `gotest.Consistently` · `JSONEq` · `t.MatchSnapshot` · `TimeIsNow` · `TimeWithin` · `NewTWithDeadline`
+`gotest.Eventually` · `gotest.Consistently` · `JSONEq` · `gotest.MatchSnapshot` · `TimeIsNow` · `TimeWithin` · `NewTWithDeadline`


### PR DESCRIPTION
- Rewrite README around specification, isolation, and parallelism as first-class concepts
- Fix ghost APIs across all docs — remove non-existent t.Eventually, t.Each, t.MatchSnapshot, t.Assert method forms; correct Eventually/Consistently callback signatures from func() bool to func(*R)
- Complete the assertion reference (31 functions), config tables (SetupTimeout, RetryDelay columns), and fixture test-output paths