### PR TITLE
Fix parent nodes not turning green when all child tests pass

### DIFF
--- a/vscode-gotest/package-lock.json
+++ b/vscode-gotest/package-lock.json
@@ -27,6 +27,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -39,6 +40,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -523,9 +525,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -533,9 +535,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -550,9 +552,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -567,9 +569,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -584,9 +586,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -601,9 +603,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -618,9 +620,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -635,9 +637,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -652,9 +654,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -669,9 +671,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -686,9 +688,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -703,9 +705,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -720,9 +722,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -737,9 +739,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -756,9 +758,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -773,9 +775,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -790,9 +792,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -804,9 +806,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -833,40 +835,41 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.118.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.118.0.tgz",
-      "integrity": "sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==",
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -875,13 +878,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -902,9 +905,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -915,13 +918,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.8",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -929,14 +932,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -945,9 +948,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -955,13 +958,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
+        "@vitest/pretty-format": "4.1.8",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1020,6 +1023,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1399,15 +1403,18 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1429,6 +1436,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1437,9 +1445,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1457,7 +1465,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1482,14 +1490,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -1498,21 +1506,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/siginfo": {
@@ -1554,9 +1562,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1564,9 +1572,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1620,17 +1628,18 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -1646,7 +1655,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -1698,19 +1707,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -1738,12 +1747,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/vscode-gotest/src/runner.ts
+++ b/vscode-gotest/src/runner.ts
@@ -5,6 +5,7 @@ import { scopedConfig } from "./cli.js";
 import {
   collectItems,
   enqueueDescendants,
+  enqueueAncestors,
   groupByPackage,
   buildRunFilter,
   resolveAncestorItems,
@@ -90,6 +91,7 @@ export class TestRunner {
         run.started(item);
         enqueueDescendants(run, item);
       }
+      enqueueAncestors(run, items);
 
       const groups = groupByPackage(items);
 

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -779,6 +779,7 @@ describe("resolveAncestorItems", () => {
 
     const controller = {
       getResult: vi.fn((_id: string) => undefined as any),
+      recordResult: vi.fn(),
       testController: {
         items: new Map<string, MockTestItem>([["dir:internal", dir]]),
       },
@@ -834,6 +835,7 @@ describe("resolveAncestorItems", () => {
           return { status: "fail" as const, duration: 200 };
         return undefined;
       }),
+      recordResult: vi.fn(),
       testController: {
         items: new Map<string, MockTestItem>([["dir:pkg", dir]]),
       },
@@ -863,6 +865,7 @@ describe("resolveAncestorItems", () => {
           return { status: "pass" as const, duration: 200 };
         return undefined;
       }),
+      recordResult: vi.fn(),
       testController: {
         items: new Map<string, MockTestItem>([["dir:pkg", dir]]),
       },
@@ -890,6 +893,7 @@ describe("resolveAncestorItems", () => {
           return { status: "fail" as const, duration: 300 };
         return undefined;
       }),
+      recordResult: vi.fn(),
       testController: {
         items: new Map<string, MockTestItem>([["dir:src", root]]),
       },
@@ -917,6 +921,7 @@ describe("resolveAncestorItems", () => {
           return { status: "pass" as const, duration: 100 };
         return undefined;
       }),
+      recordResult: vi.fn(),
       testController: {
         items: new Map<string, MockTestItem>([
           ["wsFolder:myproject", wsFolder],
@@ -954,6 +959,62 @@ describe("resolveAncestorItems", () => {
     expect(run.failed).toHaveBeenCalledWith(pkg, []);
     expect(run.failed).toHaveBeenCalledWith(dir, []);
     expect(run.passed).not.toHaveBeenCalled();
+  });
+
+  it("re-aggregates dir node instead of using stale stored result", () => {
+    const dir = createItem("dir:pkg", "pkg", undefined);
+    const pkgA = createItem("example.com/pkg/a", "a", dir, [{ id: "package" }]);
+    const suiteA = createItem("example.com/pkg/a/SuiteA", "SuiteA", pkgA);
+
+    const run = { passed: vi.fn(), failed: vi.fn() };
+    const controller = {
+      getResult: vi.fn((id: string) => {
+        if (id === "dir:pkg")
+          return { status: "fail" as const, duration: undefined };
+        if (id === "example.com/pkg/a/SuiteA")
+          return { status: "pass" as const, duration: 100 };
+        return undefined;
+      }),
+      recordResult: vi.fn(),
+      testController: {
+        items: new Map([["dir:pkg", dir]]),
+      },
+    };
+
+    resolveAncestorItems(run as any, controller as any);
+
+    expect(run.passed).toHaveBeenCalledWith(pkgA);
+    expect(run.passed).toHaveBeenCalledWith(dir);
+    expect(run.failed).not.toHaveBeenCalled();
+  });
+
+  it("re-aggregates wsFolder node instead of using stale stored result", () => {
+    const wsFolder = createItem("wsFolder:myproject", "myproject", undefined);
+    const pkg = createItem("example.com/root", "root", wsFolder, [
+      { id: "package" },
+    ]);
+    const suite = createItem("example.com/root/Suite", "Suite", pkg);
+
+    const run = { passed: vi.fn(), failed: vi.fn() };
+    const controller = {
+      getResult: vi.fn((id: string) => {
+        if (id === "wsFolder:myproject")
+          return { status: "fail" as const, duration: undefined };
+        if (id === "example.com/root/Suite")
+          return { status: "pass" as const, duration: 100 };
+        return undefined;
+      }),
+      recordResult: vi.fn(),
+      testController: {
+        items: new Map([["wsFolder:myproject", wsFolder]]),
+      },
+    };
+
+    resolveAncestorItems(run as any, controller as any);
+
+    expect(run.passed).toHaveBeenCalledWith(pkg);
+    expect(run.passed).toHaveBeenCalledWith(wsFolder);
+    expect(run.failed).not.toHaveBeenCalled();
   });
 });
 

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -469,7 +469,7 @@ describe("applyResults", () => {
     return { controller, run, passItem, failItem, skipItem };
   }
 
-  it("returns AppliedResult[] and does NOT call controller.recordResult", () => {
+  it("returns AppliedResult[] and records results to controller", () => {
     const { controller, run, passItem, failItem, skipItem } =
       makeApplyResultsFixture();
 
@@ -540,8 +540,10 @@ describe("applyResults", () => {
       duration: undefined,
     });
 
-    // Does NOT call controller.recordResult
-    expect(controller.recordResult).not.toHaveBeenCalled();
+    // Records each test result to the controller
+    expect(controller.recordResult).toHaveBeenCalledWith(passItem.id, "pass", 100);
+    expect(controller.recordResult).toHaveBeenCalledWith(failItem.id, "fail", 200);
+    expect(controller.recordResult).toHaveBeenCalledWith(skipItem.id, "skip", undefined);
 
     // Does call run methods
     expect(run.passed).toHaveBeenCalledWith(passItem, 100);
@@ -1108,5 +1110,59 @@ describe("resolveRunPatterns", () => {
 
   it("returns undefined for empty array", () => {
     expect(resolveRunPatterns([], "example.com/proj")).toBeUndefined();
+  });
+});
+
+describe("applyResults records before resolving ancestors", () => {
+  it("records package result so resolveAncestorsOf can cascade", () => {
+    const dir = createItem("dir:pkg", "pkg", undefined);
+    const pkg = createItem("example.com/pkg", "pkg", dir, [{ id: "package" }]);
+    const suite = createItem("example.com/pkg/MySuite", "MySuite", pkg);
+    const method = createItem(
+      "example.com/pkg/MySuite/TestFoo",
+      "TestFoo",
+      suite,
+    );
+
+    const results = new Map<string, { status: string; duration?: number }>();
+    const run = {
+      passed: vi.fn(),
+      failed: vi.fn(),
+      skipped: vi.fn(),
+      started: vi.fn(),
+      appendOutput: vi.fn(),
+    };
+    const controller = {
+      findItem: vi.fn((id: string) => {
+        if (id === "example.com/pkg") return pkg;
+        if (id === "example.com/pkg/MySuite") return suite;
+        if (id === "example.com/pkg/MySuite/TestFoo") return method;
+        return undefined;
+      }),
+      getResult: vi.fn((id: string) => results.get(id)),
+      recordResult: vi.fn(
+        (id: string, status: string, duration?: number) => {
+          results.set(id, { status, duration });
+        },
+      ),
+      createDynamicSubtest: vi.fn(),
+    };
+
+    const events = [
+      { Package: "example.com/pkg", Test: "MySuite/TestFoo", Action: "pass" as const, Elapsed: 0.1 },
+      { Package: "example.com/pkg", Test: "MySuite", Action: "pass" as const, Elapsed: 0.2 },
+      { Package: "example.com/pkg", Action: "pass" as const, Elapsed: 0.3 },
+    ];
+
+    applyResults(controller as any, run as any, events, "example.com/pkg", "/fake/dir");
+
+    // The package result must have been recorded
+    expect(controller.recordResult).toHaveBeenCalledWith(
+      "example.com/pkg",
+      "pass",
+      300,
+    );
+    // resolveAncestorsOf should have resolved dir:pkg because the pkg result was in the store
+    expect(run.passed).toHaveBeenCalledWith(dir);
   });
 });

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -48,6 +48,7 @@ import {
   resolveRunPatterns,
   applyResults,
   enqueueDescendants,
+  enqueueAncestors,
   resolveAncestorItems,
   resolveAncestorsOf,
 } from "./runnerUtils.js";
@@ -1018,6 +1019,39 @@ describe("resolveAncestorItems", () => {
   });
 });
 
+describe("enqueueAncestors", () => {
+  it("enqueues all ancestors of given items", () => {
+    const root = createItem("dir:pkg", "pkg", undefined);
+    const sub = createItem("dir:pkg/sub", "sub", root);
+    const pkg = createItem("example.com/pkg/sub/a", "a", sub, [
+      { id: "package" },
+    ]);
+
+    const run = { enqueued: vi.fn() };
+    enqueueAncestors(run as any, [pkg as any]);
+
+    expect(run.enqueued).toHaveBeenCalledTimes(2);
+    expect(run.enqueued).toHaveBeenCalledWith(sub);
+    expect(run.enqueued).toHaveBeenCalledWith(root);
+  });
+
+  it("deduplicates shared ancestors", () => {
+    const root = createItem("dir:pkg", "pkg", undefined);
+    const pkgA = createItem("example.com/pkg/a", "a", root, [
+      { id: "package" },
+    ]);
+    const pkgB = createItem("example.com/pkg/b", "b", root, [
+      { id: "package" },
+    ]);
+
+    const run = { enqueued: vi.fn() };
+    enqueueAncestors(run as any, [pkgA as any, pkgB as any]);
+
+    expect(run.enqueued).toHaveBeenCalledTimes(1);
+    expect(run.enqueued).toHaveBeenCalledWith(root);
+  });
+});
+
 describe("resolveAncestorsOf", () => {
   it("propagates passed to parent when all siblings resolved", () => {
     const dir = createItem("dir:pkg", "pkg", undefined);
@@ -1215,7 +1249,7 @@ describe("applyResults records before resolving ancestors", () => {
       { Package: "example.com/pkg", Action: "pass" as const, Elapsed: 0.3 },
     ];
 
-    applyResults(controller as any, run as any, events, "example.com/pkg", "/fake/dir");
+    applyResults(controller as any, run as any, events as any, "example.com/pkg", "/fake/dir");
 
     // The package result must have been recorded
     expect(controller.recordResult).toHaveBeenCalledWith(

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -542,9 +542,21 @@ describe("applyResults", () => {
     });
 
     // Records each test result to the controller
-    expect(controller.recordResult).toHaveBeenCalledWith(passItem.id, "pass", 100);
-    expect(controller.recordResult).toHaveBeenCalledWith(failItem.id, "fail", 200);
-    expect(controller.recordResult).toHaveBeenCalledWith(skipItem.id, "skip", undefined);
+    expect(controller.recordResult).toHaveBeenCalledWith(
+      passItem.id,
+      "pass",
+      100,
+    );
+    expect(controller.recordResult).toHaveBeenCalledWith(
+      failItem.id,
+      "fail",
+      200,
+    );
+    expect(controller.recordResult).toHaveBeenCalledWith(
+      skipItem.id,
+      "skip",
+      undefined,
+    );
 
     // Does call run methods
     expect(run.passed).toHaveBeenCalledWith(passItem, 100);
@@ -774,6 +786,7 @@ describe("resolveAncestorItems", () => {
     );
 
     const run = {
+      started: vi.fn(),
       passed: vi.fn(),
       failed: vi.fn(),
     };
@@ -827,7 +840,7 @@ describe("resolveAncestorItems", () => {
     const pkgB = createItem("example.com/pkg/b", "b", dir, [{ id: "package" }]);
     const suiteB = createItem("example.com/pkg/b/SuiteB", "SuiteB", pkgB);
 
-    const run = { passed: vi.fn(), failed: vi.fn() };
+    const run = { started: vi.fn(), passed: vi.fn(), failed: vi.fn() };
     const controller = {
       getResult: vi.fn((id: string) => {
         if (id === "example.com/pkg/a/SuiteA")
@@ -855,7 +868,7 @@ describe("resolveAncestorItems", () => {
     const suiteA = createItem("example.com/pkg/SuiteA", "SuiteA", pkg);
     const suiteB = createItem("example.com/pkg/SuiteB", "SuiteB", pkg);
 
-    const run = { passed: vi.fn(), failed: vi.fn() };
+    const run = { started: vi.fn(), passed: vi.fn(), failed: vi.fn() };
     const controller = {
       getResult: vi.fn((id: string) => {
         if (id === "example.com/pkg")
@@ -887,7 +900,7 @@ describe("resolveAncestorItems", () => {
     ]);
     const suite = createItem("example.com/src/internal/svc/Svc", "Svc", pkg);
 
-    const run = { passed: vi.fn(), failed: vi.fn() };
+    const run = { started: vi.fn(), passed: vi.fn(), failed: vi.fn() };
     const controller = {
       getResult: vi.fn((id: string) => {
         if (id === "example.com/src/internal/svc/Svc")
@@ -915,7 +928,7 @@ describe("resolveAncestorItems", () => {
     ]);
     const suite = createItem("example.com/root/Suite", "Suite", pkg);
 
-    const run = { passed: vi.fn(), failed: vi.fn() };
+    const run = { started: vi.fn(), passed: vi.fn(), failed: vi.fn() };
     const controller = {
       getResult: vi.fn((id: string) => {
         if (id === "example.com/root/Suite")
@@ -967,7 +980,7 @@ describe("resolveAncestorItems", () => {
     const pkgA = createItem("example.com/pkg/a", "a", dir, [{ id: "package" }]);
     const suiteA = createItem("example.com/pkg/a/SuiteA", "SuiteA", pkgA);
 
-    const run = { passed: vi.fn(), failed: vi.fn() };
+    const run = { started: vi.fn(), passed: vi.fn(), failed: vi.fn() };
     const controller = {
       getResult: vi.fn((id: string) => {
         if (id === "dir:pkg")
@@ -996,7 +1009,7 @@ describe("resolveAncestorItems", () => {
     ]);
     const suite = createItem("example.com/root/Suite", "Suite", pkg);
 
-    const run = { passed: vi.fn(), failed: vi.fn() };
+    const run = { started: vi.fn(), passed: vi.fn(), failed: vi.fn() };
     const controller = {
       getResult: vi.fn((id: string) => {
         if (id === "wsFolder:myproject")
@@ -1015,6 +1028,86 @@ describe("resolveAncestorItems", () => {
 
     expect(run.passed).toHaveBeenCalledWith(pkg);
     expect(run.passed).toHaveBeenCalledWith(wsFolder);
+    expect(run.failed).not.toHaveBeenCalled();
+  });
+
+  it("cascades through all ancestor levels when resolveAncestorsOf is followed by resolveAncestorItems", () => {
+    // Models user scenario: re-run one package, siblings passed in prior runs,
+    // structural nodes have no stored results (first run with new extension).
+    //
+    // Tree:
+    //   wsFolder:root → dir:pkg → dir:platform → [api (pkg), billing (pkg)]
+    //                           → dir:core     → [auth (pkg)]
+    const root = createItem("wsFolder:root", "root", undefined);
+    const dirPkg = createItem("dir:pkg", "pkg", root);
+    const dirPlatform = createItem("dir:platform", "platform", dirPkg);
+    const dirCore = createItem("dir:core", "core", dirPkg);
+
+    const apiPkg = createItem("example.com/platform/api", "api", dirPlatform, [
+      { id: "package" },
+    ]);
+    const apiSuite = createItem("example.com/platform/api/Api", "Api", apiPkg);
+
+    const billingPkg = createItem(
+      "example.com/platform/billing",
+      "billing",
+      dirPlatform,
+      [{ id: "package" }],
+    );
+    const billingSuite = createItem(
+      "example.com/platform/billing/Billing",
+      "Billing",
+      billingPkg,
+    );
+
+    const authPkg = createItem("example.com/core/auth", "auth", dirCore, [
+      { id: "package" },
+    ]);
+    const authSuite = createItem("example.com/core/auth/Auth", "Auth", authPkg);
+
+    // Dynamic mock: recordResult feeds back into getResult
+    const results = new Map<string, { status: string; duration?: number }>();
+    // Package + suite results from current run and prior runs
+    results.set("example.com/platform/api", { status: "pass", duration: 100 });
+    results.set("example.com/platform/api/Api", {
+      status: "pass",
+      duration: 50,
+    });
+    results.set("example.com/platform/billing", {
+      status: "pass",
+      duration: 200,
+    });
+    results.set("example.com/platform/billing/Billing", {
+      status: "pass",
+      duration: 100,
+    });
+    results.set("example.com/core/auth", { status: "pass", duration: 150 });
+    results.set("example.com/core/auth/Auth", {
+      status: "pass",
+      duration: 75,
+    });
+    // NO structural node results — simulates first run after installing fix
+
+    const run = { started: vi.fn(), passed: vi.fn(), failed: vi.fn() };
+    const controller = {
+      getResult: vi.fn((id: string) => results.get(id)),
+      recordResult: vi.fn((id: string, status: string, duration?: number) => {
+        results.set(id, { status, duration });
+      }),
+      testController: {
+        items: new Map([["wsFolder:root", root]]),
+      },
+    };
+
+    // Step 1: resolveAncestorsOf from just-ran package (streaming, during run).
+    // dir:core has no stored result but its package descendants do, so
+    // resolveAncestorsOf resolves it from descendants and cascades all the way up.
+    resolveAncestorsOf(run as any, apiPkg as any, controller as any);
+
+    expect(run.passed).toHaveBeenCalledWith(dirPlatform);
+    expect(run.passed).toHaveBeenCalledWith(dirCore);
+    expect(run.passed).toHaveBeenCalledWith(dirPkg);
+    expect(run.passed).toHaveBeenCalledWith(root);
     expect(run.failed).not.toHaveBeenCalled();
   });
 });
@@ -1058,7 +1151,7 @@ describe("resolveAncestorsOf", () => {
     const pkgA = createItem("example.com/pkg/a", "a", dir, [{ id: "package" }]);
     const pkgB = createItem("example.com/pkg/b", "b", dir, [{ id: "package" }]);
 
-    const run = { passed: vi.fn(), failed: vi.fn() };
+    const run = { started: vi.fn(), passed: vi.fn(), failed: vi.fn() };
     const controller = {
       getResult: vi.fn((id: string) => {
         if (id === "example.com/pkg/a")
@@ -1085,7 +1178,7 @@ describe("resolveAncestorsOf", () => {
     const pkgA = createItem("example.com/pkg/a", "a", dir, [{ id: "package" }]);
     const pkgB = createItem("example.com/pkg/b", "b", dir, [{ id: "package" }]);
 
-    const run = { passed: vi.fn(), failed: vi.fn() };
+    const run = { started: vi.fn(), passed: vi.fn(), failed: vi.fn() };
     const controller = {
       getResult: vi.fn((id: string) => {
         if (id === "example.com/pkg/a")
@@ -1112,7 +1205,7 @@ describe("resolveAncestorsOf", () => {
     const pkgA = createItem("example.com/pkg/a", "a", dir, [{ id: "package" }]);
     const pkgB = createItem("example.com/pkg/b", "b", dir, [{ id: "package" }]);
 
-    const run = { passed: vi.fn(), failed: vi.fn() };
+    const run = { started: vi.fn(), passed: vi.fn(), failed: vi.fn() };
     const controller = {
       getResult: vi.fn((id: string) => {
         if (id === "example.com/pkg/a")
@@ -1136,16 +1229,15 @@ describe("resolveAncestorsOf", () => {
       { id: "package" },
     ]);
 
-    const run = { passed: vi.fn(), failed: vi.fn() };
+    const results = new Map<string, { status: string; duration?: number }>();
+    results.set("example.com/internal/svc", { status: "pass", duration: 100 });
+
+    const run = { started: vi.fn(), passed: vi.fn(), failed: vi.fn() };
     const controller = {
-      getResult: vi.fn((id: string) => {
-        if (id === "example.com/internal/svc")
-          return { status: "pass" as const, duration: 100 };
-        if (id === "dir:internal")
-          return { status: "pass" as const, duration: undefined };
-        return undefined;
+      getResult: vi.fn((id: string) => results.get(id)),
+      recordResult: vi.fn((id: string, status: string, duration?: number) => {
+        results.set(id, { status, duration });
       }),
-      recordResult: vi.fn(),
     };
 
     resolveAncestorsOf(run as any, pkg as any, controller as any);
@@ -1162,6 +1254,55 @@ describe("resolveAncestorsOf", () => {
       "pass",
       undefined,
     );
+  });
+
+  it("resolves structural siblings from descendants when they have no stored result", () => {
+    // dir:pkg has two structural children: dir:platform (has package result)
+    // and dir:core (NO stored result, but its package descendant has a result).
+    // resolveAncestorsOf should resolve dir:core from its descendants and
+    // cascade to dir:pkg.
+    const root = createItem("wsFolder:root", "root", undefined);
+    const dirPkg = createItem("dir:pkg", "pkg", root);
+    const dirPlatform = createItem("dir:platform", "platform", dirPkg);
+    const dirCore = createItem("dir:core", "core", dirPkg);
+
+    const apiPkg = createItem("example.com/platform/api", "api", dirPlatform, [
+      { id: "package" },
+    ]);
+    createItem("example.com/platform/api/Api", "Api", apiPkg);
+
+    const authPkg = createItem("example.com/core/auth", "auth", dirCore, [
+      { id: "package" },
+    ]);
+    createItem("example.com/core/auth/Auth", "Auth", authPkg);
+
+    const results = new Map<string, { status: string; duration?: number }>();
+    results.set("example.com/platform/api", { status: "pass", duration: 100 });
+    results.set("example.com/platform/api/Api", {
+      status: "pass",
+      duration: 50,
+    });
+    results.set("example.com/core/auth", { status: "pass", duration: 150 });
+    results.set("example.com/core/auth/Auth", {
+      status: "pass",
+      duration: 75,
+    });
+
+    const run = { started: vi.fn(), passed: vi.fn(), failed: vi.fn() };
+    const controller = {
+      getResult: vi.fn((id: string) => results.get(id)),
+      recordResult: vi.fn((id: string, status: string, duration?: number) => {
+        results.set(id, { status, duration });
+      }),
+    };
+
+    resolveAncestorsOf(run as any, apiPkg as any, controller as any);
+
+    expect(run.passed).toHaveBeenCalledWith(dirPlatform);
+    expect(run.passed).toHaveBeenCalledWith(dirCore);
+    expect(run.passed).toHaveBeenCalledWith(dirPkg);
+    expect(run.passed).toHaveBeenCalledWith(root);
+    expect(run.failed).not.toHaveBeenCalled();
   });
 });
 
@@ -1235,21 +1376,35 @@ describe("applyResults records before resolving ancestors", () => {
         return undefined;
       }),
       getResult: vi.fn((id: string) => results.get(id)),
-      recordResult: vi.fn(
-        (id: string, status: string, duration?: number) => {
-          results.set(id, { status, duration });
-        },
-      ),
+      recordResult: vi.fn((id: string, status: string, duration?: number) => {
+        results.set(id, { status, duration });
+      }),
       createDynamicSubtest: vi.fn(),
     };
 
     const events = [
-      { Package: "example.com/pkg", Test: "MySuite/TestFoo", Action: "pass" as const, Elapsed: 0.1 },
-      { Package: "example.com/pkg", Test: "MySuite", Action: "pass" as const, Elapsed: 0.2 },
+      {
+        Package: "example.com/pkg",
+        Test: "MySuite/TestFoo",
+        Action: "pass" as const,
+        Elapsed: 0.1,
+      },
+      {
+        Package: "example.com/pkg",
+        Test: "MySuite",
+        Action: "pass" as const,
+        Elapsed: 0.2,
+      },
       { Package: "example.com/pkg", Action: "pass" as const, Elapsed: 0.3 },
     ];
 
-    applyResults(controller as any, run as any, events as any, "example.com/pkg", "/fake/dir");
+    applyResults(
+      controller as any,
+      run as any,
+      events as any,
+      "example.com/pkg",
+      "/fake/dir",
+    );
 
     // The package result must have been recorded
     expect(controller.recordResult).toHaveBeenCalledWith(

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -615,13 +615,27 @@ export function resolveAncestorsOf(
     let allResolved = true;
     current.children.forEach((child) => {
       const result = controller.getResult(child.id);
-      if (!result) {
+      if (result) {
+        if (result.status === "fail") anyFailed = true;
+        return;
+      }
+      const isStructural =
+        child.id.startsWith("dir:") ||
+        child.id.startsWith("wsFolder:") ||
+        child.id.startsWith("module:");
+      if (isStructural) {
+        const r = resolveItemRecursive(run, child, controller);
+        if (r.anyResolved) {
+          if (r.anyFailed) anyFailed = true;
+        } else {
+          allResolved = false;
+        }
+      } else {
         allResolved = false;
-      } else if (result.status === "fail") {
-        anyFailed = true;
       }
     });
     if (!allResolved) break;
+    run.started(current);
     if (anyFailed) {
       run.failed(current, []);
     } else {
@@ -666,6 +680,7 @@ function resolveItemRecursive(
   });
 
   if (anyResolved) {
+    run.started(item);
     if (anyFailed) {
       run.failed(item, []);
     } else {

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -35,6 +35,22 @@ export function enqueueDescendants(
   });
 }
 
+export function enqueueAncestors(
+  run: vscode.TestRun,
+  items: vscode.TestItem[],
+): void {
+  const seen = new Set<string>();
+  for (const item of items) {
+    let ancestor = item.parent;
+    while (ancestor) {
+      if (seen.has(ancestor.id)) break;
+      run.enqueued(ancestor);
+      seen.add(ancestor.id);
+      ancestor = ancestor.parent;
+    }
+  }
+}
+
 export function collectItems(
   controller: GoTestController,
   request: vscode.TestRunRequest,

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -225,6 +225,7 @@ export function applyResults(
         const duration =
           event.Elapsed !== undefined ? event.Elapsed * 1000 : undefined;
         applied.push({ itemId: importPath, status: event.Action, duration });
+        controller.recordResult(importPath, event.Action, duration);
 
         const pkgItem = controller.findItem(importPath);
         if (pkgItem) {
@@ -253,6 +254,7 @@ export function applyResults(
       case "pass":
         run.passed(item, duration);
         applied.push({ itemId: item.id, status: "pass", duration });
+        controller.recordResult(item.id, "pass", duration);
         break;
       case "fail": {
         const output = outputMap.get(event.Test) ?? "";
@@ -279,11 +281,13 @@ export function applyResults(
         }
         run.failed(item, vscodeMessages, duration);
         applied.push({ itemId: item.id, status: "fail", duration });
+        controller.recordResult(item.id, "fail", duration);
         break;
       }
       case "skip":
         run.skipped(item);
         applied.push({ itemId: item.id, status: "skip", duration: undefined });
+        controller.recordResult(item.id, "skip", undefined);
         break;
       case "run":
         run.started(item);

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -632,8 +632,12 @@ function resolveItemRecursive(
 ): { anyFailed: boolean; anyResolved: boolean } {
   const directResult = controller.getResult(item.id);
   const isPackage = item.tags.some((t) => t.id === "package");
+  const isStructural =
+    item.id.startsWith("dir:") ||
+    item.id.startsWith("wsFolder:") ||
+    item.id.startsWith("module:");
 
-  if (directResult && !isPackage) {
+  if (directResult && !isPackage && !isStructural) {
     return { anyFailed: directResult.status === "fail", anyResolved: true };
   }
 
@@ -650,6 +654,9 @@ function resolveItemRecursive(
       run.failed(item, []);
     } else {
       run.passed(item);
+    }
+    if (isStructural) {
+      controller.recordResult(item.id, anyFailed ? "fail" : "pass", undefined);
     }
   }
 


### PR DESCRIPTION
Parent directory nodes in the Test Explorer stayed red even after all their child packages turned green; both when re-running packages individually and when running an entire subtree. Three small fixes:

- Record test results to the store before propagating state up the tree (the propagation was reading the store before the result was written, making it silently do nothing)
- Always recompute directory node state from children instead of trusting stale results from previous runs
- Mark ancestor nodes as "enqueued" so VS Code properly tracks them during partial runs