### PR TITLE
Keep overlay cache clean by separating build artifacts

### DIFF
--- a/cmd/gotest/prepare.go
+++ b/cmd/gotest/prepare.go
@@ -45,7 +45,7 @@ func runPrepare(inv Invocation) int {
 
 	var setupProc *gotestrunner.SharedFixtureProcess
 	if len(overlay.SharedFixtures) > 0 {
-		setupProc, err = gotestrunner.StartSharedFixtures(ctx, overlay.TmpDir, overlay.SharedFixtures, 0)
+		setupProc, err = gotestrunner.StartSharedFixtures(ctx, overlay.WorkDir, overlay.SharedFixtures, 0)
 		if err != nil {
 			stop()
 			cleanup()
@@ -64,8 +64,8 @@ func runPrepare(inv Invocation) int {
 	stop()
 
 	out := prepareOutput{
-		OverlayFile: filepath.Join(overlay.TmpDir, "overlay.json"),
-		Dir:         overlay.TmpDir,
+		OverlayFile: filepath.Join(overlay.CacheDir, "overlay.json"),
+		Dir:         overlay.WorkDir,
 	}
 	if setupProc != nil {
 		out.StateFile = setupProc.StateFile()

--- a/internal/gotestrunner/overlay.go
+++ b/internal/gotestrunner/overlay.go
@@ -17,7 +17,8 @@ import (
 )
 
 type OverlayResult struct {
-	TmpDir           string
+	CacheDir         string
+	WorkDir          string
 	OverlayFlag      string
 	SharedFixtures   []gotestgen.SharedFixtureInfo
 	SuitePackages    []string
@@ -37,17 +38,27 @@ func GenerateOverlay(loaded []*gotestgen.LoadResult, debug bool, noCache bool) (
 
 	CleanStaleOverlays()
 
-	dir, cached, err := writeOverlayCached(allResults, noCache)
+	cacheDir, cached, err := writeOverlayCached(allResults, noCache)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	cleanup := func() {}
-	if !cached {
-		cleanup = func() { os.RemoveAll(dir) }
+	workDir, err := os.MkdirTemp("", "gotest-work-*")
+	if err != nil {
+		if !cached {
+			os.RemoveAll(cacheDir)
+		}
+		return nil, nil, fmt.Errorf("create work dir: %w", err)
+	}
+
+	cleanup := func() {
+		os.RemoveAll(workDir)
+		if !cached {
+			os.RemoveAll(cacheDir)
+		}
 	}
 	if debug {
-		fmt.Fprintf(os.Stderr, "DEBUG: overlay dir: %s (cached=%v)\n", dir, cached)
+		fmt.Fprintf(os.Stderr, "DEBUG: overlay dir: %s (cached=%v)\nDEBUG: work dir: %s\n", cacheDir, cached, workDir)
 		cleanup = func() {}
 	}
 
@@ -86,8 +97,9 @@ func GenerateOverlay(loaded []*gotestgen.LoadResult, debug bool, noCache bool) (
 	}
 
 	return &OverlayResult{
-		TmpDir:           dir,
-		OverlayFlag:      "-overlay=" + filepath.Join(dir, "overlay.json"),
+		CacheDir:         cacheDir,
+		WorkDir:          workDir,
+		OverlayFlag:      "-overlay=" + filepath.Join(cacheDir, "overlay.json"),
 		SharedFixtures:   allSharedFixtures,
 		SuitePackages:    suitePkgs,
 		NoSuitePackages:  noSuitePkgs,

--- a/internal/gotestrunner/pipeline.go
+++ b/internal/gotestrunner/pipeline.go
@@ -90,7 +90,7 @@ func prepareTestRun(ctx context.Context, overlay *OverlayResult, buildFlags []st
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		compiled, compileErr = CompilePackages(ctx, overlay.SuitePackages, overlay.OverlayFlag, buildFlags, overlay.TmpDir)
+		compiled, compileErr = CompilePackages(ctx, overlay.SuitePackages, overlay.OverlayFlag, buildFlags, overlay.WorkDir)
 		if compileErr != nil {
 			cancel()
 		}
@@ -100,7 +100,7 @@ func prepareTestRun(ctx context.Context, overlay *OverlayResult, buildFlags []st
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			setupProc, setupErr = StartSharedFixtures(ctx, overlay.TmpDir, overlay.SharedFixtures, setupTimeout)
+			setupProc, setupErr = StartSharedFixtures(ctx, overlay.WorkDir, overlay.SharedFixtures, setupTimeout)
 			if setupErr != nil {
 				cancel()
 				return
@@ -159,7 +159,7 @@ func setupCoverage(targets []SuiteTarget, overlay *OverlayResult, userCoverProfi
 	if userCoverProfile == "" {
 		return
 	}
-	coverDir := filepath.Join(overlay.TmpDir, "cover")
+	coverDir := filepath.Join(overlay.WorkDir, "cover")
 	os.MkdirAll(coverDir, 0o755)
 	assignCoverProfiles(targets, coverDir)
 }
@@ -220,7 +220,7 @@ func runBatch(ctx context.Context, cfg PipelineConfig, overlay *OverlayResult, p
 func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResult, pf ParsedFlags) (PipelineResult, error) {
 	var coverDir string
 	if pf.UserCoverProfile != "" {
-		coverDir = filepath.Join(overlay.TmpDir, "cover")
+		coverDir = filepath.Join(overlay.WorkDir, "cover")
 		os.MkdirAll(coverDir, 0o755)
 	}
 
@@ -239,7 +239,7 @@ func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResul
 		go func() {
 			defer fixtureWg.Done()
 			var err error
-			setupProc, err = StartSharedFixtures(streamCtx, overlay.TmpDir, overlay.SharedFixtures, cfg.SetupTimeout)
+			setupProc, err = StartSharedFixtures(streamCtx, overlay.WorkDir, overlay.SharedFixtures, cfg.SetupTimeout)
 			if err != nil {
 				fixtureStartErr = err
 				streamCancel()
@@ -250,7 +250,7 @@ func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResul
 		close(fixtureStarted)
 	}
 
-	compileCh := CompilePackagesStream(streamCtx, overlay.SuitePackages, overlay.OverlayFlag, pf.BuildFlags, overlay.TmpDir)
+	compileCh := CompilePackagesStream(streamCtx, overlay.SuitePackages, overlay.OverlayFlag, pf.BuildFlags, overlay.WorkDir)
 
 	totalSuites := 0
 	for _, suites := range overlay.SuitesByPkg {


### PR DESCRIPTION
 Compiled binaries were stored inside the overlay cache but never reused. They just accumulated as dead weight. Move them to a temporary directory that is cleaned up after each run. The overlay cache now only stores the generated test files it was designed for.