### PR TITLE
Support parallel concurrency budget in project config

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,33 @@ Preset constructors for common scenarios:
 | `DefaultSuiteConfig()` | 30 sec | 30 sec | 0 | — | Unit/integration tests |
 | `IntegrationSuiteConfig()` | 2 min | 5 min | 0 | — | Heavier integration tests |
 
+### Project Configuration
+
+Project-level defaults live in `.gotest.yml` at the repository root (or nearest parent with a `go.mod`).
+CLI flags always take precedence over config values; zero/omitted fields are ignored.
+
+```yaml
+# .gotest.yml
+tags: "integration,e2e"
+setup-timeout: 5m
+min-coverage: 80
+parallel: 12
+debounce: 500ms
+lint:
+  skip:
+    - stdlib-test
+    - testify
+```
+
+| Field | Type | CLI flag | Description |
+|-------|------|----------|-------------|
+| `tags` | string | `-tags` | Comma-separated build tags |
+| `setup-timeout` | duration | `--setup-timeout` | Total budget for shared fixture setup |
+| `min-coverage` | int | `--min` | Minimum coverage percentage (0–100) |
+| `parallel` | int | `--parallel` | Total concurrent test method budget |
+| `debounce` | duration | `--debounce` | Watch mode re-run delay |
+| `lint.skip` | list | — | Lint rules to disable project-wide |
+
 ## Test Selection
 
 ### Focus and Exclude

--- a/cmd/gotest/cli.go
+++ b/cmd/gotest/cli.go
@@ -106,6 +106,9 @@ func runTest(inv Invocation) int {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2
 	}
+	if parallel == 0 {
+		parallel = inv.Config.Parallel
+	}
 
 	var coverProfile string
 	if minCoverage > 0 {

--- a/cmd/gotest/export_test.go
+++ b/cmd/gotest/export_test.go
@@ -4,6 +4,7 @@ type ExportDiscoverOutput = discoverOutput
 type ExportDiscoverPackage = discoverPackage
 
 var ExportParseMinFlag = parseMinFlag
+var ExportParseParallelFlag = parseParallelFlag
 var ExportBuildDiscoverSuite = buildDiscoverSuite
 var ExportExtractStringFlag = extractStringFlag
 var ExportHasFlag = hasFlag

--- a/cmd/gotest/flags.go
+++ b/cmd/gotest/flags.go
@@ -31,7 +31,7 @@ var testAllowed = flagSet(
 
 var specAllowed = flagSet(
 	"--debug", "--ci", "--update-snapshots",
-	"--min", "--setup-timeout",
+	"--min", "--setup-timeout", "--parallel",
 	"--format", "--output", "--input", "--no-color",
 )
 

--- a/cmd/gotest/gotest_suite_test.go
+++ b/cmd/gotest/gotest_suite_test.go
@@ -272,6 +272,31 @@ func (s *CmdGotestTestSuite) TestParseMinFlag(t *gotest.T) {
 	}
 }
 
+func (s *CmdGotestTestSuite) TestParseParallelFlag(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []struct {
+		Desc      string
+		args      []string
+		expect    int
+		expectErr bool
+	}{
+		{Desc: "no flag", args: []string{"--debug"}, expect: 0},
+		{Desc: "equals syntax", args: []string{"--parallel=8"}, expect: 8},
+		{Desc: "space syntax", args: []string{"--parallel", "12"}, expect: 12},
+		{Desc: "empty args", args: nil, expect: 0},
+		{Desc: "invalid value", args: []string{"--parallel=abc"}, expectErr: true},
+		{Desc: "zero value", args: []string{"--parallel=0"}, expectErr: true},
+		{Desc: "negative value", args: []string{"--parallel=-4"}, expectErr: true},
+	}) {
+		got, err := ExportParseParallelFlag(tc.args)
+		if tc.expectErr {
+			gotest.True(sub, err != nil, "expected error")
+		} else {
+			gotest.NoError(sub, err)
+			gotest.Equal(sub, tc.expect, got)
+		}
+	}
+}
+
 func (s *CmdGotestTestSuite) TestRunDiscover_SimpleSuite(t *gotest.T) {
 	t.It("discovers suites in examples/cart", func(it *gotest.T) {
 		absExamples, err := filepath.Abs(filepath.Join("..", "..", "examples"))

--- a/cmd/gotest/spec.go
+++ b/cmd/gotest/spec.go
@@ -42,6 +42,15 @@ func runSpec(inv Invocation) int {
 		return 2
 	}
 
+	parallel, err := parseParallelFlag(ownArgs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+	if parallel == 0 {
+		parallel = inv.Config.Parallel
+	}
+
 	var coverProfile string
 	if minCoverage > 0 {
 		for _, arg := range goTestArgs {
@@ -60,6 +69,7 @@ func runSpec(inv Invocation) int {
 		Debug:           slices.Contains(ownArgs, "--debug"),
 		CI:              slices.Contains(ownArgs, "--ci"),
 		UpdateSnapshots: slices.Contains(ownArgs, "--update-snapshots"),
+		Parallel:        parallel,
 	}
 
 	classified := gotestrunner.ClassifyGoTestArgs(goTestArgs)

--- a/cmd/gotest/watch.go
+++ b/cmd/gotest/watch.go
@@ -64,6 +64,9 @@ func runWatch(inv Invocation) int {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2
 	}
+	if parallel == 0 {
+		parallel = inv.Config.Parallel
+	}
 	patterns := ExtractPackagePatterns(goTestArgs)
 
 	cfg := ExecConfig{

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -858,15 +858,16 @@ CacheFixture.AfterAll <span class="d">─┘</span></div>
       <p>The two scopes are independent — they don't override each other. For shared fixture timeouts specifically, <code>--setup-timeout</code> is an outer wall-clock budget on the entire setup phase, while <code>SharedFixtureConfig().Timeout</code> is an inner per-fixture deadline. Both run concurrently — whichever fires first wins. When <code>--setup-timeout</code> is omitted, only the per-fixture timeouts apply.</p>
 
       <h3>Project file — <code>.gotest.yml</code></h3>
-      <p>Place a <code>.gotest.yml</code> in your project root. gotest finds it by walking up from the working directory, stopping at the first match or at a <code>go.mod</code> boundary.</p>
+      <p>Place a <code>.gotest.yml</code> in your project root. gotest finds it by walking up from the working directory, stopping at the first match or at a <code>go.mod</code> boundary. CLI flags always take precedence; zero or omitted fields use defaults.</p>
       <table class="ref-table">
-        <thead><tr><th>Field</th><th>Type</th><th>Default</th><th>Effect</th></tr></thead>
+        <thead><tr><th>Field</th><th>Type</th><th>Default</th><th>CLI override</th><th>Effect</th></tr></thead>
         <tbody>
-          <tr><td><code>tags</code></td><td>string</td><td><em>none</em></td><td>Build tags, comma-separated (e.g. <code>"integration,e2e"</code>).</td></tr>
-          <tr><td><code>setup-timeout</code></td><td>duration</td><td><em>none</em></td><td>Total budget for all shared fixture setup. Omit to let each fixture's own config govern. Use a negative value (e.g. <code>-1s</code>) to disable (<code>--setup-timeout</code>).</td></tr>
-          <tr><td><code>min-coverage</code></td><td>int</td><td>0 (off)</td><td>Minimum coverage percentage, 0–100 (<code>--min</code>).</td></tr>
-          <tr><td><code>debounce</code></td><td>duration</td><td>200ms</td><td>Watch mode re-run delay (<code>--debounce</code>).</td></tr>
-          <tr><td><code>lint.skip</code></td><td>[string]</td><td><em>none</em></td><td>Lint rules to disable: <code>stdlib-test</code>, <code>testify</code>.</td></tr>
+          <tr><td><code>tags</code></td><td>string</td><td><em>none</em></td><td><code>-tags</code></td><td>Build tags, comma-separated (e.g. <code>"integration,e2e"</code>).</td></tr>
+          <tr><td><code>setup-timeout</code></td><td>duration</td><td><em>none</em></td><td><code>--setup-timeout</code></td><td>Total budget for all shared fixture setup. Omit to let each fixture's own config govern. Negative disables.</td></tr>
+          <tr><td><code>min-coverage</code></td><td>int</td><td>0 (off)</td><td><code>--min</code></td><td>Minimum coverage percentage, 0–100.</td></tr>
+          <tr><td><code>parallel</code></td><td>int</td><td>0 (auto)</td><td><code>--parallel</code></td><td>Total concurrent test method budget. 0 means 2×GOMAXPROCS.</td></tr>
+          <tr><td><code>debounce</code></td><td>duration</td><td>200ms</td><td><code>--debounce</code></td><td>Watch mode re-run delay.</td></tr>
+          <tr><td><code>lint.skip</code></td><td>[string]</td><td><em>none</em></td><td>—</td><td>Lint rules to disable: <code>stdlib-test</code>, <code>testify</code>.</td></tr>
         </tbody>
       </table>
       <div class="code-block">
@@ -874,6 +875,7 @@ CacheFixture.AfterAll <span class="d">─┘</span></div>
         <pre>tags: integration
 setup-timeout: 2m
 min-coverage: 80
+parallel: 12
 debounce: 500ms
 lint:
   skip:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,9 @@ type ProjectConfig struct {
 	SetupTimeout Duration `yaml:"setup-timeout"`
 	// MinCoverage is the minimum coverage percentage (0-100). The run fails if coverage is below.
 	MinCoverage int `yaml:"min-coverage"`
+	// Parallel is the total concurrency budget (concurrent test methods across all
+	// suite processes). Zero means use the default (2×GOMAXPROCS).
+	Parallel int `yaml:"parallel"`
 	// Debounce is the delay before re-running tests in watch mode. Overrides the CLI default (200ms).
 	Debounce Duration `yaml:"debounce"`
 	// Lint holds lint-specific configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,6 +14,7 @@ func TestLoad_FullConfig(t *testing.T) {
 tags: "integration,e2e"
 setup-timeout: 2m
 min-coverage: 80
+parallel: 12
 debounce: 500ms
 lint:
   skip:
@@ -29,6 +30,7 @@ lint:
 	assertEqual(t, "tags", cfg.Tags, "integration,e2e")
 	assertEqual(t, "setup-timeout", cfg.SetupTimeout.Duration(), 2*time.Minute)
 	assertEqual(t, "min-coverage", cfg.MinCoverage, 80)
+	assertEqual(t, "parallel", cfg.Parallel, 12)
 	assertEqual(t, "debounce", cfg.Debounce.Duration(), 500*time.Millisecond)
 	assertSliceEqual(t, "lint.skip", cfg.Lint.Skip, []string{"stdlib-test", "testify"})
 }
@@ -45,6 +47,7 @@ func TestLoad_NoFile_ReturnsZero(t *testing.T) {
 	assertEqual(t, "tags", cfg.Tags, "")
 	assertEqual(t, "setup-timeout", cfg.SetupTimeout.Duration(), time.Duration(0))
 	assertEqual(t, "min-coverage", cfg.MinCoverage, 0)
+	assertEqual(t, "parallel", cfg.Parallel, 0)
 	assertEqual(t, "debounce", cfg.Debounce.Duration(), time.Duration(0))
 	if len(cfg.Lint.Skip) != 0 {
 		t.Errorf("lint.skip: got %v, want empty", cfg.Lint.Skip)


### PR DESCRIPTION
Adds a parallel field to .gotest.yml that sets the total concurrent test method budget. CLI `--parallel` overrides it. Zero or omitted means use the default. Also adds `--parallel` support to gotest spec which was previously missing it.