### PR TITLE
Add timeout safeguards for test runs

### DIFF
--- a/cmd/gotest/args.go
+++ b/cmd/gotest/args.go
@@ -30,10 +30,10 @@ func (inv Invocation) TagArgs() []string {
 // each only if not already set via CLI flags.
 func (inv Invocation) DefaultArgs() []string {
 	out := inv.TagArgs()
-	if inv.Config.SetupTimeout.Duration() != 0 && !hasFlag(out, "--setup-timeout") {
+	if inv.Config.SetupTimeout != nil && !hasFlag(out, "--setup-timeout") {
 		out = append([]string{"--setup-timeout=" + inv.Config.SetupTimeout.Duration().String()}, out...)
 	}
-	if inv.Config.Timeout.Duration() != 0 && !hasFlag(out, "--timeout") {
+	if inv.Config.Timeout != nil && !hasFlag(out, "--timeout") {
 		out = append([]string{"--timeout=" + inv.Config.Timeout.Duration().String()}, out...)
 	}
 	return out

--- a/cmd/gotest/args.go
+++ b/cmd/gotest/args.go
@@ -33,6 +33,9 @@ func (inv Invocation) DefaultArgs() []string {
 	if inv.Config.SetupTimeout.Duration() != 0 && !hasFlag(out, "--setup-timeout") {
 		out = append([]string{"--setup-timeout=" + inv.Config.SetupTimeout.Duration().String()}, out...)
 	}
+	if inv.Config.Timeout.Duration() != 0 && !hasFlag(out, "--timeout") {
+		out = append([]string{"--timeout=" + inv.Config.Timeout.Duration().String()}, out...)
+	}
 	return out
 }
 
@@ -49,6 +52,7 @@ type ExecConfig struct {
 	GoTestArgs      []string
 	PackagePatterns []string
 	SetupTimeout    time.Duration
+	GlobalTimeout   time.Duration
 	Debug           bool
 	CI              bool
 	JSON            bool

--- a/cmd/gotest/cli.go
+++ b/cmd/gotest/cli.go
@@ -101,6 +101,12 @@ func runTest(inv Invocation) int {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2
 	}
+	globalTimeout, err := parseGlobalTimeoutFlag(ownArgs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+	globalTimeout = resolveGlobalTimeout(globalTimeout)
 	parallel, err := parseParallelFlag(ownArgs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
@@ -135,6 +141,7 @@ func runTest(inv Invocation) int {
 		GoTestArgs:      goTestArgs,
 		PackagePatterns: patterns,
 		SetupTimeout:    setupTimeout,
+		GlobalTimeout:   globalTimeout,
 		Debug:           slices.Contains(ownArgs, "--debug"),
 		CI:              slices.Contains(ownArgs, "--ci"),
 		JSON:            jsonMode,
@@ -235,6 +242,41 @@ func readCoverageTotal(profilePath string) (float64, error) {
 	}
 	pctStr := strings.TrimSuffix(fields[len(fields)-1], "%")
 	return strconv.ParseFloat(pctStr, 64)
+}
+
+const DefaultGlobalTimeout = 15 * time.Minute
+
+func resolveGlobalTimeout(d time.Duration) time.Duration {
+	switch {
+	case d > 0:
+		return d
+	case d < 0:
+		return 0
+	default:
+		return DefaultGlobalTimeout
+	}
+}
+
+func parseGlobalTimeoutFlag(args []string) (time.Duration, error) {
+	for i, arg := range args {
+		var raw string
+		if v, ok := strings.CutPrefix(arg, "--timeout="); ok {
+			raw = v
+		} else if arg == "--timeout" && i+1 < len(args) {
+			raw = args[i+1]
+		} else {
+			continue
+		}
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return 0, fmt.Errorf("invalid --timeout value %q: %w", raw, err)
+		}
+		if d <= 0 {
+			return -1, nil
+		}
+		return d, nil
+	}
+	return 0, nil
 }
 
 func stripJSONFlag(args []string) (bool, []string) {

--- a/cmd/gotest/cli.go
+++ b/cmd/gotest/cli.go
@@ -196,8 +196,8 @@ func parseSetupTimeoutFlag(args []string) (time.Duration, error) {
 		if err != nil {
 			return 0, fmt.Errorf("invalid --setup-timeout value %q: %w", raw, err)
 		}
-		if d == 0 {
-			return 0, fmt.Errorf("invalid --setup-timeout value %q: must be positive or negative to disable", raw)
+		if d <= 0 {
+			return -1, nil
 		}
 		return d, nil
 	}

--- a/cmd/gotest/exec.go
+++ b/cmd/gotest/exec.go
@@ -39,6 +39,12 @@ func Run(cfg ExecConfig) int {
 		shutdownSignals...)
 	defer stop()
 
+	if cfg.GlobalTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cfg.GlobalTimeout)
+		defer cancel()
+	}
+
 	result, err := gotestrunner.RunPipeline(ctx, gotestrunner.PipelineConfig{
 		GoTestArgs:      cfg.GoTestArgs,
 		SetupTimeout:    cfg.SetupTimeout,
@@ -51,6 +57,12 @@ func Run(cfg ExecConfig) int {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2
+	}
+	if cfg.GlobalTimeout > 0 && ctx.Err() == context.DeadlineExceeded {
+		fmt.Fprintf(os.Stderr, "FAIL: global --timeout exceeded after %v\n", cfg.GlobalTimeout)
+		if result.ExitCode == 0 {
+			return 1
+		}
 	}
 	return result.ExitCode
 }

--- a/cmd/gotest/export_test.go
+++ b/cmd/gotest/export_test.go
@@ -6,6 +6,10 @@ type ExportDiscoverSuite = discoverSuite
 
 var ExportParseMinFlag = parseMinFlag
 var ExportParseParallelFlag = parseParallelFlag
+var ExportParseSetupTimeoutFlag = parseSetupTimeoutFlag
+var ExportParseGlobalTimeoutFlag = parseGlobalTimeoutFlag
+var ExportResolveGlobalTimeout = resolveGlobalTimeout
+var ExportParseDebounceFlag = parseDebounceFlag
 var ExportBuildDiscoverSuite = buildDiscoverSuite
 var ExportExtractStringFlag = extractStringFlag
 var ExportHasFlag = hasFlag

--- a/cmd/gotest/flags.go
+++ b/cmd/gotest/flags.go
@@ -23,22 +23,23 @@ var gotestFlags = map[string]FlagKind{
 	"--output":           ValueFlag,
 	"--input":            ValueFlag,
 	"--parallel":         ValueFlag,
+	"--timeout":          ValueFlag,
 }
 
 var testAllowed = flagSet(
 	"--debug", "--ci", "--spec", "--update-snapshots", "--no-cache",
-	"--min", "--setup-timeout", "--parallel",
+	"--min", "--setup-timeout", "--timeout", "--parallel",
 )
 
 var specAllowed = flagSet(
 	"--debug", "--ci", "--update-snapshots", "--no-cache",
-	"--min", "--setup-timeout", "--parallel",
+	"--min", "--setup-timeout", "--timeout", "--parallel",
 	"--format", "--output", "--input", "--no-color",
 )
 
 var watchAllowed = flagSet(
 	"--debug", "--ci", "--update-snapshots", "--no-cache",
-	"--setup-timeout", "--debounce", "--parallel",
+	"--setup-timeout", "--timeout", "--debounce", "--parallel",
 )
 
 func flagSet(names ...string) map[string]bool {

--- a/cmd/gotest/gotest_suite_test.go
+++ b/cmd/gotest/gotest_suite_test.go
@@ -61,6 +61,30 @@ func (s *CmdGotestTestSuite) TestDefaultArgs(t *gotest.T) {
 				},
 				expect: []string{"--setup-timeout=3m0s", "-tags=integration", "-v"},
 			},
+			{
+				Desc: "config timeout prepended",
+				inv: Invocation{
+					Args:   []string{"-v"},
+					Config: config.ProjectConfig{Timeout: config.Duration(15 * time.Minute)},
+				},
+				expect: []string{"--timeout=15m0s", "-v"},
+			},
+			{
+				Desc: "config timeout zero: no prepend",
+				inv: Invocation{
+					Args:   []string{"-v"},
+					Config: config.ProjectConfig{Timeout: config.Duration(0)},
+				},
+				expect: []string{"-v"},
+			},
+			{
+				Desc: "config timeout negative: opt-out prepended",
+				inv: Invocation{
+					Args:   []string{"-v"},
+					Config: config.ProjectConfig{Timeout: config.Duration(-1 * time.Second)},
+				},
+				expect: []string{"--timeout=-1s", "-v"},
+			},
 		}) {
 			got := tc.inv.DefaultArgs()
 			gotest.Equal(sub, tc.expect, got)
@@ -95,6 +119,14 @@ func (s *CmdGotestTestSuite) TestDefaultArgs(t *gotest.T) {
 					Config: config.ProjectConfig{SetupTimeout: config.Duration(-1 * time.Second)},
 				},
 				expect: []string{"--setup-timeout=5m", "-v"},
+			},
+			{
+				Desc: "CLI timeout wins over config timeout",
+				inv: Invocation{
+					Args:   []string{"--timeout=20m", "-v"},
+					Config: config.ProjectConfig{Timeout: config.Duration(15 * time.Minute)},
+				},
+				expect: []string{"--timeout=20m", "-v"},
 			},
 		}) {
 			got := tc.inv.DefaultArgs()
@@ -167,6 +199,8 @@ func (s *CmdGotestTestSuite) TestSplitArgs(t *gotest.T) {
 		{Desc: "watch: json flag", inArgs: []string{"-json", "./pkg/..."}, allowed: ExportWatchAllowed, expectOwn: nil, expectGoTest: []string{"-json", "./pkg/..."}},
 		{Desc: "watch: debounce with json", inArgs: []string{"--debounce=500ms", "-json", "./..."}, allowed: ExportWatchAllowed, expectOwn: []string{"--debounce=500ms"}, expectGoTest: []string{"-json", "./..."}},
 		{Desc: "watch: debug and ci", inArgs: []string{"--debug", "--ci", "-v", "./..."}, allowed: ExportWatchAllowed, expectOwn: []string{"--debug", "--ci"}, expectGoTest: []string{"-v", "./..."}},
+		{Desc: "timeout flag with equals", inArgs: []string{"--timeout=15m", "-v"}, allowed: ExportTestAllowed, expectOwn: []string{"--timeout=15m"}, expectGoTest: []string{"-v"}},
+		{Desc: "timeout flag with space", inArgs: []string{"--timeout", "15m", "-v"}, allowed: ExportTestAllowed, expectOwn: []string{"--timeout", "15m"}, expectGoTest: []string{"-v"}},
 	}) {
 		own, goTest, err := SplitArgs(tc.inArgs, tc.allowed)
 		if tc.expectErr {
@@ -295,6 +329,117 @@ func (s *CmdGotestTestSuite) TestParseParallelFlag(t *gotest.T) {
 			gotest.Equal(sub, tc.expect, got)
 		}
 	}
+}
+
+func (s *CmdGotestTestSuite) TestParseSetupTimeoutFlag(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []struct {
+		Desc      string
+		args      []string
+		expect    time.Duration
+		expectErr bool
+	}{
+		{Desc: "no flag", args: []string{"--debug"}, expect: 0},
+		{Desc: "equals syntax", args: []string{"--setup-timeout=2m"}, expect: 2 * time.Minute},
+		{Desc: "space syntax", args: []string{"--setup-timeout", "30s"}, expect: 30 * time.Second},
+		{Desc: "empty args", args: nil, expect: 0},
+		{Desc: "invalid value", args: []string{"--setup-timeout=abc"}, expectErr: true},
+		{Desc: "zero value", args: []string{"--setup-timeout=0"}, expect: -1},
+		{Desc: "negative value", args: []string{"--setup-timeout=-5s"}, expect: -1},
+		{Desc: "small positive", args: []string{"--setup-timeout=500ms"}, expect: 500 * time.Millisecond},
+	}) {
+		got, err := ExportParseSetupTimeoutFlag(tc.args)
+		if tc.expectErr {
+			gotest.True(sub, err != nil, "expected error")
+		} else {
+			gotest.NoError(sub, err)
+			gotest.Equal(sub, tc.expect, got)
+		}
+	}
+}
+
+func (s *CmdGotestTestSuite) TestParseDebounceFlag(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []struct {
+		Desc      string
+		args      []string
+		expect    time.Duration
+		expectErr bool
+	}{
+		{Desc: "no flag: default 200ms", args: []string{"--debug"}, expect: 200 * time.Millisecond},
+		{Desc: "equals syntax", args: []string{"--debounce=500ms"}, expect: 500 * time.Millisecond},
+		{Desc: "space syntax", args: []string{"--debounce", "1s"}, expect: 1 * time.Second},
+		{Desc: "empty args: default 200ms", args: nil, expect: 200 * time.Millisecond},
+		{Desc: "invalid value", args: []string{"--debounce=abc"}, expectErr: true},
+		{Desc: "zero value", args: []string{"--debounce=0"}, expectErr: true},
+		{Desc: "negative value", args: []string{"--debounce=-1s"}, expectErr: true},
+	}) {
+		got, err := ExportParseDebounceFlag(tc.args)
+		if tc.expectErr {
+			gotest.True(sub, err != nil, "expected error")
+		} else {
+			gotest.NoError(sub, err)
+			gotest.Equal(sub, tc.expect, got)
+		}
+	}
+}
+
+func (s *CmdGotestTestSuite) TestParseGlobalTimeoutFlag(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []struct {
+		Desc      string
+		args      []string
+		expect    time.Duration
+		expectErr bool
+	}{
+		{Desc: "no flag", args: []string{"--debug"}, expect: 0},
+		{Desc: "equals syntax", args: []string{"--timeout=15m"}, expect: 15 * time.Minute},
+		{Desc: "space syntax", args: []string{"--timeout", "30s"}, expect: 30 * time.Second},
+		{Desc: "empty args", args: nil, expect: 0},
+		{Desc: "invalid value", args: []string{"--timeout=abc"}, expectErr: true},
+		{Desc: "zero value", args: []string{"--timeout=0"}, expect: -1},
+		{Desc: "negative value", args: []string{"--timeout=-5s"}, expect: -1},
+		{Desc: "small positive", args: []string{"--timeout=100ms"}, expect: 100 * time.Millisecond},
+	}) {
+		got, err := ExportParseGlobalTimeoutFlag(tc.args)
+		if tc.expectErr {
+			gotest.True(sub, err != nil, "expected error")
+		} else {
+			gotest.NoError(sub, err)
+			gotest.Equal(sub, tc.expect, got)
+		}
+	}
+}
+
+func (s *CmdGotestTestSuite) TestResolveGlobalTimeout(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []struct {
+		Desc   string
+		input  time.Duration
+		expect time.Duration
+	}{
+		{Desc: "not set: default 15m", input: 0, expect: 15 * time.Minute},
+		{Desc: "positive: passthrough", input: 20 * time.Minute, expect: 20 * time.Minute},
+		{Desc: "negative sentinel: no limit", input: -1, expect: 0},
+		{Desc: "large negative: no limit", input: -100 * time.Minute, expect: 0},
+		{Desc: "small positive: passthrough", input: 30 * time.Second, expect: 30 * time.Second},
+	}) {
+		gotest.Equal(sub, tc.expect, ExportResolveGlobalTimeout(tc.input))
+	}
+
+	t.When("end-to-end parse+resolve", func(w *gotest.T) {
+		for sub, tc := range gotest.Each(w, []struct {
+			Desc   string
+			args   []string
+			expect time.Duration
+		}{
+			{Desc: "--timeout=0 disables", args: []string{"--timeout=0"}, expect: 0},
+			{Desc: "--timeout=0s disables", args: []string{"--timeout=0s"}, expect: 0},
+			{Desc: "--timeout=-1s disables", args: []string{"--timeout=-1s"}, expect: 0},
+			{Desc: "absent defaults to 15m", args: []string{"-v"}, expect: 15 * time.Minute},
+			{Desc: "--timeout=20m passes through", args: []string{"--timeout=20m"}, expect: 20 * time.Minute},
+		}) {
+			parsed, err := ExportParseGlobalTimeoutFlag(tc.args)
+			gotest.NoError(sub, err)
+			gotest.Equal(sub, tc.expect, ExportResolveGlobalTimeout(parsed))
+		}
+	})
 }
 
 func (s *CmdGotestTestSuite) TestRunDiscover_SimpleSuite(t *gotest.T) {

--- a/cmd/gotest/gotest_suite_test.go
+++ b/cmd/gotest/gotest_suite_test.go
@@ -41,7 +41,7 @@ func (s *CmdGotestTestSuite) TestDefaultArgs(t *gotest.T) {
 				Desc: "config positive: config prepended",
 				inv: Invocation{
 					Args:   []string{"-v"},
-					Config: config.ProjectConfig{SetupTimeout: config.Duration(2 * time.Minute)},
+					Config: config.ProjectConfig{SetupTimeout: config.Dur(2 * time.Minute)},
 				},
 				expect: []string{"--setup-timeout=2m0s", "-v"},
 			},
@@ -49,7 +49,7 @@ func (s *CmdGotestTestSuite) TestDefaultArgs(t *gotest.T) {
 				Desc: "config negative: config prepended",
 				inv: Invocation{
 					Args:   []string{"-v"},
-					Config: config.ProjectConfig{SetupTimeout: config.Duration(-1 * time.Second)},
+					Config: config.ProjectConfig{SetupTimeout: config.Dur(-1 * time.Second)},
 				},
 				expect: []string{"--setup-timeout=-1s", "-v"},
 			},
@@ -57,7 +57,7 @@ func (s *CmdGotestTestSuite) TestDefaultArgs(t *gotest.T) {
 				Desc: "tags and setup-timeout both prepended",
 				inv: Invocation{
 					Args:   []string{"-v"},
-					Config: config.ProjectConfig{Tags: "integration", SetupTimeout: config.Duration(3 * time.Minute)},
+					Config: config.ProjectConfig{Tags: "integration", SetupTimeout: config.Dur(3 * time.Minute)},
 				},
 				expect: []string{"--setup-timeout=3m0s", "-tags=integration", "-v"},
 			},
@@ -65,23 +65,23 @@ func (s *CmdGotestTestSuite) TestDefaultArgs(t *gotest.T) {
 				Desc: "config timeout prepended",
 				inv: Invocation{
 					Args:   []string{"-v"},
-					Config: config.ProjectConfig{Timeout: config.Duration(15 * time.Minute)},
+					Config: config.ProjectConfig{Timeout: config.Dur(15 * time.Minute)},
 				},
 				expect: []string{"--timeout=15m0s", "-v"},
 			},
 			{
-				Desc: "config timeout zero: no prepend",
+				Desc: "config timeout zero: disables default",
 				inv: Invocation{
 					Args:   []string{"-v"},
-					Config: config.ProjectConfig{Timeout: config.Duration(0)},
+					Config: config.ProjectConfig{Timeout: config.Dur(0)},
 				},
-				expect: []string{"-v"},
+				expect: []string{"--timeout=0s", "-v"},
 			},
 			{
 				Desc: "config timeout negative: opt-out prepended",
 				inv: Invocation{
 					Args:   []string{"-v"},
-					Config: config.ProjectConfig{Timeout: config.Duration(-1 * time.Second)},
+					Config: config.ProjectConfig{Timeout: config.Dur(-1 * time.Second)},
 				},
 				expect: []string{"--timeout=-1s", "-v"},
 			},
@@ -108,7 +108,7 @@ func (s *CmdGotestTestSuite) TestDefaultArgs(t *gotest.T) {
 				Desc: "config positive: CLI wins",
 				inv: Invocation{
 					Args:   []string{"--setup-timeout=5m", "-v"},
-					Config: config.ProjectConfig{SetupTimeout: config.Duration(2 * time.Minute)},
+					Config: config.ProjectConfig{SetupTimeout: config.Dur(2 * time.Minute)},
 				},
 				expect: []string{"--setup-timeout=5m", "-v"},
 			},
@@ -116,7 +116,7 @@ func (s *CmdGotestTestSuite) TestDefaultArgs(t *gotest.T) {
 				Desc: "config negative: CLI wins",
 				inv: Invocation{
 					Args:   []string{"--setup-timeout=5m", "-v"},
-					Config: config.ProjectConfig{SetupTimeout: config.Duration(-1 * time.Second)},
+					Config: config.ProjectConfig{SetupTimeout: config.Dur(-1 * time.Second)},
 				},
 				expect: []string{"--setup-timeout=5m", "-v"},
 			},
@@ -124,7 +124,7 @@ func (s *CmdGotestTestSuite) TestDefaultArgs(t *gotest.T) {
 				Desc: "CLI timeout wins over config timeout",
 				inv: Invocation{
 					Args:   []string{"--timeout=20m", "-v"},
-					Config: config.ProjectConfig{Timeout: config.Duration(15 * time.Minute)},
+					Config: config.ProjectConfig{Timeout: config.Dur(15 * time.Minute)},
 				},
 				expect: []string{"--timeout=20m", "-v"},
 			},
@@ -151,7 +151,7 @@ func (s *CmdGotestTestSuite) TestDefaultArgs(t *gotest.T) {
 				Desc: "config positive: CLI wins",
 				inv: Invocation{
 					Args:   []string{"--setup-timeout=-1s", "-v"},
-					Config: config.ProjectConfig{SetupTimeout: config.Duration(2 * time.Minute)},
+					Config: config.ProjectConfig{SetupTimeout: config.Dur(2 * time.Minute)},
 				},
 				expect: []string{"--setup-timeout=-1s", "-v"},
 			},
@@ -159,7 +159,7 @@ func (s *CmdGotestTestSuite) TestDefaultArgs(t *gotest.T) {
 				Desc: "config negative: CLI wins",
 				inv: Invocation{
 					Args:   []string{"--setup-timeout=-1s", "-v"},
-					Config: config.ProjectConfig{SetupTimeout: config.Duration(-1 * time.Second)},
+					Config: config.ProjectConfig{SetupTimeout: config.Dur(-1 * time.Second)},
 				},
 				expect: []string{"--setup-timeout=-1s", "-v"},
 			},

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -85,6 +85,7 @@ Flags (gotest — use --double-dash):
   --no-cache              Disable overlay cache, force fresh generation
   --min=<pct>             Fail if coverage < pct%% (0-100)
   --setup-timeout=<dur>   Total budget for shared fixture setup (default: 2m, 0 to disable)
+  --timeout=<dur>         Global pipeline deadline (default: 15m, 0 to disable)
 
 Flags (go test — use -single-dash, forwarded automatically):
   -v                      Verbose output
@@ -135,6 +136,7 @@ Flags:
   --no-cache              Disable overlay cache, force fresh generation
   --min=<pct>             Fail if coverage < pct% (0-100, enables -coverprofile)
   --setup-timeout=<dur>   Total budget for shared fixture setup (default: 2m, 0 to disable)
+  --timeout=<dur>         Global pipeline deadline (default: 15m, 0 to disable)
 
 All standard go test flags (-single-dash) are forwarded automatically.
 Use a bare "--" to pass unrecognized flags without validation.
@@ -172,6 +174,7 @@ Flags:
   --no-cache              Disable overlay cache, force fresh generation
   --min=<pct>             Fail if coverage < pct% (0-100)
   --setup-timeout=<dur>   Total budget for shared fixture setup (default: 2m, 0 to disable)
+  --timeout=<dur>         Global pipeline deadline (default: 15m, 0 to disable)
 
 Examples:
   gotest spec ./...                                Run and render spec
@@ -199,6 +202,7 @@ Flags:
   --update-snapshots      Regenerate snapshot files
   --no-cache              Disable overlay cache, force fresh generation
   --setup-timeout=<dur>   Total budget for shared fixture setup (default: 2m, 0 to disable)
+  --timeout=<dur>         Global pipeline deadline (default: 15m, 0 to disable)
 
 Examples:
   gotest watch ./...                         Watch all packages
@@ -398,6 +402,7 @@ at a go.mod boundary. CLI flags override config values.
 Fields:
   tags: <string>            Build tags, comma-separated (e.g., "integration,e2e")
   setup-timeout: <duration> Total budget for all shared fixture setup (default: 2m, 0 to disable)
+  timeout: <duration>       Global pipeline deadline (default: 15m, 0 to disable)
   min-coverage: <int>       Minimum coverage percentage, 0-100
   debounce: <duration>      Watch mode re-run delay (e.g., "500ms", default: 200ms)
   lint:

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -84,7 +84,7 @@ Flags (gotest — use --double-dash):
   --update-snapshots      Regenerate snapshot files
   --no-cache              Disable overlay cache, force fresh generation
   --min=<pct>             Fail if coverage < pct%% (0-100)
-  --setup-timeout=<dur>   Total budget for shared fixture setup (-1s to disable)
+  --setup-timeout=<dur>   Total budget for shared fixture setup (default: 2m, 0 to disable)
 
 Flags (go test — use -single-dash, forwarded automatically):
   -v                      Verbose output
@@ -134,7 +134,7 @@ Flags:
   --update-snapshots      Regenerate snapshot files
   --no-cache              Disable overlay cache, force fresh generation
   --min=<pct>             Fail if coverage < pct% (0-100, enables -coverprofile)
-  --setup-timeout=<dur>   Total budget for shared fixture setup (-1s to disable)
+  --setup-timeout=<dur>   Total budget for shared fixture setup (default: 2m, 0 to disable)
 
 All standard go test flags (-single-dash) are forwarded automatically.
 Use a bare "--" to pass unrecognized flags without validation.
@@ -171,7 +171,7 @@ Flags:
   --update-snapshots      Regenerate snapshot files
   --no-cache              Disable overlay cache, force fresh generation
   --min=<pct>             Fail if coverage < pct% (0-100)
-  --setup-timeout=<dur>   Total budget for shared fixture setup (-1s to disable)
+  --setup-timeout=<dur>   Total budget for shared fixture setup (default: 2m, 0 to disable)
 
 Examples:
   gotest spec ./...                                Run and render spec
@@ -198,7 +198,7 @@ Flags:
   --debug                 Keep generated overlay
   --update-snapshots      Regenerate snapshot files
   --no-cache              Disable overlay cache, force fresh generation
-  --setup-timeout=<dur>   Total budget for shared fixture setup (-1s to disable)
+  --setup-timeout=<dur>   Total budget for shared fixture setup (default: 2m, 0 to disable)
 
 Examples:
   gotest watch ./...                         Watch all packages
@@ -397,7 +397,7 @@ at a go.mod boundary. CLI flags override config values.
 
 Fields:
   tags: <string>            Build tags, comma-separated (e.g., "integration,e2e")
-  setup-timeout: <duration> Total budget for all shared fixture setup (e.g., "2m", "-1s" to disable)
+  setup-timeout: <duration> Total budget for all shared fixture setup (default: 2m, 0 to disable)
   min-coverage: <int>       Minimum coverage percentage, 0-100
   debounce: <duration>      Watch mode re-run delay (e.g., "500ms", default: 200ms)
   lint:

--- a/cmd/gotest/spec.go
+++ b/cmd/gotest/spec.go
@@ -36,6 +36,12 @@ func runSpec(inv Invocation) int {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2
 	}
+	globalTimeout, err := parseGlobalTimeoutFlag(ownArgs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+	globalTimeout = resolveGlobalTimeout(globalTimeout)
 	minCoverage, err := parseMinFlag(ownArgs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
@@ -77,6 +83,7 @@ func runSpec(inv Invocation) int {
 		GoTestArgs:      goTestArgs,
 		PackagePatterns: patterns,
 		SetupTimeout:    setupTimeout,
+		GlobalTimeout:   globalTimeout,
 		Debug:           slices.Contains(ownArgs, "--debug"),
 		CI:              slices.Contains(ownArgs, "--ci"),
 		UpdateSnapshots: slices.Contains(ownArgs, "--update-snapshots"),
@@ -111,6 +118,12 @@ func runSpec(inv Invocation) int {
 	ctx, cancel := signal.NotifyContext(context.Background(), shutdownSignals...)
 	defer cancel()
 
+	if cfg.GlobalTimeout > 0 {
+		var timeoutCancel context.CancelFunc
+		ctx, timeoutCancel = context.WithTimeout(ctx, cfg.GlobalTimeout)
+		defer timeoutCancel()
+	}
+
 	result, err := gotestrunner.RunPipeline(ctx, gotestrunner.PipelineConfig{
 		GoTestArgs:      cfg.GoTestArgs,
 		SetupTimeout:    cfg.SetupTimeout,
@@ -126,6 +139,12 @@ func runSpec(inv Invocation) int {
 	}
 
 	code := result.ExitCode
+	if cfg.GlobalTimeout > 0 && ctx.Err() == context.DeadlineExceeded {
+		fmt.Fprintf(os.Stderr, "FAIL: global --timeout exceeded after %v\n", cfg.GlobalTimeout)
+		if code == 0 {
+			code = 1
+		}
+	}
 
 	events, err := gotestspec.ParseEvents(bytes.NewReader(result.CapturedJSON))
 	if err != nil {

--- a/cmd/gotest/watch.go
+++ b/cmd/gotest/watch.go
@@ -54,6 +54,12 @@ func runWatch(inv Invocation) int {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2
 	}
+	globalTimeout, err := parseGlobalTimeoutFlag(ownArgs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+	globalTimeout = resolveGlobalTimeout(globalTimeout)
 	debounceDuration, err := parseDebounceFlag(ownArgs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
@@ -73,6 +79,7 @@ func runWatch(inv Invocation) int {
 		GoTestArgs:      goTestArgs,
 		PackagePatterns: patterns,
 		SetupTimeout:    setupTimeout,
+		GlobalTimeout:   globalTimeout,
 		Debug:           slices.Contains(ownArgs, "--debug"),
 		CI:              slices.Contains(ownArgs, "--ci"),
 		UpdateSnapshots: slices.Contains(ownArgs, "--update-snapshots"),
@@ -200,7 +207,14 @@ func watchRunOnce(ctx context.Context, cfg ExecConfig, jsonMode bool) int {
 		mode = gotestrunner.RunStreamJSON
 	}
 
-	result, err := gotestrunner.RunPipeline(ctx, gotestrunner.PipelineConfig{
+	runCtx := ctx
+	if cfg.GlobalTimeout > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, cfg.GlobalTimeout)
+		defer cancel()
+	}
+
+	result, err := gotestrunner.RunPipeline(runCtx, gotestrunner.PipelineConfig{
 		GoTestArgs:      cfg.GoTestArgs,
 		SetupTimeout:    cfg.SetupTimeout,
 		UpdateSnapshots: cfg.UpdateSnapshots,
@@ -212,6 +226,12 @@ func watchRunOnce(ctx context.Context, cfg ExecConfig, jsonMode bool) int {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2
+	}
+	if cfg.GlobalTimeout > 0 && runCtx.Err() == context.DeadlineExceeded {
+		fmt.Fprintf(os.Stderr, "FAIL: global --timeout exceeded after %v\n", cfg.GlobalTimeout)
+		if result.ExitCode == 0 {
+			return 1
+		}
 	}
 	return result.ExitCode
 }

--- a/cmd/gotest/watch.go
+++ b/cmd/gotest/watch.go
@@ -40,7 +40,7 @@ func parseDebounceFlag(args []string) (time.Duration, error) {
 
 func runWatch(inv Invocation) int {
 	args := inv.DefaultArgs()
-	if inv.Config.Debounce.Duration() > 0 && !hasFlag(args, "--debounce") {
+	if inv.Config.Debounce != nil && !hasFlag(args, "--debounce") {
 		args = append([]string{"--debounce=" + inv.Config.Debounce.Duration().String()}, args...)
 	}
 	ownArgs, goTestArgs, err := SplitArgs(args, watchAllowed)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,23 +13,24 @@ import (
 const FileName = ".gotest.yml"
 
 // ProjectConfig holds settings loaded from .gotest.yml.
-// CLI flags take precedence over these values; zero values are ignored.
+// CLI flags take precedence over these values; nil/zero values are ignored.
 type ProjectConfig struct {
 	// Tags is a comma-separated list of build tags passed to go test (e.g. "integration,e2e").
 	Tags string `yaml:"tags"`
 	// SetupTimeout is the total budget for all shared fixture setup.
-	// When omitted, each fixture's own SharedFixtureConfig().Timeout governs.
-	SetupTimeout Duration `yaml:"setup-timeout"`
+	// When omitted, the CLI default (2m) applies. Set to 0 to disable.
+	SetupTimeout *Duration `yaml:"setup-timeout"`
 	// Timeout is the global pipeline deadline.
-	// When omitted, the CLI default (15m) applies. Use 0 on the CLI flag to disable.
-	Timeout Duration `yaml:"timeout"`
+	// When omitted, the CLI default (15m) applies. Set to 0 to disable.
+	Timeout *Duration `yaml:"timeout"`
 	// MinCoverage is the minimum coverage percentage (0-100). The run fails if coverage is below.
 	MinCoverage int `yaml:"min-coverage"`
 	// Parallel is the total concurrency budget (concurrent test methods across all
 	// suite processes). Zero means use the default (2×GOMAXPROCS).
 	Parallel int `yaml:"parallel"`
-	// Debounce is the delay before re-running tests in watch mode. Overrides the CLI default (200ms).
-	Debounce Duration `yaml:"debounce"`
+	// Debounce is the delay before re-running tests in watch mode.
+	// When omitted, the CLI default (200ms) applies.
+	Debounce *Duration `yaml:"debounce"`
 	// Lint holds lint-specific configuration.
 	Lint LintConfig `yaml:"lint"`
 }
@@ -45,6 +46,11 @@ type Duration time.Duration
 
 func (d Duration) Duration() time.Duration {
 	return time.Duration(d)
+}
+
+func Dur(d time.Duration) *Duration {
+	v := Duration(d)
+	return &v
 }
 
 func (d *Duration) UnmarshalYAML(value *yaml.Node) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,8 @@ type ProjectConfig struct {
 	// SetupTimeout is the total budget for all shared fixture setup.
 	// When omitted, each fixture's own SharedFixtureConfig().Timeout governs.
 	SetupTimeout Duration `yaml:"setup-timeout"`
+	// Timeout is the global pipeline deadline. Zero means no limit.
+	Timeout Duration `yaml:"timeout"`
 	// MinCoverage is the minimum coverage percentage (0-100). The run fails if coverage is below.
 	MinCoverage int `yaml:"min-coverage"`
 	// Parallel is the total concurrency budget (concurrent test methods across all

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,8 @@ type ProjectConfig struct {
 	// SetupTimeout is the total budget for all shared fixture setup.
 	// When omitted, each fixture's own SharedFixtureConfig().Timeout governs.
 	SetupTimeout Duration `yaml:"setup-timeout"`
-	// Timeout is the global pipeline deadline. Zero means no limit.
+	// Timeout is the global pipeline deadline.
+	// When omitted, the CLI default (15m) applies. Use 0 on the CLI flag to disable.
 	Timeout Duration `yaml:"timeout"`
 	// MinCoverage is the minimum coverage percentage (0-100). The run fails if coverage is below.
 	MinCoverage int `yaml:"min-coverage"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,6 +13,7 @@ func TestLoad_FullConfig(t *testing.T) {
 	writeFile(t, dir, FileName, `
 tags: "integration,e2e"
 setup-timeout: 2m
+timeout: 20m
 min-coverage: 80
 parallel: 12
 debounce: 500ms
@@ -28,10 +29,11 @@ lint:
 	}
 
 	assertEqual(t, "tags", cfg.Tags, "integration,e2e")
-	assertEqual(t, "setup-timeout", cfg.SetupTimeout.Duration(), 2*time.Minute)
+	assertDuration(t, "setup-timeout", cfg.SetupTimeout, 2*time.Minute)
+	assertDuration(t, "timeout", cfg.Timeout, 20*time.Minute)
 	assertEqual(t, "min-coverage", cfg.MinCoverage, 80)
 	assertEqual(t, "parallel", cfg.Parallel, 12)
-	assertEqual(t, "debounce", cfg.Debounce.Duration(), 500*time.Millisecond)
+	assertDuration(t, "debounce", cfg.Debounce, 500*time.Millisecond)
 	assertSliceEqual(t, "lint.skip", cfg.Lint.Skip, []string{"stdlib-test", "testify"})
 }
 
@@ -45,10 +47,11 @@ func TestLoad_NoFile_ReturnsZero(t *testing.T) {
 	}
 
 	assertEqual(t, "tags", cfg.Tags, "")
-	assertEqual(t, "setup-timeout", cfg.SetupTimeout.Duration(), time.Duration(0))
+	assertNilDuration(t, "setup-timeout", cfg.SetupTimeout)
+	assertNilDuration(t, "timeout", cfg.Timeout)
 	assertEqual(t, "min-coverage", cfg.MinCoverage, 0)
 	assertEqual(t, "parallel", cfg.Parallel, 0)
-	assertEqual(t, "debounce", cfg.Debounce.Duration(), time.Duration(0))
+	assertNilDuration(t, "debounce", cfg.Debounce)
 	if len(cfg.Lint.Skip) != 0 {
 		t.Errorf("lint.skip: got %v, want empty", cfg.Lint.Skip)
 	}
@@ -69,8 +72,8 @@ min-coverage: 60
 
 	assertEqual(t, "tags", cfg.Tags, "unit")
 	assertEqual(t, "min-coverage", cfg.MinCoverage, 60)
-	assertEqual(t, "setup-timeout", cfg.SetupTimeout.Duration(), time.Duration(0))
-	assertEqual(t, "debounce", cfg.Debounce.Duration(), time.Duration(0))
+	assertNilDuration(t, "setup-timeout", cfg.SetupTimeout)
+	assertNilDuration(t, "debounce", cfg.Debounce)
 }
 
 func TestLoad_WalksUpToGoMod(t *testing.T) {
@@ -109,6 +112,25 @@ func TestLoad_StopsAtGoMod(t *testing.T) {
 	assertEqual(t, "tags", cfg.Tags, "")
 }
 
+func TestLoad_ZeroDuration_IsNotNil(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "go.mod", "module test\n")
+	writeFile(t, dir, FileName, `
+setup-timeout: 0s
+timeout: 0s
+debounce: 0s
+`)
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertDuration(t, "setup-timeout", cfg.SetupTimeout, 0)
+	assertDuration(t, "timeout", cfg.Timeout, 0)
+	assertDuration(t, "debounce", cfg.Debounce, 0)
+}
+
 func TestLoad_InvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, "go.mod", "module test\n")
@@ -142,6 +164,24 @@ func assertEqual[T comparable](t *testing.T, field string, got, want T) {
 	t.Helper()
 	if got != want {
 		t.Errorf("%s: got %v, want %v", field, got, want)
+	}
+}
+
+func assertDuration(t *testing.T, field string, got *Duration, want time.Duration) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s: got nil, want %v", field, want)
+		return
+	}
+	if got.Duration() != want {
+		t.Errorf("%s: got %v, want %v", field, got.Duration(), want)
+	}
+}
+
+func assertNilDuration(t *testing.T, field string, got *Duration) {
+	t.Helper()
+	if got != nil {
+		t.Errorf("%s: got %v, want nil", field, got.Duration())
 	}
 }
 

--- a/internal/gotestrunner/export_test.go
+++ b/internal/gotestrunner/export_test.go
@@ -16,6 +16,7 @@ var ExportReadTeardownBudget = readTeardownBudget
 var ExportSplitTopLevelOr = splitTopLevelOr
 var ExportSuiteRunFilter = suiteRunFilter
 var ExportAssignCoverProfiles = assignCoverProfiles
+var ExportResolveSetupTimeout = resolveSetupTimeout
 var ExportBuildExtraEnv = buildExtraEnv
 var ExportBuildBaseEnv = buildBaseEnv
 var ExportOverlayContentHash = overlayContentHash

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -1557,6 +1557,23 @@ func (s *GotestrunnerTestSuite) TestBuildExtraEnv(t *gotest.T) {
 	})
 }
 
+func (s *GotestrunnerTestSuite) TestResolveSetupTimeout(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []struct {
+		Name   string
+		input  time.Duration
+		expect time.Duration
+	}{
+		{"not set defaults to 2m", 0, 2 * time.Minute},
+		{"positive passed through", 5 * time.Minute, 5 * time.Minute},
+		{"negative means no limit", -1, 0},
+		{"large negative means no limit", -30 * time.Second, 0},
+		{"small positive passed through", 10 * time.Second, 10 * time.Second},
+	}) {
+		got := gotestrunner.ExportResolveSetupTimeout(tc.input)
+		gotest.Equal(sub, tc.expect, got)
+	}
+}
+
 func (s *GotestrunnerTestSuite) TestCIAutoDetection(t *gotest.T) {
 	t.When("auto-detecting CI from environment", func(w *gotest.T) {
 		w.It("sets CI when CI=true and GOTEST_CI is unset", func(it *gotest.T) {

--- a/internal/gotestrunner/pipeline.go
+++ b/internal/gotestrunner/pipeline.go
@@ -250,13 +250,6 @@ func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResul
 	streamCtx, streamCancel := context.WithCancel(ctx)
 	defer streamCancel()
 
-	var setupDeadline <-chan time.Time
-	if resolvedSetupTimeout > 0 && len(overlay.SharedFixtures) > 0 {
-		timer := time.NewTimer(resolvedSetupTimeout)
-		defer timer.Stop()
-		setupDeadline = timer.C
-	}
-
 	if len(overlay.SharedFixtures) > 0 {
 		fixtureWg.Add(1)
 		go func() {
@@ -270,6 +263,12 @@ func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResul
 			close(fixtureStarted)
 			if err != nil {
 				return
+			}
+			var setupDeadline <-chan time.Time
+			if resolvedSetupTimeout > 0 {
+				timer := time.NewTimer(resolvedSetupTimeout)
+				defer timer.Stop()
+				setupDeadline = timer.C
 			}
 			select {
 			case <-setupProc.AllDone():

--- a/internal/gotestrunner/pipeline.go
+++ b/internal/gotestrunner/pipeline.go
@@ -12,6 +12,19 @@ import (
 	"github.com/mvrahden/go-test/internal/protocol"
 )
 
+const DefaultSetupTimeout = 2 * time.Minute
+
+func resolveSetupTimeout(d time.Duration) time.Duration {
+	switch {
+	case d > 0:
+		return d
+	case d < 0:
+		return 0
+	default:
+		return DefaultSetupTimeout
+	}
+}
+
 func computeDispatchConcurrency(runFlags *[]string, budget, totalSuites int) int {
 	userParallel := ExtractParallelValue(*runFlags)
 
@@ -79,6 +92,7 @@ func buildBaseEnv(cfg PipelineConfig) []string {
 }
 
 func prepareTestRun(ctx context.Context, overlay *OverlayResult, buildFlags []string, setupTimeout time.Duration) ([]CompileResult, *SharedFixtureProcess, context.CancelFunc, error) {
+	setupTimeout = resolveSetupTimeout(setupTimeout)
 	ctx, cancel := context.WithCancel(ctx)
 
 	var compiled []CompileResult
@@ -225,6 +239,7 @@ func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResul
 		os.MkdirAll(coverDir, 0o755)
 	}
 
+	resolvedSetupTimeout := resolveSetupTimeout(cfg.SetupTimeout)
 	baseEnv := buildBaseEnv(cfg)
 
 	fixtureStarted := make(chan struct{})
@@ -235,17 +250,34 @@ func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResul
 	streamCtx, streamCancel := context.WithCancel(ctx)
 	defer streamCancel()
 
+	var setupDeadline <-chan time.Time
+	if resolvedSetupTimeout > 0 && len(overlay.SharedFixtures) > 0 {
+		timer := time.NewTimer(resolvedSetupTimeout)
+		defer timer.Stop()
+		setupDeadline = timer.C
+	}
+
 	if len(overlay.SharedFixtures) > 0 {
 		fixtureWg.Add(1)
 		go func() {
 			defer fixtureWg.Done()
 			var err error
-			setupProc, err = StartSharedFixtures(streamCtx, overlay.WorkDir, overlay.SharedFixtures, cfg.SetupTimeout)
+			setupProc, err = StartSharedFixtures(streamCtx, overlay.WorkDir, overlay.SharedFixtures, resolvedSetupTimeout)
 			if err != nil {
 				fixtureStartErr = err
 				streamCancel()
 			}
 			close(fixtureStarted)
+			if err != nil {
+				return
+			}
+			select {
+			case <-setupProc.AllDone():
+			case <-streamCtx.Done():
+			case <-setupDeadline:
+				fmt.Fprintf(os.Stderr, "FAIL: shared fixture setup timed out after %v\n", resolvedSetupTimeout)
+				streamCancel()
+			}
 		}()
 	} else {
 		close(fixtureStarted)


### PR DESCRIPTION
Test runs now have built-in time limits to prevent them from hanging indefinitely. A global timeout (default 15 minutes) stops the entire pipeline if it runs too long, and test setup gets its own 2-minute cap so a stuck setup phase can't block everything. Both limits are configurable, and either can be disabled by setting it to zero.