### PR TITLE
Fix shared fixture codegen and improve documentation

### DIFF
--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -475,6 +475,16 @@ Test process:
   sf.Dehydrate(ctx)              → cleans up local resources
 ```
 
+**DAG dependencies within the subprocess:**
+
+When SharedFixture B depends on SharedFixture A, both run in the same subprocess.
+After A.BeforeAll() completes, B receives an in-memory pointer to A — not serialized state.
+B.BeforeAll() can access all fields that A.BeforeAll() set, including local fields like connection pools.
+The serialization boundary only exists between the subprocess and test processes.
+
+`BeforeAll` always sets transfer fields. Local fields only need to be set in `BeforeAll` when a dependent shared fixture accesses them — otherwise they may add an idle resource to the subprocess.
+`Hydrate` is not called within the subprocess — it runs only in test processes after JSON deserialization.
+
 **Validation at generation time:**
 
 - Shared fixture types must not live in `internal/` packages.

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -684,11 +684,22 @@ CacheFixture.AfterAll <span class="d">─┘</span></div>
     Pool    *pgxpool.Pool <span class="cm">// local — reconstructed via Hydrate</span>
 }
 
-<span class="kw">func</span> (f *<span class="tp">PostgresSharedFixture</span>) <span class="fn">Hydrate</span>(ctx context.Context) <span class="tp">error</span> {
+<span class="kw">func</span> (f *<span class="tp">PostgresSharedFixture</span>) <span class="fn">BeforeAll</span>(ctx context.Context) <span class="tp">error</span> {
+    f.ConnStr = startPostgres(ctx)
+    <span class="kw">return</span> f.connect(ctx)
+}
+
+<span class="kw">func</span> (f *<span class="tp">PostgresSharedFixture</span>) <span class="fn">Hydrate</span>(ctx context.Context) <span class="tp">error</span>   { <span class="kw">return</span> f.connect(ctx) }
+<span class="kw">func</span> (f *<span class="tp">PostgresSharedFixture</span>) <span class="fn">Dehydrate</span>(ctx context.Context) <span class="tp">error</span> { f.Pool.Close(); <span class="kw">return</span> <span class="kw">nil</span> }
+
+<span class="kw">func</span> (f *<span class="tp">PostgresSharedFixture</span>) <span class="fn">connect</span>(ctx context.Context) <span class="tp">error</span> {
     <span class="kw">var</span> err <span class="tp">error</span>
     f.Pool, err = pgxpool.New(ctx, f.ConnStr)
     <span class="kw">return</span> err
 }</pre>
+      </div>
+      <div class="callout">
+        <code>BeforeAll</code> always sets transfer fields. Local fields only need to be set in <code>BeforeAll</code> when a dependent shared fixture accesses them in the DAG — otherwise they may add an idle resource to the subprocess. <code>Hydrate</code> handles local field reconstruction in test processes.
       </div>
       <div class="callout">
         Fields assigned in <code>Hydrate</code> are automatically classified as local and excluded from serialization. Everything else transfers. No annotations needed.
@@ -706,6 +717,9 @@ CacheFixture.AfterAll <span class="d">─┘</span></div>
     <span class="cm">// f.Postgres.ConnStr is available</span>
     <span class="kw">return</span> migrate(f.Postgres.ConnStr)
 }</pre>
+      </div>
+      <div class="callout">
+        Within the setup subprocess, dependent fixtures receive in-memory pointers — not serialized state. <code>B.BeforeAll()</code> can access all of <code>A</code>'s fields, including local fields like connection pools — provided <code>A.BeforeAll()</code> set them. When a dependent only needs transfer fields, skipping local setup in the parent avoids idle resources in the subprocess.
       </div>
       <p>Suites are dispatched as soon as their specific shared fixture dependencies are ready — they don't wait for unrelated fixtures. Transitive dependencies are included automatically: if a suite needs <code>SchemaSharedFixture</code>, it also gets <code>PostgresSharedFixture</code>.</p>
     </section>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -93,7 +93,7 @@
       font-family: var(--font-sans);
       color: var(--text);
       background: var(--bg);
-      line-height: 1.7;
+      line-height: 1.6;
       -webkit-font-smoothing: antialiased;
     }
 
@@ -111,7 +111,7 @@
       backdrop-filter: blur(8px);
     }
     .nav-inner {
-      max-width: var(--max-w);
+      max-width: 1080px;
       margin: 0 auto;
       padding: 0.75rem 1.5rem;
       display: flex;
@@ -129,9 +129,35 @@
     }
     .nav-brand:hover { text-decoration: none; }
     .nav-brand img { width: 28px; height: 28px; border-radius: 50%; }
-    .nav-links { display: flex; gap: 1.25rem; font-size: 0.9rem; }
+    .nav-links { display: flex; gap: 1.25rem; font-size: 0.9rem; align-items: center; }
     .nav-links a { color: var(--text-secondary); }
     .nav-links a:hover { color: var(--text); text-decoration: none; }
+    .nav-links .nav-home {
+      padding: 0.25rem 0.65rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-weight: 600;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-links .nav-home:hover { background: var(--bg-alt); }
+    .nav-links .star-btn { font-size: 0.85rem; }
+    .star-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.3rem 0.7rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-weight: 600;
+      text-decoration: none;
+      transition: all 0.15s;
+      font-size: 0.8rem;
+    }
+    .star-btn:hover { background: var(--bg-alt); text-decoration: none; }
+    .star-btn .star-icon { color: #e3b341; }
+    .star-count { font-weight: 400; color: var(--text-dimmed); }
 
     /* ===== Layout ===== */
     .page { max-width: var(--max-w); margin: 0 auto; padding: 3rem 1.5rem 5rem; }
@@ -340,6 +366,7 @@
     }
     footer a { color: var(--text-on-dark); }
     footer a:hover { color: var(--cyan); }
+    .footer-copy { color: #484f58; font-size: 0.8rem; }
     .footer-links {
       display: flex;
       justify-content: center;
@@ -366,9 +393,10 @@
         gotest
       </a>
       <div class="nav-links">
-        <a href="./">Home</a>
-        <a href="https://github.com/mvrahden/go-test">GitHub</a>
+        <a href="./" class="nav-home">Home</a>
+        <a href="https://github.com/mvrahden/go-test" class="star-btn"><span class="star-icon">&#9734;</span> Star<span class="star-count" id="star-count"></span></a>
         <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code</a>
       </div>
     </div>
   </nav>
@@ -966,6 +994,17 @@ percentage = covered / total</div>
       <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
       <a href="https://github.com/mvrahden/go-test/blob/main/LICENSE">MIT License</a>
     </div>
+    <p class="footer-copy">Built for Go developers who want tests that explain themselves.</p>
   </footer>
+  <script>
+  fetch('https://api.github.com/repos/mvrahden/go-test')
+    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(d => {
+      if (d.stargazers_count >= 10) {
+        document.getElementById('star-count').textContent = ` ${d.stargazers_count}`;
+      }
+    })
+    .catch(() => {});
+  </script>
 </body>
 </html>

--- a/internal/gotestgen/renderer.go
+++ b/internal/gotestgen/renderer.go
@@ -95,7 +95,7 @@ func (r renderer) RenderTestSuiteSpec(pkg *packages.Package, spec SpecOutcome, r
 	hasFixtures := len(resolved.RootFixtures) > 0 || len(sfNodeVMs) > 0
 
 	buf := bytes.NewBuffer(nil)
-	if err := r.renderFileHeader(buf, pkg, spec, hasFixtures, resolved.SuiteSharedFixtures, allViewModels); err != nil {
+	if err := r.renderFileHeader(buf, pkg, spec, hasFixtures, resolved.SuiteSharedFixtures, allViewModels, sfNodeVMs); err != nil {
 		return nil, fmt.Errorf("failed rendering file header. err: %w", err)
 	}
 
@@ -119,7 +119,7 @@ func (r renderer) RenderTestSuiteSpec(pkg *packages.Package, spec SpecOutcome, r
 	return r.formatOutput(buf)
 }
 
-func (r *renderer) renderFileHeader(buf *bytes.Buffer, pkg *packages.Package, spec SpecOutcome, hasFixtures bool, suiteSharedFixtures map[string][]SharedFixtureRef, allViewModels []*FixtureViewModel) error {
+func (r *renderer) renderFileHeader(buf *bytes.Buffer, pkg *packages.Package, spec SpecOutcome, hasFixtures bool, suiteSharedFixtures map[string][]SharedFixtureRef, allViewModels []*FixtureViewModel, sfNodes []*SharedFixtureNodeVM) error {
 	type TplData struct {
 		RepoName    string
 		PackageName string
@@ -159,6 +159,12 @@ func (r *renderer) renderFileHeader(buf *bytes.Buffer, pkg *packages.Package, sp
 				imports = append(imports, headerImport{Path: sf.PkgPath})
 				seenPkg[sf.PkgPath] = true
 			}
+		}
+	}
+	for _, sf := range sfNodes {
+		if sf.PkgPath != "" && sf.PkgPath != pkg.PkgPath && !seenPkg[sf.PkgPath] {
+			imports = append(imports, headerImport{Path: sf.PkgPath})
+			seenPkg[sf.PkgPath] = true
 		}
 	}
 	for _, ts := range spec.EffectiveTestSuites {

--- a/internal/gotestgen/renderer_suite_test.go
+++ b/internal/gotestgen/renderer_suite_test.go
@@ -250,6 +250,18 @@ func (s *RendererTestSuite) TestSharedFixture(t *gotest.T) {
 		})
 	})
 
+	t.When("cross-package transitive dependency", func(w *gotest.T) {
+		w.It("imports the transitive shared fixture package", func(it *gotest.T) {
+			pkg := gotestgen.ExportMustTestPkg(it.T(), "TestRenderer_CrossPkgTransitiveSharedFixture")
+			output, _ := renderTestPkg(it.T(), pkg)
+			gotest.True(it, len(output) > 0, "expected non-empty output")
+
+			gotest.Contains(it, output, `"testpkg/extfixtures"`, "expected import for transitive shared fixture package")
+			gotest.Contains(it, output, "var ƒ_sf_extfixtures_PostgresSharedFixture = &extfixtures.PostgresSharedFixture{}")
+			gotest.Contains(it, output, "var ƒ_sf_SchemaSharedFixture = &SchemaSharedFixture{}")
+		})
+	})
+
 	t.When("empty struct", func(w *gotest.T) {
 		w.It("renders shared fixture as DAG node and struct literal wiring", func(it *gotest.T) {
 			pkg := gotestgen.ExportMustTestPkg(it.T(), "TestRenderer_SharedFixtureEmptyStruct")

--- a/internal/gotestgen/testdata/sources/TestRenderer_CrossPkgTransitiveSharedFixture/test.go
+++ b/internal/gotestgen/testdata/sources/TestRenderer_CrossPkgTransitiveSharedFixture/test.go
@@ -1,0 +1,23 @@
+package testpkg
+
+import (
+	"context"
+
+	"testpkg/extfixtures"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type SchemaSharedFixture struct {
+	PG      *extfixtures.PostgresSharedFixture
+	Version string
+}
+
+func (f *SchemaSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *SchemaSharedFixture) AfterAll(ctx context.Context) error  { return nil }
+
+type MigrationTestSuite struct {
+	Schema *SchemaSharedFixture
+}
+
+func (s *MigrationTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/extfixtures/test.go
+++ b/internal/gotestgen/testdata/sources/extfixtures/test.go
@@ -1,0 +1,10 @@
+package extfixtures
+
+import "context"
+
+type PostgresSharedFixture struct {
+	ConnStr string
+}
+
+func (f *PostgresSharedFixture) BeforeAll(ctx context.Context) error { return nil }
+func (f *PostgresSharedFixture) AfterAll(ctx context.Context) error  { return nil }


### PR DESCRIPTION
- Fix missing imports for cross-package shared fixture dependencies in generated overlay files.
- Clarify the shared fixture lifecycle in reference page and spec. When local fields need setup, the subprocess pointer semantics, and the serialization boundary.
- Align the reference page header and footer with the homepage.