### PR TITLE
Show skipped tests in output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.snap diff=snapshot
+*.snap text eol=lf diff=snapshot

--- a/cmd/gotest/exec.go
+++ b/cmd/gotest/exec.go
@@ -43,6 +43,7 @@ func Run(cfg ExecConfig) int {
 		GoTestArgs:      cfg.GoTestArgs,
 		SetupTimeout:    cfg.SetupTimeout,
 		UpdateSnapshots: cfg.UpdateSnapshots,
+		CI:              cfg.CI,
 		Parallel:        cfg.Parallel,
 		Streaming:       true,
 		OutputMode:      modeFromJSON(cfg.JSON),

--- a/cmd/gotest/spec.go
+++ b/cmd/gotest/spec.go
@@ -103,6 +103,7 @@ func runSpec(inv Invocation) int {
 		GoTestArgs:      cfg.GoTestArgs,
 		SetupTimeout:    cfg.SetupTimeout,
 		UpdateSnapshots: cfg.UpdateSnapshots,
+		CI:              cfg.CI,
 		Parallel:        cfg.Parallel,
 		Streaming:       false,
 		OutputMode:      gotestrunner.RunCaptureJSON,

--- a/cmd/gotest/watch.go
+++ b/cmd/gotest/watch.go
@@ -203,6 +203,7 @@ func watchRunOnce(ctx context.Context, cfg ExecConfig, jsonMode bool) int {
 		GoTestArgs:      cfg.GoTestArgs,
 		SetupTimeout:    cfg.SetupTimeout,
 		UpdateSnapshots: cfg.UpdateSnapshots,
+		CI:              cfg.CI,
 		Parallel:        cfg.Parallel,
 		Streaming:       false,
 		OutputMode:      mode,

--- a/internal/gotestgen/generator.go
+++ b/internal/gotestgen/generator.go
@@ -18,6 +18,7 @@ type GenerateResult struct {
 	PTest                          []byte              // generated internal test source
 	PXTest                         []byte              // generated external test source
 	SuiteNames                     []string            // suite struct identifiers (e.g. "FooTestSuite")
+	SkippedSuiteNames              []string            // identifiers of suites excluded by focus/X_ rules
 	FixtureDepSuites               []string            // test function names that depend on shared fixtures (e.g. "TestFooSuite")
 	SuiteRequiredSharedFixtureKeys map[string][]string // test func name → required state keys
 }
@@ -222,6 +223,22 @@ func generateFromLoaded(loadResults []*LoadResult) (GenerateResults, []SharedFix
 			}
 		}
 
+		var skippedNames []string
+		for _, s := range ptestSpec.SkippedTestSuites {
+			id := s.Identifier()
+			if !seen[id] {
+				seen[id] = true
+				skippedNames = append(skippedNames, id)
+			}
+		}
+		for _, s := range pxtestSpec.SkippedTestSuites {
+			id := s.Identifier()
+			if !seen[id] {
+				seen[id] = true
+				skippedNames = append(skippedNames, id)
+			}
+		}
+
 		// Merge per-suite required shared fixture keys from both test suffixes.
 		var mergedReqKeys map[string][]string
 		if len(ptestReqKeys) > 0 || len(pxtestReqKeys) > 0 {
@@ -236,6 +253,7 @@ func generateFromLoaded(loadResults []*LoadResult) (GenerateResults, []SharedFix
 			PTest:                          ptestBuf,
 			PXTest:                         pxtestBuf,
 			SuiteNames:                     suiteNames,
+			SkippedSuiteNames:              skippedNames,
 			FixtureDepSuites:               append(ptestFixtureDeps, pxtestFixtureDeps...),
 			SuiteRequiredSharedFixtureKeys: mergedReqKeys,
 		}, nil

--- a/internal/gotestrunner/export_test.go
+++ b/internal/gotestrunner/export_test.go
@@ -1,6 +1,11 @@
 package gotestrunner
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/mvrahden/go-test/internal/protocol"
+)
 
 type ExportOverlayJSON = overlayJSON
 type ExportFixtureStateEntry = fixtureStateEntry
@@ -11,6 +16,14 @@ var ExportSplitTopLevelOr = splitTopLevelOr
 var ExportSuiteRunFilter = suiteRunFilter
 var ExportAssignCoverProfiles = assignCoverProfiles
 var ExportBuildExtraEnv = buildExtraEnv
+var ExportBuildBaseEnv = buildBaseEnv
+
+func ExportAutoDetectCI(cfg PipelineConfig) PipelineConfig {
+	if !cfg.CI && os.Getenv(protocol.EnvCI) == "" && os.Getenv("CI") != "" {
+		cfg.CI = true
+	}
+	return cfg
+}
 
 var SetBuildProcessGroup = setBuildProcessGroup
 

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -196,7 +196,7 @@ func (s *GotestrunnerTestSuite) TestCoverProfile(t *gotest.T) {
 				err := gotestrunner.MergeCoverProfiles([]string{filepath.Join(dir, "missing.out"), p}, out)
 				gotest.NoError(it, err)
 
-				data, _ := os.ReadFile(out)
+				data := gotest.Must(os.ReadFile(out))
 				lines := strings.Split(strings.TrimSpace(string(data)), "\n")
 				gotest.Equal(it, 2, len(lines))
 			})
@@ -1139,7 +1139,7 @@ func normalizeJSON(raw string) string {
 		if output, ok := ev["Output"].(string); ok {
 			ev["Output"] = jsonTimestampRe.ReplaceAllString(output, "«TS»")
 		}
-		normalized, _ := json.Marshal(ev)
+		normalized := gotest.Must(json.Marshal(ev))
 		lines = append(lines, string(normalized))
 	}
 	return strings.Join(lines, "\n") + "\n"

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -1305,6 +1305,69 @@ func (s *GotestrunnerTestSuite) TestBuildExtraEnv(t *gotest.T) {
 	})
 }
 
+func (s *GotestrunnerTestSuite) TestCIAutoDetection(t *gotest.T) {
+	t.When("auto-detecting CI from environment", func(w *gotest.T) {
+		w.It("sets CI when CI=true and GOTEST_CI is unset", func(it *gotest.T) {
+			it.T().Setenv("CI", "true")
+			it.T().Setenv(protocol.EnvCI, "")
+
+			cfg := gotestrunner.ExportAutoDetectCI(gotestrunner.PipelineConfig{})
+			gotest.True(it, cfg.CI)
+		})
+
+		w.It("does not override explicit --ci flag", func(it *gotest.T) {
+			it.T().Setenv("CI", "")
+
+			cfg := gotestrunner.ExportAutoDetectCI(gotestrunner.PipelineConfig{CI: true})
+			gotest.True(it, cfg.CI)
+		})
+
+		w.It("respects GOTEST_CI=0 opt-out", func(it *gotest.T) {
+			it.T().Setenv("CI", "true")
+			it.T().Setenv(protocol.EnvCI, "0")
+
+			cfg := gotestrunner.ExportAutoDetectCI(gotestrunner.PipelineConfig{})
+			gotest.False(it, cfg.CI)
+		})
+
+		w.It("stays off when neither CI nor GOTEST_CI is set", func(it *gotest.T) {
+			it.T().Setenv("CI", "")
+			it.T().Setenv(protocol.EnvCI, "")
+
+			cfg := gotestrunner.ExportAutoDetectCI(gotestrunner.PipelineConfig{})
+			gotest.False(it, cfg.CI)
+		})
+	})
+
+	t.When("propagating CI to subprocess env", func(w *gotest.T) {
+		w.It("sets GOTEST_CI in extra env when CI is true", func(it *gotest.T) {
+			env := gotestrunner.ExportBuildExtraEnv(gotestrunner.PipelineConfig{CI: true}, nil)
+			gotest.Equal(it, "1", env[protocol.EnvCI])
+		})
+
+		w.It("omits GOTEST_CI in extra env when CI is false", func(it *gotest.T) {
+			env := gotestrunner.ExportBuildExtraEnv(gotestrunner.PipelineConfig{}, nil)
+			_, ok := env[protocol.EnvCI]
+			gotest.False(it, ok)
+		})
+
+		w.It("appends GOTEST_CI to base env when CI is true", func(it *gotest.T) {
+			it.T().Setenv("CI", "")
+			it.T().Setenv(protocol.EnvCI, "")
+
+			env := gotestrunner.ExportBuildBaseEnv(gotestrunner.PipelineConfig{CI: true})
+			found := false
+			for _, e := range env {
+				if e == protocol.EnvCI+"=1" {
+					found = true
+					break
+				}
+			}
+			gotest.True(it, found, "expected GOTEST_CI=1 in base env")
+		})
+	})
+}
+
 func (s *GotestrunnerTestSuite) TestSharedFixtureProcess(t *gotest.T) {
 	t.When("fixtureStateEntry parsing", func(w *gotest.T) {
 		w.It("parses fixture state line", func(it *gotest.T) {

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -740,6 +740,85 @@ func (s *GotestrunnerTestSuite) TestOutputCollector(t *gotest.T) {
 	})
 }
 
+func (s *GotestrunnerTestSuite) TestEmitSkippedSuites(t *gotest.T) {
+	t.When("text mode", func(w *gotest.T) {
+		w.It("produces no output", func(it *gotest.T) {
+			var stdout bytes.Buffer
+			c := gotestrunner.NewOutputCollector(gotestrunner.RunBatchText, false, gotestrunner.WithWriters(&stdout, &bytes.Buffer{}))
+			c.EmitSkippedSuites(map[string][]string{
+				"example.com/a": {"SkippedSuite"},
+			})
+			gotest.Empty(it, stdout.String())
+		})
+	})
+
+	t.When("JSON streaming mode", func(w *gotest.T) {
+		w.It("emits run, output, output, skip events per suite", func(it *gotest.T) {
+			var stdout bytes.Buffer
+			c := gotestrunner.NewOutputCollector(gotestrunner.RunStreamJSON, false, gotestrunner.WithWriters(&stdout, &bytes.Buffer{}))
+			c.EmitSkippedSuites(map[string][]string{
+				"example.com/pkg": {"FooSuite"},
+			})
+
+			lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+			gotest.Equal(it, 4, len(lines))
+
+			var ev0, ev1, ev2, ev3 map[string]any
+			gotest.NoError(it, json.Unmarshal([]byte(lines[0]), &ev0))
+			gotest.NoError(it, json.Unmarshal([]byte(lines[1]), &ev1))
+			gotest.NoError(it, json.Unmarshal([]byte(lines[2]), &ev2))
+			gotest.NoError(it, json.Unmarshal([]byte(lines[3]), &ev3))
+
+			gotest.Equal(it, "run", ev0["Action"])
+			gotest.Equal(it, "TestFooSuite", ev0["Test"])
+			gotest.Equal(it, "example.com/pkg", ev0["Package"])
+
+			gotest.Equal(it, "output", ev1["Action"])
+			gotest.Contains(it, ev1["Output"].(string), "SKIP")
+
+			gotest.Equal(it, "output", ev2["Action"])
+			gotest.Contains(it, ev2["Output"].(string), "excluded by user")
+
+			gotest.Equal(it, "skip", ev3["Action"])
+			gotest.Equal(it, "TestFooSuite", ev3["Test"])
+		})
+
+		w.It("sorts packages for deterministic output", func(it *gotest.T) {
+			var stdout bytes.Buffer
+			c := gotestrunner.NewOutputCollector(gotestrunner.RunStreamJSON, false, gotestrunner.WithWriters(&stdout, &bytes.Buffer{}))
+			c.EmitSkippedSuites(map[string][]string{
+				"example.com/z": {"ZSuite"},
+				"example.com/a": {"ASuite"},
+			})
+
+			lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+			gotest.Equal(it, 8, len(lines))
+
+			var first, fifth map[string]any
+			json.Unmarshal([]byte(lines[0]), &first)
+			json.Unmarshal([]byte(lines[4]), &fifth)
+			gotest.Equal(it, "example.com/a", first["Package"])
+			gotest.Equal(it, "example.com/z", fifth["Package"])
+		})
+	})
+
+	t.When("empty map", func(w *gotest.T) {
+		w.It("produces no output", func(it *gotest.T) {
+			var stdout bytes.Buffer
+			c := gotestrunner.NewOutputCollector(gotestrunner.RunStreamJSON, false, gotestrunner.WithWriters(&stdout, &bytes.Buffer{}))
+			c.EmitSkippedSuites(map[string][]string{})
+			gotest.Empty(it, stdout.String())
+		})
+
+		w.It("handles nil map", func(it *gotest.T) {
+			var stdout bytes.Buffer
+			c := gotestrunner.NewOutputCollector(gotestrunner.RunStreamJSON, false, gotestrunner.WithWriters(&stdout, &bytes.Buffer{}))
+			c.EmitSkippedSuites(nil)
+			gotest.Empty(it, stdout.String())
+		})
+	})
+}
+
 func capturePackageSummary(pkg string, failed bool, d time.Duration, verbose bool) string {
 	r, wr, _ := os.Pipe()
 	old := os.Stdout

--- a/internal/gotestrunner/output_collector.go
+++ b/internal/gotestrunner/output_collector.go
@@ -165,6 +165,35 @@ func (c *OutputCollector) UsesTest2JSON() bool {
 	return c.mode != RunBatchText
 }
 
+func (c *OutputCollector) EmitSkippedSuites(skippedByPkg map[string][]string) {
+	if c.mode == RunBatchText {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	w := c.jsonWriter()
+	now := time.Now()
+	for pkg, names := range skippedByPkg {
+		for _, name := range names {
+			testFunc := "Test" + name
+			writeJSONLine(w, map[string]any{
+				"Time": now, "Action": "run", "Package": pkg, "Test": testFunc,
+			})
+			writeJSONLine(w, map[string]any{
+				"Time": now, "Action": "output", "Package": pkg, "Test": testFunc,
+				"Output": fmt.Sprintf("--- SKIP: %s (0.00s)\n", testFunc),
+			})
+			writeJSONLine(w, map[string]any{
+				"Time": now, "Action": "output", "Package": pkg, "Test": testFunc,
+				"Output": "    test suite was excluded by user\n",
+			})
+			writeJSONLine(w, map[string]any{
+				"Time": now, "Action": "skip", "Package": pkg, "Test": testFunc, "Elapsed": 0,
+			})
+		}
+	}
+}
+
 func (c *OutputCollector) anyFailedLocked() bool {
 	for _, s := range c.pkgs {
 		for _, r := range s.results {

--- a/internal/gotestrunner/output_collector.go
+++ b/internal/gotestrunner/output_collector.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
+	"slices"
 	"sync"
 	"time"
 )
@@ -173,7 +175,8 @@ func (c *OutputCollector) EmitSkippedSuites(skippedByPkg map[string][]string) {
 	defer c.mu.Unlock()
 	w := c.jsonWriter()
 	now := time.Now()
-	for pkg, names := range skippedByPkg {
+	for _, pkg := range slices.Sorted(maps.Keys(skippedByPkg)) {
+		names := skippedByPkg[pkg]
 		for _, name := range names {
 			testFunc := "Test" + name
 			writeJSONLine(w, map[string]any{

--- a/internal/gotestrunner/overlay.go
+++ b/internal/gotestrunner/overlay.go
@@ -20,6 +20,7 @@ type OverlayResult struct {
 	NoSuitePackages  []string
 	SuitesByPkg      map[string][]string
 	DirsByPkg        map[string]string
+	SkippedSuitesByPkg              map[string][]string
 	FixtureDepSuites                map[string]map[string]bool
 	SuiteRequiredSharedFixtureKeys map[string]map[string][]string
 }
@@ -47,6 +48,7 @@ func GenerateOverlay(loaded []*gotestgen.LoadResult, debug bool) (*OverlayResult
 	var noSuitePkgs []string
 	suitesByPkg := map[string][]string{}
 	dirsByPkg := map[string]string{}
+	skippedSuitesByPkg := map[string][]string{}
 	fixtureDepSuites := map[string]map[string]bool{}
 	suiteReqKeys := map[string]map[string][]string{}
 	for _, r := range allResults {
@@ -60,6 +62,9 @@ func GenerateOverlay(loaded []*gotestgen.LoadResult, debug bool) (*OverlayResult
 		}
 		if r.AbsPath != "" {
 			dirsByPkg[r.PkgPath] = r.AbsPath
+		}
+		if len(r.SkippedSuiteNames) > 0 {
+			skippedSuitesByPkg[r.PkgPath] = r.SkippedSuiteNames
 		}
 		if len(r.FixtureDepSuites) > 0 {
 			s := make(map[string]bool, len(r.FixtureDepSuites))
@@ -81,6 +86,7 @@ func GenerateOverlay(loaded []*gotestgen.LoadResult, debug bool) (*OverlayResult
 		NoSuitePackages:  noSuitePkgs,
 		SuitesByPkg:      suitesByPkg,
 		DirsByPkg:        dirsByPkg,
+		SkippedSuitesByPkg:              skippedSuitesByPkg,
 		FixtureDepSuites:                fixtureDepSuites,
 		SuiteRequiredSharedFixtureKeys: suiteReqKeys,
 	}, cleanup, nil

--- a/internal/gotestrunner/pipeline.go
+++ b/internal/gotestrunner/pipeline.go
@@ -197,6 +197,7 @@ func runBatch(ctx context.Context, cfg PipelineConfig, overlay *OverlayResult, p
 	}
 
 	collector := NewOutputCollector(cfg.OutputMode, pf.Verbose)
+	collector.EmitSkippedSuites(overlay.SkippedSuitesByPkg)
 	RunSuites(ctx, targets, extraEnv, maxParallel, collector)
 	collector.Finalize(overlay.NoSuitePackages)
 
@@ -252,6 +253,7 @@ func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResul
 	var allTargets []SuiteTarget
 
 	collector := NewOutputCollector(cfg.OutputMode, pf.Verbose)
+	collector.EmitSkippedSuites(overlay.SkippedSuitesByPkg)
 	collector.SetFlushOrder(overlay.SuitePackages)
 
 loop:

--- a/internal/gotestrunner/pipeline.go
+++ b/internal/gotestrunner/pipeline.go
@@ -30,6 +30,7 @@ type PipelineConfig struct {
 	GoTestArgs      []string
 	SetupTimeout    time.Duration
 	UpdateSnapshots bool
+	CI              bool
 	Parallel        int
 	Streaming       bool
 	OutputMode      RunMode
@@ -41,6 +42,9 @@ type PipelineResult struct {
 }
 
 func RunPipeline(ctx context.Context, cfg PipelineConfig, overlay *OverlayResult) (PipelineResult, error) {
+	if !cfg.CI && os.Getenv(protocol.EnvCI) == "" && os.Getenv("CI") != "" {
+		cfg.CI = true
+	}
 	pf := ParseExecFlags(cfg.GoTestArgs)
 
 	if cfg.Streaming {
@@ -54,6 +58,9 @@ func buildExtraEnv(cfg PipelineConfig, proc *SharedFixtureProcess) map[string]st
 	if cfg.UpdateSnapshots {
 		env[protocol.EnvUpdateSnapshots] = "1"
 	}
+	if cfg.CI {
+		env[protocol.EnvCI] = "1"
+	}
 	if proc != nil {
 		env[protocol.EnvSharedStateFile] = proc.StateFile()
 	}
@@ -64,6 +71,9 @@ func buildBaseEnv(cfg PipelineConfig) []string {
 	env := os.Environ()
 	if cfg.UpdateSnapshots {
 		env = append(env, protocol.EnvUpdateSnapshots+"=1")
+	}
+	if cfg.CI {
+		env = append(env, protocol.EnvCI+"=1")
 	}
 	return env
 }

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -4,6 +4,7 @@ const (
 	EnvSharedStateFile    = "GOTEST_SHARED_STATE_FILE"
 	EnvTeardownBudgetFile = "GOTEST_TEARDOWN_BUDGET_FILE"
 	EnvUpdateSnapshots    = "GOTEST_UPDATE_SNAPSHOTS"
+	EnvCI                 = "GOTEST_CI"
 )
 
 func BudgetFilePath(binaryPath string) string {

--- a/pkg/gotest/internal/snapfile/snapfile.go
+++ b/pkg/gotest/internal/snapfile/snapfile.go
@@ -22,7 +22,8 @@ func Parse(data []byte) []Section {
 		return nil
 	}
 
-	text := strings.TrimSuffix(string(data), "\n")
+	text := strings.ReplaceAll(string(data), "\r\n", "\n")
+	text = strings.TrimSuffix(text, "\n")
 	lines := strings.Split(text, "\n")
 
 	var sections []Section

--- a/pkg/gotest/internal/snapfile/snapfile_test.go
+++ b/pkg/gotest/internal/snapfile/snapfile_test.go
@@ -82,6 +82,16 @@ func TestRoundTrip_ParseThenSerialize(t *testing.T) {
 	gotest.Equal(t, input, string(out))
 }
 
+func TestParse_CRLFLineEndings(t *testing.T) {
+	input := []byte("=== SNAP alpha ===\r\nfirst\r\n=== SNAP beta ===\r\nsecond\r\n")
+	sections := snapfile.Parse(input)
+	gotest.Len(t, sections, 2)
+	gotest.Equal(t, "alpha", sections[0].Key)
+	gotest.Equal(t, "first\n", sections[0].Content)
+	gotest.Equal(t, "beta", sections[1].Key)
+	gotest.Equal(t, "second\n", sections[1].Content)
+}
+
 func TestValidateContent_Clean(t *testing.T) {
 	err := snapfile.ValidateContent("normal content\nmore lines\n")
 	gotest.NoError(t, err)

--- a/pkg/gotest/linereport_suite_test.go
+++ b/pkg/gotest/linereport_suite_test.go
@@ -45,7 +45,7 @@ func maskPollCount(msg string) (masked string, count int) {
 	if m == nil {
 		return msg, 0
 	}
-	count, _ = strconv.Atoi(m[1])
+	count = gotest.Must(strconv.Atoi(m[1]))
 	return pollCountRe.ReplaceAllString(msg, "(N polls)"), count
 }
 

--- a/pkg/gotest/linereport_suite_test.go
+++ b/pkg/gotest/linereport_suite_test.go
@@ -2,7 +2,9 @@ package gotest_test
 
 import (
 	"fmt"
+	"regexp"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/mvrahden/go-test/pkg/gotest"
@@ -34,6 +36,17 @@ func runSpy(fn func(t *spyT)) *spyT {
 	}()
 	<-done
 	return spy
+}
+
+var pollCountRe = regexp.MustCompile(`\((\d+) polls\)`)
+
+func maskPollCount(msg string) (masked string, count int) {
+	m := pollCountRe.FindStringSubmatch(msg)
+	if m == nil {
+		return msg, 0
+	}
+	count, _ = strconv.Atoi(m[1])
+	return pollCountRe.ReplaceAllString(msg, "(N polls)"), count
 }
 
 // --- suite ---
@@ -134,7 +147,9 @@ func (s *LineReportingTestSuite) TestEventually(t *gotest.T) {
 				})
 			})
 			gotest.True(it, spy.failed)
-			gotest.MatchSnapshot(it, spy.msg)
+			masked, polls := maskPollCount(spy.msg)
+			gotest.MatchSnapshot(it, masked)
+			gotest.InDelta(it, 5, polls, 1)
 		})
 	})
 
@@ -146,7 +161,9 @@ func (s *LineReportingTestSuite) TestEventually(t *gotest.T) {
 				})
 			})
 			gotest.True(it, spy.failed)
-			gotest.MatchSnapshot(it, spy.msg)
+			masked, polls := maskPollCount(spy.msg)
+			gotest.MatchSnapshot(it, masked)
+			gotest.InDelta(it, 5, polls, 1)
 		})
 	})
 }
@@ -160,7 +177,9 @@ func (s *LineReportingTestSuite) TestHelperCallingEventually(t *gotest.T) {
 				eventuallyHelper(t)
 			})
 			gotest.True(it, spy.failed)
-			gotest.MatchSnapshot(it, spy.msg)
+			masked, polls := maskPollCount(spy.msg)
+			gotest.MatchSnapshot(it, masked)
+			gotest.InDelta(it, 5, polls, 1)
 		})
 	})
 }

--- a/pkg/gotest/snapshot.go
+++ b/pkg/gotest/snapshot.go
@@ -45,6 +45,9 @@ func isExternalPackage(callerFile string) bool {
 			return ext
 		}
 	}
+	if err := sc.Err(); err != nil {
+		return false
+	}
 	pkgCache.Store(callerFile, false)
 	return false
 }
@@ -116,6 +119,7 @@ func matchSnapshot(t testingT, callerSkip int, value any, name ...string) {
 		failf(t, "MatchSnapshot: %v", err)
 		return
 	}
+	content = strings.ReplaceAll(content, "\r\n", "\n")
 	if err := snapfile.ValidateContent(content); err != nil {
 		failf(t, "MatchSnapshot: %v", err)
 		return

--- a/pkg/gotest/snapshot.go
+++ b/pkg/gotest/snapshot.go
@@ -189,6 +189,10 @@ func matchSnapshot(t testingT, callerSkip int, value any, name ...string) {
 	}
 
 	if idx < 0 {
+		if snapshotReadonly() {
+			failf(t, "MatchSnapshot: no baseline snapshot for %q — run tests locally to generate", sectionKey)
+			return
+		}
 		sections = append(sections, snapfile.Section{Key: sectionKey, Content: content + "\n"})
 		if err := os.WriteFile(snapPath, snapfile.Serialize(sections), 0644); err != nil {
 			failf(t, "MatchSnapshot: failed to write snapshot: %v", err)
@@ -207,6 +211,14 @@ func matchSnapshot(t testingT, callerSkip int, value any, name ...string) {
 			failf(t, "MatchSnapshot: snapshot mismatch [%s]:\n  expected: %s\n  actual:   %s\nRun with GOTEST_UPDATE_SNAPSHOTS=1 to update", sectionKey, want, got)
 		}
 	}
+}
+
+// snapshotReadonly returns true when MatchSnapshot should refuse to generate
+// new baseline snapshots. Activated by GOTEST_CI=1 (set by the --ci flag).
+// Opt-out with GOTEST_CI=0 when baseline generation is intentional in CI.
+func snapshotReadonly() bool {
+	v := os.Getenv(protocol.EnvCI)
+	return v == "1" || v == "true"
 }
 
 func splitTestName(name string) (topLevel, rest string) {

--- a/pkg/gotest/snapshot_internal_test.go
+++ b/pkg/gotest/snapshot_internal_test.go
@@ -104,6 +104,46 @@ func TestMatchSnapshot_PtestUsesNoSuffix(t *testing.T) {
 	}
 }
 
+func TestMatchSnapshot_NormalizesCRLFInContent(t *testing.T) {
+	snapDir := filepath.Join(thisDir(), "testdata", "__snapshots__")
+	snapFile := filepath.Join(snapDir, "TestMatchSnapshot_NormalizesCRLFInContent.snap")
+	t.Cleanup(func() { os.Remove(snapFile) })
+
+	MatchSnapshot(t, "line1\r\nline2\r\n")
+
+	data, err := os.ReadFile(snapFile)
+	if err != nil {
+		t.Fatalf("expected snapshot file: %v", err)
+	}
+	if strings.Contains(string(data), "\r\n") {
+		t.Fatal("snapshot file should not contain \\r\\n — content must be normalized on write")
+	}
+	if !strings.Contains(string(data), "line1\nline2\n") {
+		t.Fatal("expected normalized content in snapshot file")
+	}
+
+	MatchSnapshot(t, "line1\r\nline2\r\n")
+}
+
+func TestMatchSnapshot_MatchesAfterCRLFFileCorruption(t *testing.T) {
+	snapDir := filepath.Join(thisDir(), "testdata", "__snapshots__")
+	snapFile := filepath.Join(snapDir, "TestMatchSnapshot_MatchesAfterCRLFFileCorruption.snap")
+	t.Cleanup(func() { os.Remove(snapFile) })
+
+	MatchSnapshot(t, "stable value")
+
+	data, err := os.ReadFile(snapFile)
+	if err != nil {
+		t.Fatalf("read snap: %v", err)
+	}
+	corrupted := strings.ReplaceAll(string(data), "\n", "\r\n")
+	if err := os.WriteFile(snapFile, []byte(corrupted), 0644); err != nil {
+		t.Fatalf("write corrupted snap: %v", err)
+	}
+
+	MatchSnapshot(t, "stable value")
+}
+
 func TestReadAndRestore_SeekableReader(t *testing.T) {
 	r := strings.NewReader("test data")
 	b, err := readAndRestore(r)

--- a/pkg/gotest/snapshot_internal_test.go
+++ b/pkg/gotest/snapshot_internal_test.go
@@ -225,7 +225,7 @@ func TestReadAndRestore_SeekableReader(t *testing.T) {
 	if string(b) != "test data" {
 		t.Fatalf("want %q, got %q", "test data", string(b))
 	}
-	again, _ := io.ReadAll(r)
+	again := Must(io.ReadAll(r))
 	if string(again) != "test data" {
 		t.Fatalf("reader should be restored; re-read got %q", again)
 	}
@@ -240,7 +240,7 @@ func TestReadAndRestore_NonSeekableReader(t *testing.T) {
 	if string(b) != "ephemeral" {
 		t.Fatalf("want %q, got %q", "ephemeral", string(b))
 	}
-	remaining, _ := io.ReadAll(r)
+	remaining := Must(io.ReadAll(r))
 	if len(remaining) != 0 {
 		t.Fatal("non-seekable reader should be consumed")
 	}

--- a/pkg/gotest/snapshot_internal_test.go
+++ b/pkg/gotest/snapshot_internal_test.go
@@ -6,6 +6,7 @@
 package gotest //nolint:stdlib-test
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -143,6 +144,77 @@ func TestMatchSnapshot_MatchesAfterCRLFFileCorruption(t *testing.T) {
 
 	MatchSnapshot(t, "stable value")
 }
+
+func TestSnapshotReadonly(t *testing.T) {
+	t.Run("GOTEST_CI=1 is readonly", func(t *testing.T) {
+		t.Setenv("GOTEST_CI", "1")
+		if !snapshotReadonly() {
+			t.Fatal("expected readonly")
+		}
+	})
+	t.Run("GOTEST_CI=true is readonly", func(t *testing.T) {
+		t.Setenv("GOTEST_CI", "true")
+		if !snapshotReadonly() {
+			t.Fatal("expected readonly")
+		}
+	})
+	t.Run("GOTEST_CI=0 is writable", func(t *testing.T) {
+		t.Setenv("GOTEST_CI", "0")
+		if snapshotReadonly() {
+			t.Fatal("expected writable")
+		}
+	})
+	t.Run("GOTEST_CI unset is writable", func(t *testing.T) {
+		t.Setenv("GOTEST_CI", "")
+		if snapshotReadonly() {
+			t.Fatal("expected writable")
+		}
+	})
+}
+
+func TestMatchSnapshot_CIMode_FailsOnMissingBaseline(t *testing.T) {
+	snapDir := filepath.Join(thisDir(), "testdata", "__snapshots__")
+	snapFile := filepath.Join(snapDir, "TestMatchSnapshot_CIMode_FailsOnMissingBaseline.snap")
+	t.Cleanup(func() { os.Remove(snapFile) })
+
+	t.Setenv("GOTEST_CI", "1")
+
+	mock := &mockT{name: "TestMatchSnapshot_CIMode_FailsOnMissingBaseline/subtest"}
+	MatchSnapshot(mock, "new-value")
+
+	if !mock.failed {
+		t.Fatal("expected MatchSnapshot to fail in CI mode when no baseline exists")
+	}
+	if !strings.Contains(mock.msg, "no baseline snapshot") {
+		t.Fatalf("expected 'no baseline snapshot' message, got: %s", mock.msg)
+	}
+
+	if _, err := os.Stat(snapFile); err == nil {
+		t.Fatal("expected snapshot file to NOT be written in CI mode")
+	}
+}
+
+func TestMatchSnapshot_CIMode_ComparesExistingBaseline(t *testing.T) {
+	snapDir := filepath.Join(thisDir(), "testdata", "__snapshots__")
+	snapFile := filepath.Join(snapDir, "TestMatchSnapshot_CIMode_ComparesExistingBaseline.snap")
+	t.Cleanup(func() { os.Remove(snapFile) })
+
+	MatchSnapshot(t, "expected value")
+
+	t.Setenv("GOTEST_CI", "1")
+	MatchSnapshot(t, "expected value")
+}
+
+type mockT struct {
+	name   string
+	failed bool
+	msg    string
+}
+
+func (m *mockT) Helper()                           {}
+func (m *mockT) FailNow()                          {}
+func (m *mockT) Name() string                      { return m.name }
+func (m *mockT) Errorf(format string, args ...any) { m.failed = true; m.msg = fmt.Sprintf(format, args...) }
 
 func TestReadAndRestore_SeekableReader(t *testing.T) {
 	r := strings.NewReader("test data")

--- a/pkg/gotest/snapshot_suite_test.go
+++ b/pkg/gotest/snapshot_suite_test.go
@@ -194,7 +194,7 @@ func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
 	t.When("value is a string", func(w *gotest.T) {
 		w.It("snapshots the string directly", func(it *gotest.T) {
 			gotest.MatchSnapshot(it, "plain text")
-			data, _ := os.ReadFile(snapPath)
+			data := gotest.Must(os.ReadFile(snapPath))
 			gotest.Contains(it, string(data), "plain text")
 		})
 	})
@@ -202,7 +202,7 @@ func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
 	t.When("value is []byte", func(w *gotest.T) {
 		w.It("snapshots the byte content as text", func(it *gotest.T) {
 			gotest.MatchSnapshot(it, []byte("raw bytes"))
-			data, _ := os.ReadFile(snapPath)
+			data := gotest.Must(os.ReadFile(snapPath))
 			gotest.Contains(it, string(data), "raw bytes")
 		})
 	})
@@ -210,7 +210,7 @@ func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
 	t.When("value is a TextMarshaler", func(w *gotest.T) {
 		w.It("uses MarshalText output", func(it *gotest.T) {
 			gotest.MatchSnapshot(it, snapshotTextMarshaler("marshaled text"))
-			data, _ := os.ReadFile(snapPath)
+			data := gotest.Must(os.ReadFile(snapPath))
 			gotest.Contains(it, string(data), "marshaled text")
 		})
 	})
@@ -218,7 +218,7 @@ func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
 	t.When("value is a Stringer", func(w *gotest.T) {
 		w.It("uses String output", func(it *gotest.T) {
 			gotest.MatchSnapshot(it, snapshotStringer("display text"))
-			data, _ := os.ReadFile(snapPath)
+			data := gotest.Must(os.ReadFile(snapPath))
 			gotest.Contains(it, string(data), "display text")
 		})
 	})
@@ -227,7 +227,7 @@ func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
 		w.It("uses String without consuming the buffer", func(it *gotest.T) {
 			buf := bytes.NewBufferString("buffer content")
 			gotest.MatchSnapshot(it, buf)
-			data, _ := os.ReadFile(snapPath)
+			data := gotest.Must(os.ReadFile(snapPath))
 			gotest.Contains(it, string(data), "buffer content")
 			gotest.Equal(it, "buffer content", buf.String())
 		})
@@ -236,7 +236,7 @@ func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
 	t.When("value is a json.Marshaler", func(w *gotest.T) {
 		w.It("pretty-prints the JSON output", func(it *gotest.T) {
 			gotest.MatchSnapshot(it, snapshotJSONMarshaler{data: map[string]int{"a": 1}})
-			data, _ := os.ReadFile(snapPath)
+			data := gotest.Must(os.ReadFile(snapPath))
 			gotest.Contains(it, string(data), "{\n  \"a\": 1\n}")
 		})
 	})
@@ -244,7 +244,7 @@ func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
 	t.When("value is json.RawMessage", func(w *gotest.T) {
 		w.It("pretty-prints the raw JSON", func(it *gotest.T) {
 			gotest.MatchSnapshot(it, json.RawMessage(`{"b":2,"a":1}`))
-			data, _ := os.ReadFile(snapPath)
+			data := gotest.Must(os.ReadFile(snapPath))
 			gotest.Contains(it, string(data), "\"b\": 2")
 			gotest.Contains(it, string(data), "\"a\": 1")
 		})
@@ -253,7 +253,7 @@ func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
 	t.When("value is an error", func(w *gotest.T) {
 		w.It("snapshots the error message", func(it *gotest.T) {
 			gotest.MatchSnapshot(it, fmt.Errorf("something went wrong"))
-			data, _ := os.ReadFile(snapPath)
+			data := gotest.Must(os.ReadFile(snapPath))
 			gotest.Contains(it, string(data), "something went wrong")
 		})
 	})
@@ -262,9 +262,9 @@ func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
 		w.It("reads content and restores the reader position", func(it *gotest.T) {
 			r := strings.NewReader("reader content")
 			gotest.MatchSnapshot(it, r)
-			data, _ := os.ReadFile(snapPath)
+			data := gotest.Must(os.ReadFile(snapPath))
 			gotest.Contains(it, string(data), "reader content")
-			again, _ := io.ReadAll(r)
+			again := gotest.Must(io.ReadAll(r))
 			gotest.Equal(it, "reader content", string(again))
 		})
 	})
@@ -273,7 +273,7 @@ func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
 		w.It("reads content (consuming the reader)", func(it *gotest.T) {
 			r := io.NopCloser(strings.NewReader("pipe content"))
 			gotest.MatchSnapshot(it, r)
-			data, _ := os.ReadFile(snapPath)
+			data := gotest.Must(os.ReadFile(snapPath))
 			gotest.Contains(it, string(data), "pipe content")
 		})
 	})
@@ -281,7 +281,7 @@ func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
 	t.When("value is a named string type", func(w *gotest.T) {
 		w.It("snapshots via reflect", func(it *gotest.T) {
 			gotest.MatchSnapshot(it, snapshotNamedString("typed value"))
-			data, _ := os.ReadFile(snapPath)
+			data := gotest.Must(os.ReadFile(snapPath))
 			gotest.Contains(it, string(data), "typed value")
 		})
 	})

--- a/pkg/gotest/snapshot_suite_test.go
+++ b/pkg/gotest/snapshot_suite_test.go
@@ -17,6 +17,7 @@ import (
 type SnapshotGroupingTestSuite struct{}
 
 func (s *SnapshotGroupingTestSuite) TestMatchSnapshotGrouping(t *gotest.T) {
+	t.T().Setenv(protocol.EnvCI, "0")
 	snapDir := filepath.Join("testdata", "__snapshots__")
 	t.T().Cleanup(func() { os.Remove(filepath.Join(snapDir, "TestSnapshotGroupingTestSuite_ext.snap")) })
 
@@ -73,6 +74,7 @@ func (s *SnapshotGroupingTestSuite) TestMatchSnapshotGrouping(t *gotest.T) {
 type SnapshotConcurrencyTestSuite struct{}
 
 func (s *SnapshotConcurrencyTestSuite) TestMatchSnapshotConcurrency(t *gotest.T) {
+	t.T().Setenv(protocol.EnvCI, "0")
 	snapDir := filepath.Join("testdata", "__snapshots__")
 	t.T().Cleanup(func() { os.Remove(filepath.Join(snapDir, "TestSnapshotConcurrencyTestSuite_ext.snap")) })
 
@@ -90,6 +92,7 @@ func (s *SnapshotConcurrencyTestSuite) TestMatchSnapshotConcurrency(t *gotest.T)
 type SnapshotUpdateTestSuite struct{}
 
 func (s *SnapshotUpdateTestSuite) TestMatchSnapshotUpdate(t *gotest.T) {
+	t.T().Setenv(protocol.EnvCI, "0")
 	snapDir := filepath.Join("testdata", "__snapshots__")
 	t.T().Cleanup(func() { os.Remove(filepath.Join(snapDir, "TestSnapshotUpdateTestSuite_ext.snap")) })
 
@@ -132,6 +135,7 @@ type snapshotNamedString string
 type SnapshotTestSuite struct{}
 
 func (s *SnapshotTestSuite) TestMatchSnapshot(t *gotest.T) {
+	t.T().Setenv(protocol.EnvCI, "0")
 	snapDir := filepath.Join("testdata", "__snapshots__")
 	t.T().Cleanup(func() { os.Remove(filepath.Join(snapDir, "TestSnapshotTestSuite_ext.snap")) })
 
@@ -181,6 +185,7 @@ func (s *SnapshotTestSuite) TestMatchSnapshot(t *gotest.T) {
 }
 
 func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
+	t.T().Setenv(protocol.EnvCI, "0")
 	snapDir := filepath.Join("testdata", "__snapshots__")
 
 	snapPath := filepath.Join(snapDir, "TestSnapshotTestSuite_ext.snap")

--- a/pkg/gotest/testdata/__snapshots__/TestLineReportingTestSuite_ext.snap
+++ b/pkg/gotest/testdata/__snapshots__/TestLineReportingTestSuite_ext.snap
@@ -1,50 +1,50 @@
 === SNAP TestConsistently/assertion_fails_during_polling/failure_references_this_file ===
-linereport_suite_test.go:33: Consistently failed on poll 3:
-    linereport_suite_test.go:178: True failed:
+linereport_suite_test.go:35: Consistently failed on poll 3:
+    linereport_suite_test.go:197: True failed:
   expected: true
   actual:   false
   message: broke on poll 3
 === SNAP TestDirectAssertion/called_via_*R_(Record)/reports_this_file_as_the_call_site ===
-linereport_suite_test.go:60: Equal failed:
+linereport_suite_test.go:73: Equal failed:
   expected: 1
   actual:   2
 === SNAP TestDirectAssertion/called_via_spyT_(no_Helper_method)/reports_this_file_as_the_call_site ===
-linereport_suite_test.go:33: Equal failed:
+linereport_suite_test.go:35: Equal failed:
   expected: 1
   actual:   2
 === SNAP TestEventually/called_directly_from_test_(no_helper)/timeout_references_this_file ===
-linereport_suite_test.go:33: Eventually failed after 50ms (5 polls):
+linereport_suite_test.go:35: Eventually failed after 50ms (N polls):
   last failure:
-    linereport_suite_test.go:145: True failed:
+    linereport_suite_test.go:160: True failed:
   expected: true
   actual:   false
 === SNAP TestEventually/inner_assertion_fails_(via_*R)/timeout_includes_inner_assertion_call_site ===
-linereport_suite_test.go:33: Eventually failed after 50ms (5 polls):
+linereport_suite_test.go:35: Eventually failed after 50ms (N polls):
   last failure:
-    linereport_suite_test.go:133: True failed:
+    linereport_suite_test.go:146: True failed:
   expected: true
   actual:   false
   message: condition not met
 === SNAP TestHelperCallingEventually/Eventually_times_out_inside_a_helper/traces_back_to_this_file_not_the_helper ===
-linereport_suite_test.go:33: Eventually failed after 50ms (5 polls):
+linereport_suite_test.go:35: Eventually failed after 50ms (N polls):
   last failure:
     linereport_helpers_test.go:30: True failed:
   expected: true
   actual:   false
   message: condition not met
 === SNAP TestNestedHelpers/called_via_*R_through_two_levels_of_helpers/reports_this_file_as_the_outermost_call_site ===
-linereport_suite_test.go:108: Equal failed:
+linereport_suite_test.go:121: Equal failed:
   expected: 1
   actual:   2
 === SNAP TestNestedHelpers/called_via_spyT_through_two_levels_of_helpers/reports_this_file_as_the_outermost_call_site ===
-linereport_suite_test.go:33: Equal failed:
+linereport_suite_test.go:35: Equal failed:
   expected: 1
   actual:   2
 === SNAP TestSingleHelper/called_via_*R_through_a_helper_in_another_file/reports_this_file_not_the_helper_file ===
-linereport_suite_test.go:84: Equal failed:
+linereport_suite_test.go:97: Equal failed:
   expected: 1
   actual:   2
 === SNAP TestSingleHelper/called_via_spyT_through_a_helper_in_another_file/reports_this_file_not_the_helper_file ===
-linereport_suite_test.go:33: Equal failed:
+linereport_suite_test.go:35: Equal failed:
   expected: 1
   actual:   2

--- a/tests/e2e/testdata/__snapshots__/TestE2ETestSuite_ext.snap
+++ b/tests/e2e/testdata/__snapshots__/TestE2ETestSuite_ext.snap
@@ -1,4 +1,8 @@
 === SNAP TestOutputFormatGolden/json/single_passing_package ===
+{"Action":"run","Package":"github.com/mvrahden/go-test/examples/auth","Test":"TestX_DeprecatedOAuthTestSuite","Time":"\u003cTIMESTAMP\u003e"}
+{"Action":"output","Output":"--- SKIP: TestX_DeprecatedOAuthTestSuite (\u003cTIMESTAMP\u003e)\n","Package":"github.com/mvrahden/go-test/examples/auth","Test":"TestX_DeprecatedOAuthTestSuite","Time":"\u003cTIMESTAMP\u003e"}
+{"Action":"output","Output":"    test suite was excluded by user\n","Package":"github.com/mvrahden/go-test/examples/auth","Test":"TestX_DeprecatedOAuthTestSuite","Time":"\u003cTIMESTAMP\u003e"}
+{"Action":"skip","Elapsed":"\u003cTIMESTAMP\u003e","Package":"github.com/mvrahden/go-test/examples/auth","Test":"TestX_DeprecatedOAuthTestSuite","Time":"\u003cTIMESTAMP\u003e"}
 {"Action":"run","Package":"github.com/mvrahden/go-test/examples/auth","Test":"TestTokenValidatorTestSuite","Time":"\u003cTIMESTAMP\u003e"}
 {"Action":"output","Output":"=== RUN   TestTokenValidatorTestSuite\n","Package":"github.com/mvrahden/go-test/examples/auth","Test":"TestTokenValidatorTestSuite","Time":"\u003cTIMESTAMP\u003e"}
 {"Action":"run","Package":"github.com/mvrahden/go-test/examples/auth","Test":"TestTokenValidatorTestSuite/TestValidateToken","Time":"\u003cTIMESTAMP\u003e"}


### PR DESCRIPTION
Excluded test suites (X_ prefix) now appear as "skip" entries in the JSON and spec output instead of being silently omitted.