### PR TITLE
Smarter test concurrency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,33 @@ func (s *MyTestSuite) TestTwo(t *gotest.T, ctx *MethodParallelCtx) {
 
 The returning `BeforeEach` pattern ensures each parallel method operates on its own isolated state.
 
+### Concurrency control
+
+These two dimensions — suite processes and method goroutines — multiply.
+Left unchecked, that product grows quadratically with CPU count and saturates the machine.
+`gotest` manages this automatically with a linear concurrency budget.
+
+By default the budget is `2 × GOMAXPROCS`.
+The runner caps suite processes at `GOMAXPROCS` (one per core) and distributes the remaining budget as `-test.parallel` to each subprocess.
+On a 4-core machine with 10 suites this means 4 concurrent processes, each running 2 test methods at a time — 8 total, not 32.
+
+Override with `--parallel`:
+
+```bash
+gotest ./... --parallel 16          # total budget of 16
+gotest ./... --parallel 12 -parallel 4  # 4 per suite, 3 processes (12/4)
+gotest ./... -parallel 8            # explicit per-suite, no budget management
+```
+
+| Flags | Suite processes | Methods per suite | Total |
+|:------|:---------------:|:-----------------:|:-----:|
+| *(none)* | `min(S, GOMAXPROCS)` | `budget / inter` | `2 × GOMAXPROCS` |
+| `--parallel N` | `min(S, GOMAXPROCS, N)` | `N / inter` | `N` |
+| `-parallel M` | `2 × GOMAXPROCS` | `M` | `2 × GOMAXPROCS × M` *(compat)* |
+| `--parallel N -parallel M` | `min(S, GOMAXPROCS, N/M)` | `M` | `~N` |
+
+Where *S* is the number of suites and *inter* is the computed process count.
+
 ## Testing Toolkit
 
 ### Type-Safe Assertions

--- a/cmd/gotest/args.go
+++ b/cmd/gotest/args.go
@@ -53,6 +53,7 @@ type ExecConfig struct {
 	CI              bool
 	JSON            bool
 	UpdateSnapshots bool
+	Parallel        int
 }
 
 // knownSubcommands is the set of recognized subcommands.

--- a/cmd/gotest/cli.go
+++ b/cmd/gotest/cli.go
@@ -101,6 +101,11 @@ func runTest(inv Invocation) int {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2
 	}
+	parallel, err := parseParallelFlag(ownArgs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
 
 	var coverProfile string
 	if minCoverage > 0 {
@@ -131,6 +136,7 @@ func runTest(inv Invocation) int {
 		CI:              slices.Contains(ownArgs, "--ci"),
 		JSON:            jsonMode,
 		UpdateSnapshots: slices.Contains(ownArgs, "--update-snapshots"),
+		Parallel:        parallel,
 	}
 
 	code := Run(cfg)
@@ -192,6 +198,21 @@ func parseSetupTimeoutFlag(args []string) (time.Duration, error) {
 		return d, nil
 	}
 	return 0, nil
+}
+
+func parseParallelFlag(args []string) (int, error) {
+	raw := extractStringFlag(args, "--parallel", "")
+	if raw == "" {
+		return 0, nil
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid --parallel value %q: must be a positive integer", raw)
+	}
+	if v <= 0 {
+		return 0, fmt.Errorf("invalid --parallel value %d: must be positive", v)
+	}
+	return v, nil
 }
 
 func readCoverageTotal(profilePath string) (float64, error) {

--- a/cmd/gotest/exec.go
+++ b/cmd/gotest/exec.go
@@ -224,6 +224,13 @@ func executeTests(ctx context.Context, cfg ExecConfig, overlay *overlayResult) (
 	}
 
 	extraEnv := buildExtraEnv(cfg, setupProc)
+
+	totalSuites := 0
+	for _, suites := range overlay.suitesByPkg {
+		totalSuites += len(suites)
+	}
+	maxParallel := computeDispatchConcurrency(&pf.runFlags, cfg.Parallel, totalSuites)
+
 	targets := gotestrunner.BuildSuiteTargets(compiled, overlay.suitesByPkg, overlay.dirsByPkg, pf.runFlags, pf.userRunFilter)
 
 	if len(targets) == 0 {
@@ -245,9 +252,29 @@ func executeTests(ctx context.Context, cfg ExecConfig, overlay *overlayResult) (
 		mode = gotestrunner.RunStreamJSON
 	}
 	collector := gotestrunner.NewOutputCollector(mode, pf.verbose)
-	gotestrunner.RunSuites(ctx, targets, extraEnv, 0, collector)
+	gotestrunner.RunSuites(ctx, targets, extraEnv, maxParallel, collector)
 	collector.Finalize(overlay.noSuitePackages)
 	return collector.WorstExitCode(), nil
+}
+
+// computeDispatchConcurrency determines the semaphore size and injects
+// -parallel into runFlags based on --parallel. It returns the semaphore
+// size to use for inter-suite dispatch.
+//
+// When the user explicitly set -parallel but not --parallel, the old
+// behavior is preserved for backward compatibility.
+func computeDispatchConcurrency(runFlags *[]string, budget, totalSuites int) int {
+	userParallel := gotestrunner.ExtractParallelValue(*runFlags)
+
+	if userParallel > 0 && budget == 0 {
+		return 2 * runtime.GOMAXPROCS(0)
+	}
+
+	inter, intra := gotestrunner.ComputeConcurrency(budget, totalSuites, runtime.GOMAXPROCS(0))
+	if userParallel == 0 {
+		*runFlags = gotestrunner.InjectParallel(*runFlags, intra)
+	}
+	return inter
 }
 
 func executeTestsStreaming(ctx context.Context, cfg ExecConfig, overlay *overlayResult) (int, error) {
@@ -285,7 +312,11 @@ func executeTestsStreaming(ctx context.Context, cfg ExecConfig, overlay *overlay
 
 	compileCh := gotestrunner.CompilePackagesStream(streamCtx, overlay.suitePackages, overlay.overlayFlag, pf.buildFlags, overlay.tmpDir)
 
-	maxParallel := 2 * runtime.GOMAXPROCS(0)
+	totalSuites := 0
+	for _, suites := range overlay.suitesByPkg {
+		totalSuites += len(suites)
+	}
+	maxParallel := computeDispatchConcurrency(&pf.runFlags, cfg.Parallel, totalSuites)
 	sem := make(chan struct{}, maxParallel)
 	var wg sync.WaitGroup
 	anyTargets := false
@@ -432,7 +463,14 @@ func executeTestsCaptured(ctx context.Context, cfg ExecConfig, overlay *overlayR
 	}
 
 	extraEnv := buildExtraEnv(cfg, setupProc)
+
+	totalSuites := 0
+	for _, suites := range overlay.suitesByPkg {
+		totalSuites += len(suites)
+	}
 	runFlags := append(pf.runFlags, "-v")
+	maxParallel := computeDispatchConcurrency(&runFlags, cfg.Parallel, totalSuites)
+
 	targets := gotestrunner.BuildSuiteTargets(compiled, overlay.suitesByPkg, overlay.dirsByPkg, runFlags, pf.userRunFilter)
 
 	if len(targets) == 0 {
@@ -451,7 +489,7 @@ func executeTestsCaptured(ctx context.Context, cfg ExecConfig, overlay *overlayR
 	}
 
 	collector := gotestrunner.NewOutputCollector(gotestrunner.RunCaptureJSON, false)
-	gotestrunner.RunSuites(ctx, targets, extraEnv, 0, collector)
+	gotestrunner.RunSuites(ctx, targets, extraEnv, maxParallel, collector)
 	return collector.CapturedJSON(), collector.WorstExitCode(), nil
 }
 

--- a/cmd/gotest/flags.go
+++ b/cmd/gotest/flags.go
@@ -21,11 +21,12 @@ var gotestFlags = map[string]FlagKind{
 	"--format":           ValueFlag,
 	"--output":           ValueFlag,
 	"--input":            ValueFlag,
+	"--parallel":         ValueFlag,
 }
 
 var testAllowed = flagSet(
 	"--debug", "--ci", "--spec", "--update-snapshots",
-	"--min", "--setup-timeout",
+	"--min", "--setup-timeout", "--parallel",
 )
 
 var specAllowed = flagSet(
@@ -36,7 +37,7 @@ var specAllowed = flagSet(
 
 var watchAllowed = flagSet(
 	"--debug", "--ci", "--update-snapshots",
-	"--setup-timeout", "--debounce",
+	"--setup-timeout", "--debounce", "--parallel",
 )
 
 func flagSet(names ...string) map[string]bool {

--- a/cmd/gotest/watch.go
+++ b/cmd/gotest/watch.go
@@ -59,6 +59,11 @@ func runWatch(inv Invocation) int {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2
 	}
+	parallel, err := parseParallelFlag(ownArgs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
 	patterns := ExtractPackagePatterns(goTestArgs)
 
 	cfg := ExecConfig{
@@ -68,6 +73,7 @@ func runWatch(inv Invocation) int {
 		Debug:           slices.Contains(ownArgs, "--debug"),
 		CI:              slices.Contains(ownArgs, "--ci"),
 		UpdateSnapshots: slices.Contains(ownArgs, "--update-snapshots"),
+		Parallel:        parallel,
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), shutdownSignals...)

--- a/internal/gotestrunner/args.go
+++ b/internal/gotestrunner/args.go
@@ -1,7 +1,9 @@
 package gotestrunner
 
 import (
+	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 )
 
@@ -362,6 +364,39 @@ func HasVerboseFlag(flags []string) bool {
 	return slices.ContainsFunc(flags, func(f string) bool {
 		return f == "-v" || f == "-v=true"
 	})
+}
+
+// ExtractParallelValue returns the integer value of -parallel from run flags.
+// Returns 0 if not present or not parseable. Stops scanning at -args.
+func ExtractParallelValue(runFlags []string) int {
+	for i, f := range runFlags {
+		if f == "-args" {
+			return 0
+		}
+		if v, ok := strings.CutPrefix(f, "-parallel="); ok {
+			n, _ := strconv.Atoi(v)
+			return n
+		}
+		if f == "-parallel" && i+1 < len(runFlags) {
+			n, _ := strconv.Atoi(runFlags[i+1])
+			return n
+		}
+	}
+	return 0
+}
+
+// InjectParallel appends -parallel=n to runFlags if not already present
+// before the -args boundary.
+func InjectParallel(runFlags []string, n int) []string {
+	for _, f := range runFlags {
+		if f == "-args" {
+			break
+		}
+		if strings.HasPrefix(f, "-parallel") {
+			return runFlags
+		}
+	}
+	return append(runFlags, fmt.Sprintf("-parallel=%d", n))
 }
 
 func LooksLikePackagePattern(s string) bool {

--- a/internal/gotestrunner/concurrency.go
+++ b/internal/gotestrunner/concurrency.go
@@ -1,0 +1,29 @@
+package gotestrunner
+
+// ComputeConcurrency determines inter-suite process count and per-suite
+// -test.parallel value from a total concurrency budget.
+//
+// budget is the total concurrent test methods target (0 → 2*gomaxprocs).
+// numSuites is the number of suite targets to dispatch.
+// gomaxprocs is the GOMAXPROCS value (used to cap process count).
+//
+// The inter value caps at gomaxprocs to avoid creating more OS processes
+// than CPU cores. Remaining budget flows to intra (goroutine-level
+// parallelism within each process), which is cheaper.
+func ComputeConcurrency(budget, numSuites, gomaxprocs int) (inter, intra int) {
+	if gomaxprocs <= 0 {
+		gomaxprocs = 1
+	}
+	if budget <= 0 {
+		budget = 2 * gomaxprocs
+	}
+	if numSuites <= 0 {
+		return 1, budget
+	}
+	inter = min(numSuites, gomaxprocs, budget)
+	if inter <= 0 {
+		inter = 1
+	}
+	intra = max(1, budget/inter)
+	return inter, intra
+}

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -1022,6 +1022,42 @@ func (s *GotestrunnerTestSuite) TestComputeConcurrency(t *gotest.T) {
 	}
 }
 
+func (s *GotestrunnerTestSuite) TestExtractParallelValue(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []struct {
+		Name   string
+		flags  []string
+		expect int
+	}{
+		{"empty", nil, 0},
+		{"not present", []string{"-v", "-timeout=10m"}, 0},
+		{"equals form", []string{"-v", "-parallel=4"}, 4},
+		{"space form", []string{"-parallel", "8", "-v"}, 8},
+		{"stops at -args", []string{"-args", "-parallel=4"}, 0},
+		{"invalid value", []string{"-parallel=abc"}, 0},
+	}) {
+		got := gotestrunner.ExtractParallelValue(tc.flags)
+		gotest.Equal(sub, tc.expect, got)
+	}
+}
+
+func (s *GotestrunnerTestSuite) TestInjectParallel(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []struct {
+		Name   string
+		flags  []string
+		n      int
+		expect []string
+	}{
+		{"injects into empty", nil, 4, []string{"-parallel=4"}},
+		{"injects when absent", []string{"-v", "-timeout=10m"}, 2, []string{"-v", "-timeout=10m", "-parallel=2"}},
+		{"skips when equals present", []string{"-parallel=8", "-v"}, 2, []string{"-parallel=8", "-v"}},
+		{"skips when space present", []string{"-parallel", "8", "-v"}, 2, []string{"-parallel", "8", "-v"}},
+		{"does not inject after -args", []string{"-v", "-args", "-parallel=9"}, 2, []string{"-v", "-args", "-parallel=9", "-parallel=2"}},
+	}) {
+		got := gotestrunner.InjectParallel(tc.flags, tc.n)
+		gotest.Equal(sub, tc.expect, got)
+	}
+}
+
 var jsonTimestampRe = regexp.MustCompile(`\d+\.\d+s`)
 
 func normalizeJSON(raw string) string {

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -980,6 +980,48 @@ func (s *GotestrunnerTestSuite) TestSuiteRunFilter(t *gotest.T) {
 	}
 }
 
+func (s *GotestrunnerTestSuite) TestComputeConcurrency(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []struct {
+		Name         string
+		budget       int
+		numSuites    int
+		gomaxprocs   int
+		wantInter    int
+		wantIntra    int
+	}{
+		// Default budget (2×GOMAXPROCS), 4 cores
+		{"1 suite 4 cores", 8, 1, 4, 1, 8},
+		{"2 suites 4 cores", 8, 2, 4, 2, 4},
+		{"4 suites 4 cores", 8, 4, 4, 4, 2},
+		{"20 suites 4 cores", 8, 20, 4, 4, 2},
+
+		// Default budget (2×GOMAXPROCS), 8 cores
+		{"2 suites 8 cores", 16, 2, 8, 2, 8},
+		{"8 suites 8 cores", 16, 8, 8, 8, 2},
+		{"30 suites 8 cores", 16, 30, 8, 8, 2},
+
+		// Small budget (< GOMAXPROCS)
+		{"budget 4 on 8 cores", 4, 20, 8, 4, 1},
+		{"budget 2 on 8 cores", 2, 20, 8, 2, 1},
+
+		// Large budget
+		{"budget 32 on 4 cores", 32, 20, 4, 4, 8},
+
+		// Edge: fewer suites than cores
+		{"budget 16 1 suite", 16, 1, 8, 1, 16},
+
+		// Edge: zero/negative budget uses default
+		{"zero budget", 0, 10, 4, 4, 2},
+
+		// Edge: zero suites
+		{"zero suites", 8, 0, 4, 1, 8},
+	}) {
+		inter, intra := gotestrunner.ComputeConcurrency(tc.budget, tc.numSuites, tc.gomaxprocs)
+		gotest.Equal(sub, tc.wantInter, inter, "inter")
+		gotest.Equal(sub, tc.wantIntra, intra, "intra")
+	}
+}
+
 var jsonTimestampRe = regexp.MustCompile(`\d+\.\d+s`)
 
 func normalizeJSON(raw string) string {

--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -156,7 +156,7 @@ These can be set in `.vscode/settings.json` per workspace folder:
 | `gotest.cliPath` | `""` | Path to a gotest binary (overrides all other resolution) |
 | `gotest.modulePath` | `github.com/mvrahden/go-test/cmd/gotest` | Go module path for the gotest CLI |
 | `gotest.buildTags` | `""` | Comma-separated Go build tags (e.g. `integration,e2e`) |
-| `gotest.testFlags` | `[]` | Additional flags passed to `go test` |
+| `gotest.testFlags` | `[]` | Additional flags passed to gotest (`--` prefixed) and `go test` (`-` prefixed) |
 | `gotest.buildFlags` | `[]` | Additional build flags passed to Delve |
 | `gotest.discoverOnSave` | `true` | Re-discover tests when `_test.go` files change |
 | `gotest.coverOnRun` | `true` | Collect coverage data alongside normal test runs |
@@ -186,6 +186,11 @@ These can be set in `.vscode/settings.json` per workspace folder:
 
   // Extra flags for go test (e.g. timeout, verbose)
   "gotest.testFlags": ["-timeout=120s", "-v"],
+
+  // Control parallelism:
+  //   --parallel=N  total concurrent tests across all suites (gotest flag)
+  //   -parallel=N   concurrent tests within each suite (go test flag)
+  // "gotest.testFlags": ["--parallel=12", "-parallel=4"],
 
   // Extra build flags for Delve debug sessions
   "gotest.buildFlags": ["-gcflags=all=-N -l"]

--- a/vscode-gotest/package.json
+++ b/vscode-gotest/package.json
@@ -164,7 +164,7 @@
           },
           "default": [],
           "scope": "resource",
-          "description": "Additional flags passed to gotest test"
+          "description": "Additional flags passed to gotest (--prefixed) and go test (-prefixed), e.g. [\"--parallel=12\", \"-parallel=4\"]"
         },
         "gotest.buildFlags": {
           "type": "array",


### PR DESCRIPTION
Prevents resource saturation on multi-core machines by replacing the old quadratic concurrency scaling with a single linear budget. Adds a --parallel flag for manual control when needed.