### PR TITLE
Content-addressable overlay cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ spec.txt
 .vite
 .worktrees/
 ƒƒ_*
+gotest_psuite_test.go
+gotest_pxsuite_test.go

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -674,8 +674,9 @@ t=8s    All suites done, wg.Wait() returns
    panicking suite cannot affect others. The OS enforces memory isolation.
 
 3. **Overlay filesystem**: Generated code is injected via Go's `-overlay` flag.
-   Source files are never modified. The overlay is a temp directory cleaned up
-   on exit.
+   Source files are never modified. Overlays are written to a content-addressable
+   cache (`~/.cache/gotest/overlays/<hash>/`) for reuse across runs. Cache entries
+   auto-evict after 7 days. Use `--no-cache` to force fresh generation.
 
 4. **Streaming compilation**: `CompilePackagesStream` sends results to a
    channel as each package finishes. Test execution begins before all packages

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Generated files never touch your source tree — they're created hidden before t
 you write:          gotest generates:         go test runs:
                     (hidden, auto-cleaned)
 
-MySuite struct      ƒƒ_psuite_test.go        func TestMySuite(t *testing.T)
+MySuite struct      gotest_psuite_test.go     func TestMySuite(t *testing.T)
   BeforeAll()   →     lifecycle wiring    →     t.Cleanup(AfterAll)
   TestFoo()           t.Run nesting              BeforeAll()
   AfterAll()          process isolation          t.Run("TestFoo", ...)
@@ -650,11 +650,13 @@ func (s *MySuite) F_TestCreate(t *gotest.T) {} // focus a single test
 func (s *MySuite) X_TestFlaky(t *gotest.T)  {} // exclude a single test
 ```
 
-Use `--ci` in CI to fail the build if any `F_` prefix slipped through:
+Use `--ci` in CI to fail the build if any `F_` prefix slipped through and to enable snapshot read-only mode (missing baselines fail instead of being generated):
 
 ```bash
 gotest --ci ./... -v -race
 ```
+
+CI mode is auto-detected: when the standard `CI` environment variable is set and `GOTEST_CI` is unset, `--ci` is enabled automatically. Set `GOTEST_CI=0` to opt out.
 
 ### SuiteGuard
 
@@ -727,7 +729,7 @@ gotest lint ./...              # static analysis for test suites
 gotest refactor toggle-focus . # toggle F_/X_ prefixes programmatically
 gotest migrate ./...           # convert testify/suite to go-test
 gotest generate ./...          # run code generation only (no tests)
-gotest clean ./...             # remove cached overlays (debugging)
+gotest clean ./...             # remove orphaned generated files
 gotest version                 # print version
 gotest help                    # show help
 ```

--- a/cmd/gotest/args.go
+++ b/cmd/gotest/args.go
@@ -53,6 +53,7 @@ type ExecConfig struct {
 	CI              bool
 	JSON            bool
 	UpdateSnapshots bool
+	NoCache         bool
 	Parallel        int
 }
 

--- a/cmd/gotest/cli.go
+++ b/cmd/gotest/cli.go
@@ -139,6 +139,7 @@ func runTest(inv Invocation) int {
 		CI:              slices.Contains(ownArgs, "--ci"),
 		JSON:            jsonMode,
 		UpdateSnapshots: slices.Contains(ownArgs, "--update-snapshots"),
+		NoCache:         slices.Contains(ownArgs, "--no-cache"),
 		Parallel:        parallel,
 	}
 

--- a/cmd/gotest/exec.go
+++ b/cmd/gotest/exec.go
@@ -28,7 +28,7 @@ func Run(cfg ExecConfig) int {
 		}
 	}
 
-	overlay, cleanup, err := gotestrunner.GenerateOverlay(loaded, cfg.Debug)
+	overlay, cleanup, err := gotestrunner.GenerateOverlay(loaded, cfg.Debug, cfg.NoCache)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2

--- a/cmd/gotest/flags.go
+++ b/cmd/gotest/flags.go
@@ -15,6 +15,7 @@ var gotestFlags = map[string]FlagKind{
 	"--spec":             BoolFlag,
 	"--update-snapshots": BoolFlag,
 	"--no-color":         BoolFlag,
+	"--no-cache":         BoolFlag,
 	"--min":              ValueFlag,
 	"--setup-timeout":    ValueFlag,
 	"--debounce":         ValueFlag,
@@ -25,18 +26,18 @@ var gotestFlags = map[string]FlagKind{
 }
 
 var testAllowed = flagSet(
-	"--debug", "--ci", "--spec", "--update-snapshots",
+	"--debug", "--ci", "--spec", "--update-snapshots", "--no-cache",
 	"--min", "--setup-timeout", "--parallel",
 )
 
 var specAllowed = flagSet(
-	"--debug", "--ci", "--update-snapshots",
+	"--debug", "--ci", "--update-snapshots", "--no-cache",
 	"--min", "--setup-timeout", "--parallel",
 	"--format", "--output", "--input", "--no-color",
 )
 
 var watchAllowed = flagSet(
-	"--debug", "--ci", "--update-snapshots",
+	"--debug", "--ci", "--update-snapshots", "--no-cache",
 	"--setup-timeout", "--debounce", "--parallel",
 )
 

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -78,10 +78,11 @@ Subcommands:
 Run "gotest help <subcommand>" for subcommand-specific help.
 
 Flags (gotest — use --double-dash):
-  --ci                    Fail on focused tests (F_ prefixes)
+  --ci                    CI mode: fail on F_ prefixes, snapshot read-only
   --debug                 Keep generated overlay for inspection
   --spec                  Render spec view instead of default output
   --update-snapshots      Regenerate snapshot files
+  --no-cache              Disable overlay cache, force fresh generation
   --min=<pct>             Fail if coverage < pct%% (0-100)
   --setup-timeout=<dur>   Total budget for shared fixture setup (-1s to disable)
 
@@ -97,6 +98,11 @@ Flags (go test — use -single-dash, forwarded automatically):
 
 Use a bare "--" to separate gotest flags from go test flags,
 or to pass unrecognized flags to go test without validation.
+
+Environment:
+  CI=true                 Auto-enables --ci when GOTEST_CI is unset
+  GOTEST_CI=0             Opt out of CI auto-detection
+  GOTEST_CACHE_DIR=<dir>  Override overlay cache location (default: ~/.cache/gotest)
 
 Configuration:
   Place a .gotest.yml in your project root. Run "gotest help config" for details.
@@ -119,17 +125,22 @@ Usage:
 
 When no subcommand is given, gotest discovers test suites in the target
 packages, generates an overlay with lifecycle wiring, and runs "go test".
+Generated overlays are cached by content hash for faster repeated runs.
 
 Flags:
-  --ci                    Fail on focused tests (F_ prefixes)
+  --ci                    CI mode: fail on F_ prefixes, snapshot read-only
   --debug                 Keep generated overlay for inspection
   --spec                  Render spec view instead of default output
   --update-snapshots      Regenerate snapshot files
+  --no-cache              Disable overlay cache, force fresh generation
   --min=<pct>             Fail if coverage < pct% (0-100, enables -coverprofile)
   --setup-timeout=<dur>   Total budget for shared fixture setup (-1s to disable)
 
 All standard go test flags (-single-dash) are forwarded automatically.
 Use a bare "--" to pass unrecognized flags without validation.
+
+CI auto-detection: when the standard CI env var is set and GOTEST_CI is
+unset, --ci is enabled automatically. Set GOTEST_CI=0 to opt out.
 
 Examples:
   gotest ./...                              Run all suites
@@ -155,9 +166,10 @@ Flags:
   --output=<file>         Write to file instead of stdout
   --input=<file>          Render from saved JSON ("-" for stdin)
   --no-color              Disable ANSI color codes
-  --ci                    Fail on focused tests (F_ prefixes)
+  --ci                    CI mode: fail on F_ prefixes, snapshot read-only
   --debug                 Keep generated overlay
   --update-snapshots      Regenerate snapshot files
+  --no-cache              Disable overlay cache, force fresh generation
   --min=<pct>             Fail if coverage < pct% (0-100)
   --setup-timeout=<dur>   Total budget for shared fixture setup (-1s to disable)
 
@@ -182,9 +194,10 @@ runs are scoped to the packages containing changed files.
 
 Flags:
   --debounce=<dur>        Re-run delay after change (default: 200ms)
-  --ci                    Fail on focused tests (F_ prefixes)
+  --ci                    CI mode: fail on F_ prefixes, snapshot read-only
   --debug                 Keep generated overlay
   --update-snapshots      Regenerate snapshot files
+  --no-cache              Disable overlay cache, force fresh generation
   --setup-timeout=<dur>   Total budget for shared fixture setup (-1s to disable)
 
 Examples:
@@ -365,6 +378,10 @@ Usage:
 Removes generated overlay files (gotest_*_test.go) that are no longer
 needed. These files are normally ephemeral but may be left behind
 by --debug runs or interrupted processes.
+
+The overlay cache (used for faster repeated runs) is managed separately
+and auto-evicts entries older than 7 days. Set GOTEST_CACHE_DIR to
+control the cache location; use --no-cache to bypass it entirely.
 
 Examples:
   gotest clean ./...                         Clean all packages

--- a/cmd/gotest/prepare.go
+++ b/cmd/gotest/prepare.go
@@ -36,7 +36,7 @@ func runPrepare(inv Invocation) int {
 	ctx, stop := signal.NotifyContext(context.Background(),
 		shutdownSignals...)
 
-	overlay, cleanup, err := gotestrunner.GenerateOverlay(loaded, false)
+	overlay, cleanup, err := gotestrunner.GenerateOverlay(loaded, false, false)
 	if err != nil {
 		stop()
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)

--- a/cmd/gotest/spec.go
+++ b/cmd/gotest/spec.go
@@ -69,6 +69,7 @@ func runSpec(inv Invocation) int {
 		Debug:           slices.Contains(ownArgs, "--debug"),
 		CI:              slices.Contains(ownArgs, "--ci"),
 		UpdateSnapshots: slices.Contains(ownArgs, "--update-snapshots"),
+		NoCache:         slices.Contains(ownArgs, "--no-cache"),
 		Parallel:        parallel,
 	}
 
@@ -89,7 +90,7 @@ func runSpec(inv Invocation) int {
 		}
 	}
 
-	overlay, cleanup, err := gotestrunner.GenerateOverlay(loaded, cfg.Debug)
+	overlay, cleanup, err := gotestrunner.GenerateOverlay(loaded, cfg.Debug, cfg.NoCache)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2

--- a/cmd/gotest/watch.go
+++ b/cmd/gotest/watch.go
@@ -76,6 +76,7 @@ func runWatch(inv Invocation) int {
 		Debug:           slices.Contains(ownArgs, "--debug"),
 		CI:              slices.Contains(ownArgs, "--ci"),
 		UpdateSnapshots: slices.Contains(ownArgs, "--update-snapshots"),
+		NoCache:         slices.Contains(ownArgs, "--no-cache"),
 		Parallel:        parallel,
 	}
 
@@ -178,7 +179,7 @@ func watchRunOnce(ctx context.Context, cfg ExecConfig, jsonMode bool) int {
 		}
 	}
 
-	overlay, cleanup, err := gotestrunner.GenerateOverlay(loaded, cfg.Debug)
+	overlay, cleanup, err := gotestrunner.GenerateOverlay(loaded, cfg.Debug, cfg.NoCache)
 	if err != nil {
 		if jsonMode {
 			fmt.Printf("{\"Action\":\"watch-error\",\"Output\":%q}\n", err.Error())

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -100,7 +100,8 @@ gotest [subcommand] [packages...] [go-test-flags...] [--gotest-flags...]
 | Flag | Effect |
 |------|--------|
 | `--debug` | Keep generated files after run |
-| `--ci` | Fail if `F_` focus prefixes exist |
+| `--ci` | CI mode: fail on `F_` prefixes, snapshot read-only |
+| `--no-cache` | Disable overlay cache, force fresh generation |
 | `--spec` | Append spec summary after normal output |
 | `--update-snapshots` | Regenerate snapshot files |
 | `--format=<fmt>` | Output format for `spec` (terminal, md) |
@@ -238,7 +239,8 @@ Rules:
 
 Skipped suites produce a `t.Skipf("test suite was excluded by user")` stub.
 
-The `--ci` flag performs a static analysis scan before generation — no test execution needed:
+The `--ci` flag performs a static analysis scan before generation and enables
+snapshot read-only mode (missing baselines fail instead of being generated):
 
 ```
 $ gotest --ci ./...
@@ -246,6 +248,9 @@ FAIL: focus prefix detected — remove F_ before merging:
   pkg/user/user_test.go:12    type F_UserServiceTestSuite
   pkg/payment/pay_test.go:28  func (s *PaymentTestSuite) F_TestCharge
 ```
+
+CI mode is auto-detected from the standard `CI` environment variable when
+`GOTEST_CI` is unset. Set `GOTEST_CI=0` to opt out.
 
 ### SuiteGuard
 
@@ -903,7 +908,7 @@ Use case: `//go:generate gotest generate ./...` for checked-in generated files.
 gotest clean ./...
 ```
 
-Walks directories and removes files matching `ƒƒ_p(x)?suite_test.go`.
+Walks directories and removes files matching `gotest_p(x)?suite_test.go`.
 
 ### Generated Files
 
@@ -911,10 +916,10 @@ Per package directory, up to two files:
 
 | File | Purpose |
 |------|---------|
-| `ƒƒ_psuite_test.go` | Same-package (white-box) test suites |
-| `ƒƒ_pxsuite_test.go` | External-package (black-box) test suites |
+| `gotest_psuite_test.go` | Same-package (white-box) test suites |
+| `gotest_pxsuite_test.go` | External-package (black-box) test suites |
 
-The `ƒƒ` Unicode prefix prevents naming collisions with user code.
+The `gotest_` prefix prevents naming collisions with user code.
 Files contain a `// Code generated` header.
 
 ### Generated Structure
@@ -969,7 +974,7 @@ Detects:
 - **Value receivers:** Suite methods with value receivers instead of pointer receivers
 - **Missing lifecycle pair:** `BeforeAll` without `AfterAll` — resources may leak
 - **Committed focus prefixes:** `F_` prefix on types or methods
-- **Orphaned generated files:** `ƒƒ_*` files checked into version control
+- **Orphaned generated files:** `gotest_*suite_test.go` files checked into version control
 - **Stdlib test functions:** `func TestX(t *testing.T)` in packages with suites — likely meant to be a suite method
 - **Testify imports:** `testify/suite` imports in packages using gotest — migration incomplete
 - **Poll scope errors:** Assertions inside `Eventually`/`Consistently` callbacks using the outer `t` instead of the `poll` parameter

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -503,7 +503,7 @@
       </table>
 
       <div class="callout">
-        <code>F_</code> and <code>X_</code> work on both types and methods. <code>X_</code> takes precedence over <code>F_</code>. Use <code>--ci</code> to fail the build if any focus prefix is committed.
+        <code>F_</code> and <code>X_</code> work on both types and methods. <code>X_</code> takes precedence over <code>F_</code>. Use <code>--ci</code> to fail the build if any focus prefix is committed and to enable snapshot read-only mode. CI mode is auto-detected from the <code>CI</code> environment variable.
       </div>
     </section>
 
@@ -972,9 +972,10 @@ percentage = covered / total</div>
       <table class="ref-table">
         <thead><tr><th>Flag</th><th>Effect</th></tr></thead>
         <tbody>
-          <tr><td><code>--ci</code></td><td>Fail the build if any focus prefix is committed.</td></tr>
+          <tr><td><code>--ci</code></td><td>CI mode: fail on focus prefixes, snapshot read-only. Auto-detected from <code>CI</code> env var; opt out with <code>GOTEST_CI=0</code>.</td></tr>
           <tr><td><code>--spec</code></td><td>Append spec summary after normal test output.</td></tr>
           <tr><td><code>--update-snapshots</code></td><td>Regenerate all snapshot files.</td></tr>
+          <tr><td><code>--no-cache</code></td><td>Disable overlay cache, force fresh generation.</td></tr>
           <tr><td><code>--min=&lt;pct&gt;</code></td><td>Fail if coverage falls below threshold.</td></tr>
           <tr><td><code>--format=md</code></td><td>Markdown output for <code>spec</code> command.</td></tr>
           <tr><td><code>--output=&lt;path&gt;</code></td><td>Write formatted output to file.</td></tr>

--- a/internal/gotestrunner/export_test.go
+++ b/internal/gotestrunner/export_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 
+	"github.com/mvrahden/go-test/internal/gotestgen"
 	"github.com/mvrahden/go-test/internal/protocol"
 )
 
@@ -17,12 +18,19 @@ var ExportSuiteRunFilter = suiteRunFilter
 var ExportAssignCoverProfiles = assignCoverProfiles
 var ExportBuildExtraEnv = buildExtraEnv
 var ExportBuildBaseEnv = buildBaseEnv
+var ExportOverlayContentHash = overlayContentHash
+var ExportCacheRoot = cacheRoot
 
 func ExportAutoDetectCI(cfg PipelineConfig) PipelineConfig {
 	if !cfg.CI && os.Getenv(protocol.EnvCI) == "" && os.Getenv("CI") != "" {
 		cfg.CI = true
 	}
 	return cfg
+}
+
+func ExportWriteOverlayCached(results gotestgen.GenerateResults, noCache bool) (string, error) {
+	dir, _, err := writeOverlayCached(results, noCache)
+	return dir, err
 }
 
 var SetBuildProcessGroup = setBuildProcessGroup

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -414,39 +414,6 @@ func (s *GotestrunnerTestSuite) TestOverlayCache(t *gotest.T) {
 	})
 
 	t.When("writing to cache", func(w *gotest.T) {
-		w.It("returns cached directory on cache hit", func(it *gotest.T) {
-			cacheDir := it.T().TempDir()
-			it.T().Setenv(protocol.EnvCacheDir, cacheDir)
-
-			results := gotestgen.GenerateResults{
-				{AbsPath: "/fake/pkg/x", PTest: []byte("package x\n")},
-			}
-
-			// First write — cache miss, writes files.
-			dir1, err := gotestrunner.WriteOverlay(results)
-			gotest.NoError(it, err)
-			defer os.RemoveAll(dir1)
-
-			// Manually write to cache to simulate prior run.
-			hash := gotestrunner.ExportOverlayContentHash(results)
-			cachedDir := filepath.Join(cacheDir, "overlays", hash)
-			os.MkdirAll(filepath.Join(cachedDir, "0"), 0755)
-			os.WriteFile(filepath.Join(cachedDir, "0", "gotest_psuite_test.go"), []byte("package x\n"), 0644)
-			overlayData := fmt.Sprintf(`{"Replace":{"%s":"%s"}}`,
-				filepath.Join("/fake/pkg/x", "gotest_psuite_test.go"),
-				filepath.Join(cachedDir, "0", "gotest_psuite_test.go"))
-			os.WriteFile(filepath.Join(cachedDir, "overlay.json"), []byte(overlayData), 0644)
-
-			// Second call via GenerateOverlay path — should find cache hit.
-			overlay, cleanup, err := gotestrunner.GenerateOverlay(nil, false, false)
-			if err == nil {
-				defer cleanup()
-				// If loaded is nil it produces empty results, which has a different hash.
-				// That's fine — we're testing the WriteOverlay path separately.
-				_ = overlay
-			}
-		})
-
 		w.It("creates valid overlay in cache directory", func(it *gotest.T) {
 			cacheDir := it.T().TempDir()
 			it.T().Setenv(protocol.EnvCacheDir, cacheDir)

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -338,6 +338,212 @@ func (s *GotestrunnerTestSuite) TestOverlayManagement(t *gotest.T) {
 	})
 }
 
+// --- overlay cache tests ---
+
+func (s *GotestrunnerTestSuite) TestOverlayCache(t *gotest.T) {
+	t.When("computing content hash", func(w *gotest.T) {
+		w.It("produces deterministic hash for same content", func(it *gotest.T) {
+			results := gotestgen.GenerateResults{
+				{AbsPath: "/pkg/a", PTest: []byte("package a\n")},
+				{AbsPath: "/pkg/b", PTest: []byte("package b\n"), PXTest: []byte("package b_test\n")},
+			}
+			h1 := gotestrunner.ExportOverlayContentHash(results)
+			h2 := gotestrunner.ExportOverlayContentHash(results)
+			gotest.Equal(it, h1, h2)
+			gotest.Equal(it, 64, len(h1))
+		})
+
+		w.It("is order-independent (sorted by AbsPath)", func(it *gotest.T) {
+			r1 := gotestgen.GenerateResults{
+				{AbsPath: "/pkg/a", PTest: []byte("aaa")},
+				{AbsPath: "/pkg/b", PTest: []byte("bbb")},
+			}
+			r2 := gotestgen.GenerateResults{
+				{AbsPath: "/pkg/b", PTest: []byte("bbb")},
+				{AbsPath: "/pkg/a", PTest: []byte("aaa")},
+			}
+			gotest.Equal(it, gotestrunner.ExportOverlayContentHash(r1), gotestrunner.ExportOverlayContentHash(r2))
+		})
+
+		w.It("changes when content changes", func(it *gotest.T) {
+			r1 := gotestgen.GenerateResults{
+				{AbsPath: "/pkg/a", PTest: []byte("version1")},
+			}
+			r2 := gotestgen.GenerateResults{
+				{AbsPath: "/pkg/a", PTest: []byte("version2")},
+			}
+			gotest.NotEqual(it, gotestrunner.ExportOverlayContentHash(r1), gotestrunner.ExportOverlayContentHash(r2))
+		})
+
+		w.It("changes when AbsPath changes", func(it *gotest.T) {
+			r1 := gotestgen.GenerateResults{
+				{AbsPath: "/pkg/a", PTest: []byte("same")},
+			}
+			r2 := gotestgen.GenerateResults{
+				{AbsPath: "/pkg/b", PTest: []byte("same")},
+			}
+			gotest.NotEqual(it, gotestrunner.ExportOverlayContentHash(r1), gotestrunner.ExportOverlayContentHash(r2))
+		})
+
+		w.It("returns empty-stable hash for nil results", func(it *gotest.T) {
+			h1 := gotestrunner.ExportOverlayContentHash(nil)
+			h2 := gotestrunner.ExportOverlayContentHash(gotestgen.GenerateResults{})
+			gotest.Equal(it, h1, h2)
+			gotest.Equal(it, 64, len(h1))
+		})
+	})
+
+	t.When("cache root resolution", func(w *gotest.T) {
+		w.It("respects GOTEST_CACHE_DIR env var", func(it *gotest.T) {
+			dir := it.T().TempDir()
+			it.T().Setenv(protocol.EnvCacheDir, dir)
+
+			root, err := gotestrunner.ExportCacheRoot()
+			gotest.NoError(it, err)
+			gotest.Equal(it, dir, root)
+		})
+
+		w.It("falls back to UserCacheDir/gotest when env is unset", func(it *gotest.T) {
+			it.T().Setenv(protocol.EnvCacheDir, "")
+
+			root, err := gotestrunner.ExportCacheRoot()
+			gotest.NoError(it, err)
+			gotest.True(it, strings.HasSuffix(root, filepath.Join("gotest")))
+			gotest.NotEmpty(it, root)
+		})
+	})
+
+	t.When("writing to cache", func(w *gotest.T) {
+		w.It("returns cached directory on cache hit", func(it *gotest.T) {
+			cacheDir := it.T().TempDir()
+			it.T().Setenv(protocol.EnvCacheDir, cacheDir)
+
+			results := gotestgen.GenerateResults{
+				{AbsPath: "/fake/pkg/x", PTest: []byte("package x\n")},
+			}
+
+			// First write — cache miss, writes files.
+			dir1, err := gotestrunner.WriteOverlay(results)
+			gotest.NoError(it, err)
+			defer os.RemoveAll(dir1)
+
+			// Manually write to cache to simulate prior run.
+			hash := gotestrunner.ExportOverlayContentHash(results)
+			cachedDir := filepath.Join(cacheDir, "overlays", hash)
+			os.MkdirAll(filepath.Join(cachedDir, "0"), 0755)
+			os.WriteFile(filepath.Join(cachedDir, "0", "gotest_psuite_test.go"), []byte("package x\n"), 0644)
+			overlayData := fmt.Sprintf(`{"Replace":{"%s":"%s"}}`,
+				filepath.Join("/fake/pkg/x", "gotest_psuite_test.go"),
+				filepath.Join(cachedDir, "0", "gotest_psuite_test.go"))
+			os.WriteFile(filepath.Join(cachedDir, "overlay.json"), []byte(overlayData), 0644)
+
+			// Second call via GenerateOverlay path — should find cache hit.
+			overlay, cleanup, err := gotestrunner.GenerateOverlay(nil, false, false)
+			if err == nil {
+				defer cleanup()
+				// If loaded is nil it produces empty results, which has a different hash.
+				// That's fine — we're testing the WriteOverlay path separately.
+				_ = overlay
+			}
+		})
+
+		w.It("creates valid overlay in cache directory", func(it *gotest.T) {
+			cacheDir := it.T().TempDir()
+			it.T().Setenv(protocol.EnvCacheDir, cacheDir)
+
+			results := gotestgen.GenerateResults{
+				{AbsPath: "/fake/pkg/m", PTest: []byte("package m\n"), PXTest: []byte("package m_test\n")},
+			}
+
+			hash := gotestrunner.ExportOverlayContentHash(results)
+			expectedDir := filepath.Join(cacheDir, "overlays", hash)
+
+			// Ensure it doesn't exist yet.
+			_, err := os.Stat(expectedDir)
+			gotest.True(it, os.IsNotExist(err))
+
+			// Write via the exported WriteOverlay — this uses tmpdir path.
+			// For cache path, we test the internal via GenerateOverlay with noCache=false.
+			// Since GenerateOverlay needs loaded packages, test the cache write separately.
+			// We'll use writeOverlayCached indirectly by calling the exported function.
+			dir, err := gotestrunner.ExportWriteOverlayCached(results, false)
+			gotest.NoError(it, err)
+
+			gotest.Equal(it, expectedDir, dir)
+
+			// Verify overlay.json exists and is valid.
+			data, err := os.ReadFile(filepath.Join(dir, "overlay.json"))
+			gotest.NoError(it, err)
+			var ov gotestrunner.ExportOverlayJSON
+			gotest.NoError(it, json.Unmarshal(data, &ov))
+			gotest.Equal(it, 2, len(ov.Replace))
+		})
+
+		w.It("returns same directory on repeated calls (cache hit)", func(it *gotest.T) {
+			cacheDir := it.T().TempDir()
+			it.T().Setenv(protocol.EnvCacheDir, cacheDir)
+
+			results := gotestgen.GenerateResults{
+				{AbsPath: "/fake/pkg/r", PTest: []byte("package r\n")},
+			}
+
+			dir1, err := gotestrunner.ExportWriteOverlayCached(results, false)
+			gotest.NoError(it, err)
+
+			dir2, err := gotestrunner.ExportWriteOverlayCached(results, false)
+			gotest.NoError(it, err)
+
+			gotest.Equal(it, dir1, dir2)
+		})
+
+		w.It("falls back to tmpdir when noCache is true", func(it *gotest.T) {
+			cacheDir := it.T().TempDir()
+			it.T().Setenv(protocol.EnvCacheDir, cacheDir)
+
+			results := gotestgen.GenerateResults{
+				{AbsPath: "/fake/pkg/nc", PTest: []byte("package nc\n")},
+			}
+
+			dir, err := gotestrunner.ExportWriteOverlayCached(results, true)
+			gotest.NoError(it, err)
+			defer os.RemoveAll(dir)
+
+			// Should be in tmpdir, not in cache.
+			gotest.False(it, strings.HasPrefix(dir, cacheDir))
+		})
+	})
+
+	t.When("cleaning old cache entries", func(w *gotest.T) {
+		w.It("removes entries older than 7 days", func(it *gotest.T) {
+			cacheDir := it.T().TempDir()
+			it.T().Setenv(protocol.EnvCacheDir, cacheDir)
+
+			overlaysDir := filepath.Join(cacheDir, "overlays")
+			os.MkdirAll(overlaysDir, 0755)
+
+			// Create an old entry.
+			oldDir := filepath.Join(overlaysDir, "old-hash-entry")
+			os.MkdirAll(oldDir, 0755)
+			os.WriteFile(filepath.Join(oldDir, "overlay.json"), []byte("{}"), 0644)
+			oldTime := time.Now().Add(-8 * 24 * time.Hour)
+			os.Chtimes(oldDir, oldTime, oldTime)
+
+			// Create a fresh entry.
+			freshDir := filepath.Join(overlaysDir, "fresh-hash-entry")
+			os.MkdirAll(freshDir, 0755)
+			os.WriteFile(filepath.Join(freshDir, "overlay.json"), []byte("{}"), 0644)
+
+			gotestrunner.CleanStaleOverlays()
+
+			_, err := os.Stat(oldDir)
+			gotest.True(it, os.IsNotExist(err), "expected old cache entry to be removed")
+
+			_, err = os.Stat(freshDir)
+			gotest.False(it, os.IsNotExist(err), "expected fresh cache entry to be kept")
+		})
+	})
+}
+
 // --- buildSuiteCmd tests ---
 
 func (s *GotestrunnerTestSuite) TestBuildSuiteCmd(t *gotest.T) {

--- a/internal/gotestrunner/overlay.go
+++ b/internal/gotestrunner/overlay.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/mvrahden/go-test/about"
 	"github.com/mvrahden/go-test/internal/gotestgen"
@@ -136,6 +137,8 @@ func writeToCacheDir(root string, results gotestgen.GenerateResults) (string, er
 	dir := filepath.Join(root, "overlays", hash)
 
 	if _, err := os.Stat(filepath.Join(dir, "overlay.json")); err == nil {
+		now := time.Now()
+		os.Chtimes(dir, now, now)
 		return dir, nil
 	}
 

--- a/internal/gotestrunner/overlay.go
+++ b/internal/gotestrunner/overlay.go
@@ -2,14 +2,17 @@ package gotestrunner
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 
 	"github.com/mvrahden/go-test/about"
 	"github.com/mvrahden/go-test/internal/gotestgen"
+	"github.com/mvrahden/go-test/internal/protocol"
 )
 
 type OverlayResult struct {
@@ -25,7 +28,7 @@ type OverlayResult struct {
 	SuiteRequiredSharedFixtureKeys map[string]map[string][]string
 }
 
-func GenerateOverlay(loaded []*gotestgen.LoadResult, debug bool) (*OverlayResult, func(), error) {
+func GenerateOverlay(loaded []*gotestgen.LoadResult, debug bool, noCache bool) (*OverlayResult, func(), error) {
 	allResults, allSharedFixtures, err := gotestgen.GenerateFromLoaded(loaded)
 	if err != nil {
 		return nil, nil, err
@@ -33,14 +36,17 @@ func GenerateOverlay(loaded []*gotestgen.LoadResult, debug bool) (*OverlayResult
 
 	CleanStaleOverlays()
 
-	tmpDir, err := WriteOverlay(allResults)
+	dir, cached, err := writeOverlayCached(allResults, noCache)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	cleanup := func() { os.RemoveAll(tmpDir) }
+	cleanup := func() {}
+	if !cached {
+		cleanup = func() { os.RemoveAll(dir) }
+	}
 	if debug {
-		fmt.Fprintf(os.Stderr, "DEBUG: overlay dir: %s\n", tmpDir)
+		fmt.Fprintf(os.Stderr, "DEBUG: overlay dir: %s (cached=%v)\n", dir, cached)
 		cleanup = func() {}
 	}
 
@@ -79,8 +85,8 @@ func GenerateOverlay(loaded []*gotestgen.LoadResult, debug bool) (*OverlayResult
 	}
 
 	return &OverlayResult{
-		TmpDir:           tmpDir,
-		OverlayFlag:      "-overlay=" + filepath.Join(tmpDir, "overlay.json"),
+		TmpDir:           dir,
+		OverlayFlag:      "-overlay=" + filepath.Join(dir, "overlay.json"),
 		SharedFixtures:   allSharedFixtures,
 		SuitePackages:    suitePkgs,
 		NoSuitePackages:  noSuitePkgs,
@@ -96,7 +102,55 @@ type overlayJSON struct {
 	Replace map[string]string `json:"Replace"`
 }
 
+// writeOverlayCached attempts to write the overlay to a content-addressable
+// cache directory. On cache hit it returns the existing directory. On failure
+// to resolve or write to the cache, it falls back to a temporary directory.
+// The returned bool indicates whether the directory is cached (true) or
+// ephemeral (false).
+func writeOverlayCached(results gotestgen.GenerateResults, noCache bool) (string, bool, error) {
+	if !noCache {
+		root, err := cacheRoot()
+		if err == nil {
+			dir, err := writeToCacheDir(root, results)
+			if err == nil {
+				return dir, true, nil
+			}
+		}
+	}
+
+	dir, err := writeToTmpDir(results)
+	if err != nil {
+		return "", false, err
+	}
+	return dir, false, nil
+}
+
+// WriteOverlay writes overlay files to a temporary directory (legacy behaviour).
+// Exported for backward compatibility with tests.
 func WriteOverlay(results gotestgen.GenerateResults) (string, error) {
+	return writeToTmpDir(results)
+}
+
+func writeToCacheDir(root string, results gotestgen.GenerateResults) (string, error) {
+	hash := overlayContentHash(results)
+	dir := filepath.Join(root, "overlays", hash)
+
+	if _, err := os.Stat(filepath.Join(dir, "overlay.json")); err == nil {
+		return dir, nil
+	}
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("create cache dir: %w", err)
+	}
+
+	if err := writeOverlayFiles(dir, results); err != nil {
+		os.RemoveAll(dir)
+		return "", err
+	}
+	return dir, nil
+}
+
+func writeToTmpDir(results gotestgen.GenerateResults) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("get working directory: %w", err)
@@ -113,43 +167,87 @@ func WriteOverlay(results gotestgen.GenerateResults) (string, error) {
 		return "", fmt.Errorf("write pid file: %w", err)
 	}
 
+	if err := writeOverlayFiles(tmpDir, results); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", err
+	}
+	return tmpDir, nil
+}
+
+func writeOverlayFiles(dir string, results gotestgen.GenerateResults) error {
 	overlay := overlayJSON{Replace: map[string]string{}}
 
 	for i, result := range results {
-		subDir := filepath.Join(tmpDir, strconv.Itoa(i))
-		if err := os.Mkdir(subDir, 0755); err != nil {
-			os.RemoveAll(tmpDir)
-			return "", fmt.Errorf("create overlay sub dir: %w", err)
+		subDir := filepath.Join(dir, strconv.Itoa(i))
+		if err := os.MkdirAll(subDir, 0755); err != nil {
+			return fmt.Errorf("create overlay sub dir: %w", err)
 		}
 
 		if len(result.PTest) > 0 {
 			dst := filepath.Join(subDir, about.PSuite)
 			if err := os.WriteFile(dst, result.PTest, 0644); err != nil {
-				os.RemoveAll(tmpDir)
-				return "", fmt.Errorf("write overlay ptest: %w", err)
+				return fmt.Errorf("write overlay ptest: %w", err)
 			}
 			overlay.Replace[filepath.Join(result.AbsPath, about.PSuite)] = dst
 		}
 		if len(result.PXTest) > 0 {
 			dst := filepath.Join(subDir, about.PXSuite)
 			if err := os.WriteFile(dst, result.PXTest, 0644); err != nil {
-				os.RemoveAll(tmpDir)
-				return "", fmt.Errorf("write overlay pxtest: %w", err)
+				return fmt.Errorf("write overlay pxtest: %w", err)
 			}
 			overlay.Replace[filepath.Join(result.AbsPath, about.PXSuite)] = dst
 		}
 	}
 
-	overlayPath := filepath.Join(tmpDir, "overlay.json")
 	data, err := json.Marshal(overlay)
 	if err != nil {
-		os.RemoveAll(tmpDir)
-		return "", fmt.Errorf("marshal overlay json: %w", err)
+		return fmt.Errorf("marshal overlay json: %w", err)
 	}
-	if err := os.WriteFile(overlayPath, data, 0644); err != nil {
-		os.RemoveAll(tmpDir)
-		return "", fmt.Errorf("write overlay json: %w", err)
+	// Write overlay.json last — its presence signals a complete, valid entry.
+	if err := os.WriteFile(filepath.Join(dir, "overlay.json"), data, 0644); err != nil {
+		return fmt.Errorf("write overlay json: %w", err)
 	}
+	return nil
+}
 
-	return tmpDir, nil
+// overlayContentHash computes a deterministic SHA-256 hash over the generated
+// overlay content. The hash covers AbsPath and file content for each result,
+// sorted by AbsPath for stability.
+func overlayContentHash(results gotestgen.GenerateResults) string {
+	type entry struct {
+		absPath string
+		ptest   []byte
+		pxtest  []byte
+	}
+	entries := make([]entry, len(results))
+	for i, r := range results {
+		entries[i] = entry{absPath: r.AbsPath, ptest: r.PTest, pxtest: r.PXTest}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].absPath < entries[j].absPath
+	})
+
+	h := sha256.New()
+	for _, e := range entries {
+		h.Write([]byte(e.absPath))
+		h.Write([]byte{0})
+		h.Write(e.ptest)
+		h.Write([]byte{0})
+		h.Write(e.pxtest)
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// cacheRoot returns the gotest cache directory, respecting the GOTEST_CACHE_DIR
+// env var with fallback to os.UserCacheDir()/gotest.
+func cacheRoot() (string, error) {
+	if dir := os.Getenv(protocol.EnvCacheDir); dir != "" {
+		return dir, nil
+	}
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "gotest"), nil
 }

--- a/internal/gotestrunner/overlay_cleanup.go
+++ b/internal/gotestrunner/overlay_cleanup.go
@@ -5,9 +5,17 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
+// CleanStaleOverlays removes temporary overlay directories whose owning
+// process is no longer alive, and evicts aged-out cache entries.
 func CleanStaleOverlays() {
+	cleanStaleTmpOverlays()
+	cleanOldCacheEntries()
+}
+
+func cleanStaleTmpOverlays() {
 	pattern := filepath.Join(os.TempDir(), "gotest-overlay-*")
 	dirs, err := filepath.Glob(pattern)
 	if err != nil {
@@ -22,6 +30,33 @@ func CleanStaleOverlays() {
 			continue
 		}
 		os.RemoveAll(dir)
+	}
+}
+
+const cacheMaxAge = 7 * 24 * time.Hour
+
+func cleanOldCacheEntries() {
+	root, err := cacheRoot()
+	if err != nil {
+		return
+	}
+	overlaysDir := filepath.Join(root, "overlays")
+	entries, err := os.ReadDir(overlaysDir)
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if now.Sub(info.ModTime()) > cacheMaxAge {
+			os.RemoveAll(filepath.Join(overlaysDir, e.Name()))
+		}
 	}
 }
 

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -5,6 +5,7 @@ const (
 	EnvTeardownBudgetFile = "GOTEST_TEARDOWN_BUDGET_FILE"
 	EnvUpdateSnapshots    = "GOTEST_UPDATE_SNAPSHOTS"
 	EnvCI                 = "GOTEST_CI"
+	EnvCacheDir           = "GOTEST_CACHE_DIR"
 )
 
 func BudgetFilePath(binaryPath string) string {


### PR DESCRIPTION
Caches generated overlay files by content hash so repeated runs skip regeneration. Cache entries auto-evict after 7 days. Adds `--no-cache` flag and `GOTEST_CACHE_DIR` env var. Also updates `--ci` documentation to reflect snapshot read-only mode and `CI` auto-detection, and fixes stale generated file name references across docs.