### PR TITLE
Improve shared fixture failure diagnostics

### DIFF
--- a/internal/gotestgen/static/sharedfixture.go.tpl
+++ b/internal/gotestgen/static/sharedfixture.go.tpl
@@ -117,7 +117,17 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 {{ range .TeardownFixtures }}
 		if ƒerrs[{{ .Index }}] == nil {
-			{{ .VarName }}.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_{{ .VarName }}.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_{{ .VarName }}.Timeout)
+					defer cancel()
+				}
+				if err := {{ .VarName }}.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "{{ .Identifier }}.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 {{- end }}
 		os.Exit(1)

--- a/internal/gotestgen/static/sharedfixture.go.tpl
+++ b/internal/gotestgen/static/sharedfixture.go.tpl
@@ -150,10 +150,14 @@ func main() {
 		if ƒcfg_{{ .VarName }}.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_{{ .VarName }}.Timeout)
-			{{ .VarName }}.AfterAll(ctx)
+			if err := {{ .VarName }}.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "{{ .Identifier }}.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			{{ .VarName }}.AfterAll(ctx)
+			if err := {{ .VarName }}.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "{{ .Identifier }}.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 {{- end }}

--- a/internal/gotestgen/testdata/__snapshots__/TestSharedFixtureTestSuite_ext.snap
+++ b/internal/gotestgen/testdata/__snapshots__/TestSharedFixtureTestSuite_ext.snap
@@ -143,10 +143,30 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 
 		if ƒerrs[1] == nil {
-			sf1.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf1.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf1.Timeout)
+					defer cancel()
+				}
+				if err := sf1.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "RedisFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		if ƒerrs[0] == nil {
-			sf0.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf0.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
+					defer cancel()
+				}
+				if err := sf0.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		os.Exit(1)
 	} else {
@@ -288,7 +308,17 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 
 		if ƒerrs[0] == nil {
-			sf0.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf0.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
+					defer cancel()
+				}
+				if err := sf0.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		os.Exit(1)
 	} else {
@@ -400,7 +430,17 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 
 		if ƒerrs[0] == nil {
-			sf0.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf0.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
+					defer cancel()
+				}
+				if err := sf0.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "SetupFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		os.Exit(1)
 	} else {
@@ -525,7 +565,17 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 
 		if ƒerrs[0] == nil {
-			sf0.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf0.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
+					defer cancel()
+				}
+				if err := sf0.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		os.Exit(1)
 	} else {
@@ -699,10 +749,30 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 
 		if ƒerrs[1] == nil {
-			sf1.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf1.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf1.Timeout)
+					defer cancel()
+				}
+				if err := sf1.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "RedisFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		if ƒerrs[0] == nil {
-			sf0.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf0.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
+					defer cancel()
+				}
+				if err := sf0.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		os.Exit(1)
 	} else {
@@ -842,7 +912,17 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 
 		if ƒerrs[0] == nil {
-			sf0.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf0.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
+					defer cancel()
+				}
+				if err := sf0.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		os.Exit(1)
 	} else {
@@ -967,7 +1047,17 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 
 		if ƒerrs[0] == nil {
-			sf0.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf0.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
+					defer cancel()
+				}
+				if err := sf0.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		os.Exit(1)
 	} else {
@@ -1092,7 +1182,17 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 
 		if ƒerrs[0] == nil {
-			sf0.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf0.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
+					defer cancel()
+				}
+				if err := sf0.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		os.Exit(1)
 	} else {
@@ -1217,7 +1317,17 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 
 		if ƒerrs[0] == nil {
-			sf0.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf0.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
+					defer cancel()
+				}
+				if err := sf0.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		os.Exit(1)
 	} else {
@@ -1392,10 +1502,30 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 
 		if ƒerrs[1] == nil {
-			sf1.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf1.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf1.Timeout)
+					defer cancel()
+				}
+				if err := sf1.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "RedisFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		if ƒerrs[0] == nil {
-			sf0.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf0.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
+					defer cancel()
+				}
+				if err := sf0.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		os.Exit(1)
 	} else {
@@ -1535,7 +1665,17 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 
 		if ƒerrs[0] == nil {
-			sf0.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf0.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
+					defer cancel()
+				}
+				if err := sf0.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		os.Exit(1)
 	} else {
@@ -1661,7 +1801,17 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 
 		if ƒerrs[0] == nil {
-			sf0.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf0.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
+					defer cancel()
+				}
+				if err := sf0.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		os.Exit(1)
 	} else {
@@ -1838,10 +1988,30 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"error\":\"one or more shared fixtures failed\"}\n")
 
 		if ƒerrs[1] == nil {
-			sf1.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf1.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf1.Timeout)
+					defer cancel()
+				}
+				if err := sf1.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "GCSFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		if ƒerrs[0] == nil {
-			sf0.AfterAll(context.Background())
+			{
+				ctx := context.Background()
+				if ƒcfg_sf0.Timeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
+					defer cancel()
+				}
+				if err := sf0.AfterAll(ctx); err != nil {
+					fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+				}
+			}
 		}
 		os.Exit(1)
 	} else {

--- a/internal/gotestgen/testdata/__snapshots__/TestSharedFixtureTestSuite_ext.snap
+++ b/internal/gotestgen/testdata/__snapshots__/TestSharedFixtureTestSuite_ext.snap
@@ -192,10 +192,14 @@ func main() {
 		if ƒcfg_sf1.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf1.Timeout)
-			sf1.AfterAll(ctx)
+			if err := sf1.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "RedisFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf1.AfterAll(ctx)
+			if err := sf1.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "RedisFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 	if ƒerrs[0] == nil {
@@ -203,10 +207,14 @@ func main() {
 		if ƒcfg_sf0.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 }
@@ -340,10 +348,14 @@ func main() {
 		if ƒcfg_sf0.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 }
@@ -462,10 +474,14 @@ func main() {
 		if ƒcfg_sf0.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "SetupFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "SetupFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 }
@@ -597,10 +613,14 @@ func main() {
 		if ƒcfg_sf0.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 }
@@ -798,10 +818,14 @@ func main() {
 		if ƒcfg_sf1.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf1.Timeout)
-			sf1.AfterAll(ctx)
+			if err := sf1.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "RedisFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf1.AfterAll(ctx)
+			if err := sf1.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "RedisFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 	if ƒerrs[0] == nil {
@@ -809,10 +833,14 @@ func main() {
 		if ƒcfg_sf0.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 }
@@ -944,10 +972,14 @@ func main() {
 		if ƒcfg_sf0.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 }
@@ -1079,10 +1111,14 @@ func main() {
 		if ƒcfg_sf0.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 }
@@ -1214,10 +1250,14 @@ func main() {
 		if ƒcfg_sf0.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 }
@@ -1349,10 +1389,14 @@ func main() {
 		if ƒcfg_sf0.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 }
@@ -1551,10 +1595,14 @@ func main() {
 		if ƒcfg_sf1.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf1.Timeout)
-			sf1.AfterAll(ctx)
+			if err := sf1.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "RedisFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf1.AfterAll(ctx)
+			if err := sf1.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "RedisFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 	if ƒerrs[0] == nil {
@@ -1562,10 +1610,14 @@ func main() {
 		if ƒcfg_sf0.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 }
@@ -1697,10 +1749,14 @@ func main() {
 		if ƒcfg_sf0.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 }
@@ -1833,10 +1889,14 @@ func main() {
 		if ƒcfg_sf0.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PGFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 }
@@ -2037,10 +2097,14 @@ func main() {
 		if ƒcfg_sf1.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf1.Timeout)
-			sf1.AfterAll(ctx)
+			if err := sf1.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "GCSFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf1.AfterAll(ctx)
+			if err := sf1.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "GCSFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 	if ƒerrs[0] == nil {
@@ -2048,10 +2112,14 @@ func main() {
 		if ƒcfg_sf0.Timeout > 0 {
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(ctx, ƒcfg_sf0.Timeout)
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+			}
 			cancel()
 		} else {
-			sf0.AfterAll(ctx)
+			if err := sf0.AfterAll(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "PostgresFixture.AfterAll failed: %v\n", err)
+			}
 		}
 	}
 }

--- a/internal/gotestrunner/pipeline.go
+++ b/internal/gotestrunner/pipeline.go
@@ -272,6 +272,10 @@ func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResul
 			}
 			select {
 			case <-setupProc.AllDone():
+				if err := setupProc.SetupErr(); err != nil {
+					fmt.Fprintf(os.Stderr, "FAIL: shared fixture setup failed: %v\n", err)
+					streamCancel()
+				}
 			case <-streamCtx.Done():
 			case <-setupDeadline:
 				fmt.Fprintf(os.Stderr, "FAIL: shared fixture setup timed out after %v\n", resolvedSetupTimeout)

--- a/internal/gotestrunner/sharedfixture.go
+++ b/internal/gotestrunner/sharedfixture.go
@@ -154,6 +154,7 @@ func (p *SharedFixtureProcess) Teardown() error {
 	select {
 	case <-p.done:
 	case <-time.After(timeout):
+		fmt.Fprintf(os.Stderr, "WARN: shared fixture process did not exit within %v, forcing termination\n", timeout)
 		ForceKillProcessGroup(p.cmd.Process.Pid)
 		<-p.done
 	}


### PR DESCRIPTION
When a shared fixture's BeforeAll failed, the test run could hang indefinitely instead of failing fast, and AfterAll errors were silently swallowed. This makes all failure paths visible and responsive:

  - Cancel the test run immediately when shared fixture setup fails instead of hanging until the global timeout
  - Log AfterAll errors that were previously discarded in both the failure-cleanup and teardown paths
  - Apply timeouts to failure-cleanup AfterAll calls that previously ran with no deadline
  - Warn when the shared fixture process has to be force-killed