### PR TITLE
Fix diagram alignment and remove duplicate install prompt

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -27,7 +27,7 @@
  │  │   go test -c per    │    │   JSON state from stdout   │  │
  │  │   pkg (NumCPU par)  │    │   → write state.json       │  │
  │  └────────┬────────────┘    └────────────┬───────────────┘  │
- │           │ <-chan CompileResult          │ *SharedFixtureProcess
+ │           │ <-chan CompileResult         │ *SharedFixtureProcess
  └───────────┼──────────────────────────────┼──────────────────┘
              │    (overlap: exec starts     │
              │     as packages compile)     │

--- a/README.md
+++ b/README.md
@@ -332,9 +332,9 @@ type APIFixture struct {
 ```
 InfraFixture.BeforeEach  ─┐
 CacheFixture.BeforeEach  ─┤
-                           └─ APIFixture.BeforeEach
-                                └─ Suite.BeforeEach → TestCase → Suite.AfterEach
-                           ┌─ APIFixture.AfterEach
+                          └─ APIFixture.BeforeEach
+                               └─ Suite.BeforeEach → TestCase → Suite.AfterEach
+                          ┌─ APIFixture.AfterEach
 InfraFixture.AfterEach  ──┤
 CacheFixture.AfterEach  ──┘
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -801,15 +801,6 @@
       </div>
     </section>
 
-    <!-- Bottom CTA -->
-    <section class="hero" style="padding: 3rem 1.5rem;">
-      <div class="container">
-        <div class="install-cmd">
-          <code>go install github.com/mvrahden/go-test/cmd/gotest@latest</code>
-          <button onclick="navigator.clipboard.writeText('go install github.com/mvrahden/go-test/cmd/gotest@latest').then(()=>{this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500);gtag('event','copy_install_command')})" aria-label="Copy install command">Copy</button>
-        </div>
-      </div>
-    </section>
   </main>
 
   <footer>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -666,13 +666,13 @@ Fixture.AfterEach</div>
 }</pre>
       </div>
       <p>Dependencies are set up first. Independent fixtures set up in parallel; teardown runs in reverse:</p>
-      <div class="diagram">DBFixture.BeforeAll <span class="d">──┐</span>
-                        <span class="d">├──</span> APIFixture.BeforeAll
+      <div class="diagram">DBFixture.BeforeAll <span class="d">───┐</span>
+                       <span class="d">├──</span> APIFixture.BeforeAll
 CacheFixture.BeforeAll <span class="d">┘</span>
                              <span class="d">└──</span> Suite.BeforeAll
                                    <span class="d">├──</span> Suite.BeforeEach <span class="d">→</span> Test <span class="d">→</span> Suite.AfterEach
                              <span class="d">└──</span> Suite.AfterAll
-                        <span class="d">┌──</span> APIFixture.AfterAll
+                       <span class="d">┌──</span> APIFixture.AfterAll
 DBFixture.AfterAll <span class="d">────┘</span>
 CacheFixture.AfterAll <span class="d">─┘</span></div>
 


### PR DESCRIPTION
Align box-drawing characters in lifecycle diagrams across README, ARCHITECTURE, and reference page.
Remove the redundant install command at the bottom of the home page.