### PR TITLE
Fix test races and add gotestast coverage

### DIFF
--- a/cmd/gotest/gotest_suite_test.go
+++ b/cmd/gotest/gotest_suite_test.go
@@ -282,16 +282,7 @@ func (s *CmdGotestTestSuite) TestRunDiscover_SimpleSuite(t *gotest.T) {
 			it.T().Skipf("examples directory not found: %v", err)
 		}
 
-		origDir, err := os.Getwd()
-		if err != nil {
-			it.T().Fatal(err)
-		}
-		if err := os.Chdir(absExamples); err != nil {
-			it.T().Fatal(err)
-		}
-		defer os.Chdir(origDir)
-
-		loadResults, err := gotestgen.LoadPackages([]string{"./cart"}, nil)
+		loadResults, err := gotestgen.LoadPackages([]string{filepath.Join(absExamples, "cart")}, nil)
 		if err != nil {
 			it.T().Fatalf("LoadPackages: %v", err)
 		}
@@ -422,16 +413,7 @@ func (s *CmdGotestTestSuite) TestGenerateOverlay(t *gotest.T) {
 				it.T().Skipf("examples directory not found: %v", err)
 			}
 
-			origDir, err := os.Getwd()
-			if err != nil {
-				it.T().Fatal(err)
-			}
-			if err := os.Chdir(absExamples); err != nil {
-				it.T().Fatal(err)
-			}
-			defer os.Chdir(origDir)
-
-			loaded, err := gotestgen.LoadPackages([]string{"./cart"}, nil)
+			loaded, err := gotestgen.LoadPackages([]string{filepath.Join(absExamples, "cart")}, nil)
 			if err != nil {
 				it.T().Fatalf("LoadPackages: %v", err)
 			}
@@ -483,16 +465,7 @@ func (s *CmdGotestTestSuite) TestGenerateOverlay(t *gotest.T) {
 				it.T().Fatal(err)
 			}
 
-			origDir, err := os.Getwd()
-			if err != nil {
-				it.T().Fatal(err)
-			}
-			if err := os.Chdir(tmpDir); err != nil {
-				it.T().Fatal(err)
-			}
-			defer os.Chdir(origDir)
-
-			loaded, err := gotestgen.LoadPackages([]string{"."}, nil)
+			loaded, err := gotestgen.LoadPackages([]string{tmpDir}, nil)
 			if err != nil {
 				it.T().Fatalf("LoadPackages: %v", err)
 			}

--- a/internal/gotestast/gotestast_suite_test.go
+++ b/internal/gotestast/gotestast_suite_test.go
@@ -1093,6 +1093,173 @@ func (f *PGSharedFixture) setupB(ctx context.Context) error {
 	})
 }
 
+// SpecTestSuite tests TestSuiteSpecSet.ReduceToEffectiveSet, DetermineTestSuite,
+// DetermineTestSuiteHarness, and TestSuiteSpec accessor methods.
+type SpecTestSuite struct{}
+
+func (s *SpecTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{Parallel: true}
+}
+
+func (s *SpecTestSuite) TestReduceToEffectiveSet(t *gotest.T) {
+	t.When("no focused or excluded suites", func(w *gotest.T) {
+		w.It("returns all suites as effective", func(it *gotest.T) {
+			suites := gotestast.TestSuiteSpecSet{
+				gotestast.NewTestSuiteSpecForTest("AlphaTestSuite", "pkg", false),
+				gotestast.NewTestSuiteSpecForTest("BetaTestSuite", "pkg", false),
+			}
+			effective, skippedSuites, skippedCases := suites.ReduceToEffectiveSet()
+			gotest.Equal(it, 2, len(effective))
+			gotest.Empty(it, skippedSuites)
+			gotest.Equal(it, 2, len(skippedCases)) // entries exist but with nil values
+		})
+	})
+
+	t.When("focused suite present", func(w *gotest.T) {
+		w.It("keeps only focused suites, skips unfocused", func(it *gotest.T) {
+			suites := gotestast.TestSuiteSpecSet{
+				gotestast.NewTestSuiteSpecForTest("F_FocusedTestSuite", "pkg", false),
+				gotestast.NewTestSuiteSpecForTest("NormalTestSuite", "pkg", false),
+			}
+			effective, skippedSuites, _ := suites.ReduceToEffectiveSet()
+			gotest.Equal(it, 1, len(effective))
+			gotest.Equal(it, "F_FocusedTestSuite", effective[0].Identifier())
+			gotest.Equal(it, 1, len(skippedSuites))
+			gotest.Equal(it, "NormalTestSuite", skippedSuites[0].Identifier())
+		})
+	})
+
+	t.When("excluded suite present", func(w *gotest.T) {
+		w.It("removes excluded suites", func(it *gotest.T) {
+			suites := gotestast.TestSuiteSpecSet{
+				gotestast.NewTestSuiteSpecForTest("X_ExcludedTestSuite", "pkg", false),
+				gotestast.NewTestSuiteSpecForTest("NormalTestSuite", "pkg", false),
+			}
+			effective, skippedSuites, _ := suites.ReduceToEffectiveSet()
+			gotest.Equal(it, 1, len(effective))
+			gotest.Equal(it, "NormalTestSuite", effective[0].Identifier())
+			gotest.Equal(it, 1, len(skippedSuites))
+		})
+	})
+}
+
+func (s *SpecTestSuite) TestDetermineTestSuite(t *gotest.T) {
+	t.When("valid test suite type", func(w *gotest.T) {
+		w.It("detects struct type ending in TestSuite", func(it *gotest.T) {
+			pkg, genDecls := loadFixtureAST(it.T(), `
+				package testpkg
+				type MyTestSuite struct{ Value string }
+			`)
+			spec, _, err := gotestast.DetermineTestSuite(genDecls[0], pkg)
+			gotest.NoError(it, err)
+			gotest.True(it, spec != nil)
+			gotest.Equal(it, "MyTestSuite", spec.Identifier())
+		})
+	})
+
+	t.When("non-suite type", func(w *gotest.T) {
+		w.It("returns nil for types not ending in TestSuite", func(it *gotest.T) {
+			pkg, genDecls := loadFixtureAST(it.T(), `
+				package testpkg
+				type MyService struct{}
+			`)
+			spec, _, err := gotestast.DetermineTestSuite(genDecls[0], pkg)
+			gotest.NoError(it, err)
+			gotest.True(it, spec == nil)
+		})
+	})
+
+	t.When("generated suite wrapper", func(w *gotest.T) {
+		w.It("ignores ƒƒ_GOTEST_ prefixed types", func(it *gotest.T) {
+			gotest.False(it, gotestast.IS_TEST_SUITE.MatchString("ƒƒ_GOTEST_MyTestSuite"))
+			gotest.True(it, gotestast.IS_TEST_SUITE.MatchString("MyTestSuite"))
+		})
+	})
+
+	t.When("focused and excluded prefixes", func(w *gotest.T) {
+		w.It("accepts F_ prefix as focused", func(it *gotest.T) {
+			gotest.True(it, gotestast.IS_TEST_SUITE.MatchString("F_MyTestSuite"))
+		})
+		w.It("accepts X_ prefix as excluded", func(it *gotest.T) {
+			gotest.True(it, gotestast.IS_TEST_SUITE.MatchString("X_MyTestSuite"))
+		})
+		w.It("rejects underscore-only prefix", func(it *gotest.T) {
+			gotest.False(it, gotestast.IS_TEST_SUITE.MatchString("_PrivateTestSuite"))
+		})
+	})
+}
+
+func (s *SpecTestSuite) TestDetermineTestSuiteHarness(t *gotest.T) {
+	t.When("lifecycle methods", func(w *gotest.T) {
+		w.It("discovers BeforeAll and AfterAll", func(it *gotest.T) {
+			fm := loadFixtureWithMethods(it.T(), `
+				package testpkg
+				import "testing"
+				type MyTestSuite struct{}
+				func (s *MyTestSuite) BeforeAll(t *testing.T) {}
+				func (s *MyTestSuite) AfterAll(t *testing.T) {}
+				func (s *MyTestSuite) TestOne(t *testing.T) {}
+			`)
+			spec, _, err := gotestast.DetermineTestSuite(fm.genDecls[0], fm.pkg)
+			gotest.NoError(it, err)
+			gotest.True(it, spec != nil)
+
+			for _, fd := range fm.funcDecls {
+				_, err := gotestast.DetermineTestSuiteHarness(fd, fm.pkg, spec)
+				gotest.NoError(it, err)
+			}
+
+			gotest.True(it, spec.BeforeAll() != nil, "BeforeAll should be detected")
+			gotest.True(it, spec.AfterAll() != nil, "AfterAll should be detected")
+			gotest.Equal(it, 1, len(spec.TestCases()))
+		})
+	})
+
+	t.When("test case methods", func(w *gotest.T) {
+		w.It("detects focused and excluded test cases", func(it *gotest.T) {
+			gotest.True(it, gotestast.IS_TEST_CASE.MatchString("TestSomething"))
+			gotest.True(it, gotestast.IS_TEST_CASE.MatchString("F_TestFocused"))
+			gotest.True(it, gotestast.IS_TEST_CASE.MatchString("X_TestExcluded"))
+			gotest.False(it, gotestast.IS_TEST_CASE.MatchString("NotATest"))
+		})
+	})
+}
+
+func (s *SpecTestSuite) TestTestSuiteSpecAccessors(t *gotest.T) {
+	t.When("accessor methods", func(w *gotest.T) {
+		w.It("returns correct identifiers", func(it *gotest.T) {
+			spec := gotestast.NewTestSuiteSpecForTest("MyTestSuite", "mypkg", false)
+			gotest.Equal(it, "MyTestSuite", spec.Identifier())
+			gotest.Equal(it, "mypkg", spec.PackageName())
+			gotest.False(it, spec.IsFocused())
+			gotest.False(it, spec.IsExcluded())
+			gotest.False(it, spec.IsGenericAlias())
+		})
+		w.It("detects focused prefix", func(it *gotest.T) {
+			spec := gotestast.NewTestSuiteSpecForTest("F_MyTestSuite", "mypkg", false)
+			gotest.True(it, spec.IsFocused())
+			gotest.False(it, spec.IsExcluded())
+		})
+		w.It("detects excluded prefix", func(it *gotest.T) {
+			spec := gotestast.NewTestSuiteSpecForTest("X_MyTestSuite", "mypkg", false)
+			gotest.False(it, spec.IsFocused())
+			gotest.True(it, spec.IsExcluded())
+		})
+		w.It("detects generic alias", func(it *gotest.T) {
+			spec := gotestast.NewTestSuiteSpecForTest("MyTestSuite", "mypkg", true)
+			gotest.True(it, spec.IsGenericAlias())
+		})
+		w.It("detects pxtest package", func(it *gotest.T) {
+			spec := gotestast.NewTestSuiteSpecForTest("MyTestSuite", "mypkg_test", false)
+			gotest.True(it, spec.IsPxTestSuite())
+		})
+		w.It("detects internal test package", func(it *gotest.T) {
+			spec := gotestast.NewTestSuiteSpecForTest("MyTestSuite", "mypkg", false)
+			gotest.False(it, spec.IsPxTestSuite())
+		})
+	})
+}
+
 func (s *GotestastTestSuite) TestRegexp(t *gotest.T) {
 	testCases := []struct {
 		desc string

--- a/internal/gotestgen/testonly_suite_test.go
+++ b/internal/gotestgen/testonly_suite_test.go
@@ -1,7 +1,6 @@
 package gotestgen_test
 
 import (
-	"os"
 	"path/filepath"
 
 	"github.com/mvrahden/go-test/internal/gotestgen"
@@ -14,28 +13,20 @@ type TestOnlyTestSuite struct{}
 func (s *TestOnlyTestSuite) TestIsTestOnly(t *gotest.T) {
 	t.When("example packages", func(w *gotest.T) {
 		w.It("reports IsTestOnly correctly for each", func(it *gotest.T) {
-			examplesDir := filepath.Join("..", "..", "examples")
-			absExamples, err := filepath.Abs(examplesDir)
+			absExamples, err := filepath.Abs(filepath.Join("..", "..", "examples"))
 			gotest.NoError(it, err)
-
-			origDir, err := os.Getwd()
-			gotest.NoError(it, err)
-
-			err = os.Chdir(absExamples)
-			gotest.NoError(it, err)
-			defer os.Chdir(origDir)
 
 			tests := []struct {
 				pattern  string
 				expected bool
 			}{
-				{"./cart", false},
-				{"./auth", false},
-				{"./search", false},
+				{"cart", false},
+				{"auth", false},
+				{"search", false},
 			}
 
 			for _, tc := range tests {
-				results, _, err := gotestgen.LoadPackagesForDiscovery([]string{tc.pattern}, nil)
+				results, _, err := gotestgen.LoadPackagesForDiscovery([]string{filepath.Join(absExamples, tc.pattern)}, nil)
 				gotest.NoError(it, err)
 				gotest.NotEmpty(it, results, "no packages found for %s", tc.pattern)
 


### PR DESCRIPTION
Replaces `os.Chdir` with absolute paths to eliminate a parallel test race, and adds suite detection/reduction coverage for the AST package.