### PR TITLE
Extract fixture runtime library from generated code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Init workspace
         run: go work init . ./examples
       - run: go vet ./... ./examples/...
-      - run: go test ./... -race
+      - run: go test -ldflags=-checklinkname=0 ./... -race
       - run: go run ./cmd/gotest spec --no-color --min=40 ./... ./examples/... -race
 
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Init workspace
         run: go work init . ./examples
       - name: Test (stdlib)
-        run: go test ./... -race
+        run: go test -ldflags=-checklinkname=0 ./... -race
       - name: Install gotest
         run: go install ./cmd/gotest
       - name: Test (suites)
@@ -61,7 +61,7 @@ jobs:
       - name: Lint
         run: go run ./cmd/gotest-lint ./... ./examples/...
       - name: Test (stdlib)
-        run: go test ./... -race
+        run: go test -ldflags=-checklinkname=0 ./... -race
       - name: Test (suites)
         run: go run ./cmd/gotest spec --no-color --min=40 --output=spec.txt ./... ./examples/... -race -coverprofile=coverage.out
       - name: Summary

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,653 @@
+# gotest CLI: Architecture Deep Dive
+
+## High-Level Pipeline
+
+```
+ User invokes: gotest ./...
+                  │
+                  ▼
+ ┌─────────────────────────────────────────────────────────────┐
+ │  1. DISCOVERY                                               │
+ │     packages.Load(./...) → AST Inspector → Suites/Fixtures  │
+ └──────────────────────────┬──────────────────────────────────┘
+                            │  []*LoadResult (Ptest + Pxtest per pkg)
+                            ▼
+ ┌─────────────────────────────────────────────────────────────┐
+ │  2. CODE GENERATION                                         │
+ │     Collector → Resolver → Renderer → overlay.json          │
+ └──────────────────────────┬──────────────────────────────────┘
+                            │  overlayResult (tmpDir, fixture info)
+                            ▼
+ ┌─────────────────────────────────────────────────────────────┐
+ │  3. PREPARE (concurrent)                                    │
+ │                                                             │
+ │  ┌─────────────────────┐    ┌────────────────────────────┐  │
+ │  │ CompilePackages-    │    │ startSharedFixtures        │  │
+ │  │ Stream              │    │   go build → start → read  │  │
+ │  │   go test -c per    │    │   JSON state from stdout   │  │
+ │  │   pkg (NumCPU par)  │    │   → write state.json       │  │
+ │  └────────┬────────────┘    └────────────┬───────────────┘  │
+ │           │ <-chan CompileResult          │ *SharedFixtureProcess
+ └───────────┼──────────────────────────────┼──────────────────┘
+             │    (overlap: exec starts     │
+             │     as packages compile)     │
+             ▼                              │
+ ┌─────────────────────────────────────────────────────────────┐
+ │  4. EXECUTION                                               │
+ │     Per-suite subprocesses, 2×GOMAXPROCS concurrency        │
+ │     Suites needing shared fixtures block on resolveFixture- │
+ │     Env(); others start immediately with base env           │
+ └──────────────────────────┬──────────────────────────────────┘
+                            │  exit code (worst of all suites)
+                            ▼
+ ┌─────────────────────────────────────────────────────────────┐
+ │  5. TEARDOWN                                                │
+ │     SIGTERM → shared fixture subprocess                     │
+ │     → AfterAll per fixture (reverse order) → exit           │
+ └─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 1. Discovery
+
+Discovery is fully static -- AST-based, no reflection at runtime.
+
+### Package Loading
+
+```
+cli.go:runTest() / discover.go:runDiscover()
+  │
+  ├─ LoadPackages(patterns, buildFlags)        [exec path]
+  │    mode: NeedModule | NeedSyntax | NeedName | NeedTypes
+  │           | NeedTypesInfo | NeedImports | NeedDeps
+  │
+  └─ LoadPackagesForDiscovery(patterns, ...)   [discover path]
+       mode: same but NeedFiles instead of NeedDeps
+       (avoids type-checking the full transitive dep graph)
+```
+
+`packages.Load()` with `Tests: true` returns both internal-test (`pkg_test.go`
+in the same package) and external-test (`pkg_test.go` in `pkg_test` package)
+packages. These are grouped into `LoadResult` structs:
+
+```
+LoadResult {
+    PkgDir    "/path/to/pkg"
+    PkgPath   "github.com/example/repo/auth"
+    Ptest     *packages.Package   ← internal test package (same pkg name)
+    Pxtest    *packages.Package   ← external test package (pkg_test name)
+}
+```
+
+### Suite Detection (AST)
+
+The `collector.CollectSuiteSpecs(pkg)` orchestrates a multi-pass AST traversal
+using `go/ast/inspector.Inspector.Preorder()`:
+
+```
+Pass 1: Find Suites
+  ├─ Walk GenDecl nodes
+  ├─ Match: ^(?!ƒƒ_GOTEST_|_)(?:X_|F_)?.+TestSuite$
+  │         (excludes generated wrappers and leading underscores)
+  ├─ Must be a struct type (resolve through aliases for generics)
+  └─ Result: []*TestSuiteSpec
+
+Pass 2: Find Fixtures
+  ├─ Walk GenDecl nodes
+  ├─ Match suffix: *SharedFixture → SharedFixture kind
+  │                *Fixture        → PackageFixture kind
+  └─ Result: []*FixtureSpec
+
+Pass 3: Find Suite Methods (per suite)
+  ├─ Walk FuncDecl nodes
+  ├─ Match pointer receiver to suite type
+  ├─ Classify by name:
+  │   ├─ BeforeAll / AfterAll / BeforeEach / AfterEach
+  │   ├─ SuiteConfig / SuiteGuard
+  │   └─ ^(X_|F_)?Test.+$ → test case method
+  ├─ Validate signatures (param types, return types)
+  └─ Parse SuiteConfig AST for Parallel: true
+
+Pass 4: Validate Context Consistency
+  ├─ If BeforeEach returns a context type:
+  │   all test methods MUST accept it as 2nd param
+  │   AfterEach MUST accept it as 2nd param
+  └─ Parallel: true requires returning BeforeEach
+
+Pass 5: Find Fixture Methods (per fixture)
+  ├─ Lifecycle: BeforeAll, AfterAll, BeforeEach, AfterEach
+  ├─ Config: FixtureConfig() or SharedFixtureConfig()
+  ├─ Hydrate/Dehydrate (shared fixtures only)
+  └─ Validate signatures: all must be (ctx context.Context) error
+
+Pass 6: Validate Fixture Consistency
+  └─ Hydrate and Dehydrate must appear together (or not at all)
+```
+
+### Focus/Exclude System
+
+```
+Name prefix → behavior:
+  F_FooTestSuite     → focused  (only focused suites run)
+  X_BarTestSuite     → excluded (always skipped)
+  F_TestCreateUser   → focused method within suite
+  X_TestDeleteUser   → excluded method within suite
+
+ReduceToEffectiveSet() logic:
+  1. If any suite has F_ prefix → run ONLY focused suites, skip rest
+  2. Remove all X_ prefixed suites
+  3. Within each surviving suite, apply same logic to methods
+```
+
+---
+
+## 2. Code Generation
+
+The resolver walks the type graph starting from discovered suites,
+building a fixture tree and collecting shared fixture references.
+
+### Fixture Resolution
+
+```
+Resolve(targetPkg, suites, localFixtures)
+  │
+  for each suite:
+  │
+  ├─ Inspect struct fields:
+  │   ├─ *FooSharedFixture → build SharedFixtureRef
+  │   │   ├─ Validate: not in internal/ package
+  │   │   ├─ Register in sharedSeen map (deduped by pkgPath.Name)
+  │   │   └─ Classify transfer vs local fields via Hydrate AST
+  │   │
+  │   └─ *BarFixture → resolveFixture(named)
+  │       ├─ Check resolved cache (avoid re-resolving)
+  │       ├─ Cycle detection via resolving map
+  │       ├─ Lookup method set: BeforeAll (required), AfterAll,
+  │       │   BeforeEach, AfterEach, Hydrate, Dehydrate, Config
+  │       └─ Recurse into fixture struct fields for:
+  │           ├─ Parent fixture (at most one, builds tree)
+  │           └─ SharedFixture references
+  │
+  ├─ Suite gets linked: fixture.ChildSuites ← append(suite)
+  └─ Suite categorized: FixtureBound or Standalone
+```
+
+Constraint: at most **one root PackageFixture per package**.
+Fixtures form a single-inheritance tree (parent via embedding).
+
+### What Gets Generated
+
+For **standalone suites** (no fixture):
+
+```go
+// Generated wrapper struct
+type ƒƒ_GOTEST_FooTestSuite struct { FooTestSuite }
+
+// Generated test function
+func TestFooTestSuite(t *testing.T) {
+    s := &ƒƒ_GOTEST_FooTestSuite{}
+    // optional: read shared state from GOTEST_SHARED_STATE_FILE
+    // apply SuiteConfig, deadlines
+    s.BeforeAll(setupT)
+    t.Cleanup(func() { s.AfterAll(teardownT) })
+
+    t.Run("TestCreateUser", func(it *testing.T) {
+        s.BeforeEach(ttt)
+        defer s.AfterEach(ttt)
+        s.TestCreateUser(ttt)
+    })
+}
+```
+
+For **fixture-bound suites** (have a fixture), a `TestMain` is generated:
+
+```go
+func TestMain(m *testing.M) { os.Exit(ƒƒ_GOTEST_main(m)) }
+
+func ƒƒ_GOTEST_main(m *testing.M) (code int) {
+    // 1. Read shared fixture state (if needed)
+    // 2. Instantiate root fixture
+    // 3. BeforeAll on root fixture (with retries, timeout)
+    // 4. Instantiate child fixtures (concurrent)
+    // 5. BeforeAll on each child fixture (concurrent, with retries)
+    // 6. Compute teardown budget → write to budget file
+    // 7. code = m.Run()   ← runs all TestXxx functions
+    // 8. defer: AfterAll children (concurrent), then AfterAll root
+}
+```
+
+The overlay filesystem (`-overlay=path/overlay.json`) injects generated files
+without modifying source. Go's compiler reads virtual paths from the overlay.
+
+---
+
+## 3. Fixtures: Lifecycle Models
+
+### PackageFixture Lifecycle
+
+```
+┌──────────────────── PER PACKAGE (via TestMain) ─────────────────────┐
+│                                                                      │
+│  ┌─ RootFixture.BeforeAll(ctx) ─────────────────────────────────┐   │
+│  │  timeout: FixtureConfig.Timeout (default 2m)                 │   │
+│  │  retries: FixtureConfig.Retries (default 0)                  │   │
+│  │                                                               │   │
+│  │  ┌─ ChildFixture.BeforeAll(ctx) ──────────────────────┐      │   │
+│  │  │  (runs concurrently with sibling child fixtures)    │      │   │
+│  │  └────────────────────────────────────────────────────┘      │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+│                                                                      │
+│  ┌──── PER SUITE (each TestXxxTestSuite function) ──────────────┐   │
+│  │                                                               │   │
+│  │  Suite.BeforeAll(setupT)    ← deadline: SuiteConfig.SetupTimeout │
+│  │                                                               │   │
+│  │  ┌──── PER TEST METHOD (t.Run subtests) ──────────────────┐  │   │
+│  │  │                                                         │  │   │
+│  │  │  Fixture.BeforeEach(ctx)  ← if fixture has it          │  │   │
+│  │  │  Suite.BeforeEach(ttt)    ← if suite has it            │  │   │
+│  │  │  Suite.TestXxx(ttt)       ← deadline: SuiteConfig.Timeout│ │   │
+│  │  │  Suite.AfterEach(ttt)     ← deferred                   │  │   │
+│  │  │  Fixture.AfterEach(ctx)   ← deferred, if fixture has it│  │   │
+│  │  │                                                         │  │   │
+│  │  └─────────────────────────────────────────────────────────┘  │   │
+│  │                                                               │   │
+│  │  Suite.AfterAll(teardownT)  ← deferred via t.Cleanup         │   │
+│  │                                                               │   │
+│  └───────────────────────────────────────────────────────────────┘   │
+│                                                                      │
+│  deferred: ChildFixture.AfterAll(ctx)  ← concurrent                 │
+│  deferred: RootFixture.AfterAll(ctx)   ← after children complete    │
+│  deferred: flush coverage counters                                   │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### SharedFixture Lifecycle
+
+SharedFixtures live in a **separate subprocess** that outlives all test
+binaries. State is transferred via JSON serialization.
+
+```
+┌── SETUP SUBPROCESS ──────────────────────────────────────────────────┐
+│                                                                       │
+│  for each SharedFixture (concurrent):                                 │
+│    sf.BeforeAll(ctx)     timeout: SharedFixtureConfig.Timeout (5m)    │
+│                          retries: SharedFixtureConfig.Retries (1)     │
+│                                                                       │
+│  Serialize transfer fields → JSON → stdout                            │
+│  Include _teardownBudget = maxTimeout + 30s                           │
+│                                                                       │
+│  ═══════════ block on SIGTERM/SIGINT ═══════════                      │
+│                                                                       │
+│  for each SharedFixture (reverse order):                              │
+│    sf.AfterAll(ctx)      timeout: SharedFixtureConfig.Timeout         │
+│                                                                       │
+└───────────────────────────────────────────────────────────────────────┘
+
+         │ stdout: JSON state       │ state.json file
+         ▼                          ▼
+
+┌── TEST PROCESS (per suite binary) ───────────────────────────────────┐
+│                                                                       │
+│  Read GOTEST_SHARED_STATE_FILE                                        │
+│  json.Unmarshal → SharedFixture struct (transfer fields only)         │
+│  sf.Hydrate(ctx)    ← reconstruct local fields (e.g., DB handles)    │
+│  t.Cleanup → sf.Dehydrate(ctx)   ← release local resources           │
+│                                                                       │
+│  Suite runs with shared fixture pointer available on its struct       │
+│                                                                       │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+**Transfer vs Local fields:**
+- Transfer fields: exported, JSON-serializable, sent across processes
+- Local fields: assigned inside `Hydrate()`, reconstructed in each test
+  process (e.g., `*sql.DB` handles that can't serialize)
+
+The `ClassifyLocalFieldsRaw()` function performs AST analysis on the Hydrate
+method body to determine which exported fields are assigned (and therefore
+"local"). It also follows one level of receiver method calls
+(e.g., `f.connect()` → inspects `connect` body for assignments).
+
+---
+
+## 4. Process Parallelism
+
+The system has **four levels of parallelism**, each with distinct mechanisms:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ Level 1: Package COMPILATION            semaphore: runtime.NumCPU()│
+│                                                                     │
+│  ┌─────┐ ┌─────┐ ┌─────┐ ┌─────┐                                  │
+│  │ go  │ │ go  │ │ go  │ │ go  │  ← goroutines, each runs         │
+│  │test │ │test │ │test │ │test │    `go test -c -overlay=...`      │
+│  │ -c  │ │ -c  │ │ -c  │ │ -c  │                                  │
+│  │pkg1 │ │pkg2 │ │pkg3 │ │pkg4 │                                  │
+│  └──┬──┘ └──┬──┘ └──┬──┘ └──┬──┘                                  │
+│     │       │       │       │                                       │
+│     └───────┴───────┴───────┘                                       │
+│               │                                                     │
+│               ▼  CompileResult streamed to channel                  │
+│                  (execution starts as each package finishes)        │
+├─────────────────────────────────────────────────────────────────────┤
+│ Level 2: Shared fixture SETUP           concurrent with compilation│
+│                                                                     │
+│  ┌──────────────────────────────┐                                   │
+│  │ setup subprocess             │  ← single process                 │
+│  │  sf0.BeforeAll() ──┐        │    but fixture BeforeAll calls     │
+│  │  sf1.BeforeAll() ──┤ (conc) │    run concurrently inside it      │
+│  │  sf2.BeforeAll() ──┘        │                                    │
+│  └──────────────────────────────┘                                   │
+├─────────────────────────────────────────────────────────────────────┤
+│ Level 3: Suite EXECUTION           semaphore: 2×GOMAXPROCS(0)      │
+│                                                                     │
+│  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐           │
+│  │suite │ │suite │ │suite │ │suite │ │suite │ │suite │  ← OS      │
+│  │proc  │ │proc  │ │proc  │ │proc  │ │proc  │ │proc  │    procs   │
+│  │(bin  │ │(bin  │ │(bin  │ │(bin  │ │(bin  │ │(bin  │            │
+│  │ -run │ │ -run │ │ -run │ │ -run │ │ -run │ │ -run │            │
+│  │ ^A$) │ │ ^B$) │ │ ^C$) │ │ ^D$) │ │ ^E$) │ │ ^F$) │           │
+│  └──────┘ └──────┘ └──────┘ └──────┘ └──────┘ └──────┘           │
+│  Each suite = separate OS subprocess with own process group         │
+│  One compiled binary may serve multiple suites (diff -test.run)     │
+├─────────────────────────────────────────────────────────────────────┤
+│ Level 4: Within-suite test PARALLELISM     (optional, in-process)  │
+│                                                                     │
+│  Enabled by: SuiteConfig{ Parallel: true }                          │
+│  Requires:   BeforeEach returns per-test context struct             │
+│  Mechanism:  it.Parallel() + sync.WaitGroup                         │
+│  Concurrency governed by `-test.parallel` (default: GOMAXPROCS)     │
+│                                                                     │
+│  ┌─ Suite subprocess ──────────────────────────────────────────┐    │
+│  │ BeforeAll()                                                  │    │
+│  │ t.Run("TestA", func() { it.Parallel(); ctx := BeforeEach(); │    │
+│  │                          TestA(t, ctx); AfterEach(t, ctx) }) │    │
+│  │ t.Run("TestB", func() { it.Parallel(); ctx := BeforeEach(); │    │
+│  │                          TestB(t, ctx); AfterEach(t, ctx) }) │    │
+│  │ wg.Wait()                                                    │    │
+│  │ AfterAll()                                                   │    │
+│  └──────────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Streaming Execution (Compile-Execute Overlap)
+
+`executeTestsStreaming` is the primary execution path. It overlaps compilation
+with test execution:
+
+```
+time ─────────────────────────────────────────────────────────────────▶
+
+CompilePackagesStream:
+  [compile pkg1] [compile pkg2] [compile pkg3] [compile pkg4]
+       │              │              │              │
+       ▼              ▼              │              │
+  [run suites    [run suites     │              │
+   from pkg1]    from pkg2]      ▼              │
+                            [run suites         ▼
+                             from pkg3]    [run suites
+                                            from pkg4]
+
+Each CompileResult immediately produces SuiteTargets that enter
+the execution semaphore. No "compile all, then run all" barrier.
+```
+
+### Lazy Fixture Environment Resolution
+
+Suites that need shared fixtures call `resolveFixtureEnv()` which blocks
+(via `sync.Once`) until the shared fixture setup completes. Suites that
+don't need shared fixtures skip this entirely and use `baseEnv`:
+
+```
+Suite goroutine:
+  │
+  ├─ needsFixture? ──yes──▶ resolveFixtureEnv()
+  │                              │
+  │                              ├─ sync.Once blocks until fixtureReady
+  │                              ├─ Returns env with GOTEST_SHARED_STATE_FILE
+  │                              └─ Error? → streamCancel(), return
+  │
+  └─ needsFixture? ──no───▶ use baseEnv directly (no blocking)
+```
+
+---
+
+## 5. Timeout Architecture
+
+```
+┌────────────────────── Timeout Hierarchy ──────────────────────────────┐
+│                                                                        │
+│  --setup-timeout (CLI flag)                                            │
+│  └─ Total budget for shared fixture subprocess to emit JSON state      │
+│     Default: 0 (no external deadline; per-fixture timeouts govern)     │
+│                                                                        │
+│  SharedFixtureConfig.Timeout (per shared fixture)                      │
+│  └─ Deadline on each BeforeAll/AfterAll call in the setup subprocess   │
+│     Default: 2m (DefaultFixtureConfig)                                 │
+│     Container preset: 5m + 1 retry + 5s delay (ContainerFixtureConfig) │
+│                                                                        │
+│  FixtureConfig.Timeout (per package fixture)                           │
+│  └─ Deadline on BeforeAll/AfterAll in TestMain                         │
+│     Default: 2m                                                        │
+│                                                                        │
+│  SuiteConfig.SetupTimeout (per suite)                                  │
+│  └─ Deadline on suite-level BeforeAll/AfterAll                         │
+│     Default: 30s                                                       │
+│                                                                        │
+│  SuiteConfig.Timeout (per test method)                                 │
+│  └─ Deadline on each t.Run subtest body                                │
+│     Default: 30s                                                       │
+│                                                                        │
+│  Teardown Budget (per suite subprocess)                                │
+│  └─ Written to BudgetFile after fixture setup in TestMain              │
+│     = max(fixture tree path timeout) + max(suite setup timeout) + 30s  │
+│     Used by RunSingleSuite on context cancellation before SIGKILL      │
+│                                                                        │
+│  GracefulShutdownDelay (hardcoded: 5m30s)                              │
+│  └─ Fallback when no budget file exists                                │
+│     Must cover longest possible fixture teardown                       │
+│                                                                        │
+│  BuildShutdownDelay (hardcoded: 10s)                                   │
+│  └─ WaitDelay for go build / go test -c compile commands               │
+│                                                                        │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+### Timeout Enforcement Points
+
+```
+                     ┌─────────────────────────┐
+                     │   CLI invocation         │
+                     │   signal.NotifyContext   │
+                     │   (SIGINT, SIGTERM)      │
+                     └───────────┬─────────────┘
+                                 │ ctx
+                    ┌────────────┼────────────┐
+                    │            │            │
+                    ▼            ▼            ▼
+            ┌──────────┐  ┌──────────┐  ┌──────────┐
+            │ compile  │  │ shared   │  │ suite    │
+            │ cmd      │  │ fixture  │  │ cmd      │
+            │          │  │ cmd      │  │          │
+            │ Cancel:  │  │ Cancel:  │  │ Cancel:  │
+            │ SIGTERM  │  │ SIGTERM  │  │ SIGTERM  │
+            │ →pgroup  │  │ →pgroup  │  │ →pgroup  │
+            │          │  │          │  │          │
+            │ WaitDly: │  │ WaitDly: │  │ WaitDly: │
+            │ 10s      │  │ 0 (mgd)  │  │ 0 (mgd)  │
+            └──────────┘  └──────────┘  └──────────┘
+                                             │
+                                 On ctx.Done():
+                                 ┌───────────┘
+                                 │
+                                 ▼
+                          read budget file
+                          (or use 5m30s default)
+                                 │
+                                 ▼
+                          time.After(budget)
+                                 │
+                          still running?
+                                 │
+                         yes ────┼──── no
+                          │             │
+                   ForceKillProcess   normal
+                   Group(SIGKILL)     exit
+```
+
+### Process Group Isolation
+
+Every subprocess gets its own process group via `Setpgid: true`:
+
+```go
+cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+cmd.Cancel = func() error {
+    return syscall.Kill(-pid, syscall.SIGTERM)  // negative PID = group
+}
+```
+
+This ensures that when a suite subprocess is terminated, all its child
+processes (e.g., processes spawned by tests) are also killed. SIGTERM goes
+to the entire group, not just the leader process.
+
+---
+
+## 6. Output Modes
+
+```
+┌─ RunBatchText (default) ────────────────────────────────────────────┐
+│                                                                      │
+│  PackageBatcher collects results per package.                        │
+│  When ALL suites for a package complete → flush in deterministic     │
+│  order (by registration index, not completion time).                 │
+│                                                                      │
+│  Trailing PASS/FAIL line stripped from each suite, replaced with     │
+│  a single package summary:  ok  pkg/path  1.234s                    │
+│                                                                      │
+├─ RunStreamJSON (-json flag) ─────────────────────────────────────────┤
+│                                                                      │
+│  Each suite wrapped with `go tool test2json -p <pkg> -t <binary>`    │
+│  JSON events streamed to stdout as each suite completes.             │
+│  No batching; order depends on completion time.                      │
+│                                                                      │
+├─ RunCaptureJSON (internal, for watch mode) ──────────────────────────┤
+│                                                                      │
+│  Same as StreamJSON but captured into bytes.Buffer.                   │
+│  Nothing written to stdout. Used for programmatic consumption.       │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 7. Suite Target Construction
+
+```
+BuildSuiteTargets(compiled, suitesByPkg, dirsByPkg, runFlags, userRunFilter)
+  │
+  for each package:
+    for each suite struct name (e.g., "FooTestSuite"):
+      │
+      ├─ testFuncName = "Test" + "FooTestSuite" = "TestFooTestSuite"
+      │
+      ├─ If userRunFilter set:
+      │   ├─ Split filter on first "/" → topLevel / subtest
+      │   ├─ Match topLevel regex against testFuncName
+      │   └─ Skip suite if no match
+      │
+      └─ SuiteTarget {
+           Package:    "github.com/example/auth"
+           Dir:        "/path/to/auth"
+           BinaryPath: "/tmp/gotest/bin/auth_a1b2c3d4.test"
+           SuiteName:  "TestFooTestSuite"
+           RunFilter:  "" or user's -run value
+           RunFlags:   ["-test.v", "-test.timeout=30s", ...]
+           CoverProfile: "/tmp/gotest/cover/0.out" (if -coverprofile)
+           BudgetFile:   "/tmp/gotest/bin/auth_a1b2c3d4.test.budget"
+         }
+```
+
+Each target becomes one `exec.Command`:
+```
+go tool test2json -p <pkg> -t <binary> -test.run=^TestFooTestSuite$ [flags]
+```
+
+Or without test2json:
+```
+<binary> -test.run=^TestFooTestSuite$ [flags]
+```
+
+---
+
+## 8. Full Timeline (Happy Path)
+
+```
+t=0s    CLI starts
+        ├─ Parse flags, load config
+        ├─ LoadPackages(./...)
+        ├─ GenerateFromLoaded → overlay.json
+        ├─ signal.NotifyContext (SIGINT/SIGTERM → ctx cancel)
+        │
+t=0.5s  executeTestsStreaming begins
+        ├─ Start goroutine: CompilePackagesStream → compileCh
+        ├─ Start goroutine: startSharedFixtures (if any)
+        │
+t=1s    pkg/auth compiles first → CompileResult on compileCh
+        ├─ BuildSuiteTargets → [AuthTestSuite, TokenTestSuite]
+        ├─ AuthTestSuite needs shared fixtures → blocks on resolveFixtureEnv()
+        └─ TokenTestSuite doesn't → acquires sem slot, starts subprocess
+           └─ ./auth_hash.test -test.run=^TestTokenTestSuite$ -test.v=test2json
+        │
+t=2s    pkg/cart compiles → 2 more suites start
+        │
+t=3s    Shared fixture setup completes → JSON state written
+        ├─ resolveFixtureEnv() unblocks
+        └─ AuthTestSuite now starts (had been waiting)
+        │
+t=4s    TokenTestSuite finishes (exit 0)
+        ├─ batcher.Record("pkg/auth", 1, result) → not all done yet
+        │
+t=5s    AuthTestSuite finishes (exit 0)
+        ├─ batcher.Record("pkg/auth", 0, result) → all done!
+        └─ batcher.Flush("pkg/auth") → print both suites, package summary
+        │
+t=8s    All suites done, wg.Wait() returns
+        ├─ setupProc.Teardown()
+        │   ├─ TerminateProcessGroup(pid) → SIGTERM
+        │   └─ Shared fixture subprocess runs AfterAll, exits
+        └─ Return worst exit code
+```
+
+---
+
+## Key Design Decisions
+
+1. **AST over reflection**: Discovery is compile-time, not runtime. This
+   enables static analysis, IDE integration (`gotest discover` JSON), and
+   code generation without running test code.
+
+2. **One subprocess per suite**: Each suite runs in complete isolation. A
+   panicking suite cannot affect others. The OS enforces memory isolation.
+
+3. **Overlay filesystem**: Generated code is injected via Go's `-overlay` flag.
+   Source files are never modified. The overlay is a temp directory cleaned up
+   on exit.
+
+4. **Streaming compilation**: `CompilePackagesStream` sends results to a
+   channel as each package finishes. Test execution begins before all packages
+   are compiled, reducing total wall-clock time.
+
+5. **Process groups**: Every subprocess gets `Setpgid: true`. Signals target
+   the group (negative PID), ensuring child processes spawned by tests are
+   also cleaned up.
+
+6. **Budget-based teardown**: Each suite subprocess computes its own teardown
+   budget (max fixture timeout + max suite setup timeout + 30s headroom) and
+   writes it to a sidecar file. The runner reads this before deciding when to
+   escalate from SIGTERM to SIGKILL.
+
+7. **Coverage interception**: The fixture template intercepts Go's coverage
+   `tearDown` function via `go:linkname` to ensure coverage counters survive
+   past `m.Run()` and capture fixture teardown code.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -301,9 +301,16 @@ binaries. State is transferred via JSON serialization.
 ```
 
 **Transfer vs Local fields:**
-- Transfer fields: exported, JSON-serializable, sent across processes
+- Transfer fields: exported, JSON-serializable, sent across processes.
+  These should be stable connection parameters (host, port, credentials),
+  not ephemeral handles or runtime state.
 - Local fields: assigned inside `Hydrate()`, reconstructed in each test
   process (e.g., `*sql.DB` handles that can't serialize)
+
+**Design intent:** the state file is a connection-parameter snapshot, not a
+general data bus. `Hydrate()` turns those parameters into live connections;
+`Dehydrate()` releases them. This keeps fixture state deterministic across
+the N test processes that read the same snapshot.
 
 The `ClassifyLocalFieldsRaw()` function performs AST analysis on the Hydrate
 method body to determine which exported fields are assigned (and therefore

--- a/internal/gotestgen/export_test.go
+++ b/internal/gotestgen/export_test.go
@@ -157,6 +157,8 @@ type ExportRenderer = renderer
 var ExportPackageEvalMode = packageEvalMode
 var ExportIsInternalPkgPath = isInternalPkgPath
 var ExportBuildFixtureViewModelsFromResolved = buildFixtureViewModelsFromResolved
+var ExportFlattenFixtures = flattenFixtures
+var ExportFlattenSuites = flattenSuites
 
 // ExportMakeFixtureSpec creates a minimal FixtureSpec for validation testing.
 func ExportMakeFixtureSpec(name string, kind gotestast.FixtureKind, hasBeforeAll bool) *gotestast.FixtureSpec {

--- a/internal/gotestgen/renderer.go
+++ b/internal/gotestgen/renderer.go
@@ -25,6 +25,7 @@ var (
 type FixtureViewModel struct {
 	Identifier          string
 	QualifiedIdentifier string // "pkg.Name" for cross-package, "Name" for same
+	ParentIdentifier    string // Identifier of the parent fixture (empty for roots)
 	ParentFieldName     string // field name in this fixture's struct for the parent fixture pointer
 	PkgPath             string // import path, empty if same package
 	HasConfig           bool
@@ -37,6 +38,14 @@ type FixtureViewModel struct {
 	ChildSuites         []*gotestast.TestSuiteSpec
 	ChildFixtures       []*FixtureViewModel
 	SharedFixtures      []SharedFixtureRef
+}
+
+// FlatFixtureSuite describes a suite with its full fixture ancestry chain,
+// used for generating per-suite Test functions at arbitrary tree depth.
+type FlatFixtureSuite struct {
+	Suite        *gotestast.TestSuiteSpec
+	Fixture      *FixtureViewModel   // the fixture this suite is directly bound to
+	FixtureChain []*FixtureViewModel // root → ... → parent fixture (full path)
 }
 
 // SharedFixtureRef describes a shared fixture embedded in a package fixture.
@@ -76,7 +85,7 @@ func (r renderer) RenderTestSuiteSpec(pkg *packages.Package, spec SpecOutcome, r
 	}
 
 	if len(fixtureBound) > 0 {
-		if err := r.renderFixtures(buf, pkg, fixtureBound, viewModels); err != nil {
+		if err := r.renderFixtures(buf, fixtureBound, viewModels); err != nil {
 			return nil, fmt.Errorf("failed rendering fixture suites. err: %w", err)
 		}
 	}
@@ -107,16 +116,17 @@ func (r *renderer) renderFileHeader(buf *bytes.Buffer, pkg *packages.Package, sp
 	}
 	hasSuiteSharedFixtures := len(suiteSharedFixtures) > 0
 	if hasFixtures {
-		imports = append(imports, headerImport{Path: "fmt"})
+		imports = append(imports, headerImport{Path: about.Repo + "/pkg/gotestruntime"})
+		imports = append(imports, headerImport{Path: "context"})
+		imports = append(imports, headerImport{Path: "os"})
 		imports = append(imports, headerImport{Path: "time"})
-		imports = append(imports, headerImport{Name: "_", Path: "unsafe"})
 	}
-	if hasFixtures || slices.Any(spec.EffectiveTestSuites, func(v *gotestast.TestSuiteSpec, idx int) bool {
+	if slices.Any(spec.EffectiveTestSuites, func(v *gotestast.TestSuiteSpec, idx int) bool {
 		return v.IsMethodParallel()
 	}) {
 		imports = append(imports, headerImport{Path: "sync"})
 	}
-	if hasFixtures || hasSuiteSharedFixtures {
+	if !hasFixtures && hasSuiteSharedFixtures {
 		imports = append(imports, headerImport{Path: "context"})
 		imports = append(imports, headerImport{Path: "os"})
 	}
@@ -127,7 +137,7 @@ func (r *renderer) renderFileHeader(buf *bytes.Buffer, pkg *packages.Package, sp
 			imports = append(imports, headerImport{Path: vm.PkgPath})
 			seenPkg[vm.PkgPath] = true
 		}
-		collectFixtureImports(vm, &imports, seenPkg, &hasSharedFixtures)
+		collectFixtureImports(vm, &imports, seenPkg)
 	}
 	for _, refs := range suiteSharedFixtures {
 		for _, sf := range refs {
@@ -154,9 +164,8 @@ func (r *renderer) renderFileHeader(buf *bytes.Buffer, pkg *packages.Package, sp
 	return headerTpl.ExecuteTemplate(buf, "header.go.tpl", map[string]any{"Header": data})
 }
 
-func collectFixtureImports(vm *FixtureViewModel, imports *[]headerImport, seenPkg map[string]bool, hasSharedFixtures *bool) {
+func collectFixtureImports(vm *FixtureViewModel, imports *[]headerImport, seenPkg map[string]bool) {
 	for _, sf := range vm.SharedFixtures {
-		*hasSharedFixtures = true
 		if sf.PkgPath != "" && !seenPkg[sf.PkgPath] {
 			*imports = append(*imports, headerImport{Path: sf.PkgPath})
 			seenPkg[sf.PkgPath] = true
@@ -167,7 +176,7 @@ func collectFixtureImports(vm *FixtureViewModel, imports *[]headerImport, seenPk
 			*imports = append(*imports, headerImport{Path: child.PkgPath})
 			seenPkg[child.PkgPath] = true
 		}
-		collectFixtureImports(child, imports, seenPkg, hasSharedFixtures)
+		collectFixtureImports(child, imports, seenPkg)
 	}
 }
 
@@ -178,7 +187,7 @@ func (r *renderer) renderTestSuites(buf *bytes.Buffer, spec SpecOutcome, suiteSh
 	})
 }
 
-func (r *renderer) renderFixtures(buf *bytes.Buffer, pkg *packages.Package, fixtureBound []*gotestast.TestSuiteSpec, viewModels []*FixtureViewModel) error {
+func (r *renderer) renderFixtures(buf *bytes.Buffer, fixtureBound []*gotestast.TestSuiteSpec, viewModels []*FixtureViewModel) error {
 	if len(viewModels) == 0 {
 		return nil
 	}
@@ -186,17 +195,9 @@ func (r *renderer) renderFixtures(buf *bytes.Buffer, pkg *packages.Package, fixt
 	return gotestTpl.ExecuteTemplate(buf, "gotest.fixture.tpl", map[string]any{
 		"RootFixtures":       viewModels,
 		"FixtureBoundSuites": fixtureBound,
-		"CoverVarName":       detectCoverVarName(pkg),
+		"AllFixtures":        flattenFixtures(viewModels),
+		"FlatSuites":         flattenSuites(viewModels),
 	})
-}
-
-func detectCoverVarName(pkg *packages.Package) string {
-	if tp := pkg.Imports["testing"]; tp != nil && tp.Types != nil {
-		if tp.Types.Scope().Lookup("cover2") != nil {
-			return "cover2"
-		}
-	}
-	return "cover"
 }
 
 func (renderer) formatOutput(buf *bytes.Buffer) ([]byte, error) {
@@ -232,8 +233,47 @@ func resolvedToViewModel(rf *ResolvedFixture) *FixtureViewModel {
 		SharedFixtures:      rf.SharedFixtures,
 	}
 	for _, child := range rf.Children {
-		vm.ChildFixtures = append(vm.ChildFixtures, resolvedToViewModel(child))
+		childVM := resolvedToViewModel(child)
+		childVM.ParentIdentifier = vm.Identifier
+		vm.ChildFixtures = append(vm.ChildFixtures, childVM)
 	}
 	return vm
+}
+
+func flattenFixtures(roots []*FixtureViewModel) []*FixtureViewModel {
+	var result []*FixtureViewModel
+	var walk func(node *FixtureViewModel)
+	walk = func(node *FixtureViewModel) {
+		result = append(result, node)
+		for _, child := range node.ChildFixtures {
+			walk(child)
+		}
+	}
+	for _, root := range roots {
+		walk(root)
+	}
+	return result
+}
+
+func flattenSuites(roots []*FixtureViewModel) []FlatFixtureSuite {
+	var result []FlatFixtureSuite
+	var walk func(node *FixtureViewModel, chain []*FixtureViewModel)
+	walk = func(node *FixtureViewModel, chain []*FixtureViewModel) {
+		currentChain := append(chain, node)
+		for _, suite := range node.ChildSuites {
+			result = append(result, FlatFixtureSuite{
+				Suite:        suite,
+				Fixture:      node,
+				FixtureChain: append([]*FixtureViewModel(nil), currentChain...),
+			})
+		}
+		for _, child := range node.ChildFixtures {
+			walk(child, currentChain)
+		}
+	}
+	for _, root := range roots {
+		walk(root, nil)
+	}
+	return result
 }
 

--- a/internal/gotestgen/renderer_suite_test.go
+++ b/internal/gotestgen/renderer_suite_test.go
@@ -48,22 +48,20 @@ func (s *RendererTestSuite) TestFixtureRendering(t *gotest.T) {
 
 			// Verify the output contains key structural elements
 			gotest.True(it, strings.Contains(output, "func TestMain(m *testing.M)"), "expected TestMain")
-			gotest.True(it, strings.Contains(output, "os.Exit(ƒƒ_GOTEST_main(m))"), "expected os.Exit(ƒƒ_GOTEST_main(m))")
-			gotest.True(it, strings.Contains(output, "func ƒƒ_GOTEST_main(m *testing.M)"), "expected ƒƒ_GOTEST_main")
+			gotest.True(it, strings.Contains(output, "gotestruntime.RunFixtureMain(m,"), "expected RunFixtureMain delegation")
 			gotest.True(it, strings.Contains(output, `"os"`), "expected os import")
 			gotest.True(it, strings.Contains(output, "ƒ_DBFixture = &DBFixture{}"), "expected fixture instantiation")
 			gotest.True(it, strings.Contains(output, "ƒ_DBFixture.BeforeAll(ctx)"), "expected BeforeAll call")
-			gotest.True(it, strings.Contains(output, `"FAIL: DBFixture.BeforeAll failed after`), "expected BeforeAll error attribution")
 			gotest.True(it, strings.Contains(output, "ƒ_DBFixture.AfterAll(ctx)"), "expected AfterAll in cleanup")
-			gotest.True(it, strings.Contains(output, `"DBFixture.AfterAll failed:`), "expected AfterAll error attribution")
 			gotest.True(it, strings.Contains(output, "func TestQueryTestSuite(t *testing.T)"), "expected top-level TestQueryTestSuite func")
 			gotest.True(it, strings.Contains(output, "ƒƒ_GOTEST_QueryTestSuite"), "expected wrapper struct")
 			gotest.True(it, strings.Contains(output, "DBFixture: ƒ_DBFixture"), "expected fixture injection")
 			gotest.True(it, strings.Contains(output, `t.Run("TestInsert"`), "expected TestInsert test case")
 			gotest.True(it, strings.Contains(output, `t.Run("TestSelect"`), "expected TestSelect test case")
 
-			// Verify it does NOT contain old-style Test_DBFixture or t.Run for suites
+			// Verify it does NOT contain old-style patterns
 			gotest.True(it, !strings.Contains(output, "func Test_DBFixture("), "should NOT have old-style Test_DBFixture")
+			gotest.True(it, !strings.Contains(output, "go:linkname"), "should NOT have linkname directives")
 
 			// Verify wrapper struct and lifecycle methods are at file scope (not nested in functions)
 			gotest.True(it, strings.Contains(output, "type ƒƒ_GOTEST_QueryTestSuite struct"), "expected wrapper struct declaration")
@@ -78,7 +76,7 @@ func (s *RendererTestSuite) TestFixtureRendering(t *gotest.T) {
 			pkg := gotestgen.ExportMustTestPkg(it.T(), "TestRenderer_FixtureWithoutAfterAll")
 			output, _ := renderTestPkg(it.T(), pkg)
 
-			gotest.True(it, strings.Contains(output, "func ƒƒ_GOTEST_main(m *testing.M)"), "expected ƒƒ_GOTEST_main")
+			gotest.True(it, strings.Contains(output, "gotestruntime.RunFixtureMain(m,"), "expected RunFixtureMain")
 			gotest.True(it, !strings.Contains(output, "ƒ_SimpleFixture.AfterAll"), "should NOT have AfterAll call")
 		})
 	})
@@ -89,7 +87,7 @@ func (s *RendererTestSuite) TestFixtureRendering(t *gotest.T) {
 			output, _ := renderTestPkg(it.T(), pkg)
 
 			gotest.True(it, strings.Contains(output, "func TestMain(m *testing.M)"), "expected TestMain for fixture")
-			gotest.True(it, strings.Contains(output, "func ƒƒ_GOTEST_main(m *testing.M)"), "expected ƒƒ_GOTEST_main")
+			gotest.True(it, strings.Contains(output, "gotestruntime.RunFixtureMain(m,"), "expected RunFixtureMain")
 			gotest.True(it, strings.Contains(output, "func TestBoundTestSuite(t *testing.T)"), "expected top-level TestBoundTestSuite func")
 			gotest.True(it, strings.Contains(output, "func TestStandaloneTestSuite(t *testing.T)"), "expected standalone test func")
 		})
@@ -219,22 +217,23 @@ func (s *RendererTestSuite) TestStdlibTSupport(t *gotest.T) {
 
 func (s *RendererTestSuite) TestSharedFixture(t *gotest.T) {
 	t.When("embedding", func(w *gotest.T) {
-		w.It("renders shared fixture deserialization and lifecycle", func(it *gotest.T) {
+		w.It("renders shared fixture binding in fixture node", func(it *gotest.T) {
 			pkg := gotestgen.ExportMustTestPkg(it.T(), "TestRenderer_SharedFixtureEmbedding")
 			output, _ := renderTestPkg(it.T(), pkg)
 			gotest.True(it, len(output) > 0, "expected non-empty output")
 
-			// Shared fixture deserialized from JSON state
-			gotest.Contains(it, output, "sf0 := &PostgresSharedFixture{}")
-			gotest.Contains(it, output, `os.Getenv("GOTEST_SHARED_STATE_FILE")`)
-			gotest.Contains(it, output, `"FAIL: GOTEST_SHARED_STATE_FILE not set`)
-			gotest.Contains(it, output, `json.Unmarshal`)
+			// Shared fixture allocated at package level
+			gotest.Contains(it, output, "var ƒ_sf0_E2EFixture = &PostgresSharedFixture{}")
 
-			// Shared fixture should be assigned to the package fixture
-			gotest.Contains(it, output, "ƒ_E2EFixture.PostgresSharedFixture = sf0")
+			// Shared fixture binding in FixtureNode
+			gotest.Contains(it, output, "gotestruntime.SharedFixtureBinding")
+			gotest.Contains(it, output, "Target:   ƒ_sf0_E2EFixture")
+
+			// Shared fixture should be assigned to the package fixture via Assign closure
+			gotest.Contains(it, output, "ƒ_E2EFixture.PostgresSharedFixture = ƒ_sf0_E2EFixture")
 
 			// Package fixture lifecycle should still work
-			gotest.Contains(it, output, "func ƒƒ_GOTEST_main(m *testing.M)")
+			gotest.Contains(it, output, "gotestruntime.RunFixtureMain(m,")
 			gotest.Contains(it, output, "ƒ_E2EFixture = &E2EFixture{}")
 			gotest.Contains(it, output, "ƒ_E2EFixture.BeforeAll(ctx)")
 			gotest.Contains(it, output, "ƒ_E2EFixture.AfterAll(ctx)")
@@ -243,10 +242,8 @@ func (s *RendererTestSuite) TestSharedFixture(t *gotest.T) {
 			gotest.Contains(it, output, "func TestQueryTestSuite(t *testing.T)")
 			gotest.Contains(it, output, "E2EFixture: ƒ_E2EFixture")
 
-			// JSON state deserialization should appear before ƒ_E2EFixture.BeforeAll
-			sfIdx := strings.Index(output, "json.Unmarshal(ƒb, sf0)")
-			beforeAllIdx := strings.Index(output, "ƒ_E2EFixture.BeforeAll(ctx)")
-			gotest.True(it, sfIdx < beforeAllIdx, "shared fixture JSON deserialization must precede fixture.BeforeAll")
+			// Runtime enforces ordering: SharedFixtures processed before BeforeAll is called
+			gotest.Contains(it, output, `"E2EFixture"`)
 		})
 	})
 
@@ -255,9 +252,9 @@ func (s *RendererTestSuite) TestSharedFixture(t *gotest.T) {
 			pkg := gotestgen.ExportMustTestPkg(it.T(), "TestRenderer_SharedFixtureEmptyStruct")
 			output, _ := renderTestPkg(it.T(), pkg)
 
-			gotest.Contains(it, output, "sf0 := &SetupSharedFixture{}")
-			gotest.Contains(it, output, "ƒ_AppFixture.SetupSharedFixture = sf0")
-			gotest.Contains(it, output, `os.Getenv("GOTEST_SHARED_STATE_FILE")`)
+			gotest.Contains(it, output, "var ƒ_sf0_AppFixture = &SetupSharedFixture{}")
+			gotest.Contains(it, output, "ƒ_AppFixture.SetupSharedFixture = ƒ_sf0_AppFixture")
+			gotest.Contains(it, output, "Target:   ƒ_sf0_AppFixture")
 		})
 	})
 }
@@ -266,15 +263,14 @@ func (s *RendererTestSuite) TestSharedFixture(t *gotest.T) {
 
 func (s *RendererTestSuite) TestFixtureConfig(t *gotest.T) {
 	t.When("fixture with config", func(w *gotest.T) {
-		w.It("renders config overlay and timeout", func(it *gotest.T) {
+		w.It("renders config overlay in fixture node", func(it *gotest.T) {
 			pkg := gotestgen.ExportMustTestPkg(it.T(), "TestRenderer_FixtureWithConfig")
 			output, _ := renderTestPkg(it.T(), pkg)
 
 			gotest.Contains(it, output, "gotest.DefaultFixtureConfig()")
-			gotest.Contains(it, output, "gotest.OverlayFixtureConfig(&ƒcfg_CFGFixture, ƒ_CFGFixture.FixtureConfig())")
-			gotest.Contains(it, output, "ƒattempts := 1 + ƒcfg_CFGFixture.Retries")
+			gotest.Contains(it, output, "gotest.OverlayFixtureConfig(&cfg, (&CFGFixture{}).FixtureConfig())")
 			gotest.Contains(it, output, "ƒ_CFGFixture.BeforeAll(ctx)")
-			gotest.Contains(it, output, "context.WithTimeout(ƒctx, ƒcfg_CFGFixture.Timeout)")
+			gotest.Contains(it, output, `Name: "CFGFixture"`)
 		})
 	})
 
@@ -342,7 +338,7 @@ func (s *RendererTestSuite) TestNamedFields(t *gotest.T) {
 			pkg := gotestgen.ExportMustTestPkg(it.T(), "TestRenderer_NamedField_SharedFixtureInFixture")
 			output, _ := renderTestPkg(it.T(), pkg)
 
-			gotest.Contains(it, output, "ƒ_AppFixture.pg = sf0", "shared fixture injection should use named field")
+			gotest.Contains(it, output, "ƒ_AppFixture.pg = ƒ_sf0_AppFixture", "shared fixture injection should use named field")
 			gotest.True(it, !strings.Contains(output, "ƒ_AppFixture.PGSharedFixture"), "should NOT use type name for shared fixture field")
 		})
 	})

--- a/internal/gotestgen/resolver.go
+++ b/internal/gotestgen/resolver.go
@@ -110,14 +110,6 @@ func Resolve(targetPkg *packages.Package, suites []*gotestast.TestSuiteSpec, loc
 		}
 	}
 
-	if len(result.RootFixtures) > 1 {
-		names := make([]string, len(result.RootFixtures))
-		for i, rf := range result.RootFixtures {
-			names[i] = rf.Identifier
-		}
-		return nil, fmt.Errorf("at most one root package fixture per package is allowed, found: %s", strings.Join(names, ", "))
-	}
-
 	// Collect deduplicated shared fixtures
 	for _, sf := range r.sharedSeen {
 		result.RequiredSharedFixtures = append(result.RequiredSharedFixtures, *sf)

--- a/internal/gotestgen/static/gotest.fixture.tpl
+++ b/internal/gotestgen/static/gotest.fixture.tpl
@@ -16,474 +16,166 @@ func (ts *ƒƒ_GOTEST_{{ $ts.Identifier }}) AfterEach(it *gotest.T) { {{ if $ts.
 {{- end }}
 {{- end }}
 
-{{- /* Package-level fixture variables */ -}}
-{{ range $f := .RootFixtures }}
+{{- /* Package-level fixture variables for all fixtures in the tree */ -}}
+{{ range $f := .AllFixtures }}
 var ƒ_{{ $f.Identifier }} *{{ $f.QualifiedIdentifier }}
-{{ range $cf := $f.ChildFixtures }}
-var ƒ_{{ $cf.Identifier }} *{{ $cf.QualifiedIdentifier }}
-{{ end }}
+{{- range $sf := $f.SharedFixtures }}
+var ƒ_{{ $sf.LocalVar }}_{{ $f.Identifier }} = &{{ $sf.QualifiedType }}{}
+{{- end }}
 {{ end }}
 
-{{- /*
-Go flushes coverage counters inside m.Run(), before fixture AfterAll runs.
-We swap tearDown with a no-op so counters survive, then flush after teardown.
-The linkname struct layout is guarded by TestLinknameCompat tests.
-*/}}
-// ƒflushCoverage triggers coverage report writing.
-//go:linkname ƒflushCoverage testing.coverReport
-func ƒflushCoverage()
+func TestMain(m *testing.M) {
+    var ƒmaxSuiteSetup time.Duration
+{{ range $fs := .FlatSuites }}
+    {
+        ƒscfg := gotest.DefaultSuiteConfig()
+{{- if $fs.Suite.HasConfig }}
+        gotest.OverlaySuiteConfig(&ƒscfg, (&{{ $fs.Suite.Identifier }}{ {{ $fs.Suite.FixtureFieldName }}: ƒ_{{ $fs.Fixture.Identifier }} }).SuiteConfig())
+{{- end }}
+        if ƒscfg.SetupTimeout > ƒmaxSuiteSetup { ƒmaxSuiteSetup = ƒscfg.SetupTimeout }
+    }
+{{ end }}
 
-// ƒtestingCover exposes the stdlib coverage state for tearDown interception.
-//go:linkname ƒtestingCover testing.{{ .CoverVarName }}
-var ƒtestingCover struct {
-    mode        string
-    tearDown    func(coverprofile string, gocoverdir string) (string, error)
-    snapshotcov func() float64
+    os.Exit(gotestruntime.RunFixtureMain(m, gotestruntime.MainConfig{
+        Roots: []*gotestruntime.FixtureNode{
+{{- range $f := .RootFixtures }}
+{{ template "fixtureNode" $f }}
+{{- end }}
+        },
+        MaxSuiteSetupTimeout: ƒmaxSuiteSetup,
+    }))
 }
 
-func TestMain(m *testing.M) { os.Exit(ƒƒ_GOTEST_main(m)) }
+{{- /* Render fixture-bound suites as top-level Test functions */ -}}
+{{ range $fs := .FlatSuites }}
 
-func ƒƒ_GOTEST_main(m *testing.M) (ƒcode int) {
-{{ range $f := .RootFixtures }}
-    var ƒcfg_{{ $f.Identifier }} gotest.FixtureConfig
-    var ƒok_{{ $f.Identifier }} bool
-{{ range $cf := $f.ChildFixtures }}
-    var ƒcfg_{{ $cf.Identifier }} gotest.FixtureConfig
-    var ƒok_{{ $cf.Identifier }} bool
-{{ end }}
-{{ end }}
-
-    var ƒorigTearDown func(string, string) (string, error)
-    if testing.CoverMode() != "" {
-        ƒorigTearDown = ƒtestingCover.tearDown
-        ƒtestingCover.tearDown = func(string, string) (string, error) { return "", nil }
+func Test{{ $fs.Suite.Identifier }}(t *testing.T) {
+    s := &ƒƒ_GOTEST_{{ $fs.Suite.Identifier }}{
+        {{ $fs.Suite.Identifier }}: {{ $fs.Suite.Identifier }}{
+            {{ $fs.Suite.FixtureFieldName }}: ƒ_{{ $fs.Fixture.Identifier }},
+        },
     }
+    ƒcfg := gotest.DefaultSuiteConfig()
+{{- if $fs.Suite.HasConfig }}
+    gotest.OverlaySuiteConfig(&ƒcfg, s.{{ $fs.Suite.Identifier }}.SuiteConfig())
+{{- end }}
 
-    defer func() {
-        var ƒtwg sync.WaitGroup
-        ƒtdfails := make([]bool, {{ len .RootFixtures }})
-{{ range $i, $f := .RootFixtures }}
-        ƒtwg.Add(1)
-        go func() {
-            defer ƒtwg.Done()
-{{ if $f.ChildFixtures }}
-            var ƒcwg sync.WaitGroup
-            ƒcdfails := make([]bool, {{ len $f.ChildFixtures }})
-{{ range $j, $cf := $f.ChildFixtures }}
-{{- if $cf.AfterAll }}
-            if ƒok_{{ $cf.Identifier }} {
-                ƒcwg.Add(1)
-                go func() {
-                    defer ƒcwg.Done()
-                    ctx := context.Background()
-                    if ƒcfg_{{ $cf.Identifier }}.Timeout > 0 {
-                        var cancel context.CancelFunc
-                        ctx, cancel = context.WithTimeout(ctx, ƒcfg_{{ $cf.Identifier }}.Timeout)
-                        defer cancel()
-                    }
-                    if err := ƒ_{{ $cf.Identifier }}.AfterAll(ctx); err != nil {
-                        fmt.Fprintf(os.Stderr, "{{ $cf.Identifier }}.AfterAll failed: %v\n", err)
-                        ƒcdfails[{{ $j }}] = true
-                    }
-                }()
-            }
+{{- if $fs.Suite.IsMethodParallel }}
+    wg := &sync.WaitGroup{}
 {{- end }}
-{{ end }}
-            ƒcwg.Wait()
-            for _, ƒf := range ƒcdfails {
-                if ƒf { ƒtdfails[{{ $i }}] = true; break }
-            }
-{{ end }}
-{{- if $f.AfterAll }}
-            if ƒok_{{ $f.Identifier }} {
-                ctx := context.Background()
-                if ƒcfg_{{ $f.Identifier }}.Timeout > 0 {
-                    var cancel context.CancelFunc
-                    ctx, cancel = context.WithTimeout(ctx, ƒcfg_{{ $f.Identifier }}.Timeout)
-                    defer cancel()
-                }
-                if err := ƒ_{{ $f.Identifier }}.AfterAll(ctx); err != nil {
-                    fmt.Fprintf(os.Stderr, "{{ $f.Identifier }}.AfterAll failed: %v\n", err)
-                    ƒtdfails[{{ $i }}] = true
-                }
-            }
+
+    ƒsetupT := gotest.NewT(t)
+    if ƒcfg.SetupTimeout > 0 {
+        ƒsetupT = gotest.NewTWithDeadline(t, ƒcfg.SetupTimeout)
+    }
+    t.Cleanup(func() {
+{{- if $fs.Suite.IsMethodParallel }}
+        wg.Wait()
 {{- end }}
-{{- range $sf := $f.SharedFixtures }}
-{{- if $sf.HasDehydrate }}
-            if ƒok_{{ $f.Identifier }} {
-                ƒ_{{ $f.Identifier }}.{{ $sf.FieldName }}.Dehydrate(context.Background())
+        ƒteardownT := gotest.NewT(t)
+        if ƒcfg.SetupTimeout > 0 {
+            ƒteardownT = gotest.NewTWithDeadline(t, ƒcfg.SetupTimeout)
+        }
+        s.AfterAll(ƒteardownT)
+    })
+    s.BeforeAll(ƒsetupT)
+
+{{ range $tc := $fs.Suite.TestCases }}
+    t.Run("{{ $tc.Identifier }}", func(it *testing.T) {
+{{- if $fs.Suite.IsMethodParallel }}
+        wg.Add(1)
+        it.Parallel()
+        defer wg.Done()
+{{- end }}
+        ttt := gotest.NewT(it)
+        if ƒcfg.Timeout > 0 {
+            ttt = gotest.NewTWithDeadline(it, ƒcfg.Timeout)
+        }
+{{- range $fix := $fs.FixtureChain }}
+{{- if $fix.AfterEach }}
+        defer func() {
+            if err := ƒ_{{ $fix.Identifier }}.AfterEach(context.Background()); err != nil {
+                it.Errorf("{{ $fix.Identifier }}.AfterEach failed: %v", err)
             }
-{{- end }}
-{{- end }}
         }()
-{{ end }}
-        ƒtwg.Wait()
-        for _, ƒf := range ƒtdfails {
-            if ƒf && ƒcode == 0 { ƒcode = 1; break }
+{{- end }}
+{{- end }}
+{{- range $fix := $fs.FixtureChain }}
+{{- if $fix.BeforeEach }}
+        if err := ƒ_{{ $fix.Identifier }}.BeforeEach(it.Context()); err != nil {
+            it.Fatalf("{{ $fix.Identifier }}.BeforeEach failed: %v", err)
         }
-        if ƒorigTearDown != nil {
-            ƒtestingCover.tearDown = ƒorigTearDown
-            ƒflushCoverage()
-        }
-    }()
-
-    ƒctx, ƒcancel := context.WithCancel(context.Background())
-    defer ƒcancel()
-
-    {
-        var ƒswg sync.WaitGroup
-        ƒtfails := make([]bool, {{ len .RootFixtures }})
-{{ range $i, $f := .RootFixtures }}
-        ƒswg.Add(1)
-        go func() {
-            defer ƒswg.Done()
-{{ if $f.SharedFixtures }}
-            ƒsharedFile := os.Getenv("GOTEST_SHARED_STATE_FILE")
-            if ƒsharedFile == "" {
-                fmt.Fprintln(os.Stderr, "FAIL: GOTEST_SHARED_STATE_FILE not set — run via gotest CLI")
-                ƒtfails[{{ $i }}] = true
-                ƒcancel()
-                return
-            }
-            ƒsharedRaw, ƒsharedErr := os.ReadFile(ƒsharedFile)
-            if ƒsharedErr != nil {
-                fmt.Fprintf(os.Stderr, "FAIL: read shared state file: %v\n", ƒsharedErr)
-                ƒtfails[{{ $i }}] = true
-                ƒcancel()
-                return
-            }
-            ƒsharedState := map[string]json.RawMessage{}
-            if err := json.Unmarshal(ƒsharedRaw, &ƒsharedState); err != nil {
-                fmt.Fprintf(os.Stderr, "FAIL: unmarshal shared state: %v\n", err)
-                ƒtfails[{{ $i }}] = true
-                ƒcancel()
-                return
-            }
-{{ range $sf := $f.SharedFixtures }}
-            {{ $sf.LocalVar }} := &{{ $sf.QualifiedType }}{}
-            if ƒb, ok := ƒsharedState["{{ $sf.StateKey }}"]; ok {
-                if err := json.Unmarshal(ƒb, {{ $sf.LocalVar }}); err != nil {
-                    fmt.Fprintf(os.Stderr, "FAIL: unmarshal {{ $sf.FieldName }} state: %v\n", err)
-                    ƒtfails[{{ $i }}] = true
-                    ƒcancel()
-                    return
-                }
-            }
-{{- if $sf.HasHydrate }}
-            if err := {{ $sf.LocalVar }}.Hydrate(context.Background()); err != nil {
-                fmt.Fprintf(os.Stderr, "FAIL: {{ $sf.FieldName }}.Hydrate: %v\n", err)
-                ƒtfails[{{ $i }}] = true
-                ƒcancel()
-                return
-            }
 {{- end }}
+{{- end }}
+{{- if $fs.Suite.HasReturningBeforeEach }}
+        ctx := s.BeforeEach(ttt)
+        defer s.AfterEach(ttt, ctx)
+        s.{{ $tc.Identifier }}({{ if $tc.UsesStdlibT }}ttt.T(){{ else }}ttt{{ end }}, ctx)
+{{- else }}
+        defer s.AfterEach(ttt)
+        s.BeforeEach(ttt)
+        ƒƒ_GOTEST_exec({{ if $tc.UsesStdlibT }}func(t *gotest.T) { s.{{ $tc.Identifier }}(t.T()) }{{ else }}s.{{ $tc.Identifier }}{{ end }}, ttt)
+{{- end }}
+    })
+    if ƒcfg.FailFast && t.Failed() {
+        return
+    }
 {{ end }}
+}
 {{ end }}
-            ƒ_{{ $f.Identifier }} = &{{ $f.QualifiedIdentifier }}{}
-{{- range $sf := $f.SharedFixtures }}
-            ƒ_{{ $f.Identifier }}.{{ $sf.FieldName }} = {{ $sf.LocalVar }}
-{{- end }}
-            ƒcfg_{{ $f.Identifier }} = gotest.DefaultFixtureConfig()
-{{- if $f.HasConfig }}
-            gotest.OverlayFixtureConfig(&ƒcfg_{{ $f.Identifier }}, ƒ_{{ $f.Identifier }}.FixtureConfig())
-{{- end }}
-            var ƒerr error
-            ƒattempts := 1 + ƒcfg_{{ $f.Identifier }}.Retries
-            for ƒi := range ƒattempts {
-                ctx := ƒctx
-                if ƒcfg_{{ $f.Identifier }}.Timeout > 0 {
-                    var cancel context.CancelFunc
-                    ctx, cancel = context.WithTimeout(ƒctx, ƒcfg_{{ $f.Identifier }}.Timeout)
-                    defer cancel()
-                }
-                ƒerr = ƒ_{{ $f.Identifier }}.BeforeAll(ctx)
-                if ƒerr == nil {
-                    break
-                }
-                if ƒctx.Err() != nil {
-                    break
-                }
-                if ƒi < ƒattempts-1 {
-                    fmt.Fprintf(os.Stderr, "{{ $f.Identifier }}.BeforeAll attempt %d/%d failed: %v\n", ƒi+1, ƒattempts, ƒerr)
-                    if ƒcfg_{{ $f.Identifier }}.RetryDelay > 0 {
-                        time.Sleep(ƒcfg_{{ $f.Identifier }}.RetryDelay)
-                    }
-                }
-            }
-            if ƒerr != nil {
-                fmt.Fprintf(os.Stderr, "FAIL: {{ $f.Identifier }}.BeforeAll failed after %d attempt(s): %v\n", ƒattempts, ƒerr)
-                ƒtfails[{{ $i }}] = true
-                ƒcancel()
-                return
-            }
-            ƒok_{{ $f.Identifier }} = true
-{{ if $f.ChildFixtures }}
+
+{{- define "fixtureNode" -}}
             {
-                ƒcfails := make([]bool, {{ len $f.ChildFixtures }})
-                var ƒcwg sync.WaitGroup
-{{ range $j, $cf := $f.ChildFixtures }}
-                ƒcwg.Add(1)
-                go func() {
-                    defer ƒcwg.Done()
-                    ƒ_{{ $cf.Identifier }} = &{{ $cf.QualifiedIdentifier }}{
-                        {{ $cf.ParentFieldName }}: ƒ_{{ $f.Identifier }},
-                    }
-                    ƒcfg_{{ $cf.Identifier }} = gotest.DefaultFixtureConfig()
-{{- if $cf.HasConfig }}
-                    gotest.OverlayFixtureConfig(&ƒcfg_{{ $cf.Identifier }}, ƒ_{{ $cf.Identifier }}.FixtureConfig())
-{{- end }}
-                    var ƒerr error
-                    ƒattempts := 1 + ƒcfg_{{ $cf.Identifier }}.Retries
-                    for ƒi := range ƒattempts {
-                        ctx := ƒctx
-                        if ƒcfg_{{ $cf.Identifier }}.Timeout > 0 {
-                            var cancel context.CancelFunc
-                            ctx, cancel = context.WithTimeout(ƒctx, ƒcfg_{{ $cf.Identifier }}.Timeout)
-                            defer cancel()
-                        }
-                        ƒerr = ƒ_{{ $cf.Identifier }}.BeforeAll(ctx)
-                        if ƒerr == nil {
-                            break
-                        }
-                        if ƒctx.Err() != nil {
-                            break
-                        }
-                        if ƒi < ƒattempts-1 {
-                            fmt.Fprintf(os.Stderr, "{{ $cf.Identifier }}.BeforeAll attempt %d/%d failed: %v\n", ƒi+1, ƒattempts, ƒerr)
-                            if ƒcfg_{{ $cf.Identifier }}.RetryDelay > 0 {
-                                time.Sleep(ƒcfg_{{ $cf.Identifier }}.RetryDelay)
-                            }
-                        }
-                    }
-                    if ƒerr != nil {
-                        fmt.Fprintf(os.Stderr, "FAIL: {{ $cf.Identifier }}.BeforeAll failed after %d attempt(s): %v\n", ƒattempts, ƒerr)
-                        ƒcfails[{{ $j }}] = true
-                        ƒcancel()
-                        return
-                    }
-                    ƒok_{{ $cf.Identifier }} = true
-                }()
-{{ end }}
-                ƒcwg.Wait()
-                for _, ƒf := range ƒcfails {
-                    if ƒf { ƒtfails[{{ $i }}] = true; break }
-                }
-            }
-{{ end }}
-        }()
-{{ end }}
-        ƒswg.Wait()
-        for _, ƒf := range ƒtfails {
-            if ƒf { return 2 }
-        }
-    }
-
-    {
-        var ƒmaxTreePath time.Duration
-        var ƒmaxSuiteSetup time.Duration
-{{ range $f := .RootFixtures }}
-        {
-{{- if $f.ChildFixtures }}
-            var ƒmaxChild time.Duration
-{{ range $cf := $f.ChildFixtures }}
-            if ƒcfg_{{ $cf.Identifier }}.Timeout > ƒmaxChild { ƒmaxChild = ƒcfg_{{ $cf.Identifier }}.Timeout }
-{{ end }}
-            ƒtreePath := ƒcfg_{{ $f.Identifier }}.Timeout + ƒmaxChild
+                Name: "{{ .Identifier }}",
+{{- if .HasConfig }}
+                Config: func() gotest.FixtureConfig {
+                    cfg := gotest.DefaultFixtureConfig()
+                    gotest.OverlayFixtureConfig(&cfg, (&{{ .QualifiedIdentifier }}{}).FixtureConfig())
+                    return cfg
+                }(),
 {{- else }}
-            ƒtreePath := ƒcfg_{{ $f.Identifier }}.Timeout
+                Config: gotest.DefaultFixtureConfig(),
 {{- end }}
-            if ƒtreePath > ƒmaxTreePath { ƒmaxTreePath = ƒtreePath }
-        }
-{{ range $ts := $f.ChildSuites }}
-        {
-            ƒscfg := gotest.DefaultSuiteConfig()
-{{- if $ts.HasConfig }}
-            gotest.OverlaySuiteConfig(&ƒscfg, (&{{ $ts.Identifier }}{ {{ $ts.FixtureFieldName }}: ƒ_{{ $f.Identifier }} }).SuiteConfig())
-{{- end }}
-            if ƒscfg.SetupTimeout > ƒmaxSuiteSetup { ƒmaxSuiteSetup = ƒscfg.SetupTimeout }
-        }
-{{ end }}
-{{ range $cf := $f.ChildFixtures }}
-{{ range $ts := $cf.ChildSuites }}
-        {
-            ƒscfg := gotest.DefaultSuiteConfig()
-{{- if $ts.HasConfig }}
-            gotest.OverlaySuiteConfig(&ƒscfg, (&{{ $ts.Identifier }}{ {{ $ts.FixtureFieldName }}: ƒ_{{ $cf.Identifier }} }).SuiteConfig())
-{{- end }}
-            if ƒscfg.SetupTimeout > ƒmaxSuiteSetup { ƒmaxSuiteSetup = ƒscfg.SetupTimeout }
-        }
-{{ end }}
-{{ end }}
-{{ end }}
-        if ƒbudgetFile := os.Getenv("GOTEST_TEARDOWN_BUDGET_FILE"); ƒbudgetFile != "" {
-            os.WriteFile(ƒbudgetFile, []byte((ƒmaxTreePath + ƒmaxSuiteSetup + 30*time.Second).String()), 0644)
-        }
-    }
-
-    ƒcode = m.Run()
-    return
-}
-
-{{- /* Render fixture-bound suites as top-level functions */ -}}
-{{ range $f := .RootFixtures }}
-{{ range $ts := $f.ChildSuites }}
-
-func Test{{ $ts.Identifier }}(t *testing.T) {
-    s := &ƒƒ_GOTEST_{{ $ts.Identifier }}{
-        {{ $ts.Identifier }}: {{ $ts.Identifier }}{
-            {{ $ts.FixtureFieldName }}: ƒ_{{ $f.Identifier }},
-        },
-    }
-    ƒcfg := gotest.DefaultSuiteConfig()
-{{- if $ts.HasConfig }}
-    gotest.OverlaySuiteConfig(&ƒcfg, s.{{ $ts.Identifier }}.SuiteConfig())
-{{- end }}
-
-{{- if $ts.IsMethodParallel }}
-    wg := &sync.WaitGroup{}
-{{- end }}
-
-    ƒsetupT := gotest.NewT(t)
-    if ƒcfg.SetupTimeout > 0 {
-        ƒsetupT = gotest.NewTWithDeadline(t, ƒcfg.SetupTimeout)
-    }
-    t.Cleanup(func() {
-{{- if $ts.IsMethodParallel }}
-        wg.Wait()
-{{- end }}
-        ƒteardownT := gotest.NewT(t)
-        if ƒcfg.SetupTimeout > 0 {
-            ƒteardownT = gotest.NewTWithDeadline(t, ƒcfg.SetupTimeout)
-        }
-        s.AfterAll(ƒteardownT)
-    })
-    s.BeforeAll(ƒsetupT)
-
-{{ range $tc := $ts.TestCases }}
-    t.Run("{{ $tc.Identifier }}", func(it *testing.T) {
-{{- if $ts.IsMethodParallel }}
-        wg.Add(1)
-        it.Parallel()
-        defer wg.Done()
-{{- end }}
-        ttt := gotest.NewT(it)
-        if ƒcfg.Timeout > 0 {
-            ttt = gotest.NewTWithDeadline(it, ƒcfg.Timeout)
-        }
-{{- if $f.AfterEach }}
-        defer func() {
-            if err := ƒ_{{ $f.Identifier }}.AfterEach(context.Background()); err != nil {
-                it.Errorf("{{ $f.Identifier }}.AfterEach failed: %v", err)
-            }
-        }()
-{{- end }}
-{{- if $f.BeforeEach }}
-        if err := ƒ_{{ $f.Identifier }}.BeforeEach(it.Context()); err != nil {
-            it.Fatalf("{{ $f.Identifier }}.BeforeEach failed: %v", err)
-        }
-{{- end }}
-{{- if $ts.HasReturningBeforeEach }}
-        ctx := s.BeforeEach(ttt)
-        defer s.AfterEach(ttt, ctx)
-        s.{{ $tc.Identifier }}({{ if $tc.UsesStdlibT }}ttt.T(){{ else }}ttt{{ end }}, ctx)
+                Init: func() {
+{{- if .ParentIdentifier }}
+                    ƒ_{{ .Identifier }} = &{{ .QualifiedIdentifier }}{
+                        {{ .ParentFieldName }}: ƒ_{{ .ParentIdentifier }},
+                    }
 {{- else }}
-        defer s.AfterEach(ttt)
-        s.BeforeEach(ttt)
-        ƒƒ_GOTEST_exec({{ if $tc.UsesStdlibT }}func(t *gotest.T) { s.{{ $tc.Identifier }}(t.T()) }{{ else }}s.{{ $tc.Identifier }}{{ end }}, ttt)
+                    ƒ_{{ .Identifier }} = &{{ .QualifiedIdentifier }}{}
 {{- end }}
-    })
-    if ƒcfg.FailFast && t.Failed() {
-        return
-    }
-{{ end }}
-}
-{{ end }}
-
-{{- /* Render child fixture's child suites as top-level functions */ -}}
-{{ range $cf := $f.ChildFixtures }}
-{{ range $ts := $cf.ChildSuites }}
-
-func Test{{ $ts.Identifier }}(t *testing.T) {
-    s := &ƒƒ_GOTEST_{{ $ts.Identifier }}{
-        {{ $ts.Identifier }}: {{ $ts.Identifier }}{
-            {{ $ts.FixtureFieldName }}: ƒ_{{ $cf.Identifier }},
-        },
-    }
-    ƒcfg := gotest.DefaultSuiteConfig()
-{{- if $ts.HasConfig }}
-    gotest.OverlaySuiteConfig(&ƒcfg, s.{{ $ts.Identifier }}.SuiteConfig())
+                },
+                BeforeAll: func(ctx context.Context) error {
+                    return ƒ_{{ .Identifier }}.BeforeAll(ctx)
+                },
+{{- if .AfterAll }}
+                AfterAll: func(ctx context.Context) error {
+                    return ƒ_{{ .Identifier }}.AfterAll(ctx)
+                },
 {{- end }}
-
-{{- if $ts.IsMethodParallel }}
-    wg := &sync.WaitGroup{}
+{{- if .SharedFixtures }}
+                SharedFixtures: []gotestruntime.SharedFixtureBinding{
+{{- range $sf := .SharedFixtures }}
+                    {
+                        StateKey: "{{ $sf.StateKey }}",
+                        Target: ƒ_{{ $sf.LocalVar }}_{{ $.Identifier }},
+{{- if $sf.HasHydrate }}
+                        Hydrate: func(ctx context.Context) error { return ƒ_{{ $sf.LocalVar }}_{{ $.Identifier }}.Hydrate(ctx) },
 {{- end }}
-
-    ƒsetupT := gotest.NewT(t)
-    if ƒcfg.SetupTimeout > 0 {
-        ƒsetupT = gotest.NewTWithDeadline(t, ƒcfg.SetupTimeout)
-    }
-    t.Cleanup(func() {
-{{- if $ts.IsMethodParallel }}
-        wg.Wait()
+{{- if $sf.HasDehydrate }}
+                        Dehydrate: func(ctx context.Context) error { return ƒ_{{ $sf.LocalVar }}_{{ $.Identifier }}.Dehydrate(ctx) },
 {{- end }}
-        ƒteardownT := gotest.NewT(t)
-        if ƒcfg.SetupTimeout > 0 {
-            ƒteardownT = gotest.NewTWithDeadline(t, ƒcfg.SetupTimeout)
-        }
-        s.AfterAll(ƒteardownT)
-    })
-    s.BeforeAll(ƒsetupT)
-
-{{ range $tc := $ts.TestCases }}
-    t.Run("{{ $tc.Identifier }}", func(it *testing.T) {
-{{- if $ts.IsMethodParallel }}
-        wg.Add(1)
-        it.Parallel()
-        defer wg.Done()
+                        Assign: func() { ƒ_{{ $.Identifier }}.{{ $sf.FieldName }} = ƒ_{{ $sf.LocalVar }}_{{ $.Identifier }} },
+                    },
 {{- end }}
-        ttt := gotest.NewT(it)
-        if ƒcfg.Timeout > 0 {
-            ttt = gotest.NewTWithDeadline(it, ƒcfg.Timeout)
-        }
-{{- if $f.AfterEach }}
-        defer func() {
-            if err := ƒ_{{ $f.Identifier }}.AfterEach(context.Background()); err != nil {
-                it.Errorf("{{ $f.Identifier }}.AfterEach failed: %v", err)
-            }
-        }()
+                },
 {{- end }}
-{{- if $f.BeforeEach }}
-        if err := ƒ_{{ $f.Identifier }}.BeforeEach(it.Context()); err != nil {
-            it.Fatalf("{{ $f.Identifier }}.BeforeEach failed: %v", err)
-        }
+{{- if .ChildFixtures }}
+                Children: []*gotestruntime.FixtureNode{
+{{- range $child := .ChildFixtures }}
+{{ template "fixtureNode" $child }}
 {{- end }}
-{{- if $cf.AfterEach }}
-        defer func() {
-            if err := ƒ_{{ $cf.Identifier }}.AfterEach(context.Background()); err != nil {
-                it.Errorf("{{ $cf.Identifier }}.AfterEach failed: %v", err)
-            }
-        }()
+                },
 {{- end }}
-{{- if $cf.BeforeEach }}
-        if err := ƒ_{{ $cf.Identifier }}.BeforeEach(it.Context()); err != nil {
-            it.Fatalf("{{ $cf.Identifier }}.BeforeEach failed: %v", err)
-        }
-{{- end }}
-{{- if $ts.HasReturningBeforeEach }}
-        ctx := s.BeforeEach(ttt)
-        defer s.AfterEach(ttt, ctx)
-        s.{{ $tc.Identifier }}({{ if $tc.UsesStdlibT }}ttt.T(){{ else }}ttt{{ end }}, ctx)
-{{- else }}
-        defer s.AfterEach(ttt)
-        s.BeforeEach(ttt)
-        ƒƒ_GOTEST_exec({{ if $tc.UsesStdlibT }}func(t *gotest.T) { s.{{ $tc.Identifier }}(t.T()) }{{ else }}s.{{ $tc.Identifier }}{{ end }}, ttt)
-{{- end }}
-    })
-    if ƒcfg.FailFast && t.Failed() {
-        return
-    }
-{{ end }}
-}
-{{ end }}
-{{ end }}
-{{ end -}}
+            },
+{{- end -}}

--- a/internal/gotestgen/testdata/__snapshots__/TestGeneratorTestSuite_ext.snap
+++ b/internal/gotestgen/testdata/__snapshots__/TestGeneratorTestSuite_ext.snap
@@ -5,13 +5,11 @@ package fixturepkg
 
 import (
 	"context"
-	"fmt"
 	"github.com/mvrahden/go-test/pkg/gotest"
+	"github.com/mvrahden/go-test/pkg/gotestruntime"
 	"os"
-	"sync"
 	"testing"
 	"time"
-	_ "unsafe"
 )
 
 //go:noinline
@@ -28,149 +26,39 @@ func (ts *ƒƒ_GOTEST_AppTestSuite) AfterEach(it *gotest.T)  { ts.AppTestSuite.A
 
 var ƒ_AppFixture *AppFixture
 
-// ƒflushCoverage triggers coverage report writing.
-//
-//go:linkname ƒflushCoverage testing.coverReport
-func ƒflushCoverage()
-
-// ƒtestingCover exposes the stdlib coverage state for tearDown interception.
-//
-//go:linkname ƒtestingCover testing.cover
-var ƒtestingCover struct {
-	mode        string
-	tearDown    func(coverprofile string, gocoverdir string) (string, error)
-	snapshotcov func() float64
-}
-
-func TestMain(m *testing.M) { os.Exit(ƒƒ_GOTEST_main(m)) }
-
-func ƒƒ_GOTEST_main(m *testing.M) (ƒcode int) {
-
-	var ƒcfg_AppFixture gotest.FixtureConfig
-	var ƒok_AppFixture bool
-
-	var ƒorigTearDown func(string, string) (string, error)
-	if testing.CoverMode() != "" {
-		ƒorigTearDown = ƒtestingCover.tearDown
-		ƒtestingCover.tearDown = func(string, string) (string, error) { return "", nil }
-	}
-
-	defer func() {
-		var ƒtwg sync.WaitGroup
-		ƒtdfails := make([]bool, 1)
-
-		ƒtwg.Add(1)
-		go func() {
-			defer ƒtwg.Done()
-
-			if ƒok_AppFixture {
-				ctx := context.Background()
-				if ƒcfg_AppFixture.Timeout > 0 {
-					var cancel context.CancelFunc
-					ctx, cancel = context.WithTimeout(ctx, ƒcfg_AppFixture.Timeout)
-					defer cancel()
-				}
-				if err := ƒ_AppFixture.AfterAll(ctx); err != nil {
-					fmt.Fprintf(os.Stderr, "AppFixture.AfterAll failed: %v\n", err)
-					ƒtdfails[0] = true
-				}
-			}
-		}()
-
-		ƒtwg.Wait()
-		for _, ƒf := range ƒtdfails {
-			if ƒf && ƒcode == 0 {
-				ƒcode = 1
-				break
-			}
-		}
-		if ƒorigTearDown != nil {
-			ƒtestingCover.tearDown = ƒorigTearDown
-			ƒflushCoverage()
-		}
-	}()
-
-	ƒctx, ƒcancel := context.WithCancel(context.Background())
-	defer ƒcancel()
+func TestMain(m *testing.M) {
+	var ƒmaxSuiteSetup time.Duration
 
 	{
-		var ƒswg sync.WaitGroup
-		ƒtfails := make([]bool, 1)
-
-		ƒswg.Add(1)
-		go func() {
-			defer ƒswg.Done()
-
-			ƒ_AppFixture = &AppFixture{}
-			ƒcfg_AppFixture = gotest.DefaultFixtureConfig()
-			gotest.OverlayFixtureConfig(&ƒcfg_AppFixture, ƒ_AppFixture.FixtureConfig())
-			var ƒerr error
-			ƒattempts := 1 + ƒcfg_AppFixture.Retries
-			for ƒi := range ƒattempts {
-				ctx := ƒctx
-				if ƒcfg_AppFixture.Timeout > 0 {
-					var cancel context.CancelFunc
-					ctx, cancel = context.WithTimeout(ƒctx, ƒcfg_AppFixture.Timeout)
-					defer cancel()
-				}
-				ƒerr = ƒ_AppFixture.BeforeAll(ctx)
-				if ƒerr == nil {
-					break
-				}
-				if ƒctx.Err() != nil {
-					break
-				}
-				if ƒi < ƒattempts-1 {
-					fmt.Fprintf(os.Stderr, "AppFixture.BeforeAll attempt %d/%d failed: %v\n", ƒi+1, ƒattempts, ƒerr)
-					if ƒcfg_AppFixture.RetryDelay > 0 {
-						time.Sleep(ƒcfg_AppFixture.RetryDelay)
-					}
-				}
-			}
-			if ƒerr != nil {
-				fmt.Fprintf(os.Stderr, "FAIL: AppFixture.BeforeAll failed after %d attempt(s): %v\n", ƒattempts, ƒerr)
-				ƒtfails[0] = true
-				ƒcancel()
-				return
-			}
-			ƒok_AppFixture = true
-
-		}()
-
-		ƒswg.Wait()
-		for _, ƒf := range ƒtfails {
-			if ƒf {
-				return 2
-			}
+		ƒscfg := gotest.DefaultSuiteConfig()
+		gotest.OverlaySuiteConfig(&ƒscfg, (&AppTestSuite{App: ƒ_AppFixture}).SuiteConfig())
+		if ƒscfg.SetupTimeout > ƒmaxSuiteSetup {
+			ƒmaxSuiteSetup = ƒscfg.SetupTimeout
 		}
 	}
 
-	{
-		var ƒmaxTreePath time.Duration
-		var ƒmaxSuiteSetup time.Duration
-
-		{
-			ƒtreePath := ƒcfg_AppFixture.Timeout
-			if ƒtreePath > ƒmaxTreePath {
-				ƒmaxTreePath = ƒtreePath
-			}
-		}
-
-		{
-			ƒscfg := gotest.DefaultSuiteConfig()
-			gotest.OverlaySuiteConfig(&ƒscfg, (&AppTestSuite{App: ƒ_AppFixture}).SuiteConfig())
-			if ƒscfg.SetupTimeout > ƒmaxSuiteSetup {
-				ƒmaxSuiteSetup = ƒscfg.SetupTimeout
-			}
-		}
-
-		if ƒbudgetFile := os.Getenv("GOTEST_TEARDOWN_BUDGET_FILE"); ƒbudgetFile != "" {
-			os.WriteFile(ƒbudgetFile, []byte((ƒmaxTreePath + ƒmaxSuiteSetup + 30*time.Second).String()), 0644)
-		}
-	}
-
-	ƒcode = m.Run()
-	return
+	os.Exit(gotestruntime.RunFixtureMain(m, gotestruntime.MainConfig{
+		Roots: []*gotestruntime.FixtureNode{
+			{
+				Name: "AppFixture",
+				Config: func() gotest.FixtureConfig {
+					cfg := gotest.DefaultFixtureConfig()
+					gotest.OverlayFixtureConfig(&cfg, (&AppFixture{}).FixtureConfig())
+					return cfg
+				}(),
+				Init: func() {
+					ƒ_AppFixture = &AppFixture{}
+				},
+				BeforeAll: func(ctx context.Context) error {
+					return ƒ_AppFixture.BeforeAll(ctx)
+				},
+				AfterAll: func(ctx context.Context) error {
+					return ƒ_AppFixture.AfterAll(ctx)
+				},
+			},
+		},
+		MaxSuiteSetupTimeout: ƒmaxSuiteSetup,
+	}))
 }
 
 func TestAppTestSuite(t *testing.T) {

--- a/pkg/gotest/config.go
+++ b/pkg/gotest/config.go
@@ -6,6 +6,12 @@ import "time"
 // shared fixtures. Returned by the optional FixtureConfig() or
 // SharedFixtureConfig() marker method on a fixture struct.
 // A zero value means "keep the default."
+//
+// For shared fixtures, state is captured once during setup and distributed to
+// all test processes as a JSON snapshot. Transfer fields (exported, not assigned
+// in Hydrate) should contain stable connection parameters (host, port,
+// credentials) rather than ephemeral handles. Each test process calls Hydrate()
+// to establish live connections from those parameters.
 type FixtureConfig struct {
 	// Timeout is the deadline for each lifecycle operation (BeforeAll/AfterAll).
 	// Use -1 to disable. Default: 2m (DefaultFixtureConfig).

--- a/pkg/gotestruntime/coverage/coverage.go
+++ b/pkg/gotestruntime/coverage/coverage.go
@@ -1,0 +1,10 @@
+package coverage
+
+// coverState mirrors the internal testing.cover/cover2 struct layout.
+// The field order and types are validated by LinknameCompatTestSuite
+// in internal/gotestgen/.
+type coverState struct {
+	mode        string
+	tearDown    func(coverprofile string, gocoverdir string) (string, error)
+	snapshotcov func() float64
+}

--- a/pkg/gotestruntime/coverage/coverage_test.go
+++ b/pkg/gotestruntime/coverage/coverage_test.go
@@ -1,0 +1,40 @@
+package coverage
+
+import (
+	"testing"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+func TestInterceptTeardown_NoCoverageMode(t *testing.T) {
+	// When run without -cover, CoverMode() is empty.
+	// InterceptTeardown should return a callable no-op.
+	restore := InterceptTeardown()
+	gotest.NotEqual(t, nil, restore)
+	restore() // must not panic
+}
+
+func TestFlushCoverage_NoCoverageMode(t *testing.T) {
+	// When run without -cover, FlushCoverage should be a no-op.
+	FlushCoverage() // must not panic
+}
+
+func TestInterceptTeardown_WithCoverage(t *testing.T) {
+	if testing.CoverMode() == "" {
+		t.Skip("test requires -cover flag")
+	}
+
+	// Verify the tearDown is swapped
+	origTearDown := testingCover.tearDown
+	gotest.True(t, origTearDown != nil)
+
+	restore := InterceptTeardown()
+
+	// tearDown should now be the no-op
+	_, err := testingCover.tearDown("", "")
+	gotest.NoError(t, err)
+
+	// Restore should bring back original
+	restore()
+	gotest.True(t, testingCover.tearDown != nil)
+}

--- a/pkg/gotestruntime/coverage/coverage_test.go
+++ b/pkg/gotestruntime/coverage/coverage_test.go
@@ -1,4 +1,4 @@
-package coverage
+package coverage //nolint:stdlib-test
 
 import (
 	"testing"

--- a/pkg/gotestruntime/coverage/intercept.go
+++ b/pkg/gotestruntime/coverage/intercept.go
@@ -1,0 +1,33 @@
+//go:build !gotest_no_coverage_intercept
+
+package coverage
+
+import (
+	"testing"
+	_ "unsafe"
+)
+
+//go:linkname coverReport testing.coverReport
+func coverReport()
+
+// InterceptTeardown swaps testing's coverage tearDown with a no-op
+// and returns a restore function. If coverage mode is off, returns a no-op.
+func InterceptTeardown() func() {
+	if testing.CoverMode() == "" {
+		return func() {}
+	}
+	orig := testingCover.tearDown
+	testingCover.tearDown = func(string, string) (string, error) { return "", nil }
+	return func() {
+		testingCover.tearDown = orig
+		coverReport()
+	}
+}
+
+// FlushCoverage writes coverage data. No-op if coverage is disabled.
+func FlushCoverage() {
+	if testing.CoverMode() == "" {
+		return
+	}
+	coverReport()
+}

--- a/pkg/gotestruntime/coverage/linkname_go124.go
+++ b/pkg/gotestruntime/coverage/linkname_go124.go
@@ -1,0 +1,8 @@
+//go:build !go1.25 && !gotest_no_coverage_intercept
+
+package coverage
+
+import _ "unsafe"
+
+//go:linkname testingCover testing.cover2
+var testingCover coverState

--- a/pkg/gotestruntime/coverage/linkname_go125.go
+++ b/pkg/gotestruntime/coverage/linkname_go125.go
@@ -1,0 +1,8 @@
+//go:build go1.25 && !gotest_no_coverage_intercept
+
+package coverage
+
+import _ "unsafe"
+
+//go:linkname testingCover testing.cover
+var testingCover coverState

--- a/pkg/gotestruntime/coverage/noop.go
+++ b/pkg/gotestruntime/coverage/noop.go
@@ -1,0 +1,9 @@
+//go:build gotest_no_coverage_intercept
+
+package coverage
+
+// InterceptTeardown is a no-op when coverage intercept is disabled.
+func InterceptTeardown() func() { return func() {} }
+
+// FlushCoverage is a no-op when coverage intercept is disabled.
+func FlushCoverage() {}

--- a/pkg/gotestruntime/fixture.go
+++ b/pkg/gotestruntime/fixture.go
@@ -1,0 +1,43 @@
+package gotestruntime
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// FixtureNode describes one fixture in the tree.
+// Generated code populates this as a struct literal.
+type FixtureNode struct {
+	Name           string
+	Config         gotest.FixtureConfig
+	Init           func()
+	BeforeAll      func(ctx context.Context) error
+	AfterAll       func(ctx context.Context) error
+	SharedFixtures []SharedFixtureBinding
+	Children       []*FixtureNode
+}
+
+// SharedFixtureBinding describes how to deserialize and hydrate a shared
+// fixture, then assign it to the parent fixture struct.
+type SharedFixtureBinding struct {
+	StateKey  string
+	Target    any
+	Hydrate   func(ctx context.Context) error
+	Dehydrate func(ctx context.Context) error
+	Assign    func()
+}
+
+// MainConfig holds the configuration for RunFixtureMain.
+type MainConfig struct {
+	Roots                []*FixtureNode
+	MaxSuiteSetupTimeout time.Duration
+}
+
+// RunFixtureMain replaces the generated ƒƒ_GOTEST_main function.
+// It orchestrates fixture tree setup, m.Run(), and teardown.
+func RunFixtureMain(m *testing.M, cfg MainConfig) int {
+	return run(m.Run, cfg)
+}

--- a/pkg/gotestruntime/runtime.go
+++ b/pkg/gotestruntime/runtime.go
@@ -1,0 +1,350 @@
+package gotestruntime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/mvrahden/go-test/pkg/gotestruntime/coverage"
+)
+
+func run(runTests func() int, cfg MainConfig) int {
+	restoreCoverage := coverage.InterceptTeardown()
+
+	tracker := &nodeTracker{succeeded: make(map[*FixtureNode]bool)}
+
+	var sharedState map[string]json.RawMessage
+	if anyNodeHasSharedFixtures(cfg.Roots) {
+		var err error
+		sharedState, err = loadSharedState()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: %v\n", err)
+			restoreCoverage()
+			return 2
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := setupRoots(ctx, cfg.Roots, sharedState, tracker); err != nil {
+		_ = teardownRoots(cfg.Roots, tracker)
+		restoreCoverage()
+		return 2
+	}
+
+	writeBudgetFile(cfg)
+
+	code := runTests()
+
+	if teardownRoots(cfg.Roots, tracker) && code == 0 {
+		code = 1
+	}
+	restoreCoverage()
+
+	return code
+}
+
+func setupRoots(ctx context.Context, roots []*FixtureNode, sharedState map[string]json.RawMessage, tracker *nodeTracker) error {
+	errs := make([]error, len(roots))
+	var wg sync.WaitGroup
+
+	childCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for i, root := range roots {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := setupNode(childCtx, root, sharedState, tracker); err != nil {
+				errs[i] = err
+				cancel()
+			}
+		}()
+	}
+	wg.Wait()
+
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setupNode(ctx context.Context, node *FixtureNode, sharedState map[string]json.RawMessage, tracker *nodeTracker) error {
+	// 1-2. Unmarshal and hydrate shared fixtures
+	if len(node.SharedFixtures) > 0 {
+		for _, sf := range node.SharedFixtures {
+			raw, ok := sharedState[sf.StateKey]
+			if !ok {
+				return fmt.Errorf("shared fixture state key %q not found in state file", sf.StateKey)
+			}
+			if err := json.Unmarshal(raw, sf.Target); err != nil {
+				return fmt.Errorf("unmarshal shared fixture %q: %w", sf.StateKey, err)
+			}
+			if sf.Hydrate != nil {
+				if err := sf.Hydrate(ctx); err != nil {
+					return fmt.Errorf("hydrate shared fixture %q: %w", sf.StateKey, err)
+				}
+			}
+		}
+	}
+
+	// 3. Init
+	if node.Init != nil {
+		node.Init()
+	}
+
+	// 4. Assign shared fixtures
+	for _, sf := range node.SharedFixtures {
+		if sf.Assign != nil {
+			sf.Assign()
+		}
+	}
+
+	// 5. BeforeAll with retry/timeout
+	if err := runBeforeAllWithRetry(ctx, node); err != nil {
+		return err
+	}
+
+	tracker.markSucceeded(node)
+
+	// 6. Setup children concurrently
+	if len(node.Children) > 0 {
+		errs := make([]error, len(node.Children))
+		var wg sync.WaitGroup
+
+		childCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		for i, child := range node.Children {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := setupNode(childCtx, child, sharedState, tracker); err != nil {
+					errs[i] = err
+					cancel()
+				}
+			}()
+		}
+		wg.Wait()
+
+		for _, err := range errs {
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func runBeforeAllWithRetry(ctx context.Context, node *FixtureNode) error {
+	attempts := 1 + node.Config.Retries
+	var lastErr error
+
+	for i := range attempts {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		var attemptCtx context.Context
+		var attemptCancel context.CancelFunc
+		if node.Config.Timeout > 0 {
+			attemptCtx, attemptCancel = context.WithTimeout(ctx, node.Config.Timeout)
+		} else {
+			attemptCtx, attemptCancel = context.WithCancel(ctx)
+		}
+
+		lastErr = node.BeforeAll(attemptCtx)
+		attemptCancel()
+
+		if lastErr == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if i < attempts-1 {
+			fmt.Fprintf(os.Stderr, "%s.BeforeAll attempt %d/%d failed: %v\n", node.Name, i+1, attempts, lastErr)
+			if node.Config.RetryDelay > 0 {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(node.Config.RetryDelay):
+				}
+			}
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "FAIL: %s.BeforeAll failed after %d attempt(s): %v\n", node.Name, attempts, lastErr)
+	return lastErr
+}
+
+func teardownRoots(roots []*FixtureNode, tracker *nodeTracker) bool {
+	failed := make([]bool, len(roots))
+	var wg sync.WaitGroup
+	for i, root := range roots {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if teardownNode(root, tracker) {
+				failed[i] = true
+			}
+		}()
+	}
+	wg.Wait()
+	for _, f := range failed {
+		if f {
+			return true
+		}
+	}
+	return false
+}
+
+func teardownNode(node *FixtureNode, tracker *nodeTracker) bool {
+	var anyFailed bool
+
+	if len(node.Children) > 0 {
+		childFailed := make([]bool, len(node.Children))
+		var wg sync.WaitGroup
+		for i, child := range node.Children {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if teardownNode(child, tracker) {
+					childFailed[i] = true
+				}
+			}()
+		}
+		wg.Wait()
+		for _, f := range childFailed {
+			if f {
+				anyFailed = true
+				break
+			}
+		}
+	}
+
+	if tracker.isSucceeded(node) {
+		if node.AfterAll != nil {
+			ctx := context.Background()
+			if node.Config.Timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, node.Config.Timeout)
+				defer cancel()
+			}
+			if err := node.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "%s.AfterAll failed: %v\n", node.Name, err)
+				anyFailed = true
+			}
+		}
+
+		for _, sf := range node.SharedFixtures {
+			if sf.Dehydrate != nil {
+				if err := sf.Dehydrate(context.Background()); err != nil {
+					fmt.Fprintf(os.Stderr, "%s: dehydrate failed: %v\n", node.Name, err)
+					anyFailed = true
+				}
+			}
+		}
+	}
+
+	return anyFailed
+}
+
+func writeBudgetFile(cfg MainConfig) {
+	path := os.Getenv("GOTEST_TEARDOWN_BUDGET_FILE")
+	if path == "" {
+		return
+	}
+
+	maxTreePath := computeMaxTreePath(cfg.Roots)
+	budget := maxTreePath + cfg.MaxSuiteSetupTimeout + 30*time.Second
+	os.WriteFile(path, []byte(budget.String()), 0644)
+}
+
+func computeMaxTreePath(roots []*FixtureNode) time.Duration {
+	var maxPath time.Duration
+	for _, root := range roots {
+		path := nodeTreePath(root)
+		if path > maxPath {
+			maxPath = path
+		}
+	}
+	return maxPath
+}
+
+func nodeTreePath(node *FixtureNode) time.Duration {
+	own := node.Config.Timeout
+	if own < 0 {
+		own = 0
+	}
+	var maxChild time.Duration
+	for _, child := range node.Children {
+		childPath := nodeTreePath(child)
+		if childPath > maxChild {
+			maxChild = childPath
+		}
+	}
+	return own + maxChild
+}
+
+func loadSharedState() (map[string]json.RawMessage, error) {
+	path := os.Getenv("GOTEST_SHARED_STATE_FILE")
+	if path == "" {
+		return nil, fmt.Errorf("GOTEST_SHARED_STATE_FILE not set — run via gotest CLI")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read shared state file: %w", err)
+	}
+	var state map[string]json.RawMessage
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("unmarshal shared state: %w", err)
+	}
+	return state, nil
+}
+
+func anyNodeHasSharedFixtures(roots []*FixtureNode) bool {
+	for _, root := range roots {
+		if hasSharedFixtures(root) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasSharedFixtures(node *FixtureNode) bool {
+	if len(node.SharedFixtures) > 0 {
+		return true
+	}
+	for _, child := range node.Children {
+		if hasSharedFixtures(child) {
+			return true
+		}
+	}
+	return false
+}
+
+type nodeTracker struct {
+	mu        sync.Mutex
+	succeeded map[*FixtureNode]bool
+}
+
+func (t *nodeTracker) markSucceeded(node *FixtureNode) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.succeeded[node] = true
+}
+
+func (t *nodeTracker) isSucceeded(node *FixtureNode) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.succeeded[node]
+}
+

--- a/pkg/gotestruntime/runtime_test.go
+++ b/pkg/gotestruntime/runtime_test.go
@@ -1,0 +1,995 @@
+package gotestruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type recorder struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (r *recorder) record(event string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event)
+}
+
+func (r *recorder) names() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+func TestSingleRoot_LifecycleOrder(t *testing.T) {
+	rec := &recorder{}
+
+	node := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() { rec.record("root.init") },
+		BeforeAll: func(ctx context.Context) error {
+			rec.record("root.beforeAll")
+			return nil
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("root.afterAll")
+			return nil
+		},
+	}
+
+	exitCode := run(func() int {
+		rec.record("m.run")
+		return 0
+	}, MainConfig{Roots: []*FixtureNode{node}})
+
+	gotest.Equal(t, 0, exitCode)
+	gotest.Equal(t, []string{"root.init", "root.beforeAll", "m.run", "root.afterAll"}, rec.names())
+}
+
+func TestSingleRoot_ExitCodeForwarded(t *testing.T) {
+	node := &FixtureNode{
+		Name:      "Root",
+		Config:    gotest.DefaultFixtureConfig(),
+		Init:      func() {},
+		BeforeAll: func(ctx context.Context) error { return nil },
+		AfterAll:  func(ctx context.Context) error { return nil },
+	}
+
+	exitCode := run(func() int {
+		return 42
+	}, MainConfig{Roots: []*FixtureNode{node}})
+
+	gotest.Equal(t, 42, exitCode)
+}
+
+func TestSingleRoot_AfterAllCalledOnNonZeroExit(t *testing.T) {
+	rec := &recorder{}
+
+	node := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			return nil
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("root.afterAll")
+			return nil
+		},
+	}
+
+	exitCode := run(func() int {
+		return 1
+	}, MainConfig{Roots: []*FixtureNode{node}})
+
+	gotest.Equal(t, 1, exitCode)
+	gotest.Contains(t, rec.names(), "root.afterAll")
+}
+
+func TestSingleRoot_NilAfterAll(t *testing.T) {
+	rec := &recorder{}
+
+	node := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() { rec.record("root.init") },
+		BeforeAll: func(ctx context.Context) error {
+			rec.record("root.beforeAll")
+			return nil
+		},
+		AfterAll: nil,
+	}
+
+	exitCode := run(func() int {
+		rec.record("m.run")
+		return 0
+	}, MainConfig{Roots: []*FixtureNode{node}})
+
+	gotest.Equal(t, 0, exitCode)
+	gotest.Equal(t, []string{"root.init", "root.beforeAll", "m.run"}, rec.names())
+}
+
+func TestSingleRoot_NilInit(t *testing.T) {
+	rec := &recorder{}
+
+	node := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   nil,
+		BeforeAll: func(ctx context.Context) error {
+			rec.record("root.beforeAll")
+			return nil
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("root.afterAll")
+			return nil
+		},
+	}
+
+	exitCode := run(func() int {
+		rec.record("m.run")
+		return 0
+	}, MainConfig{Roots: []*FixtureNode{node}})
+
+	gotest.Equal(t, 0, exitCode)
+	gotest.Equal(t, []string{"root.beforeAll", "m.run", "root.afterAll"}, rec.names())
+}
+
+func TestRetry_SucceedsOnSecondAttempt(t *testing.T) {
+	rec := &recorder{}
+	attempts := 0
+
+	node := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.FixtureConfig{Timeout: 2 * time.Minute, Retries: 2, RetryDelay: 10 * time.Millisecond},
+		Init:   func() { rec.record("root.init") },
+		BeforeAll: func(ctx context.Context) error {
+			attempts++
+			if attempts < 2 {
+				return errors.New("transient failure")
+			}
+			rec.record("root.beforeAll")
+			return nil
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("root.afterAll")
+			return nil
+		},
+	}
+
+	exitCode := run(func() int {
+		rec.record("m.run")
+		return 0
+	}, MainConfig{Roots: []*FixtureNode{node}})
+
+	gotest.Equal(t, 0, exitCode)
+	gotest.Equal(t, 2, attempts)
+	gotest.Equal(t, []string{"root.init", "root.beforeAll", "m.run", "root.afterAll"}, rec.names())
+}
+
+func TestRetry_ExhaustedRetriesReturnsExitCode2(t *testing.T) {
+	rec := &recorder{}
+	attempts := 0
+
+	node := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.FixtureConfig{Timeout: 2 * time.Minute, Retries: 1},
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			attempts++
+			return errors.New("permanent failure")
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("root.afterAll")
+			return nil
+		},
+	}
+
+	mRunCalled := false
+	exitCode := run(func() int {
+		mRunCalled = true
+		return 0
+	}, MainConfig{Roots: []*FixtureNode{node}})
+
+	gotest.Equal(t, 2, exitCode)
+	gotest.Equal(t, 2, attempts)
+	gotest.False(t, mRunCalled)
+	gotest.Equal(t, []string{}, rec.names())
+}
+
+func TestRetry_DelayObservedBetweenAttempts(t *testing.T) {
+	attempts := 0
+	var timestamps []time.Time
+
+	node := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.FixtureConfig{Timeout: 2 * time.Minute, Retries: 1, RetryDelay: 50 * time.Millisecond},
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			timestamps = append(timestamps, time.Now())
+			attempts++
+			if attempts < 2 {
+				return errors.New("transient")
+			}
+			return nil
+		},
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{Roots: []*FixtureNode{node}})
+
+	gotest.Equal(t, 0, exitCode)
+	gotest.Equal(t, 2, len(timestamps))
+	elapsed := timestamps[1].Sub(timestamps[0])
+	gotest.GreaterOrEqual(t, elapsed, 40*time.Millisecond)
+}
+
+func TestTimeout_BeforeAllExceedsTimeout(t *testing.T) {
+	node := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.FixtureConfig{Timeout: 50 * time.Millisecond},
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(200 * time.Millisecond):
+				return nil
+			}
+		},
+		AfterAll: func(ctx context.Context) error { return nil },
+	}
+
+	mRunCalled := false
+	exitCode := run(func() int {
+		mRunCalled = true
+		return 0
+	}, MainConfig{Roots: []*FixtureNode{node}})
+
+	gotest.Equal(t, 2, exitCode)
+	gotest.False(t, mRunCalled)
+}
+
+func TestTimeout_BeforeAllCompletesWithinTimeout(t *testing.T) {
+	node := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.FixtureConfig{Timeout: 500 * time.Millisecond},
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(10 * time.Millisecond):
+				return nil
+			}
+		},
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{Roots: []*FixtureNode{node}})
+
+	gotest.Equal(t, 0, exitCode)
+}
+
+func TestTimeout_DisabledWithNegativeOne(t *testing.T) {
+	node := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.FixtureConfig{Timeout: -1},
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			deadline, hasDeadline := ctx.Deadline()
+			_ = deadline
+			gotest.False(t, hasDeadline)
+			return nil
+		},
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{Roots: []*FixtureNode{node}})
+	gotest.Equal(t, 0, exitCode)
+}
+
+func TestChildren_SetupOrder(t *testing.T) {
+	rec := &recorder{}
+
+	childA := &FixtureNode{
+		Name:   "ChildA",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() { rec.record("childA.init") },
+		BeforeAll: func(ctx context.Context) error {
+			rec.record("childA.beforeAll")
+			return nil
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("childA.afterAll")
+			return nil
+		},
+	}
+	childB := &FixtureNode{
+		Name:   "ChildB",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() { rec.record("childB.init") },
+		BeforeAll: func(ctx context.Context) error {
+			rec.record("childB.beforeAll")
+			return nil
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("childB.afterAll")
+			return nil
+		},
+	}
+
+	root := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() { rec.record("root.init") },
+		BeforeAll: func(ctx context.Context) error {
+			rec.record("root.beforeAll")
+			return nil
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("root.afterAll")
+			return nil
+		},
+		Children: []*FixtureNode{childA, childB},
+	}
+
+	exitCode := run(func() int {
+		rec.record("m.run")
+		return 0
+	}, MainConfig{Roots: []*FixtureNode{root}})
+
+	gotest.Equal(t, 0, exitCode)
+
+	events := rec.names()
+
+	// Root must come before any child
+	rootInitIdx := indexOf(events, "root.init")
+	rootBeforeAllIdx := indexOf(events, "root.beforeAll")
+	gotest.True(t, rootInitIdx >= 0)
+	gotest.True(t, rootBeforeAllIdx >= 0)
+	gotest.True(t, rootInitIdx < rootBeforeAllIdx)
+
+	// Children must come after root.beforeAll
+	for _, ev := range []string{"childA.init", "childA.beforeAll", "childB.init", "childB.beforeAll"} {
+		idx := indexOf(events, ev)
+		gotest.True(t, idx > rootBeforeAllIdx, "expected %s after root.beforeAll", ev)
+	}
+
+	// m.run must come after all children setup
+	mRunIdx := indexOf(events, "m.run")
+	for _, ev := range []string{"childA.beforeAll", "childB.beforeAll"} {
+		idx := indexOf(events, ev)
+		gotest.True(t, idx < mRunIdx, "expected %s before m.run", ev)
+	}
+
+	// Root AfterAll must come after children AfterAll
+	rootAfterAllIdx := indexOf(events, "root.afterAll")
+	for _, ev := range []string{"childA.afterAll", "childB.afterAll"} {
+		idx := indexOf(events, ev)
+		gotest.True(t, idx < rootAfterAllIdx, "expected %s before root.afterAll", ev)
+	}
+}
+
+func TestChildren_ConcurrentSetup(t *testing.T) {
+	childAStarted := make(chan struct{})
+	childBStarted := make(chan struct{})
+
+	childA := &FixtureNode{
+		Name:   "ChildA",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			close(childAStarted)
+			// Wait for B to also start (proves concurrency)
+			select {
+			case <-childBStarted:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	}
+	childB := &FixtureNode{
+		Name:   "ChildB",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			close(childBStarted)
+			// Wait for A to also start (proves concurrency)
+			select {
+			case <-childAStarted:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	}
+
+	root := &FixtureNode{
+		Name:      "Root",
+		Config:    gotest.DefaultFixtureConfig(),
+		Init:      func() {},
+		BeforeAll: func(ctx context.Context) error { return nil },
+		Children:  []*FixtureNode{childA, childB},
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{Roots: []*FixtureNode{root}})
+	gotest.Equal(t, 0, exitCode)
+}
+
+func TestChildFailure_CancelsSiblings(t *testing.T) {
+	rec := &recorder{}
+	childAStarted := make(chan struct{})
+
+	childA := &FixtureNode{
+		Name:   "ChildA",
+		Config: gotest.FixtureConfig{Timeout: 2 * time.Minute},
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			close(childAStarted)
+			return errors.New("childA fails")
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("childA.afterAll")
+			return nil
+		},
+	}
+	childB := &FixtureNode{
+		Name:   "ChildB",
+		Config: gotest.FixtureConfig{Timeout: 2 * time.Minute},
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			// Wait for A to have started (and likely failed)
+			<-childAStarted
+			// Give time for cancellation to propagate
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(500 * time.Millisecond):
+				rec.record("childB.beforeAll.completed")
+				return nil
+			}
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("childB.afterAll")
+			return nil
+		},
+	}
+
+	root := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			return nil
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("root.afterAll")
+			return nil
+		},
+		Children: []*FixtureNode{childA, childB},
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{Roots: []*FixtureNode{root}})
+
+	gotest.Equal(t, 2, exitCode)
+	events := rec.names()
+	// ChildA.AfterAll NOT called (never succeeded)
+	gotest.NotContains(t, events, "childA.afterAll")
+	// ChildB.AfterAll NOT called (cancelled before success)
+	gotest.NotContains(t, events, "childB.afterAll")
+	// ChildB.BeforeAll should have been cancelled, not completed
+	gotest.NotContains(t, events, "childB.beforeAll.completed")
+	// Root.AfterAll IS called (root succeeded)
+	gotest.Contains(t, events, "root.afterAll")
+}
+
+func TestChildFailure_SucceededSiblingGetsAfterAll(t *testing.T) {
+	rec := &recorder{}
+	childBReady := make(chan struct{})
+
+	childA := &FixtureNode{
+		Name:   "ChildA",
+		Config: gotest.FixtureConfig{Timeout: 2 * time.Minute},
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			// Wait for B to succeed first
+			<-childBReady
+			return errors.New("childA fails after B succeeded")
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("childA.afterAll")
+			return nil
+		},
+	}
+	childB := &FixtureNode{
+		Name:   "ChildB",
+		Config: gotest.FixtureConfig{Timeout: 2 * time.Minute},
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			close(childBReady)
+			return nil
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("childB.afterAll")
+			return nil
+		},
+	}
+
+	root := &FixtureNode{
+		Name:      "Root",
+		Config:    gotest.DefaultFixtureConfig(),
+		Init:      func() {},
+		BeforeAll: func(ctx context.Context) error { return nil },
+		AfterAll: func(ctx context.Context) error {
+			rec.record("root.afterAll")
+			return nil
+		},
+		Children: []*FixtureNode{childA, childB},
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{Roots: []*FixtureNode{root}})
+
+	gotest.Equal(t, 2, exitCode)
+	events := rec.names()
+	// ChildA never succeeded
+	gotest.NotContains(t, events, "childA.afterAll")
+	// ChildB succeeded → AfterAll must be called
+	gotest.Contains(t, events, "childB.afterAll")
+	// Root succeeded → AfterAll must be called
+	gotest.Contains(t, events, "root.afterAll")
+}
+
+func TestTreeDepth_ThreeLevels(t *testing.T) {
+	rec := &recorder{}
+
+	grandchild := &FixtureNode{
+		Name:   "Grandchild",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() { rec.record("grandchild.init") },
+		BeforeAll: func(ctx context.Context) error {
+			rec.record("grandchild.beforeAll")
+			return nil
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("grandchild.afterAll")
+			return nil
+		},
+	}
+
+	child := &FixtureNode{
+		Name:   "Child",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() { rec.record("child.init") },
+		BeforeAll: func(ctx context.Context) error {
+			rec.record("child.beforeAll")
+			return nil
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("child.afterAll")
+			return nil
+		},
+		Children: []*FixtureNode{grandchild},
+	}
+
+	root := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() { rec.record("root.init") },
+		BeforeAll: func(ctx context.Context) error {
+			rec.record("root.beforeAll")
+			return nil
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("root.afterAll")
+			return nil
+		},
+		Children: []*FixtureNode{child},
+	}
+
+	exitCode := run(func() int {
+		rec.record("m.run")
+		return 0
+	}, MainConfig{Roots: []*FixtureNode{root}})
+
+	gotest.Equal(t, 0, exitCode)
+	events := rec.names()
+
+	// Setup order: root → child → grandchild
+	rootBA := indexOf(events, "root.beforeAll")
+	childBA := indexOf(events, "child.beforeAll")
+	grandchildBA := indexOf(events, "grandchild.beforeAll")
+	mRun := indexOf(events, "m.run")
+
+	gotest.True(t, rootBA < childBA)
+	gotest.True(t, childBA < grandchildBA)
+	gotest.True(t, grandchildBA < mRun)
+
+	// Teardown order: grandchild → child → root
+	grandchildAA := indexOf(events, "grandchild.afterAll")
+	childAA := indexOf(events, "child.afterAll")
+	rootAA := indexOf(events, "root.afterAll")
+
+	gotest.True(t, mRun < grandchildAA)
+	gotest.True(t, grandchildAA < childAA)
+	gotest.True(t, childAA < rootAA)
+}
+
+func TestMultipleRoots_ConcurrentSetup(t *testing.T) {
+	rootAStarted := make(chan struct{})
+	rootBStarted := make(chan struct{})
+
+	rootA := &FixtureNode{
+		Name:   "RootA",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			close(rootAStarted)
+			select {
+			case <-rootBStarted:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+		AfterAll: func(ctx context.Context) error { return nil },
+	}
+	rootB := &FixtureNode{
+		Name:   "RootB",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			close(rootBStarted)
+			select {
+			case <-rootAStarted:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+		AfterAll: func(ctx context.Context) error { return nil },
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{Roots: []*FixtureNode{rootA, rootB}})
+	gotest.Equal(t, 0, exitCode)
+}
+
+func TestMultipleRoots_OneFailsCancelsOther(t *testing.T) {
+	rec := &recorder{}
+
+	rootA := &FixtureNode{
+		Name:   "RootA",
+		Config: gotest.FixtureConfig{Timeout: 2 * time.Minute},
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			return errors.New("rootA fails immediately")
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("rootA.afterAll")
+			return nil
+		},
+	}
+	rootB := &FixtureNode{
+		Name:   "RootB",
+		Config: gotest.FixtureConfig{Timeout: 2 * time.Minute},
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			// Block until cancelled
+			<-ctx.Done()
+			return ctx.Err()
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("rootB.afterAll")
+			return nil
+		},
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{Roots: []*FixtureNode{rootA, rootB}})
+
+	gotest.Equal(t, 2, exitCode)
+	events := rec.names()
+	gotest.NotContains(t, events, "rootA.afterAll")
+	gotest.NotContains(t, events, "rootB.afterAll")
+}
+
+func TestMultipleRoots_ConcurrentTeardown(t *testing.T) {
+	rootATeardownStarted := make(chan struct{})
+	rootBTeardownStarted := make(chan struct{})
+
+	rootA := &FixtureNode{
+		Name:      "RootA",
+		Config:    gotest.DefaultFixtureConfig(),
+		Init:      func() {},
+		BeforeAll: func(ctx context.Context) error { return nil },
+		AfterAll: func(ctx context.Context) error {
+			close(rootATeardownStarted)
+			<-rootBTeardownStarted
+			return nil
+		},
+	}
+	rootB := &FixtureNode{
+		Name:      "RootB",
+		Config:    gotest.DefaultFixtureConfig(),
+		Init:      func() {},
+		BeforeAll: func(ctx context.Context) error { return nil },
+		AfterAll: func(ctx context.Context) error {
+			close(rootBTeardownStarted)
+			<-rootATeardownStarted
+			return nil
+		},
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{Roots: []*FixtureNode{rootA, rootB}})
+	gotest.Equal(t, 0, exitCode)
+}
+
+func TestSharedFixture_LoadAndHydrate(t *testing.T) {
+	rec := &recorder{}
+
+	type SharedDB struct {
+		Host string `json:"host"`
+		Port int    `json:"port"`
+	}
+
+	stateData := map[string]json.RawMessage{
+		"example.com/fixtures.SharedDB": json.RawMessage(`{"host":"localhost","port":5432}`),
+	}
+	stateBytes, _ := json.Marshal(stateData)
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+	os.WriteFile(stateFile, stateBytes, 0644)
+	t.Setenv("GOTEST_SHARED_STATE_FILE", stateFile)
+
+	var target SharedDB
+	var assignedHost string
+
+	node := &FixtureNode{
+		Name:   "Root",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() { rec.record("root.init") },
+		BeforeAll: func(ctx context.Context) error {
+			rec.record("root.beforeAll")
+			return nil
+		},
+		AfterAll: func(ctx context.Context) error {
+			rec.record("root.afterAll")
+			return nil
+		},
+		SharedFixtures: []SharedFixtureBinding{
+			{
+				StateKey: "example.com/fixtures.SharedDB",
+				Target:   &target,
+				Hydrate: func(ctx context.Context) error {
+					rec.record("sf.hydrate")
+					return nil
+				},
+				Dehydrate: func(ctx context.Context) error {
+					rec.record("sf.dehydrate")
+					return nil
+				},
+				Assign: func() {
+					rec.record("sf.assign")
+					assignedHost = target.Host
+				},
+			},
+		},
+	}
+
+	exitCode := run(func() int {
+		rec.record("m.run")
+		return 0
+	}, MainConfig{Roots: []*FixtureNode{node}})
+
+	gotest.Equal(t, 0, exitCode)
+	gotest.Equal(t, "localhost", target.Host)
+	gotest.Equal(t, 5432, target.Port)
+	gotest.Equal(t, "localhost", assignedHost)
+
+	events := rec.names()
+	// Order: hydrate → init → assign → beforeAll → m.run → afterAll → dehydrate
+	hydrateIdx := indexOf(events, "sf.hydrate")
+	initIdx := indexOf(events, "root.init")
+	assignIdx := indexOf(events, "sf.assign")
+	beforeAllIdx := indexOf(events, "root.beforeAll")
+	mRunIdx := indexOf(events, "m.run")
+	afterAllIdx := indexOf(events, "root.afterAll")
+	dehydrateIdx := indexOf(events, "sf.dehydrate")
+
+	gotest.True(t, hydrateIdx < initIdx)
+	gotest.True(t, initIdx < assignIdx)
+	gotest.True(t, assignIdx < beforeAllIdx)
+	gotest.True(t, beforeAllIdx < mRunIdx)
+	gotest.True(t, mRunIdx < afterAllIdx)
+	gotest.True(t, afterAllIdx < dehydrateIdx)
+}
+
+func TestSharedFixture_MissingEnvVar(t *testing.T) {
+	t.Setenv("GOTEST_SHARED_STATE_FILE", "")
+
+	node := &FixtureNode{
+		Name:      "Root",
+		Config:    gotest.DefaultFixtureConfig(),
+		Init:      func() {},
+		BeforeAll: func(ctx context.Context) error { return nil },
+		SharedFixtures: []SharedFixtureBinding{
+			{
+				StateKey: "example.com/fixtures.SharedDB",
+				Target:   &struct{}{},
+			},
+		},
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{Roots: []*FixtureNode{node}})
+	gotest.Equal(t, 2, exitCode)
+}
+
+func TestSharedFixture_NilHydrateAndDehydrate(t *testing.T) {
+	type SharedDB struct {
+		Host string `json:"host"`
+	}
+
+	stateData := map[string]json.RawMessage{
+		"key": json.RawMessage(`{"host":"db"}`),
+	}
+	stateBytes, _ := json.Marshal(stateData)
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+	os.WriteFile(stateFile, stateBytes, 0644)
+	t.Setenv("GOTEST_SHARED_STATE_FILE", stateFile)
+
+	var target SharedDB
+	node := &FixtureNode{
+		Name:      "Root",
+		Config:    gotest.DefaultFixtureConfig(),
+		Init:      func() {},
+		BeforeAll: func(ctx context.Context) error { return nil },
+		SharedFixtures: []SharedFixtureBinding{
+			{
+				StateKey:  "key",
+				Target:    &target,
+				Hydrate:   nil,
+				Dehydrate: nil,
+				Assign:    func() {},
+			},
+		},
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{Roots: []*FixtureNode{node}})
+	gotest.Equal(t, 0, exitCode)
+	gotest.Equal(t, "db", target.Host)
+}
+
+func TestBudgetFile_WrittenCorrectly(t *testing.T) {
+	budgetFile := filepath.Join(t.TempDir(), "budget")
+	t.Setenv("GOTEST_TEARDOWN_BUDGET_FILE", budgetFile)
+
+	root := &FixtureNode{
+		Name:      "Root",
+		Config:    gotest.FixtureConfig{Timeout: 2 * time.Minute},
+		Init:      func() {},
+		BeforeAll: func(ctx context.Context) error { return nil },
+		Children: []*FixtureNode{
+			{
+				Name:      "Child",
+				Config:    gotest.FixtureConfig{Timeout: 1 * time.Minute},
+				Init:      func() {},
+				BeforeAll: func(ctx context.Context) error { return nil },
+			},
+		},
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{
+		Roots:                []*FixtureNode{root},
+		MaxSuiteSetupTimeout: 30 * time.Second,
+	})
+
+	gotest.Equal(t, 0, exitCode)
+
+	data, err := os.ReadFile(budgetFile)
+	gotest.NoError(t, err)
+
+	// Budget = max tree path (2m root + 1m child) + max suite setup (30s) + 30s
+	expected := (2*time.Minute + 1*time.Minute + 30*time.Second + 30*time.Second).String()
+	gotest.Equal(t, expected, string(data))
+}
+
+func TestBudgetFile_NotWrittenWhenEnvUnset(t *testing.T) {
+	t.Setenv("GOTEST_TEARDOWN_BUDGET_FILE", "")
+
+	root := &FixtureNode{
+		Name:      "Root",
+		Config:    gotest.FixtureConfig{Timeout: 2 * time.Minute},
+		Init:      func() {},
+		BeforeAll: func(ctx context.Context) error { return nil },
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{Roots: []*FixtureNode{root}})
+	gotest.Equal(t, 0, exitCode)
+}
+
+func TestBudgetFile_MultipleRootsUsesMax(t *testing.T) {
+	budgetFile := filepath.Join(t.TempDir(), "budget")
+	t.Setenv("GOTEST_TEARDOWN_BUDGET_FILE", budgetFile)
+
+	rootA := &FixtureNode{
+		Name:      "RootA",
+		Config:    gotest.FixtureConfig{Timeout: 1 * time.Minute},
+		Init:      func() {},
+		BeforeAll: func(ctx context.Context) error { return nil },
+	}
+	rootB := &FixtureNode{
+		Name:      "RootB",
+		Config:    gotest.FixtureConfig{Timeout: 3 * time.Minute},
+		Init:      func() {},
+		BeforeAll: func(ctx context.Context) error { return nil },
+		Children: []*FixtureNode{
+			{
+				Name:      "ChildB1",
+				Config:    gotest.FixtureConfig{Timeout: 2 * time.Minute},
+				Init:      func() {},
+				BeforeAll: func(ctx context.Context) error { return nil },
+			},
+		},
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{
+		Roots:                []*FixtureNode{rootA, rootB},
+		MaxSuiteSetupTimeout: 45 * time.Second,
+	})
+
+	gotest.Equal(t, 0, exitCode)
+
+	data, err := os.ReadFile(budgetFile)
+	gotest.NoError(t, err)
+
+	// Max tree path: max(1m, 3m+2m) = 5m; + 45s suite + 30s headroom
+	expected := (5*time.Minute + 45*time.Second + 30*time.Second).String()
+	gotest.Equal(t, expected, string(data))
+}
+
+func TestTeardownFailure_SetsExitCode1WhenTestsPassed(t *testing.T) {
+	node := &FixtureNode{
+		Name:      "Root",
+		Config:    gotest.DefaultFixtureConfig(),
+		Init:      func() {},
+		BeforeAll: func(ctx context.Context) error { return nil },
+		AfterAll: func(ctx context.Context) error {
+			return errors.New("teardown exploded")
+		},
+	}
+
+	exitCode := run(func() int { return 0 }, MainConfig{Roots: []*FixtureNode{node}})
+	gotest.Equal(t, 1, exitCode)
+}
+
+func TestTeardownFailure_PreservesNonZeroExitCode(t *testing.T) {
+	node := &FixtureNode{
+		Name:      "Root",
+		Config:    gotest.DefaultFixtureConfig(),
+		Init:      func() {},
+		BeforeAll: func(ctx context.Context) error { return nil },
+		AfterAll: func(ctx context.Context) error {
+			return errors.New("teardown exploded")
+		},
+	}
+
+	exitCode := run(func() int { return 3 }, MainConfig{Roots: []*FixtureNode{node}})
+	gotest.Equal(t, 3, exitCode)
+}
+
+func indexOf(slice []string, val string) int {
+	for i, s := range slice {
+		if s == val {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/gotestruntime/runtime_test.go
+++ b/pkg/gotestruntime/runtime_test.go
@@ -1,4 +1,4 @@
-package gotestruntime
+package gotestruntime //nolint:stdlib-test
 
 import (
 	"context"

--- a/tests/sharedfixture/sharedfixture_suite_test.go
+++ b/tests/sharedfixture/sharedfixture_suite_test.go
@@ -204,10 +204,12 @@ func (s *SharedFixtureIntegrationTestSuite) TestSharedFixtureIntegration(t *gote
 
 			if strings.HasSuffix(r.PkgPath, "/fixturebound") {
 				w.It("fixturebound", func(it *gotest.T) {
-					gotest.Contains(it, code, `os.Getenv("GOTEST_SHARED_STATE_FILE")`)
-					gotest.Contains(it, code, "os.ReadFile(ƒsharedFile)")
-					gotest.Contains(it, code, "ƒ_InfraFixture.Alpha = sf0")
-					gotest.Contains(it, code, "sf0.Hydrate(context.Background())")
+					gotest.Contains(it, code, "gotestruntime.RunFixtureMain(m,")
+					gotest.Contains(it, code, "gotestruntime.SharedFixtureBinding")
+					gotest.Contains(it, code, "var ƒ_sf0_InfraFixture = &fixtures.AlphaSharedFixture{}")
+					gotest.Contains(it, code, "ƒ_InfraFixture.Alpha = ƒ_sf0_InfraFixture")
+					gotest.Contains(it, code, "ƒ_sf0_InfraFixture.Hydrate(ctx)")
+					gotest.Contains(it, code, "ƒ_sf0_InfraFixture.Dehydrate(ctx)")
 				})
 			}
 		}


### PR DESCRIPTION
Moves fixture orchestration (lifecycle, retries, timeouts, coverage, teardown) from the code generator template into a tested runtime library at `pkg/gotestruntime/`. Reduces the fixture template from ~490 lines to ~180 lines of declarative struct literals. Removes the single-root-fixture constraint, enabling arbitrary fixture tree depth and multiple roots per package.