### PR TITLE
Fix flaky snapshot tests under concurrent suite execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Specification-driven test suites for Go with isolation and parallelism as first-class citizens.
 
 Write test suites as Go structs.
-`gotest` generates the lifecycle wiring, `t.Run` nesting, and process isolation that you'd write by hand — then cleans up after.
+`gotest` generates the lifecycle wiring, `t.Run` nesting, and process isolation that you'd write by hand.
 What runs is standard `go test`.
 What you read back is a behavioral specification.
 
@@ -94,7 +94,7 @@ UserService
 ```
 
 No generated code leaks into your workflow.
-`gotest` creates it before tests run and cleans it up after.
+`gotest` creates it before tests run - invisible to the project's filetree.
 
 ## Why gotest?
 
@@ -112,7 +112,7 @@ Test output is standard — but the mechanism behind it isn't.
 - **Safely parallel.** Suite-level parallelism is automatic. Method-level is opt-in. Because isolation is built in, parallel tests can't interfere with each other.
 
 Under the hood, `gotest` generates the same `t.Run`, `t.Cleanup`, and `defer` code you'd write by hand.
-Generated files never touch your source tree — they're created before tests run and cleaned up after.
+Generated files never touch your source tree — they're created hidden before tests run and cleaned up after.
 
 ## How It Works
 

--- a/pkg/gotest/snapshot.go
+++ b/pkg/gotest/snapshot.go
@@ -150,14 +150,14 @@ func matchSnapshot(t testingT, callerSkip int, value any, name ...string) {
 	snapDir := filepath.Join(filepath.Dir(callerFile), "testdata", "__snapshots__")
 	snapPath := filepath.Join(snapDir, topLevel+suffix+".snap")
 
+	mu := fileMutex(snapPath)
+	mu.Lock()
+	defer mu.Unlock()
+
 	if err := os.MkdirAll(snapDir, 0755); err != nil {
 		failf(t, "MatchSnapshot: failed to create snapshot dir: %v", err)
 		return
 	}
-
-	mu := fileMutex(snapPath)
-	mu.Lock()
-	defer mu.Unlock()
 
 	existing, _ := os.ReadFile(snapPath)
 	sections := snapfile.Parse(existing)

--- a/pkg/gotest/snapshot_internal_test.go
+++ b/pkg/gotest/snapshot_internal_test.go
@@ -85,7 +85,7 @@ func TestSplitTestName(t *testing.T) {
 
 func TestMatchSnapshot_PtestUsesNoSuffix(t *testing.T) {
 	snapDir := filepath.Join(thisDir(), "testdata", "__snapshots__")
-	t.Cleanup(func() { os.RemoveAll(snapDir) })
+	t.Cleanup(func() { os.Remove(filepath.Join(snapDir, "TestMatchSnapshot_PtestUsesNoSuffix.snap")) })
 
 	MatchSnapshot(t, "ptest-value")
 

--- a/pkg/gotest/snapshot_suite_test.go
+++ b/pkg/gotest/snapshot_suite_test.go
@@ -17,7 +17,7 @@ type SnapshotGroupingTestSuite struct{}
 
 func (s *SnapshotGroupingTestSuite) TestMatchSnapshotGrouping(t *gotest.T) {
 	snapDir := filepath.Join("testdata", "__snapshots__")
-	t.T().Cleanup(func() { os.RemoveAll(snapDir) })
+	t.T().Cleanup(func() { os.Remove(filepath.Join(snapDir, "TestSnapshotGroupingTestSuite_ext.snap")) })
 
 	t.When("subtests write snapshots", func(w *gotest.T) {
 		w.It("creates a file with named sections per subtest", func(it *gotest.T) {
@@ -73,7 +73,7 @@ type SnapshotConcurrencyTestSuite struct{}
 
 func (s *SnapshotConcurrencyTestSuite) TestMatchSnapshotConcurrency(t *gotest.T) {
 	snapDir := filepath.Join("testdata", "__snapshots__")
-	t.T().Cleanup(func() { os.RemoveAll(snapDir) })
+	t.T().Cleanup(func() { os.Remove(filepath.Join(snapDir, "TestSnapshotConcurrencyTestSuite_ext.snap")) })
 
 	t.When("multiple goroutines write concurrently", func(w *gotest.T) {
 		for i := range 10 {
@@ -90,7 +90,7 @@ type SnapshotUpdateTestSuite struct{}
 
 func (s *SnapshotUpdateTestSuite) TestMatchSnapshotUpdate(t *gotest.T) {
 	snapDir := filepath.Join("testdata", "__snapshots__")
-	t.T().Cleanup(func() { os.RemoveAll(snapDir) })
+	t.T().Cleanup(func() { os.Remove(filepath.Join(snapDir, "TestSnapshotUpdateTestSuite_ext.snap")) })
 
 	t.When("GOTEST_UPDATE_SNAPSHOTS is set", func(w *gotest.T) {
 		w.It("replaces original content with updated content and removes the old value", func(it *gotest.T) {
@@ -132,7 +132,7 @@ type SnapshotTestSuite struct{}
 
 func (s *SnapshotTestSuite) TestMatchSnapshot(t *gotest.T) {
 	snapDir := filepath.Join("testdata", "__snapshots__")
-	t.T().Cleanup(func() { os.RemoveAll(snapDir) })
+	t.T().Cleanup(func() { os.Remove(filepath.Join(snapDir, "TestSnapshotTestSuite_ext.snap")) })
 
 	t.When("no snapshot exists", func(w *gotest.T) {
 		w.It("creates a grouped snapshot file on first run", func(it *gotest.T) {
@@ -182,8 +182,8 @@ func (s *SnapshotTestSuite) TestMatchSnapshot(t *gotest.T) {
 func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
 	snapDir := filepath.Join("testdata", "__snapshots__")
 
-	t.T().Cleanup(func() { os.RemoveAll(snapDir) })
 	snapPath := filepath.Join(snapDir, "TestSnapshotTestSuite_ext.snap")
+	t.T().Cleanup(func() { os.Remove(snapPath) })
 
 	t.When("value is a string", func(w *gotest.T) {
 		w.It("snapshots the string directly", func(it *gotest.T) {


### PR DESCRIPTION
Snapshot test cleanups were deleting the entire `__snapshots__/` directory, racing with other suites when `gotest spec` runs them as parallel processes. Each suite now only removes its own `.snap` file.