### PR TITLE
Include fixture name in BeforeAll error messages

### DIFF
--- a/pkg/gotestruntime/runtime.go
+++ b/pkg/gotestruntime/runtime.go
@@ -371,9 +371,16 @@ func runBeforeAllWithRetry(ctx context.Context, node *FixtureNode) error {
 	attempts := 1 + node.Config.Retries
 	var lastErr error
 
+	wrapErr := func(err error) error {
+		if err == nil {
+			return nil
+		}
+		return fmt.Errorf("%s.BeforeAll: %w", node.Name, err)
+	}
+
 	for i := range attempts {
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return wrapErr(ctx.Err())
 		}
 
 		var attemptCtx context.Context
@@ -391,14 +398,14 @@ func runBeforeAllWithRetry(ctx context.Context, node *FixtureNode) error {
 			return nil
 		}
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return wrapErr(ctx.Err())
 		}
 		if i < attempts-1 {
 			fmt.Fprintf(os.Stderr, "%s.BeforeAll attempt %d/%d failed: %v\n", node.Name, i+1, attempts, lastErr)
 			if node.Config.RetryDelay > 0 {
 				select {
 				case <-ctx.Done():
-					return ctx.Err()
+					return wrapErr(ctx.Err())
 				case <-time.After(node.Config.RetryDelay):
 				}
 			}
@@ -406,7 +413,7 @@ func runBeforeAllWithRetry(ctx context.Context, node *FixtureNode) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "FAIL: %s.BeforeAll failed after %d attempt(s): %v\n", node.Name, attempts, lastErr)
-	return lastErr
+	return fmt.Errorf("%s.BeforeAll: %w", node.Name, lastErr)
 }
 
 func teardownRoots(roots []*FixtureNode, tracker *nodeTracker) bool {

--- a/pkg/gotestruntime/runtime_test.go
+++ b/pkg/gotestruntime/runtime_test.go
@@ -1562,6 +1562,74 @@ func TestDAG_SharedStateNode_MissingStateFile(t *testing.T) {
 	gotest.Contains(t, events, "plain.afterAll")
 }
 
+func TestBeforeAllError_IncludesFixtureName(t *testing.T) {
+	node := &FixtureNode{
+		Name:   "Database",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			return errors.New("connection refused")
+		},
+	}
+
+	err := runBeforeAllWithRetry(context.Background(), node)
+
+	gotest.ErrorContains(t, err, "Database.BeforeAll")
+	gotest.ErrorContains(t, err, "connection refused")
+}
+
+func TestBeforeAllError_WrapsOriginalError(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	node := &FixtureNode{
+		Name:   "Cache",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			return sentinel
+		},
+	}
+
+	err := runBeforeAllWithRetry(context.Background(), node)
+
+	gotest.ErrorIs(t, err, sentinel)
+}
+
+func TestBeforeAllError_ContextCancelIncludesFixtureName(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	node := &FixtureNode{
+		Name:   "Slow",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			return nil
+		},
+	}
+
+	err := runBeforeAllWithRetry(ctx, node)
+
+	gotest.ErrorContains(t, err, "Slow.BeforeAll")
+	gotest.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDAGSetupError_IncludesFixtureName(t *testing.T) {
+	node := &FixtureNode{
+		Name:   "Redis",
+		Config: gotest.DefaultFixtureConfig(),
+		Init:   func() {},
+		BeforeAll: func(ctx context.Context) error {
+			return errors.New("dial tcp: connection refused")
+		},
+	}
+
+	tracker := &nodeTracker{succeeded: make(map[*FixtureNode]bool)}
+	err := setupDAG(context.Background(), []*FixtureNode{node}, nil, tracker)
+
+	gotest.ErrorContains(t, err, "Redis.BeforeAll")
+	gotest.ErrorContains(t, err, "dial tcp: connection refused")
+}
+
 func indexOf(slice []string, val string) int {
 	for i, s := range slice {
 		if s == val {


### PR DESCRIPTION
When a shared fixture's `BeforeAll` fails, the error now includes the fixture name (e.g. `Database.BeforeAll: connection refused` instead of just `connection refused`), making it easier to identify which fixture failed.