### PR TITLE
Fix Test Explorer real-time status display

### DIFF
--- a/vscode-gotest/src/batchRunner.ts
+++ b/vscode-gotest/src/batchRunner.ts
@@ -7,7 +7,8 @@ import type { CoverageStore } from "./coverageStore.js";
 import { type TestEvent } from "./outputParser.js";
 import { buildCliCommand, formatCliCommand } from "./cli.js";
 import {
-  applyResults,
+  applyEvent,
+  skipUnresolved,
   spawnTestProcess,
   resolveRunPatterns,
   readWorkspacePatterns,
@@ -103,7 +104,7 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
     outputChannel.info(`[${label}] ${formatCliCommand(cmd)}`);
 
     const streamedPkgs = new Set<string>();
-    const pkgEventBuffers = new Map<string, TestEvent[]>();
+    const pkgOutputMaps = new Map<string, Map<string, string>>();
     const pkgDirMap = new Map(pkgInfos.map((p) => [p.importPath, p.dir]));
 
     const handleStdoutLine = (line: string) => {
@@ -115,12 +116,24 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
         return;
       }
 
-      let buffer = pkgEventBuffers.get(event.Package);
-      if (!buffer) {
-        buffer = [];
-        pkgEventBuffers.set(event.Package, buffer);
+      const dir = pkgDirMap.get(event.Package);
+      if (!dir) return;
+
+      let outputMap = pkgOutputMaps.get(event.Package);
+      if (!outputMap) {
+        outputMap = new Map();
+        pkgOutputMaps.set(event.Package, outputMap);
       }
-      buffer.push(event);
+
+      const result = applyEvent(
+        controller,
+        run,
+        event,
+        outputMap,
+        event.Package,
+        dir,
+      );
+      if (result) onResults?.([result]);
 
       const isTerminal =
         !event.Test &&
@@ -128,19 +141,8 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
           event.Action === "fail" ||
           event.Action === "skip");
       if (isTerminal) {
-        const dir = pkgDirMap.get(event.Package);
-        if (dir) {
-          const applied = applyResults(
-            controller,
-            run,
-            buffer,
-            event.Package,
-            dir,
-          );
-          onResults?.(applied);
-          streamedPkgs.add(event.Package);
-        }
-        pkgEventBuffers.set(event.Package, []);
+        streamedPkgs.add(event.Package);
+        pkgOutputMaps.delete(event.Package);
       }
     };
 
@@ -155,26 +157,6 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
       handleStdoutLine,
     );
 
-    for (const [pkg, buffer] of pkgEventBuffers) {
-      if (buffer.length > 0) {
-        const dir = pkgDirMap.get(pkg);
-        if (dir) {
-          const applied = applyResults(controller, run, buffer, pkg, dir);
-          onResults?.(applied);
-          const hasTerminal = buffer.some(
-            (e) =>
-              !e.Test &&
-              (e.Action === "pass" ||
-                e.Action === "fail" ||
-                e.Action === "skip"),
-          );
-          if (hasTerminal) {
-            streamedPkgs.add(pkg);
-          }
-        }
-      }
-    }
-
     if (token.isCancellationRequested) {
       const skippedPkgs = pkgInfos.filter(
         (i) => !streamedPkgs.has(i.importPath),
@@ -187,6 +169,7 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
       for (const info of skippedPkgs) {
         for (const item of info.items) {
           run.skipped(item);
+          skipUnresolved(run, item, controller);
         }
       }
       return { stdout: result.stdout };
@@ -217,6 +200,7 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
           .join("\n\n");
         for (const item of info.items) {
           run.errored(item, new vscode.TestMessage(diagnostic));
+          skipUnresolved(run, item, controller);
         }
       }
     }
@@ -269,6 +253,7 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
     for (const info of pkgInfos) {
       for (const item of info.items) {
         run.errored(item, new vscode.TestMessage(message));
+        skipUnresolved(run, item, controller);
       }
     }
     return { stdout: "" };

--- a/vscode-gotest/src/runner.ts
+++ b/vscode-gotest/src/runner.ts
@@ -6,6 +6,7 @@ import {
   collectItems,
   enqueueDescendants,
   startAncestors,
+  skipUnresolved,
   groupByPackage,
   buildRunFilter,
   resolveAncestorItems,
@@ -208,6 +209,9 @@ export class TestRunner {
       }
 
       resolveAncestorItems(run, this.controller);
+      for (const item of items) {
+        skipUnresolved(run, item, this.controller);
+      }
 
       if (anyCoverOnRun) {
         const { coverages: allCoverages } =
@@ -292,11 +296,7 @@ export class TestRunner {
       label: "runner",
       env,
       coverage: coverOnRun ? { store: this.coverageStore! } : undefined,
-      onResults: (applied) => {
-        for (const r of applied) {
-          this.controller.recordResult(r.itemId, r.status, r.duration);
-        }
-      },
+      onResults: () => {},
     });
     this._lastJsonOutput += result.stdout;
   }

--- a/vscode-gotest/src/runner.ts
+++ b/vscode-gotest/src/runner.ts
@@ -5,7 +5,7 @@ import { scopedConfig } from "./cli.js";
 import {
   collectItems,
   enqueueDescendants,
-  enqueueAncestors,
+  startAncestors,
   groupByPackage,
   buildRunFilter,
   resolveAncestorItems,
@@ -91,7 +91,7 @@ export class TestRunner {
         run.started(item);
         enqueueDescendants(run, item);
       }
-      enqueueAncestors(run, items);
+      startAncestors(run, items);
 
       const groups = groupByPackage(items);
 

--- a/vscode-gotest/src/runner.ts
+++ b/vscode-gotest/src/runner.ts
@@ -296,7 +296,6 @@ export class TestRunner {
       label: "runner",
       env,
       coverage: coverOnRun ? { store: this.coverageStore! } : undefined,
-      onResults: () => {},
     });
     this._lastJsonOutput += result.stdout;
   }

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -734,7 +734,15 @@ describe("applyEvent", () => {
       appendOutput: vi.fn(),
     };
 
-    return { controller, run, pkgItem, suiteItem, passItem, failItem, skipItem };
+    return {
+      controller,
+      run,
+      pkgItem,
+      suiteItem,
+      passItem,
+      failItem,
+      skipItem,
+    };
   }
 
   it("processes 'run' event — calls run.started, returns undefined", () => {
@@ -744,7 +752,11 @@ describe("applyEvent", () => {
     const result = applyEvent(
       controller as any,
       run as any,
-      { Action: "run", Test: "TestMySuite/TestPass", Package: "example.com/pkg" } as any,
+      {
+        Action: "run",
+        Test: "TestMySuite/TestPass",
+        Package: "example.com/pkg",
+      } as any,
       outputMap,
       "example.com/pkg",
       "/some/dir",
@@ -761,15 +773,28 @@ describe("applyEvent", () => {
     const result = applyEvent(
       controller as any,
       run as any,
-      { Action: "pass", Test: "TestMySuite/TestPass", Package: "example.com/pkg", Elapsed: 0.1 } as any,
+      {
+        Action: "pass",
+        Test: "TestMySuite/TestPass",
+        Package: "example.com/pkg",
+        Elapsed: 0.1,
+      } as any,
       outputMap,
       "example.com/pkg",
       "/some/dir",
     );
 
-    expect(result).toEqual({ itemId: passItem.id, status: "pass", duration: 100 });
+    expect(result).toEqual({
+      itemId: passItem.id,
+      status: "pass",
+      duration: 100,
+    });
     expect(run.passed).toHaveBeenCalledWith(passItem, 100);
-    expect(controller.recordResult).toHaveBeenCalledWith(passItem.id, "pass", 100);
+    expect(controller.recordResult).toHaveBeenCalledWith(
+      passItem.id,
+      "pass",
+      100,
+    );
   });
 
   it("processes 'skip' event — calls run.skipped, records result, returns AppliedResult", () => {
@@ -779,15 +804,27 @@ describe("applyEvent", () => {
     const result = applyEvent(
       controller as any,
       run as any,
-      { Action: "skip", Test: "TestMySuite/TestSkip", Package: "example.com/pkg" } as any,
+      {
+        Action: "skip",
+        Test: "TestMySuite/TestSkip",
+        Package: "example.com/pkg",
+      } as any,
       outputMap,
       "example.com/pkg",
       "/some/dir",
     );
 
-    expect(result).toEqual({ itemId: skipItem.id, status: "skip", duration: undefined });
+    expect(result).toEqual({
+      itemId: skipItem.id,
+      status: "skip",
+      duration: undefined,
+    });
     expect(run.skipped).toHaveBeenCalledWith(skipItem);
-    expect(controller.recordResult).toHaveBeenCalledWith(skipItem.id, "skip", undefined);
+    expect(controller.recordResult).toHaveBeenCalledWith(
+      skipItem.id,
+      "skip",
+      undefined,
+    );
   });
 
   it("processes 'output' event — accumulates in outputMap, appends to run", () => {
@@ -797,34 +834,57 @@ describe("applyEvent", () => {
     const result = applyEvent(
       controller as any,
       run as any,
-      { Action: "output", Test: "TestMySuite/TestFail", Package: "example.com/pkg", Output: "    fail_test.go:14: boom\n" } as any,
+      {
+        Action: "output",
+        Test: "TestMySuite/TestFail",
+        Package: "example.com/pkg",
+        Output: "    fail_test.go:14: boom\n",
+      } as any,
       outputMap,
       "example.com/pkg",
       "/some/dir",
     );
 
     expect(result).toBeUndefined();
-    expect(outputMap.get("TestMySuite/TestFail")).toBe("    fail_test.go:14: boom\n");
+    expect(outputMap.get("TestMySuite/TestFail")).toBe(
+      "    fail_test.go:14: boom\n",
+    );
     expect(run.appendOutput).toHaveBeenCalled();
   });
 
   it("processes 'fail' event — uses accumulated output for diagnostics", () => {
     const { controller, run, failItem } = makeApplyEventFixture();
     const outputMap = new Map<string, string>();
-    outputMap.set("TestMySuite/TestFail", "    fail_test.go:14: Equal failed:\n          expected: 1\n          actual:   2\n");
+    outputMap.set(
+      "TestMySuite/TestFail",
+      "    fail_test.go:14: Equal failed:\n          expected: 1\n          actual:   2\n",
+    );
 
     const result = applyEvent(
       controller as any,
       run as any,
-      { Action: "fail", Test: "TestMySuite/TestFail", Package: "example.com/pkg", Elapsed: 0.2 } as any,
+      {
+        Action: "fail",
+        Test: "TestMySuite/TestFail",
+        Package: "example.com/pkg",
+        Elapsed: 0.2,
+      } as any,
       outputMap,
       "example.com/pkg",
       "/some/dir",
     );
 
-    expect(result).toEqual({ itemId: failItem.id, status: "fail", duration: 200 });
+    expect(result).toEqual({
+      itemId: failItem.id,
+      status: "fail",
+      duration: 200,
+    });
     expect(run.failed).toHaveBeenCalledWith(failItem, expect.any(Array), 200);
-    expect(controller.recordResult).toHaveBeenCalledWith(failItem.id, "fail", 200);
+    expect(controller.recordResult).toHaveBeenCalledWith(
+      failItem.id,
+      "fail",
+      200,
+    );
   });
 
   it("processes package terminal event — resolves package and ancestors", () => {
@@ -840,9 +900,17 @@ describe("applyEvent", () => {
       "/some/dir",
     );
 
-    expect(result).toEqual({ itemId: "example.com/pkg", status: "pass", duration: 1500 });
+    expect(result).toEqual({
+      itemId: "example.com/pkg",
+      status: "pass",
+      duration: 1500,
+    });
     expect(run.passed).toHaveBeenCalledWith(pkgItem, 1500);
-    expect(controller.recordResult).toHaveBeenCalledWith("example.com/pkg", "pass", 1500);
+    expect(controller.recordResult).toHaveBeenCalledWith(
+      "example.com/pkg",
+      "pass",
+      1500,
+    );
   });
 
   it("returns undefined for unknown test path", () => {
@@ -852,7 +920,12 @@ describe("applyEvent", () => {
     const result = applyEvent(
       controller as any,
       run as any,
-      { Action: "pass", Test: "TestUnknown/Method", Package: "example.com/pkg", Elapsed: 0.1 } as any,
+      {
+        Action: "pass",
+        Test: "TestUnknown/Method",
+        Package: "example.com/pkg",
+        Elapsed: 0.1,
+      } as any,
       outputMap,
       "example.com/pkg",
       "/some/dir",
@@ -869,7 +942,11 @@ describe("applyEvent", () => {
     applyEvent(
       controller as any,
       run as any,
-      { Action: "output", Package: "example.com/pkg", Output: "exit status 1\n" } as any,
+      {
+        Action: "output",
+        Package: "example.com/pkg",
+        Output: "exit status 1\n",
+      } as any,
       outputMap,
       "example.com/pkg",
       "/some/dir",

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -49,7 +49,7 @@ import {
   applyResults,
   applyEvent,
   enqueueDescendants,
-  enqueueAncestors,
+  startAncestors,
   resolveAncestorItems,
   resolveAncestorsOf,
   skipUnresolved,
@@ -1308,20 +1308,20 @@ describe("resolveAncestorItems", () => {
   });
 });
 
-describe("enqueueAncestors", () => {
-  it("enqueues all ancestors of given items", () => {
+describe("startAncestors", () => {
+  it("starts all ancestors of given items", () => {
     const root = createItem("dir:pkg", "pkg", undefined);
     const sub = createItem("dir:pkg/sub", "sub", root);
     const pkg = createItem("example.com/pkg/sub/a", "a", sub, [
       { id: "package" },
     ]);
 
-    const run = { enqueued: vi.fn() };
-    enqueueAncestors(run as any, [pkg as any]);
+    const run = { started: vi.fn() };
+    startAncestors(run as any, [pkg as any]);
 
-    expect(run.enqueued).toHaveBeenCalledTimes(2);
-    expect(run.enqueued).toHaveBeenCalledWith(sub);
-    expect(run.enqueued).toHaveBeenCalledWith(root);
+    expect(run.started).toHaveBeenCalledTimes(2);
+    expect(run.started).toHaveBeenCalledWith(sub);
+    expect(run.started).toHaveBeenCalledWith(root);
   });
 
   it("deduplicates shared ancestors", () => {
@@ -1333,11 +1333,11 @@ describe("enqueueAncestors", () => {
       { id: "package" },
     ]);
 
-    const run = { enqueued: vi.fn() };
-    enqueueAncestors(run as any, [pkgA as any, pkgB as any]);
+    const run = { started: vi.fn() };
+    startAncestors(run as any, [pkgA as any, pkgB as any]);
 
-    expect(run.enqueued).toHaveBeenCalledTimes(1);
-    expect(run.enqueued).toHaveBeenCalledWith(root);
+    expect(run.started).toHaveBeenCalledTimes(1);
+    expect(run.started).toHaveBeenCalledWith(root);
   });
 });
 

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -52,6 +52,7 @@ import {
   enqueueAncestors,
   resolveAncestorItems,
   resolveAncestorsOf,
+  skipUnresolved,
 } from "./runnerUtils.js";
 import { buildPathTrie, collapsePathTrie, type PathNode } from "./pathTrie.js";
 
@@ -1609,5 +1610,86 @@ describe("applyResults records before resolving ancestors", () => {
     );
     // resolveAncestorsOf should have resolved dir:pkg because the pkg result was in the store
     expect(run.passed).toHaveBeenCalledWith(dir);
+  });
+});
+
+describe("skipUnresolved", () => {
+  it("marks descendants without results as skipped", () => {
+    const pkg = createItem("example.com/pkg", "pkg", undefined, [
+      { id: "package" },
+    ]);
+    const suite = createItem("example.com/pkg/SuiteA", "SuiteA", pkg);
+    const method1 = createItem("example.com/pkg/SuiteA/Test1", "Test1", suite);
+    const method2 = createItem("example.com/pkg/SuiteA/Test2", "Test2", suite);
+
+    const run = { skipped: vi.fn() };
+    const controller = {
+      getResult: vi.fn(() => undefined),
+    };
+
+    skipUnresolved(run as any, pkg as any, controller as any);
+
+    expect(run.skipped).toHaveBeenCalledTimes(3);
+    expect(run.skipped).toHaveBeenCalledWith(suite);
+    expect(run.skipped).toHaveBeenCalledWith(method1);
+    expect(run.skipped).toHaveBeenCalledWith(method2);
+  });
+
+  it("does not touch items that have results", () => {
+    const pkg = createItem("example.com/pkg", "pkg", undefined, [
+      { id: "package" },
+    ]);
+    const suite = createItem("example.com/pkg/SuiteA", "SuiteA", pkg);
+    const method1 = createItem("example.com/pkg/SuiteA/Test1", "Test1", suite);
+    const method2 = createItem("example.com/pkg/SuiteA/Test2", "Test2", suite);
+
+    const run = { skipped: vi.fn() };
+    const controller = {
+      getResult: vi.fn((id: string) => {
+        if (id === "example.com/pkg/SuiteA/Test1")
+          return { status: "pass" as const, duration: 100 };
+        return undefined;
+      }),
+    };
+
+    skipUnresolved(run as any, pkg as any, controller as any);
+
+    expect(run.skipped).toHaveBeenCalledTimes(2);
+    expect(run.skipped).toHaveBeenCalledWith(suite);
+    expect(run.skipped).toHaveBeenCalledWith(method2);
+    expect(run.skipped).not.toHaveBeenCalledWith(method1);
+  });
+
+  it("is a no-op for leaf items with no children", () => {
+    const method = createItem("example.com/pkg/SuiteA/Test1", "Test1");
+    const run = { skipped: vi.fn() };
+    const controller = { getResult: vi.fn(() => undefined) };
+
+    skipUnresolved(run as any, method as any, controller as any);
+
+    expect(run.skipped).not.toHaveBeenCalled();
+  });
+
+  it("recurses through dynamic subtests", () => {
+    const method = createItem("example.com/pkg/Suite/Test1", "Test1");
+    const dynamic1 = createItem(
+      "example.com/pkg/Suite/Test1/dynamic/sub1",
+      "sub1",
+      method,
+    );
+    const dynamic2 = createItem(
+      "example.com/pkg/Suite/Test1/dynamic/sub2",
+      "sub2",
+      method,
+    );
+
+    const run = { skipped: vi.fn() };
+    const controller = { getResult: vi.fn(() => undefined) };
+
+    skipUnresolved(run as any, method as any, controller as any);
+
+    expect(run.skipped).toHaveBeenCalledTimes(2);
+    expect(run.skipped).toHaveBeenCalledWith(dynamic1);
+    expect(run.skipped).toHaveBeenCalledWith(dynamic2);
   });
 });

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -47,6 +47,7 @@ import {
   computeWildcard,
   resolveRunPatterns,
   applyResults,
+  applyEvent,
   enqueueDescendants,
   enqueueAncestors,
   resolveAncestorItems,
@@ -680,6 +681,200 @@ describe("applyResults", () => {
     expect(messages[0].message).toBe(
       "Equal failed: expected 720000000000, actual 120000000000",
     );
+  });
+});
+
+describe("applyEvent", () => {
+  function makeApplyEventFixture() {
+    const suiteItem = createItem("example.com/pkg/MySuite", "MySuite");
+    const passItem = createItem(
+      "example.com/pkg/MySuite/TestPass",
+      "TestPass",
+      suiteItem,
+    );
+    const failItem = createItem(
+      "example.com/pkg/MySuite/TestFail",
+      "TestFail",
+      suiteItem,
+    );
+    const skipItem = createItem(
+      "example.com/pkg/MySuite/TestSkip",
+      "TestSkip",
+      suiteItem,
+    );
+    const pkgItem = createItem("example.com/pkg", "pkg", undefined, [
+      { id: "package" },
+    ]);
+
+    const itemMap = new Map<string, MockTestItem>([
+      ["example.com/pkg", pkgItem],
+      ["example.com/pkg/MySuite", suiteItem],
+      ["example.com/pkg/MySuite/TestPass", passItem],
+      ["example.com/pkg/MySuite/TestFail", failItem],
+      ["example.com/pkg/MySuite/TestSkip", skipItem],
+    ]);
+
+    const results = new Map<string, { status: string; duration?: number }>();
+
+    const controller = {
+      findItem: vi.fn((id: string) => itemMap.get(id) ?? undefined),
+      recordResult: vi.fn((id: string, status: string, duration?: number) => {
+        results.set(id, { status, duration });
+      }),
+      getResult: vi.fn((id: string) => results.get(id)),
+      createDynamicSubtest: vi.fn(),
+    };
+
+    const run = {
+      passed: vi.fn(),
+      failed: vi.fn(),
+      skipped: vi.fn(),
+      started: vi.fn(),
+      appendOutput: vi.fn(),
+    };
+
+    return { controller, run, pkgItem, suiteItem, passItem, failItem, skipItem };
+  }
+
+  it("processes 'run' event — calls run.started, returns undefined", () => {
+    const { controller, run, passItem } = makeApplyEventFixture();
+    const outputMap = new Map<string, string>();
+
+    const result = applyEvent(
+      controller as any,
+      run as any,
+      { Action: "run", Test: "TestMySuite/TestPass", Package: "example.com/pkg" } as any,
+      outputMap,
+      "example.com/pkg",
+      "/some/dir",
+    );
+
+    expect(result).toBeUndefined();
+    expect(run.started).toHaveBeenCalledWith(passItem);
+  });
+
+  it("processes 'pass' event — calls run.passed, records result, returns AppliedResult", () => {
+    const { controller, run, passItem } = makeApplyEventFixture();
+    const outputMap = new Map<string, string>();
+
+    const result = applyEvent(
+      controller as any,
+      run as any,
+      { Action: "pass", Test: "TestMySuite/TestPass", Package: "example.com/pkg", Elapsed: 0.1 } as any,
+      outputMap,
+      "example.com/pkg",
+      "/some/dir",
+    );
+
+    expect(result).toEqual({ itemId: passItem.id, status: "pass", duration: 100 });
+    expect(run.passed).toHaveBeenCalledWith(passItem, 100);
+    expect(controller.recordResult).toHaveBeenCalledWith(passItem.id, "pass", 100);
+  });
+
+  it("processes 'skip' event — calls run.skipped, records result, returns AppliedResult", () => {
+    const { controller, run, skipItem } = makeApplyEventFixture();
+    const outputMap = new Map<string, string>();
+
+    const result = applyEvent(
+      controller as any,
+      run as any,
+      { Action: "skip", Test: "TestMySuite/TestSkip", Package: "example.com/pkg" } as any,
+      outputMap,
+      "example.com/pkg",
+      "/some/dir",
+    );
+
+    expect(result).toEqual({ itemId: skipItem.id, status: "skip", duration: undefined });
+    expect(run.skipped).toHaveBeenCalledWith(skipItem);
+    expect(controller.recordResult).toHaveBeenCalledWith(skipItem.id, "skip", undefined);
+  });
+
+  it("processes 'output' event — accumulates in outputMap, appends to run", () => {
+    const { controller, run } = makeApplyEventFixture();
+    const outputMap = new Map<string, string>();
+
+    const result = applyEvent(
+      controller as any,
+      run as any,
+      { Action: "output", Test: "TestMySuite/TestFail", Package: "example.com/pkg", Output: "    fail_test.go:14: boom\n" } as any,
+      outputMap,
+      "example.com/pkg",
+      "/some/dir",
+    );
+
+    expect(result).toBeUndefined();
+    expect(outputMap.get("TestMySuite/TestFail")).toBe("    fail_test.go:14: boom\n");
+    expect(run.appendOutput).toHaveBeenCalled();
+  });
+
+  it("processes 'fail' event — uses accumulated output for diagnostics", () => {
+    const { controller, run, failItem } = makeApplyEventFixture();
+    const outputMap = new Map<string, string>();
+    outputMap.set("TestMySuite/TestFail", "    fail_test.go:14: Equal failed:\n          expected: 1\n          actual:   2\n");
+
+    const result = applyEvent(
+      controller as any,
+      run as any,
+      { Action: "fail", Test: "TestMySuite/TestFail", Package: "example.com/pkg", Elapsed: 0.2 } as any,
+      outputMap,
+      "example.com/pkg",
+      "/some/dir",
+    );
+
+    expect(result).toEqual({ itemId: failItem.id, status: "fail", duration: 200 });
+    expect(run.failed).toHaveBeenCalledWith(failItem, expect.any(Array), 200);
+    expect(controller.recordResult).toHaveBeenCalledWith(failItem.id, "fail", 200);
+  });
+
+  it("processes package terminal event — resolves package and ancestors", () => {
+    const { controller, run, pkgItem } = makeApplyEventFixture();
+    const outputMap = new Map<string, string>();
+
+    const result = applyEvent(
+      controller as any,
+      run as any,
+      { Action: "pass", Package: "example.com/pkg", Elapsed: 1.5 } as any,
+      outputMap,
+      "example.com/pkg",
+      "/some/dir",
+    );
+
+    expect(result).toEqual({ itemId: "example.com/pkg", status: "pass", duration: 1500 });
+    expect(run.passed).toHaveBeenCalledWith(pkgItem, 1500);
+    expect(controller.recordResult).toHaveBeenCalledWith("example.com/pkg", "pass", 1500);
+  });
+
+  it("returns undefined for unknown test path", () => {
+    const { controller, run } = makeApplyEventFixture();
+    const outputMap = new Map<string, string>();
+
+    const result = applyEvent(
+      controller as any,
+      run as any,
+      { Action: "pass", Test: "TestUnknown/Method", Package: "example.com/pkg", Elapsed: 0.1 } as any,
+      outputMap,
+      "example.com/pkg",
+      "/some/dir",
+    );
+
+    expect(result).toBeUndefined();
+    expect(run.passed).not.toHaveBeenCalled();
+  });
+
+  it("filters 'exit status' output lines", () => {
+    const { controller, run } = makeApplyEventFixture();
+    const outputMap = new Map<string, string>();
+
+    applyEvent(
+      controller as any,
+      run as any,
+      { Action: "output", Package: "example.com/pkg", Output: "exit status 1\n" } as any,
+      outputMap,
+      "example.com/pkg",
+      "/some/dir",
+    );
+
+    expect(run.appendOutput).not.toHaveBeenCalled();
   });
 });
 

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -48,7 +48,7 @@ export function skipUnresolved(
   });
 }
 
-export function enqueueAncestors(
+export function startAncestors(
   run: vscode.TestRun,
   items: vscode.TestItem[],
 ): void {
@@ -57,7 +57,7 @@ export function enqueueAncestors(
     let ancestor = item.parent;
     while (ancestor) {
       if (seen.has(ancestor.id)) break;
-      run.enqueued(ancestor);
+      run.started(ancestor);
       seen.add(ancestor.id);
       ancestor = ancestor.parent;
     }

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -35,6 +35,19 @@ export function enqueueDescendants(
   });
 }
 
+export function skipUnresolved(
+  run: vscode.TestRun,
+  item: vscode.TestItem,
+  controller: GoTestController,
+): void {
+  item.children.forEach((child) => {
+    skipUnresolved(run, child, controller);
+    if (!controller.getResult(child.id)) {
+      run.skipped(child);
+    }
+  });
+}
+
 export function enqueueAncestors(
   run: vscode.TestRun,
   items: vscode.TestItem[],

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -328,7 +328,14 @@ export function applyResults(
   const outputMap = new Map<string, string>();
   const applied: AppliedResult[] = [];
   for (const event of events) {
-    const result = applyEvent(controller, run, event, outputMap, importPath, pkgDir);
+    const result = applyEvent(
+      controller,
+      run,
+      event,
+      outputMap,
+      importPath,
+      pkgDir,
+    );
     if (result) applied.push(result);
   }
   return applied;

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -202,6 +202,109 @@ export interface AppliedResult {
   duration?: number;
 }
 
+export function applyEvent(
+  controller: GoTestController,
+  run: vscode.TestRun,
+  event: TestEvent,
+  outputMap: Map<string, string>,
+  importPath: string,
+  pkgDir: string,
+): AppliedResult | undefined {
+  if (event.Action === "output" && event.Test) {
+    const existing = outputMap.get(event.Test) ?? "";
+    outputMap.set(event.Test, existing + (event.Output ?? ""));
+  }
+
+  if (event.Action === "output" && event.Output) {
+    if (!event.Test && /^exit status \d+\n?$/.test(event.Output)) {
+      return undefined;
+    }
+    const line = event.Output.replace(/\n$/, "\r\n");
+    const testItem = event.Test
+      ? resolveTestItem(controller, event.Test, importPath)
+      : undefined;
+    run.appendOutput(line, undefined, testItem);
+    return undefined;
+  }
+
+  if (!event.Test) {
+    if (
+      event.Action === "pass" ||
+      event.Action === "fail" ||
+      event.Action === "skip"
+    ) {
+      const duration =
+        event.Elapsed !== undefined ? event.Elapsed * 1000 : undefined;
+      controller.recordResult(importPath, event.Action, duration);
+
+      const pkgItem = controller.findItem(importPath);
+      if (pkgItem) {
+        if (event.Action === "fail") {
+          run.failed(pkgItem, [], duration);
+        } else if (event.Action === "pass") {
+          run.passed(pkgItem, duration);
+        } else {
+          run.skipped(pkgItem);
+        }
+        resolveAncestorsOf(run, pkgItem, controller);
+      }
+      return { itemId: importPath, status: event.Action, duration };
+    }
+    return undefined;
+  }
+
+  const item = resolveTestItem(controller, event.Test, importPath);
+  if (!item) {
+    return undefined;
+  }
+
+  const duration =
+    event.Elapsed !== undefined ? event.Elapsed * 1000 : undefined;
+
+  switch (event.Action) {
+    case "pass":
+      run.passed(item, duration);
+      controller.recordResult(item.id, "pass", duration);
+      return { itemId: item.id, status: "pass", duration };
+    case "fail": {
+      const output = outputMap.get(event.Test) ?? "";
+      const testMessages = extractTestMessages(output, pkgDir);
+      const vscodeMessages = testMessages.map((msg) => {
+        const parsed = parseExpectedActual(msg.message);
+        const message = new vscode.TestMessage(
+          parsed
+            ? `${msg.message.split("\n")[0].replace(/:\s*$/, "")}: expected ${parsed.expected}, actual ${parsed.actual}`
+            : msg.message,
+        );
+        if (parsed) {
+          message.expectedOutput = parsed.expected;
+          message.actualOutput = parsed.actual;
+        }
+        message.location = new vscode.Location(
+          vscode.Uri.file(msg.file),
+          new vscode.Position(msg.line - 1, 0),
+        );
+        return message;
+      });
+      if (vscodeMessages.length === 0) {
+        vscodeMessages.push(new vscode.TestMessage(output || "Test failed"));
+      }
+      run.failed(item, vscodeMessages, duration);
+      controller.recordResult(item.id, "fail", duration);
+      return { itemId: item.id, status: "fail", duration };
+    }
+    case "skip":
+      run.skipped(item);
+      controller.recordResult(item.id, "skip", undefined);
+      return { itemId: item.id, status: "skip", duration: undefined };
+    case "run":
+      run.started(item);
+      return undefined;
+  }
+
+  return undefined;
+}
+
 export function applyResults(
   controller: GoTestController,
   run: vscode.TestRun,
@@ -210,107 +313,11 @@ export function applyResults(
   pkgDir: string,
 ): AppliedResult[] {
   const outputMap = new Map<string, string>();
-
-  for (const event of events) {
-    if (event.Action === "output" && event.Test) {
-      const existing = outputMap.get(event.Test) ?? "";
-      outputMap.set(event.Test, existing + (event.Output ?? ""));
-    }
-  }
-
   const applied: AppliedResult[] = [];
-
   for (const event of events) {
-    if (event.Action === "output" && event.Output) {
-      if (!event.Test && /^exit status \d+\n?$/.test(event.Output)) {
-        continue;
-      }
-      const line = event.Output.replace(/\n$/, "\r\n");
-      const testItem = event.Test
-        ? resolveTestItem(controller, event.Test, importPath)
-        : undefined;
-      run.appendOutput(line, undefined, testItem);
-    }
-
-    if (!event.Test) {
-      if (
-        event.Action === "pass" ||
-        event.Action === "fail" ||
-        event.Action === "skip"
-      ) {
-        const duration =
-          event.Elapsed !== undefined ? event.Elapsed * 1000 : undefined;
-        applied.push({ itemId: importPath, status: event.Action, duration });
-        controller.recordResult(importPath, event.Action, duration);
-
-        const pkgItem = controller.findItem(importPath);
-        if (pkgItem) {
-          if (event.Action === "fail") {
-            run.failed(pkgItem, [], duration);
-          } else if (event.Action === "pass") {
-            run.passed(pkgItem, duration);
-          } else {
-            run.skipped(pkgItem);
-          }
-          resolveAncestorsOf(run, pkgItem, controller);
-        }
-      }
-      continue;
-    }
-
-    const item = resolveTestItem(controller, event.Test, importPath);
-    if (!item) {
-      continue;
-    }
-
-    const duration =
-      event.Elapsed !== undefined ? event.Elapsed * 1000 : undefined;
-
-    switch (event.Action) {
-      case "pass":
-        run.passed(item, duration);
-        applied.push({ itemId: item.id, status: "pass", duration });
-        controller.recordResult(item.id, "pass", duration);
-        break;
-      case "fail": {
-        const output = outputMap.get(event.Test) ?? "";
-        const testMessages = extractTestMessages(output, pkgDir);
-        const vscodeMessages = testMessages.map((msg) => {
-          const parsed = parseExpectedActual(msg.message);
-          const message = new vscode.TestMessage(
-            parsed
-              ? `${msg.message.split("\n")[0].replace(/:\s*$/, "")}: expected ${parsed.expected}, actual ${parsed.actual}`
-              : msg.message,
-          );
-          if (parsed) {
-            message.expectedOutput = parsed.expected;
-            message.actualOutput = parsed.actual;
-          }
-          message.location = new vscode.Location(
-            vscode.Uri.file(msg.file),
-            new vscode.Position(msg.line - 1, 0),
-          );
-          return message;
-        });
-        if (vscodeMessages.length === 0) {
-          vscodeMessages.push(new vscode.TestMessage(output || "Test failed"));
-        }
-        run.failed(item, vscodeMessages, duration);
-        applied.push({ itemId: item.id, status: "fail", duration });
-        controller.recordResult(item.id, "fail", duration);
-        break;
-      }
-      case "skip":
-        run.skipped(item);
-        applied.push({ itemId: item.id, status: "skip", duration: undefined });
-        controller.recordResult(item.id, "skip", undefined);
-        break;
-      case "run":
-        run.started(item);
-        break;
-    }
+    const result = applyEvent(controller, run, event, outputMap, importPath, pkgDir);
+    if (result) applied.push(result);
   }
-
   return applied;
 }
 

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -397,16 +397,7 @@ export class WatchManager implements vscode.Disposable {
     for (const [importPath, pkgEvents] of byPackage) {
       const pkgDir = this.cache.resolveImportPath(importPath);
       if (pkgDir) {
-        const applied = applyResults(
-          this.controller,
-          run,
-          pkgEvents,
-          importPath,
-          pkgDir,
-        );
-        for (const r of applied) {
-          this.controller.recordResult(r.itemId, r.status, r.duration);
-        }
+        applyResults(this.controller, run, pkgEvents, importPath, pkgDir);
       }
     }
 


### PR DESCRIPTION
Tests now show their status as they run instead of waiting for the entire package to finish. Cancelled or errored test runs no longer leave items stuck in a pending state. Folder and workspace nodes show a running spinner from the start.