### PR TITLE
Fix assertion failure line reporting and update documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,12 @@ All assertions accept both `*gotest.T` and `*testing.T` as first argument.
 
 These override any default instincts from stdlib `testing` or other Go test frameworks.
 
-**Never call `t.T().Helper()`.**
-gotest uses `CallerTrace` to automatically walk the call stack and attribute assertion failures to the correct user code location.
-Calling `t.T().Helper()` is harmless but unnecessary noise — it's already handled by the framework.
-Same applies to `t.Helper()` in methods that accept `*testing.T` directly.
+**Never call `t.T().Helper()` when using gotest assertions.**
+gotest automatically resolves assertion failures to the correct call site in your test code.
+Calling `t.T().Helper()` is counterproductive — it removes useful location information from failure output.
+Without it, failures show both where the assertion was called (inside the helper) and where the helper was called (in the test).
+This applies to all gotest assertion functions (`gotest.Equal`, `gotest.True`, etc.).
+If you pass `t.T()` to third-party code that uses Go's standard `t.Errorf`, Go's `t.Helper()` convention applies as normal.
 
 **Never call `t.T().Cleanup()` inside suite methods.**
 Use `BeforeAll`/`AfterAll` for suite-level resources and `BeforeEach`/`AfterEach` for per-test resources.
@@ -145,6 +147,18 @@ gotest.TimeIsNow(t, ts time.Time, tolerance time.Duration)
 gotest.Panics(t, f func()) any  // asserts f panics, returns recovered value
 ```
 
+### Snapshots
+
+```go
+gotest.MatchSnapshot(t, value any, name ...string)   // compare value against stored snapshot
+```
+
+Snapshots are stored in `testdata/__snapshots__/<TestSuiteName>.snap` next to the test file.
+On first run (or with `--update-snapshots`), the snapshot is created.
+On subsequent runs, the value is compared against the stored snapshot.
+The optional `name` disambiguates multiple snapshots within the same test case.
+Snapshot entries are written in deterministic order and are thread-safe — parallel test methods can use `MatchSnapshot` without coordination.
+
 ## Eventually & Consistently
 
 Package-level functions for async polling. Both use `*gotest.R` — an assertion recorder that captures failures without propagating them.
@@ -181,9 +195,8 @@ type MyServiceTestSuite struct { /* state */ }           // test suite
 ### Test methods
 
 ```go
-func (s *MyTestSuite) TestCreate(t *gotest.T) {}                 // sequential
-func (s *MyTestSuite) TestRead(t *gotest.T) {}                   // standard test method
-func (s *MyTestSuite) TestLongPollAsync(t *gotest.T, done func()) {} // async (call done() when finished)
+func (s *MyTestSuite) TestCreate(t *gotest.T) {}         // standard test method
+func (s *MyTestSuite) TestRead(t *gotest.T) {}
 ```
 
 Methods can also accept `*testing.T` for stdlib compatibility.
@@ -240,6 +253,84 @@ func (s *MyTestSuite) X_TestBroken(t *gotest.T) {}    // EXCLUDED test case
 - `X_` — exclude. Always skipped. Compile-time decision (AST level). Use for permanently/temporarily disabled tests.
 
 Focus and exclude apply independently at both suite and test case levels.
+
+## Fixtures
+
+### Package fixtures
+
+Shared setup for suites in the same package. Name must end with `Fixture`.
+
+```go
+type DBFixture struct {
+    Pool *pgxpool.Pool
+}
+
+func (f *DBFixture) BeforeAll(ctx context.Context) error  { /* start db, set f.Pool */ return nil }
+func (f *DBFixture) AfterAll(ctx context.Context) error   { f.Pool.Close(); return nil }
+func (f *DBFixture) BeforeEach(ctx context.Context) error { /* truncate tables */ return nil }
+func (f *DBFixture) AfterEach(ctx context.Context) error  { return nil }
+```
+
+`BeforeAll` is required. All other methods are optional.
+Fixture hooks use `(ctx context.Context) error` — different from suite hooks.
+
+Suites wire fixtures via pointer fields:
+
+```go
+type UserTestSuite struct {
+    DB *DBFixture
+}
+```
+
+Fixtures compose via pointer fields (DAG — dependencies set up first):
+
+```go
+type APIFixture struct {
+    DB    *DBFixture     // set up before APIFixture
+    Cache *CacheFixture  // set up before APIFixture (parallel with DB)
+}
+```
+
+### FixtureConfig (optional)
+
+```go
+func (f *DBFixture) FixtureConfig() gotest.FixtureConfig {
+    return gotest.ContainerFixtureConfig() // Timeout: 5m, Retries: 1, RetryDelay: 5s
+}
+```
+
+Presets: `DefaultFixtureConfig()` (2m timeout), `ContainerFixtureConfig()` (5m, 1 retry, 5s delay).
+
+### Shared fixtures
+
+Cross-package fixtures that run in a subprocess. Name must end with `SharedFixture`.
+State transfers via JSON serialization — non-serializable fields are reconstructed via `Hydrate`.
+
+```go
+type PostgresSharedFixture struct {
+    ConnStr string         // transfer field — serialized across processes
+    Pool    *pgxpool.Pool  // local field — assigned in Hydrate, excluded from serialization
+}
+
+func (f *PostgresSharedFixture) BeforeAll(ctx context.Context) error {
+    f.ConnStr = startPostgres(ctx)
+    return f.connect(ctx)
+}
+func (f *PostgresSharedFixture) AfterAll(ctx context.Context) error   { return stopPostgres() }
+func (f *PostgresSharedFixture) Hydrate(ctx context.Context) error    { return f.connect(ctx) }
+func (f *PostgresSharedFixture) Dehydrate(ctx context.Context) error  { f.Pool.Close(); return nil }
+
+func (f *PostgresSharedFixture) connect(ctx context.Context) error {
+    var err error
+    f.Pool, err = pgxpool.New(ctx, f.ConnStr)
+    return err
+}
+```
+
+Fields assigned in `Hydrate` are automatically classified as local and excluded from serialization.
+
+Suites reference shared fixtures via pointer fields (same as package fixtures).
+Shared fixtures must not live in `internal/` packages.
 
 ## Parallel Semantics
 

--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ val  := gotest.Must(cache.Get(key))
 ```
 
 All assertions work with `*gotest.T` (suites), `*testing.T` (standalone tests), and `*gotest.R` (polling callbacks).
+Assertion failures automatically trace back to the test call site — no `t.Helper()` calls needed in helper functions.
 
 ### Data-Driven Tests
 
@@ -557,6 +558,7 @@ func (s *Suite) TestRender(t *gotest.T) {
 Snapshots are stored in `testdata/__snapshots__/`.
 On first run, the snapshot is created.
 On subsequent runs, the output is compared.
+Snapshot entries are written in deterministic order and are thread-safe — parallel test methods can use `MatchSnapshot` without coordination.
 Update all snapshots with:
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -658,7 +658,7 @@
           </div>
           <div class="feature-card">
             <h3><span class="check">&#10003;</span> Type-Safe Assertions</h3>
-            <p>Generic assertions that catch type mismatches at compile time. Equality failures include diffs. Works with both suite and standalone tests.</p>
+            <p>Generic assertions that catch type mismatches at compile time. Equality failures include diffs. Failures trace back to the test call site automatically — no <code>t.Helper()</code> needed.</p>
           </div>
           <div class="feature-card">
             <h3><span class="check">&#10003;</span> Snapshot Testing</h3>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -601,7 +601,8 @@ AfterAll <span class="d">(via t.Cleanup — always runs)</span></div>
         <pre>gotest.MatchSnapshot(t, render(input))              <span class="cm">// auto-named from test path</span>
 gotest.MatchSnapshot(t, render(other), <span class="st">"variant"</span>)  <span class="cm">// explicit snapshot name</span></pre>
       </div>
-      <p>On first run, the snapshot is created. On subsequent runs, the output is compared and failures include a diff. Update all snapshots with <code>gotest --update-snapshots ./...</code>.</p>
+      <p>Snapshots are stored in <code>testdata/__snapshots__/</code> next to the test file. On first run, the snapshot is created. On subsequent runs, the output is compared and failures include a diff. Snapshot entries are written in deterministic order and are thread-safe — parallel test methods can use <code>MatchSnapshot</code> without coordination.</p>
+      <p>Update all snapshots with <code>gotest --update-snapshots ./...</code> or <code>GOTEST_UPDATE_SNAPSHOTS=1 go test ./...</code> when running <code>go test</code> directly.</p>
 
       <h3>Async polling</h3>
       <p>Package-level functions for polling conditions. Callbacks receive <code>*gotest.R</code> — an assertion recorder that captures failures without propagating them:</p>
@@ -756,6 +757,9 @@ CacheFixture.AfterAll <span class="d">─┘</span></div>
     <section class="ref-section" id="assertions">
       <h2>Assertions</h2>
       <p class="lead">Type-safe generics with compile-time checking. Zero external dependencies. Works with both <code>*gotest.T</code> and <code>*testing.T</code>.</p>
+      <div class="callout">
+        Assertion failures automatically trace back to the test call site. Helper functions don't need <code>t.Helper()</code> — the framework resolves the outermost caller from the test file.
+      </div>
 
       <h3>Equality &amp; identity</h3>
       <table class="ref-table">

--- a/pkg/gotest/assertions.go
+++ b/pkg/gotest/assertions.go
@@ -24,10 +24,8 @@ func fail(t testingT, msg string, msgAndArgs []any) {
 	if userMsg := assert.FormatMessage(msgAndArgs); userMsg != "" {
 		msg = msg + "\n  message: " + userMsg
 	}
-	if _, ok := t.(interface{ Helper() }); ok {
-		if frame := assert.CallerFrame(); frame != "" {
-			msg = frame + ": " + msg
-		}
+	if frame := assert.CallerFrame(); frame != "" {
+		msg = frame + ": " + msg
 	}
 	t.Errorf("%s", msg)
 	t.FailNow()

--- a/pkg/gotest/internal/assert/helper.go
+++ b/pkg/gotest/internal/assert/helper.go
@@ -1,6 +1,8 @@
 package assert
 
 import (
+	"fmt"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"sync"
@@ -18,11 +20,15 @@ var (
 // frame PCs in tt's helperPCs map. This causes Go's testing.T.decorate to
 // skip those frames when choosing the file:line prefix for error output.
 //
+// Returns the "file:line" of the first non-gotest user frame — the frame
+// Go's decoration will show. Returns "" on any failure or if no user frame
+// is found.
+//
 // Uses reflect + unsafe to access unexported fields. Runtime type guards
 // ensure a silent no-op if Go's testing internals change.
-func SkipInternalFrames(tt *testing.T) {
+func SkipInternalFrames(tt *testing.T) string {
 	if tt == nil {
-		return
+		return ""
 	}
 
 	v := reflect.ValueOf(tt).Elem()
@@ -32,24 +38,27 @@ func SkipInternalFrames(tt *testing.T) {
 	hnField := v.FieldByName("helperNames")
 
 	if !muField.IsValid() || !muField.CanAddr() || muField.Type() != rwMutexType {
-		return
+		return ""
 	}
 	if !hpField.IsValid() || !hpField.CanAddr() || hpField.Type() != helperPCsType {
-		return
+		return ""
 	}
 
 	pcs := make([]uintptr, 32)
 	n := runtime.Callers(2, pcs) // skip runtime.Callers + SkipInternalFrames
 	if n == 0 {
-		return
+		return ""
 	}
 
 	var toMark []uintptr
+	var firstUserFrame string
 	frames := runtime.CallersFrames(pcs[:n])
 	for {
 		frame, more := frames.Next()
 		if IsGotestSource(frame.File) || IsGeneratedBridge(frame.File) {
 			toMark = append(toMark, frame.PC)
+		} else if firstUserFrame == "" {
+			firstUserFrame = fmt.Sprintf("%s:%d", filepath.Base(frame.File), frame.Line)
 		}
 		if !more {
 			break
@@ -57,7 +66,7 @@ func SkipInternalFrames(tt *testing.T) {
 	}
 
 	if len(toMark) == 0 {
-		return
+		return firstUserFrame
 	}
 
 	mu := (*sync.RWMutex)(unsafe.Pointer(muField.UnsafeAddr()))
@@ -76,4 +85,6 @@ func SkipInternalFrames(tt *testing.T) {
 		hn := (*map[string]struct{})(unsafe.Pointer(hnField.UnsafeAddr()))
 		*hn = nil
 	}
+
+	return firstUserFrame
 }

--- a/pkg/gotest/internal/assert/trace.go
+++ b/pkg/gotest/internal/assert/trace.go
@@ -9,20 +9,6 @@ import (
 
 const gotestDirMarker = "/pkg/gotest/"
 
-// CallerTrace walks the call stack and returns a "called from: file:line"
-// annotation pointing to the user's call site.
-//
-// It skips gotest-internal frames (assertion mechanics), collects user
-// frames, and stops at the first boundary sentinel (execTestFn from
-// T.It/T.When, or ƒƒ_GOTEST_exec from the generated bridge).
-func CallerTrace() string {
-	f := callerFrame(2)
-	if f == nil {
-		return ""
-	}
-	return fmt.Sprintf("\n  called from: %s:%d", filepath.Base(f.File), f.Line)
-}
-
 // CallerFrame returns the user's call site as "file:line",
 // or "" if no user frame is found.
 func CallerFrame() string {

--- a/pkg/gotest/internal/assert/trace_test.go
+++ b/pkg/gotest/internal/assert/trace_test.go
@@ -12,55 +12,6 @@ import (
 	"github.com/mvrahden/go-test/pkg/gotest/internal/assert"
 )
 
-func TestCallerTrace_DirectCall_ReturnsTrace(t *testing.T) {
-	trace := assert.CallerTrace()
-	if trace == "" {
-		t.Fatalf("expected non-empty trace for direct call, got empty")
-	}
-	if !strings.Contains(trace, "called from:") {
-		t.Fatalf("expected 'called from:' in trace, got: %q", trace)
-	}
-}
-
-func helperThatCallsCallerTrace() string {
-	return assert.CallerTrace()
-}
-
-func TestCallerTrace_SingleHelper_ReturnsTrace(t *testing.T) {
-	trace := helperThatCallsCallerTrace()
-	if trace == "" {
-		t.Fatalf("expected non-empty trace for helper call, got empty")
-	}
-	if !strings.Contains(trace, "called from:") {
-		t.Fatalf("expected 'called from:' in trace, got: %q", trace)
-	}
-	if !strings.Contains(trace, "trace_test.go:") {
-		t.Fatalf("expected 'trace_test.go:' in trace, got: %q", trace)
-	}
-}
-
-func simulateFailClosure() string {
-	return assert.CallerTrace()
-}
-
-func simulateIsTrue() string {
-	return simulateFailClosure()
-}
-
-func userHelper() string {
-	return simulateIsTrue()
-}
-
-func TestCallerTrace_DeepHelperChain_ReturnsTrace(t *testing.T) {
-	trace := userHelper()
-	if trace == "" {
-		t.Fatalf("expected non-empty trace for deep helper chain")
-	}
-	if !strings.Contains(trace, "called from:") {
-		t.Fatalf("expected 'called from:' in trace, got: %q", trace)
-	}
-}
-
 func TestCallerFrame_DirectCall_ReturnsFrame(t *testing.T) {
 	frame := assert.CallerFrame()
 	if frame == "" {

--- a/pkg/gotest/linereport_helpers_test.go
+++ b/pkg/gotest/linereport_helpers_test.go
@@ -1,0 +1,32 @@
+package gotest_test
+
+import (
+	"time"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// Helper functions in a SEPARATE file from the test suite.
+// CallerFrame resolves file:line from the call stack. Having helpers here
+// means CallerFrame output says "linereport_helpers_test.go" when it
+// resolves to this file, vs "linereport_suite_test.go" for the test file.
+// Tests assert on the filename to verify which frame was chosen.
+
+type testingTLike interface {
+	Errorf(format string, args ...any)
+	FailNow()
+}
+
+func equalHelper[V comparable](t testingTLike, expected, actual V) {
+	gotest.Equal(t, expected, actual)
+}
+
+func nestedHelper[V comparable](t testingTLike, expected, actual V) {
+	equalHelper(t, expected, actual)
+}
+
+func eventuallyHelper(t testingTLike) {
+	gotest.Eventually(t, 50*time.Millisecond, 10*time.Millisecond, func(poll *gotest.R) {
+		gotest.True(poll, false, "condition not met")
+	})
+}

--- a/pkg/gotest/linereport_suite_test.go
+++ b/pkg/gotest/linereport_suite_test.go
@@ -1,0 +1,186 @@
+package gotest_test
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// --- spy infrastructure (in THIS file so the goroutine frame is in the suite file) ---
+
+type spyT struct {
+	msg    string
+	failed bool
+}
+
+func (s *spyT) Errorf(format string, args ...any) {
+	s.msg = fmt.Sprintf(format, args...)
+	s.failed = true
+}
+
+func (s *spyT) FailNow() {
+	s.failed = true
+	runtime.Goexit()
+}
+
+func runSpy(fn func(t *spyT)) *spyT {
+	spy := &spyT{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn(spy)
+	}()
+	<-done
+	return spy
+}
+
+// --- suite ---
+
+// LineReportingTestSuite verifies that assertion failures report the correct
+// call site — the outermost user frame, not gotest internals or intermediate
+// helpers.
+//
+// Helpers live in linereport_helpers_test.go so that CallerFrame output
+// distinguishes "resolved to test file" (this file) from "resolved to helper
+// file" by filename.
+type LineReportingTestSuite struct{}
+
+func (s *LineReportingTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{Parallel: true}
+}
+
+// --- Direct assertions (no helper chain) ---
+
+func (s *LineReportingTestSuite) TestDirectAssertion(t *gotest.T) {
+	t.When("called via *R (Record)", func(w *gotest.T) {
+		w.It("reports this file as the call site", func(it *gotest.T) {
+			rec := gotest.Record(func(r *gotest.R) {
+				gotest.Equal(r, 1, 2)
+			})
+			gotest.True(it, rec.Failed())
+			gotest.MatchSnapshot(it, rec.Message())
+		})
+	})
+
+	t.When("called via spyT (no Helper method)", func(w *gotest.T) {
+		w.It("reports this file as the call site", func(it *gotest.T) {
+			spy := runSpy(func(t *spyT) {
+				gotest.Equal(t, 1, 2)
+			})
+			gotest.True(it, spy.failed)
+			gotest.MatchSnapshot(it, spy.msg)
+		})
+	})
+}
+
+// --- Single helper ---
+
+func (s *LineReportingTestSuite) TestSingleHelper(t *gotest.T) {
+	t.When("called via *R through a helper in another file", func(w *gotest.T) {
+		w.It("reports this file not the helper file", func(it *gotest.T) {
+			rec := gotest.Record(func(r *gotest.R) {
+				equalHelper(r, 1, 2)
+			})
+			gotest.True(it, rec.Failed())
+			gotest.MatchSnapshot(it, rec.Message())
+		})
+	})
+
+	t.When("called via spyT through a helper in another file", func(w *gotest.T) {
+		w.It("reports this file not the helper file", func(it *gotest.T) {
+			spy := runSpy(func(t *spyT) {
+				equalHelper(t, 1, 2)
+			})
+			gotest.True(it, spy.failed)
+			gotest.MatchSnapshot(it, spy.msg)
+		})
+	})
+}
+
+// --- Nested helpers ---
+
+func (s *LineReportingTestSuite) TestNestedHelpers(t *gotest.T) {
+	t.When("called via *R through two levels of helpers", func(w *gotest.T) {
+		w.It("reports this file as the outermost call site", func(it *gotest.T) {
+			rec := gotest.Record(func(r *gotest.R) {
+				nestedHelper(r, 1, 2)
+			})
+			gotest.True(it, rec.Failed())
+			gotest.MatchSnapshot(it, rec.Message())
+		})
+	})
+
+	t.When("called via spyT through two levels of helpers", func(w *gotest.T) {
+		w.It("reports this file as the outermost call site", func(it *gotest.T) {
+			spy := runSpy(func(t *spyT) {
+				nestedHelper(t, 1, 2)
+			})
+			gotest.True(it, spy.failed)
+			gotest.MatchSnapshot(it, spy.msg)
+		})
+	})
+}
+
+// --- Eventually ---
+
+func (s *LineReportingTestSuite) TestEventually(t *gotest.T) {
+	t.When("inner assertion fails (via *R)", func(w *gotest.T) {
+		w.It("timeout includes inner assertion call site", func(it *gotest.T) {
+			spy := runSpy(func(t *spyT) {
+				gotest.Eventually(t, 50*time.Millisecond, 10*time.Millisecond, func(poll *gotest.R) {
+					gotest.True(poll, false, "condition not met")
+				})
+			})
+			gotest.True(it, spy.failed)
+			gotest.MatchSnapshot(it, spy.msg)
+		})
+	})
+
+	t.When("called directly from test (no helper)", func(w *gotest.T) {
+		w.It("timeout references this file", func(it *gotest.T) {
+			spy := runSpy(func(t *spyT) {
+				gotest.Eventually(t, 50*time.Millisecond, 10*time.Millisecond, func(poll *gotest.R) {
+					gotest.True(poll, false)
+				})
+			})
+			gotest.True(it, spy.failed)
+			gotest.MatchSnapshot(it, spy.msg)
+		})
+	})
+}
+
+// --- Helper calling Eventually (the WaitForStatus pattern) ---
+
+func (s *LineReportingTestSuite) TestHelperCallingEventually(t *gotest.T) {
+	t.When("Eventually times out inside a helper", func(w *gotest.T) {
+		w.It("traces back to this file not the helper", func(it *gotest.T) {
+			spy := runSpy(func(t *spyT) {
+				eventuallyHelper(t)
+			})
+			gotest.True(it, spy.failed)
+			gotest.MatchSnapshot(it, spy.msg)
+		})
+	})
+}
+
+// --- Consistently ---
+
+func (s *LineReportingTestSuite) TestConsistently(t *gotest.T) {
+	t.When("assertion fails during polling", func(w *gotest.T) {
+		w.It("failure references this file", func(it *gotest.T) {
+			spy := runSpy(func(t *spyT) {
+				count := 0
+				gotest.Consistently(t, 50*time.Millisecond, 10*time.Millisecond, func(poll *gotest.R) {
+					count++
+					if count > 2 {
+						gotest.True(poll, false, "broke on poll %d", count)
+					}
+				})
+			})
+			gotest.True(it, spy.failed)
+			gotest.MatchSnapshot(it, spy.msg)
+		})
+	})
+}

--- a/pkg/gotest/r.go
+++ b/pkg/gotest/r.go
@@ -26,8 +26,6 @@ func (r *R) FailNow() {
 	runtime.Goexit()
 }
 
-func (r *R) Helper() {}
-
 func (r *R) Failed() bool    { return r.failed }
 func (r *R) Message() string { return r.message }
 

--- a/pkg/gotest/t.go
+++ b/pkg/gotest/t.go
@@ -2,6 +2,8 @@ package gotest
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,8 +39,11 @@ func NewTWithDeadline(t *testing.T, timeout time.Duration) *T {
 }
 
 func (t *T) Errorf(format string, args ...any) {
-	assert.SkipInternalFrames(t.t)
-	t.t.Errorf(format, args...)
+	msg := fmt.Sprintf(format, args...)
+	if goFrame := assert.SkipInternalFrames(t.t); goFrame != "" {
+		msg = strings.TrimPrefix(msg, goFrame+": ")
+	}
+	t.t.Errorf("%s", msg)
 }
 
 func (t *T) FailNow() {

--- a/pkg/gotest/testdata/__snapshots__/TestLineReportingTestSuite_ext.snap
+++ b/pkg/gotest/testdata/__snapshots__/TestLineReportingTestSuite_ext.snap
@@ -1,0 +1,50 @@
+=== SNAP TestConsistently/assertion_fails_during_polling/failure_references_this_file ===
+linereport_suite_test.go:33: Consistently failed on poll 3:
+    linereport_suite_test.go:178: True failed:
+  expected: true
+  actual:   false
+  message: broke on poll 3
+=== SNAP TestDirectAssertion/called_via_*R_(Record)/reports_this_file_as_the_call_site ===
+linereport_suite_test.go:60: Equal failed:
+  expected: 1
+  actual:   2
+=== SNAP TestDirectAssertion/called_via_spyT_(no_Helper_method)/reports_this_file_as_the_call_site ===
+linereport_suite_test.go:33: Equal failed:
+  expected: 1
+  actual:   2
+=== SNAP TestEventually/called_directly_from_test_(no_helper)/timeout_references_this_file ===
+linereport_suite_test.go:33: Eventually failed after 50ms (5 polls):
+  last failure:
+    linereport_suite_test.go:145: True failed:
+  expected: true
+  actual:   false
+=== SNAP TestEventually/inner_assertion_fails_(via_*R)/timeout_includes_inner_assertion_call_site ===
+linereport_suite_test.go:33: Eventually failed after 50ms (5 polls):
+  last failure:
+    linereport_suite_test.go:133: True failed:
+  expected: true
+  actual:   false
+  message: condition not met
+=== SNAP TestHelperCallingEventually/Eventually_times_out_inside_a_helper/traces_back_to_this_file_not_the_helper ===
+linereport_suite_test.go:33: Eventually failed after 50ms (5 polls):
+  last failure:
+    linereport_helpers_test.go:30: True failed:
+  expected: true
+  actual:   false
+  message: condition not met
+=== SNAP TestNestedHelpers/called_via_*R_through_two_levels_of_helpers/reports_this_file_as_the_outermost_call_site ===
+linereport_suite_test.go:108: Equal failed:
+  expected: 1
+  actual:   2
+=== SNAP TestNestedHelpers/called_via_spyT_through_two_levels_of_helpers/reports_this_file_as_the_outermost_call_site ===
+linereport_suite_test.go:33: Equal failed:
+  expected: 1
+  actual:   2
+=== SNAP TestSingleHelper/called_via_*R_through_a_helper_in_another_file/reports_this_file_not_the_helper_file ===
+linereport_suite_test.go:84: Equal failed:
+  expected: 1
+  actual:   2
+=== SNAP TestSingleHelper/called_via_spyT_through_a_helper_in_another_file/reports_this_file_not_the_helper_file ===
+linereport_suite_test.go:33: Equal failed:
+  expected: 1
+  actual:   2

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -63,6 +63,8 @@ func (s *E2ETestSuite) TestT(t *gotest.T) {
 		"pkg/gotest/snapshot_internal_test.go",
 		"pkg/gotest/snapshot_suite_test.go",
 		"pkg/gotest/t_suite_test.go",
+		"pkg/gotest/linereport_helpers_test.go",
+		"pkg/gotest/linereport_suite_test.go",
 		"pkg/gotest/gotest_",
 	)
 	testutils.CopyModuleUnderTestToTmp(t.T(), tmp, "../..", excludedPaths...)

--- a/tests/e2e/testdata/t.golden
+++ b/tests/e2e/testdata/t.golden
@@ -48,7 +48,7 @@
           actual:   false
 === RUN   TestSimpleTestSuite/TestHelperTrace
 === RUN   TestSimpleTestSuite/TestHelperTrace/shows_called_from_trace
-    t_test.go:88: True failed:
+    t_test.go:88: t_test.go:93: True failed:
           expected: true
           actual:   false
 --- FAIL: TestSimpleTestSuite (<TIMESTAMP>)


### PR DESCRIPTION
Assertion failures through helper functions now trace back to the test file automatically.

>No `t.Helper()` calls needed.

Previously, failures inside test helpers only showed the helper's file and line, not which test triggered it.
Updated AGENTS.md with fixture conventions, snapshot testing, and corrected guidance.
Added snapshot thread-safety notes to README and reference page.