### PR TITLE
Auto-exclude generated test files from git

### DIFF
--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -26,6 +26,7 @@ import {
 } from "./runnerUtils.js";
 import { copyCoverageSummary, copyTestResults } from "./reporting.js";
 import { execFile } from "node:child_process";
+import { ensureGitExclude } from "./gitExclude.js";
 
 let flushOnDeactivate: (() => Promise<void>) | undefined;
 
@@ -604,6 +605,7 @@ async function initializeAsync(deps: {
         }
       },
     );
+    ensureGitExclude(folder.uri.fsPath, outputChannel);
   }
 
   await runRegistry.load();

--- a/vscode-gotest/src/gitExclude.test.ts
+++ b/vscode-gotest/src/gitExclude.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { ensureGitExclude } from "./gitExclude.js";
+
+function makeFakeOutputChannel() {
+  return {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  } as any;
+}
+
+describe("ensureGitExclude", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "git-exclude-test-"));
+  });
+
+  it("appends patterns to an existing exclude file", () => {
+    const infoDir = path.join(tmpDir, ".git", "info");
+    fs.mkdirSync(infoDir, { recursive: true });
+    fs.writeFileSync(path.join(infoDir, "exclude"), "# existing\n*.swp\n");
+
+    ensureGitExclude(tmpDir, makeFakeOutputChannel());
+
+    const content = fs.readFileSync(path.join(infoDir, "exclude"), "utf-8");
+    expect(content).toContain("gotest_psuite_test.go");
+    expect(content).toContain("gotest_pxsuite_test.go");
+    expect(content).toContain("# gotest generated files");
+    expect(content).toContain("*.swp");
+  });
+
+  it("is idempotent — does not duplicate on second call", () => {
+    const infoDir = path.join(tmpDir, ".git", "info");
+    fs.mkdirSync(infoDir, { recursive: true });
+    fs.writeFileSync(path.join(infoDir, "exclude"), "");
+
+    const ch = makeFakeOutputChannel();
+    ensureGitExclude(tmpDir, ch);
+    ensureGitExclude(tmpDir, ch);
+
+    const content = fs.readFileSync(path.join(infoDir, "exclude"), "utf-8");
+    const count = content.split("gotest_psuite_test.go").length - 1;
+    expect(count).toBe(1);
+  });
+
+  it("does nothing when .git directory does not exist", () => {
+    ensureGitExclude(tmpDir, makeFakeOutputChannel());
+    expect(fs.existsSync(path.join(tmpDir, ".git", "info", "exclude"))).toBe(
+      false,
+    );
+  });
+
+  it("creates .git/info/exclude when .git exists but file does not", () => {
+    fs.mkdirSync(path.join(tmpDir, ".git"), { recursive: true });
+
+    ensureGitExclude(tmpDir, makeFakeOutputChannel());
+
+    const content = fs.readFileSync(
+      path.join(tmpDir, ".git", "info", "exclude"),
+      "utf-8",
+    );
+    expect(content).toContain("gotest_psuite_test.go");
+    expect(content).toContain("gotest_pxsuite_test.go");
+  });
+
+  it("does nothing when patterns already present", () => {
+    const infoDir = path.join(tmpDir, ".git", "info");
+    fs.mkdirSync(infoDir, { recursive: true });
+    const original = "# manual\ngotest_psuite_test.go\n";
+    fs.writeFileSync(path.join(infoDir, "exclude"), original);
+
+    ensureGitExclude(tmpDir, makeFakeOutputChannel());
+
+    const content = fs.readFileSync(path.join(infoDir, "exclude"), "utf-8");
+    expect(content).toBe(original);
+  });
+});

--- a/vscode-gotest/src/gitExclude.ts
+++ b/vscode-gotest/src/gitExclude.ts
@@ -1,0 +1,52 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type * as vscode from "vscode";
+
+const GENERATED_FILE_PATTERNS = [
+  "gotest_psuite_test.go",
+  "gotest_pxsuite_test.go",
+];
+
+const MARKER = "# gotest generated files";
+
+export function ensureGitExclude(
+  workspaceDir: string,
+  outputChannel: vscode.LogOutputChannel,
+): void {
+  const excludePath = path.join(workspaceDir, ".git", "info", "exclude");
+
+  const gitDir = path.join(workspaceDir, ".git");
+  if (!fs.existsSync(gitDir)) {
+    return;
+  }
+
+  const infoDir = path.dirname(excludePath);
+  let content: string;
+  try {
+    content = fs.readFileSync(excludePath, "utf-8");
+  } catch {
+    try {
+      fs.mkdirSync(infoDir, { recursive: true });
+    } catch {
+      return;
+    }
+    content = "";
+  }
+
+  if (content.includes(GENERATED_FILE_PATTERNS[0])) {
+    return;
+  }
+
+  const block = ["", MARKER, ...GENERATED_FILE_PATTERNS].join("\n") + "\n";
+
+  try {
+    fs.appendFileSync(excludePath, block);
+    outputChannel.debug(
+      "[activate] added generated file patterns to .git/info/exclude",
+    );
+  } catch (err) {
+    outputChannel.debug(
+      `[activate] could not update .git/info/exclude: ${err}`,
+    );
+  }
+}


### PR DESCRIPTION
The VS Code extension now adds `gotest_psuite_test.go` and `gotest_pxsuite_test.go` to `.git/info/exclude` on startup, preventing generated files from showing up in git status.