### PR TITLE
Kill child process trees on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/mvrahden/go-test
 go 1.24.0
 
 require (
-	github.com/dlclark/regexp2 v1.10.0
-	github.com/fsnotify/fsnotify v1.9.0
+	github.com/dlclark/regexp2 v1.12.0
+	github.com/fsnotify/fsnotify v1.10.1
 	golang.org/x/sys v0.41.0
 	golang.org/x/tools v0.42.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
-github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
+github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=

--- a/internal/gotestrunner/jobobject_other.go
+++ b/internal/gotestrunner/jobobject_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package gotestrunner
+
+type jobObject struct{}
+
+func newJobObject() (*jobObject, error) { return nil, nil }
+func (j *jobObject) assign(pid int) error { return nil }
+func (j *jobObject) terminate(exitCode uint32) error { return nil }
+func (j *jobObject) close() {}

--- a/internal/gotestrunner/jobobject_windows.go
+++ b/internal/gotestrunner/jobobject_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package gotestrunner
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type jobObject struct {
+	handle windows.Handle
+}
+
+func newJobObject() (*jobObject, error) {
+	handle, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	_, err = windows.SetInformationJobObject(
+		handle,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	)
+	if err != nil {
+		windows.CloseHandle(handle)
+		return nil, err
+	}
+
+	return &jobObject{handle: handle}, nil
+}
+
+func (j *jobObject) assign(pid int) error {
+	proc, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(pid))
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(proc)
+	return windows.AssignProcessToJobObject(j.handle, proc)
+}
+
+func (j *jobObject) terminate(exitCode uint32) error {
+	return windows.TerminateJobObject(j.handle, exitCode)
+}
+
+func (j *jobObject) close() {
+	windows.CloseHandle(j.handle)
+}

--- a/internal/gotestrunner/managed_process.go
+++ b/internal/gotestrunner/managed_process.go
@@ -25,19 +25,20 @@ type ManagedProcess struct {
 	cmd    *exec.Cmd
 	config ProcessConfig
 	done   chan struct{}
+	job    *jobObject
 }
 
 func NewManagedProcess(cmd *exec.Cmd, cfg ProcessConfig) *ManagedProcess {
 	setProcessGroupAttr(cmd)
 	cmd.WaitDelay = 0
+	job, _ := newJobObject()
+	mp := &ManagedProcess{cmd: cmd, config: cfg, done: make(chan struct{}), job: job}
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return nil
 		}
 		if cfg.Grace == GraceKill {
-			if err := ForceKillProcessGroup(cmd.Process.Pid); err != nil {
-				return os.ErrProcessDone
-			}
+			mp.forceKill()
 			return nil
 		}
 		if err := TerminateProcessGroup(cmd.Process.Pid); err != nil {
@@ -45,19 +46,33 @@ func NewManagedProcess(cmd *exec.Cmd, cfg ProcessConfig) *ManagedProcess {
 		}
 		return nil
 	}
-	return &ManagedProcess{cmd: cmd, config: cfg, done: make(chan struct{})}
+	return mp
 }
 
 func (p *ManagedProcess) Start() error {
 	if err := p.cmd.Start(); err != nil {
 		return err
 	}
-	go func() { p.cmd.Wait(); close(p.done) }()
+	p.assignJob()
+	go func() { p.cmd.Wait(); p.closeJob(); close(p.done) }()
 	return nil
 }
 
 func (p *ManagedProcess) Adopt() {
-	go func() { p.cmd.Wait(); close(p.done) }()
+	p.assignJob()
+	go func() { p.cmd.Wait(); p.closeJob(); close(p.done) }()
+}
+
+func (p *ManagedProcess) assignJob() {
+	if p.job != nil && p.cmd.Process != nil {
+		p.job.assign(p.cmd.Process.Pid)
+	}
+}
+
+func (p *ManagedProcess) closeJob() {
+	if p.job != nil {
+		p.job.close()
+	}
 }
 
 func (p *ManagedProcess) Done() <-chan struct{}       { return p.done }
@@ -82,9 +97,7 @@ func (p *ManagedProcess) WaitWithGrace(ctx context.Context) error {
 	select {
 	case <-p.done:
 	case <-time.After(grace):
-		if p.cmd.Process != nil {
-			ForceKillProcessGroup(p.cmd.Process.Pid)
-		}
+		p.forceKill()
 		<-p.done
 	}
 	if p.cmd.ProcessState != nil && !p.cmd.ProcessState.Success() {
@@ -102,10 +115,18 @@ func (p *ManagedProcess) Terminate() {
 	select {
 	case <-p.done:
 	case <-time.After(grace):
-		if p.cmd.Process != nil {
-			ForceKillProcessGroup(p.cmd.Process.Pid)
-		}
+		p.forceKill()
 		<-p.done
+	}
+}
+
+func (p *ManagedProcess) forceKill() {
+	if p.job != nil {
+		p.job.terminate(1)
+		return
+	}
+	if p.cmd.Process != nil {
+		ForceKillProcessGroup(p.cmd.Process.Pid)
 	}
 }
 


### PR DESCRIPTION
When a test subprocess is force-killed on Windows, its child processes now die too. Previously only the direct process was terminated, leaving orphans. Uses Windows Job Objects to track and clean up the full process tree, matching the existing Unix behavior.