### PR TITLE
Merge stdlib and suite coverage profiles in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,9 +61,17 @@ jobs:
       - name: Lint
         run: go run ./cmd/gotest-lint ./... ./examples/...
       - name: Test (stdlib)
-        run: go test -ldflags=-checklinkname=0 ./... -race
+        run: go test -ldflags=-checklinkname=0 -tags gotest_no_coverage_intercept -coverprofile=coverage-stdlib.out ./... -race
       - name: Test (suites)
-        run: go run ./cmd/gotest spec --no-color --min=40 --output=spec.txt ./... ./examples/... -race -coverprofile=coverage.out
+        run: go run ./cmd/gotest spec --no-color --min=40 --output=spec.txt ./... ./examples/... -race -coverprofile=coverage-suites.out
+      - name: Merge coverage
+        run: |
+          # Merge stdlib + suite coverage profiles: dedup blocks, keep max hit count
+          awk '
+            FNR==1 && /^mode:/ { if(!mode){mode=$0}; next }
+            { key=$1" "$2; if(!(key in max)||$3+0>max[key]+0){max[key]=$3+0;line[key]=$0} }
+            END { print mode; n=asorti(line,sorted); for(i=1;i<=n;i++) print line[sorted[i]] }
+          ' coverage-stdlib.out coverage-suites.out > coverage.out
       - name: Summary
         if: always()
         run: |

--- a/pkg/gotestruntime/coverage/coverage_test.go
+++ b/pkg/gotestruntime/coverage/coverage_test.go
@@ -1,3 +1,5 @@
+//go:build !gotest_no_coverage_intercept
+
 package coverage //nolint:stdlib-test
 
 import (


### PR DESCRIPTION
Collects coverage from both go test and gotest suite runs, then merges them into a single profile for accurate reporting.