### PR TITLE
Retry discovery before showing error toast

### DIFF
--- a/vscode-gotest/src/discovery.test.ts
+++ b/vscode-gotest/src/discovery.test.ts
@@ -1,23 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const {
-  mockExecFileAsync,
-  mockAccess,
-  mockReadFile,
-  mockShowWarningMessage,
-} = vi.hoisted(() => ({
-  mockExecFileAsync: vi.fn(
-    async (): Promise<{ stdout: string; stderr: string }> => ({
-      stdout: "{}",
-      stderr: "",
+const { mockExecFileAsync, mockAccess, mockReadFile, mockShowWarningMessage } =
+  vi.hoisted(() => ({
+    mockExecFileAsync: vi.fn(
+      async (): Promise<{ stdout: string; stderr: string }> => ({
+        stdout: "{}",
+        stderr: "",
+      }),
+    ),
+    mockAccess: vi.fn(async () => {}),
+    mockReadFile: vi.fn(async (): Promise<string> => {
+      throw new Error("ENOENT");
     }),
-  ),
-  mockAccess: vi.fn(async () => {}),
-  mockReadFile: vi.fn(async (): Promise<string> => {
-    throw new Error("ENOENT");
-  }),
-  mockShowWarningMessage: vi.fn(async () => undefined),
-}));
+    mockShowWarningMessage: vi.fn(async () => undefined),
+  }));
 
 vi.mock("vscode", () => ({
   workspace: {
@@ -81,7 +77,7 @@ function successResponse(pkgs: Array<{ importPath: string; dir: string }>) {
   };
 }
 
-describe("DiscoveryService retry", () => {
+describe("DiscoveryService", () => {
   let cache: DiscoveryCache;
   let outputChannel: ReturnType<typeof makeOutputChannel>;
   let service: DiscoveryService;
@@ -99,131 +95,186 @@ describe("DiscoveryService retry", () => {
     );
   });
 
-  it("succeeds on first attempt without retry", async () => {
-    mockExecFileAsync.mockResolvedValueOnce(
-      successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
-    );
-
-    await service.discover("/ws", ["./..."]);
-
-    expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
-    expect(cache.packages).toHaveLength(1);
-    expect(outputChannel.debug).not.toHaveBeenCalled();
-    expect(mockShowWarningMessage).not.toHaveBeenCalled();
-  });
-
-  it("retries on transient failure and succeeds on second attempt", async () => {
-    mockExecFileAsync
-      .mockRejectedValueOnce(new Error("cannot find package"))
-      .mockResolvedValueOnce(
+  describe("when discovery succeeds immediately", () => {
+    it("updates the cache with discovered packages", async () => {
+      mockExecFileAsync.mockResolvedValueOnce(
         successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
       );
 
-    const p = service.discover("/ws", ["./..."]);
-    await vi.advanceTimersByTimeAsync(2_000);
-    await p;
+      await service.discover("/ws", ["./..."]);
 
-    expect(mockExecFileAsync).toHaveBeenCalledTimes(2);
-    expect(cache.packages).toHaveLength(1);
-    expect(outputChannel.debug).toHaveBeenCalledWith(
-      expect.stringContaining("attempt 1/3 failed"),
-    );
-    expect(mockShowWarningMessage).not.toHaveBeenCalled();
-  });
+      expect(cache.packages).toHaveLength(1);
+      expect(cache.getPackage("example.com/pkg")).toBeDefined();
+    });
 
-  it("retries twice and succeeds on third attempt", async () => {
-    mockExecFileAsync
-      .mockRejectedValueOnce(new Error("fail 1"))
-      .mockRejectedValueOnce(new Error("fail 2"))
-      .mockResolvedValueOnce(
+    it("does not show a warning toast", async () => {
+      mockExecFileAsync.mockResolvedValueOnce(
         successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
       );
 
-    const p = service.discover("/ws", ["./..."]);
-    await vi.advanceTimersByTimeAsync(2_000);
-    await vi.advanceTimersByTimeAsync(4_000);
-    await p;
+      await service.discover("/ws", ["./..."]);
 
-    expect(mockExecFileAsync).toHaveBeenCalledTimes(3);
-    expect(cache.packages).toHaveLength(1);
-    expect(outputChannel.debug).toHaveBeenCalledTimes(2);
-    expect(mockShowWarningMessage).not.toHaveBeenCalled();
+      expect(mockShowWarningMessage).not.toHaveBeenCalled();
+    });
+
+    it("does not log at debug level", async () => {
+      mockExecFileAsync.mockResolvedValueOnce(
+        successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
+      );
+
+      await service.discover("/ws", ["./..."]);
+
+      expect(outputChannel.debug).not.toHaveBeenCalled();
+    });
   });
 
-  it("shows toast only after all retries exhausted", async () => {
-    mockExecFileAsync.mockRejectedValue(new Error("persistent failure"));
+  describe("when discovery fails transiently then recovers", () => {
+    it("retries after 2s and updates cache on success", async () => {
+      mockExecFileAsync
+        .mockRejectedValueOnce(new Error("cannot find package"))
+        .mockResolvedValueOnce(
+          successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
+        );
 
-    const p = service.discover("/ws", ["./..."]);
-    await vi.advanceTimersByTimeAsync(2_000);
-    await vi.advanceTimersByTimeAsync(4_000);
-    await p;
+      const p = service.discover("/ws", ["./..."]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await p;
 
-    expect(mockExecFileAsync).toHaveBeenCalledTimes(3);
-    expect(cache.packages).toHaveLength(0);
-    expect(outputChannel.error).toHaveBeenCalledWith(
-      expect.stringContaining("failed after 3 attempts"),
-    );
-    expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
+      expect(cache.packages).toHaveLength(1);
+    });
+
+    it("logs the transient failure at debug level", async () => {
+      mockExecFileAsync
+        .mockRejectedValueOnce(new Error("cannot find package"))
+        .mockResolvedValueOnce(
+          successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
+        );
+
+      const p = service.discover("/ws", ["./..."]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await p;
+
+      expect(outputChannel.debug).toHaveBeenCalledWith(
+        expect.stringContaining("attempt 1/3 failed, retrying"),
+      );
+    });
+
+    it("does not show a warning toast", async () => {
+      mockExecFileAsync
+        .mockRejectedValueOnce(new Error("cannot find package"))
+        .mockResolvedValueOnce(
+          successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
+        );
+
+      const p = service.discover("/ws", ["./..."]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await p;
+
+      expect(mockShowWarningMessage).not.toHaveBeenCalled();
+    });
+
+    it("recovers on third attempt after two failures", async () => {
+      mockExecFileAsync
+        .mockRejectedValueOnce(new Error("fail 1"))
+        .mockRejectedValueOnce(new Error("fail 2"))
+        .mockResolvedValueOnce(
+          successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
+        );
+
+      const p = service.discover("/ws", ["./..."]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(4_000);
+      await p;
+
+      expect(cache.packages).toHaveLength(1);
+      expect(outputChannel.debug).toHaveBeenCalledTimes(2);
+      expect(mockShowWarningMessage).not.toHaveBeenCalled();
+    });
   });
 
-  it("does not show duplicate toast on repeated total failures", async () => {
-    mockExecFileAsync.mockRejectedValue(new Error("persistent failure"));
+  describe("when all retry attempts fail", () => {
+    beforeEach(async () => {
+      mockExecFileAsync.mockRejectedValue(new Error("persistent failure"));
+      const p = service.discover("/ws", ["./..."]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(4_000);
+      await p;
+    });
 
-    const p1 = service.discover("/ws", ["./..."]);
-    await vi.advanceTimersByTimeAsync(2_000);
-    await vi.advanceTimersByTimeAsync(4_000);
-    await p1;
+    it("does not update the cache", () => {
+      expect(cache.packages).toHaveLength(0);
+    });
 
-    const p2 = service.discover("/ws", ["./..."]);
-    await vi.advanceTimersByTimeAsync(2_000);
-    await vi.advanceTimersByTimeAsync(4_000);
-    await p2;
+    it("logs the final failure at error level", () => {
+      expect(outputChannel.error).toHaveBeenCalledWith(
+        expect.stringContaining("failed after 3 attempts"),
+      );
+      expect(outputChannel.error).toHaveBeenCalledTimes(1);
+    });
 
-    expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
+    it("shows a warning toast to the user", () => {
+      expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
+      expect(mockShowWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining("discovery failed"),
+        "Open Output",
+      );
+    });
+
+    it("does not show duplicate toasts on subsequent failures", async () => {
+      const p = service.discover("/ws", ["./..."]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(4_000);
+      await p;
+
+      expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it("resets hasShownError after a successful discovery", async () => {
-    mockExecFileAsync.mockRejectedValue(new Error("fail"));
+  describe("when discovery recovers after a previous total failure", () => {
+    it("re-enables the warning toast for future failures", async () => {
+      mockExecFileAsync.mockRejectedValue(new Error("fail"));
 
-    const p1 = service.discover("/ws", ["./..."]);
-    await vi.advanceTimersByTimeAsync(2_000);
-    await vi.advanceTimersByTimeAsync(4_000);
-    await p1;
-    expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
+      const p1 = service.discover("/ws", ["./..."]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(4_000);
+      await p1;
+      expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
 
-    mockExecFileAsync.mockResolvedValue(
-      successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
-    );
+      mockExecFileAsync.mockResolvedValueOnce(
+        successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
+      );
+      await service.discover("/ws", ["./..."]);
 
-    await service.discover("/ws", ["./..."]);
+      mockExecFileAsync.mockRejectedValue(new Error("fail again"));
+      const p3 = service.discover("/ws", ["./..."]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(4_000);
+      await p3;
 
-    mockExecFileAsync.mockRejectedValue(new Error("fail again"));
-
-    const p3 = service.discover("/ws", ["./..."]);
-    await vi.advanceTimersByTimeAsync(2_000);
-    await vi.advanceTimersByTimeAsync(4_000);
-    await p3;
-
-    expect(mockShowWarningMessage).toHaveBeenCalledTimes(2);
+      expect(mockShowWarningMessage).toHaveBeenCalledTimes(2);
+    });
   });
 
-  it("logs retries at debug level, final failure at error level", async () => {
-    mockExecFileAsync.mockRejectedValue(new Error("bad"));
+  describe("when a newer discovery request is queued during retry", () => {
+    it("aborts the retry loop", async () => {
+      mockExecFileAsync
+        .mockRejectedValueOnce(new Error("transient"))
+        .mockResolvedValue(
+          successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
+        );
 
-    const p = service.discover("/ws", ["./..."]);
-    await vi.advanceTimersByTimeAsync(2_000);
-    await vi.advanceTimersByTimeAsync(4_000);
-    await p;
+      const p1 = service.discover("/ws", ["./..."]);
+      // While retrying, queue a second request for same workspace
+      const p2 = service.discover("/ws", ["./..."]);
 
-    expect(outputChannel.debug).toHaveBeenCalledWith(
-      expect.stringContaining("attempt 1/3 failed, retrying"),
-    );
-    expect(outputChannel.debug).toHaveBeenCalledWith(
-      expect.stringContaining("attempt 2/3 failed, retrying"),
-    );
-    expect(outputChannel.error).toHaveBeenCalledWith(
-      expect.stringContaining("failed after 3 attempts"),
-    );
-    expect(outputChannel.error).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(4_000);
+      await p1;
+      await p2;
+
+      expect(outputChannel.debug).toHaveBeenCalledWith(
+        expect.stringContaining("superseded by queued request"),
+      );
+    });
   });
 });

--- a/vscode-gotest/src/discovery.test.ts
+++ b/vscode-gotest/src/discovery.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockExecFileAsync,
+  mockAccess,
+  mockReadFile,
+  mockShowWarningMessage,
+} = vi.hoisted(() => ({
+  mockExecFileAsync: vi.fn(
+    async (): Promise<{ stdout: string; stderr: string }> => ({
+      stdout: "{}",
+      stderr: "",
+    }),
+  ),
+  mockAccess: vi.fn(async () => {}),
+  mockReadFile: vi.fn(async (): Promise<string> => {
+    throw new Error("ENOENT");
+  }),
+  mockShowWarningMessage: vi.fn(async () => undefined),
+}));
+
+vi.mock("vscode", () => ({
+  workspace: {
+    workspaceFolders: [],
+    getConfiguration: () => ({ get: () => undefined }),
+  },
+  Uri: { file: (p: string) => ({ fsPath: p }) },
+  window: { showWarningMessage: mockShowWarningMessage },
+  EventEmitter: class {
+    private listeners: Array<() => void> = [];
+    event = (listener: () => void) => {
+      this.listeners.push(listener);
+      return { dispose: () => {} };
+    };
+    fire = () => {
+      for (const l of this.listeners) l();
+    };
+    dispose = () => {};
+  },
+}));
+
+vi.mock("node:fs/promises", () => ({
+  access: mockAccess,
+  readFile: mockReadFile,
+}));
+
+vi.mock("node:child_process", async () => {
+  const util = await import("node:util");
+  const execFileFn: Record<symbol, unknown> = vi.fn() as never;
+  execFileFn[util.promisify.custom] = mockExecFileAsync;
+  return { execFile: execFileFn };
+});
+
+vi.mock("./cli.js", () => ({
+  buildCliCommand: async () => ({ bin: "go", args: ["run", "discover"] }),
+  formatCliCommand: () => "go run discover",
+}));
+
+import { DiscoveryCache, DiscoveryService } from "./discovery.js";
+
+function makeOutputChannel() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    show: vi.fn(),
+  } as unknown as import("vscode").LogOutputChannel;
+}
+
+function successResponse(pkgs: Array<{ importPath: string; dir: string }>) {
+  return {
+    stdout: JSON.stringify({
+      packages: pkgs.map((p) => ({
+        importPath: p.importPath,
+        dir: p.dir,
+        suites: [],
+      })),
+    }),
+    stderr: "",
+  };
+}
+
+describe("DiscoveryService retry", () => {
+  let cache: DiscoveryCache;
+  let outputChannel: ReturnType<typeof makeOutputChannel>;
+  let service: DiscoveryService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    cache = new DiscoveryCache();
+    outputChannel = makeOutputChannel();
+    service = new DiscoveryService(
+      cache,
+      outputChannel as unknown as import("vscode").LogOutputChannel,
+    );
+  });
+
+  it("succeeds on first attempt without retry", async () => {
+    mockExecFileAsync.mockResolvedValueOnce(
+      successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
+    );
+
+    await service.discover("/ws", ["./..."]);
+
+    expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
+    expect(cache.packages).toHaveLength(1);
+    expect(outputChannel.debug).not.toHaveBeenCalled();
+    expect(mockShowWarningMessage).not.toHaveBeenCalled();
+  });
+
+  it("retries on transient failure and succeeds on second attempt", async () => {
+    mockExecFileAsync
+      .mockRejectedValueOnce(new Error("cannot find package"))
+      .mockResolvedValueOnce(
+        successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
+      );
+
+    const p = service.discover("/ws", ["./..."]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await p;
+
+    expect(mockExecFileAsync).toHaveBeenCalledTimes(2);
+    expect(cache.packages).toHaveLength(1);
+    expect(outputChannel.debug).toHaveBeenCalledWith(
+      expect.stringContaining("attempt 1/3 failed"),
+    );
+    expect(mockShowWarningMessage).not.toHaveBeenCalled();
+  });
+
+  it("retries twice and succeeds on third attempt", async () => {
+    mockExecFileAsync
+      .mockRejectedValueOnce(new Error("fail 1"))
+      .mockRejectedValueOnce(new Error("fail 2"))
+      .mockResolvedValueOnce(
+        successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
+      );
+
+    const p = service.discover("/ws", ["./..."]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(4_000);
+    await p;
+
+    expect(mockExecFileAsync).toHaveBeenCalledTimes(3);
+    expect(cache.packages).toHaveLength(1);
+    expect(outputChannel.debug).toHaveBeenCalledTimes(2);
+    expect(mockShowWarningMessage).not.toHaveBeenCalled();
+  });
+
+  it("shows toast only after all retries exhausted", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("persistent failure"));
+
+    const p = service.discover("/ws", ["./..."]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(4_000);
+    await p;
+
+    expect(mockExecFileAsync).toHaveBeenCalledTimes(3);
+    expect(cache.packages).toHaveLength(0);
+    expect(outputChannel.error).toHaveBeenCalledWith(
+      expect.stringContaining("failed after 3 attempts"),
+    );
+    expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show duplicate toast on repeated total failures", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("persistent failure"));
+
+    const p1 = service.discover("/ws", ["./..."]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(4_000);
+    await p1;
+
+    const p2 = service.discover("/ws", ["./..."]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(4_000);
+    await p2;
+
+    expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets hasShownError after a successful discovery", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("fail"));
+
+    const p1 = service.discover("/ws", ["./..."]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(4_000);
+    await p1;
+    expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
+
+    mockExecFileAsync.mockResolvedValue(
+      successResponse([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]),
+    );
+
+    await service.discover("/ws", ["./..."]);
+
+    mockExecFileAsync.mockRejectedValue(new Error("fail again"));
+
+    const p3 = service.discover("/ws", ["./..."]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(4_000);
+    await p3;
+
+    expect(mockShowWarningMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs retries at debug level, final failure at error level", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("bad"));
+
+    const p = service.discover("/ws", ["./..."]);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(4_000);
+    await p;
+
+    expect(outputChannel.debug).toHaveBeenCalledWith(
+      expect.stringContaining("attempt 1/3 failed, retrying"),
+    );
+    expect(outputChannel.debug).toHaveBeenCalledWith(
+      expect.stringContaining("attempt 2/3 failed, retrying"),
+    );
+    expect(outputChannel.error).toHaveBeenCalledWith(
+      expect.stringContaining("failed after 3 attempts"),
+    );
+    expect(outputChannel.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/vscode-gotest/src/discovery.ts
+++ b/vscode-gotest/src/discovery.ts
@@ -186,6 +186,9 @@ export class DiscoveryService {
     return ["./..."];
   }
 
+  private static readonly MAX_RETRIES = 3;
+  private static readonly RETRY_DELAYS_MS = [2_000, 4_000];
+
   private async execute(
     workspaceDir: string,
     patterns?: string[],
@@ -197,50 +200,71 @@ export class DiscoveryService {
       return;
     }
 
-    try {
-      const effectivePatterns =
-        patterns ?? (await this.resolveWorkspacePatterns(workspaceDir));
-      const cmd = await buildCliCommand(
-        ["discover", ...effectivePatterns],
-        workspaceDir,
-        this.outputChannel,
-      );
-      this.outputChannel.info(`[discovery] ${formatCliCommand(cmd)}`);
+    const effectivePatterns =
+      patterns ?? (await this.resolveWorkspacePatterns(workspaceDir));
 
-      const { stdout } = await execFileAsync(cmd.bin, cmd.args, {
-        cwd: workspaceDir,
-        timeout: 30_000,
-      });
-
-      const jsonStart = stdout.indexOf("{");
-      const json = jsonStart > 0 ? stdout.substring(jsonStart) : stdout;
-      const output: DiscoverOutput = JSON.parse(json);
-      const fullScan = effectivePatterns.some((p) => p.includes("..."));
-      const warnings = output.warnings ?? [];
-      const packages = output.packages ?? [];
-      this.cache.update(packages, fullScan, workspaceDir, warnings);
-      this.hasShownError = false;
-      for (const w of warnings) {
-        const loc = w.file ? ` (${w.file}:${w.line ?? 0})` : "";
-        this.outputChannel.warn(
-          `[discovery] ${w.importPath}${loc}: ${w.message}`,
+    for (let attempt = 1; attempt <= DiscoveryService.MAX_RETRIES; attempt++) {
+      if (this.pending.some((p) => p.workspaceDir === workspaceDir)) {
+        this.outputChannel.debug(
+          `[discovery] superseded by queued request, aborting retry`,
         );
+        return;
       }
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.outputChannel.error(`[discovery] ${message}`);
-      if (!this.hasShownError) {
-        this.hasShownError = true;
-        vscode.window
-          .showWarningMessage(
-            `gotest: discovery failed. Ensure 'go' is installed and the gotest module is accessible.`,
-            "Open Output",
-          )
-          .then((choice) => {
-            if (choice === "Open Output") {
-              this.outputChannel.show();
-            }
-          });
+
+      try {
+        const cmd = await buildCliCommand(
+          ["discover", ...effectivePatterns],
+          workspaceDir,
+          this.outputChannel,
+        );
+        this.outputChannel.info(`[discovery] ${formatCliCommand(cmd)}`);
+
+        const { stdout } = await execFileAsync(cmd.bin, cmd.args, {
+          cwd: workspaceDir,
+          timeout: 30_000,
+        });
+
+        const jsonStart = stdout.indexOf("{");
+        const json = jsonStart > 0 ? stdout.substring(jsonStart) : stdout;
+        const output: DiscoverOutput = JSON.parse(json);
+        const fullScan = effectivePatterns.some((p) => p.includes("..."));
+        const warnings = output.warnings ?? [];
+        const packages = output.packages ?? [];
+        this.cache.update(packages, fullScan, workspaceDir, warnings);
+        this.hasShownError = false;
+        for (const w of warnings) {
+          const loc = w.file ? ` (${w.file}:${w.line ?? 0})` : "";
+          this.outputChannel.warn(
+            `[discovery] ${w.importPath}${loc}: ${w.message}`,
+          );
+        }
+        return;
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (attempt < DiscoveryService.MAX_RETRIES) {
+          this.outputChannel.debug(
+            `[discovery] attempt ${attempt}/${DiscoveryService.MAX_RETRIES} failed, retrying: ${message}`,
+          );
+          const delay = DiscoveryService.RETRY_DELAYS_MS[attempt - 1] ?? 4_000;
+          await new Promise((r) => setTimeout(r, delay));
+          continue;
+        }
+        this.outputChannel.error(
+          `[discovery] failed after ${DiscoveryService.MAX_RETRIES} attempts: ${message}`,
+        );
+        if (!this.hasShownError) {
+          this.hasShownError = true;
+          vscode.window
+            .showWarningMessage(
+              `gotest: discovery failed. Ensure 'go' is installed and the gotest module is accessible.`,
+              "Open Output",
+            )
+            .then((choice) => {
+              if (choice === "Open Output") {
+                this.outputChannel.show();
+              }
+            });
+        }
       }
     }
   }


### PR DESCRIPTION
Discovery retries up to 3 times with backoff before surfacing failures to the user, preventing spurious toasts on transient errors like branch switches.