### PR TITLE
CI-friendly test failure summaries with GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,11 +720,29 @@ gotest lint ./...
 Detects: lifecycle hook typos, value receivers on suite methods, missing `AfterAll` when `BeforeAll` exists, committed `F_` prefixes, and orphaned generated files.
 Also available as a standalone binary (`gotest-lint`) compatible with `golangci-lint` via `go/analysis`.
 
+## GitHub Actions
+
+Use the official action for CI pipelines with failure summaries, inline PR annotations, and coverage reporting:
+
+```yaml
+- uses: mvrahden/go-test@v1
+  with:
+    packages: ./...
+    race: true
+    coverage: true
+    min-coverage: 80
+```
+
+By default (`version: gomod`), the action resolves `gotest` from your `go.mod` — no version drift between CI and local development. Set `version: latest` or a specific tag to install a standalone binary instead.
+
+The action emits `::error` annotations that appear inline on PR diffs and writes a markdown summary to the GitHub step summary panel. See the [reference](https://mvrahden.github.io/go-test/reference.html#ci-integration) for the full inputs/outputs table.
+
 ## Commands
 
 ```bash
 gotest ./... -v -race          # generate overlays and run tests (default)
 gotest spec ./...              # behavioral specification view
+gotest summary ./...           # failure-focused summary for CI
 gotest watch ./... -v          # watch mode with auto-rerun
 gotest scaffold ./pkg/user.Svc # generate suite skeleton from type
 gotest lint ./...              # static analysis for test suites

--- a/action.yml
+++ b/action.yml
@@ -25,8 +25,9 @@ inputs:
     description: "Additional go test flags (-single-dash style)"
     required: false
   version:
-    description: "gotest version to install (e.g. v1.0.0)"
-    default: "latest"
+    description: "gotest version to install (e.g. v1.0.0, latest). When omitted, uses 'go run' with the version from go.mod."
+    required: false
+    default: ""
 
 outputs:
   exit-code:
@@ -40,6 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Install gotest
+      if: ${{ inputs.version != '' }}
       shell: bash
       run: go install github.com/mvrahden/go-test/cmd/gotest@${{ inputs.version }}
 
@@ -53,7 +55,14 @@ runs:
         INPUT_MIN_COVERAGE: ${{ inputs.min-coverage }}
         INPUT_FLAGS: ${{ inputs.flags }}
         INPUT_GO_TEST_FLAGS: ${{ inputs.go-test-flags }}
+        INPUT_VERSION: ${{ inputs.version }}
       run: |
+        if [ -n "$INPUT_VERSION" ]; then
+          cmd=(gotest)
+        else
+          cmd=(go run github.com/mvrahden/go-test/cmd/gotest)
+        fi
+
         args=(summary --github)
 
         cover_profile=""
@@ -88,7 +97,7 @@ runs:
         fi
 
         set +e
-        gotest "${args[@]}"
+        "${cmd[@]}" "${args[@]}"
         exit_code=$?
         set -e
 

--- a/action.yml
+++ b/action.yml
@@ -25,9 +25,8 @@ inputs:
     description: "Additional go test flags (-single-dash style)"
     required: false
   version:
-    description: "gotest version to install (e.g. v1.0.0, latest). When omitted, uses 'go run' with the version from go.mod."
-    required: false
-    default: ""
+    description: "gotest version: 'gomod' (default) resolves from go.mod, or a version tag (e.g. v1.0.0, latest) to install globally."
+    default: "gomod"
 
 outputs:
   exit-code:
@@ -41,7 +40,7 @@ runs:
   using: "composite"
   steps:
     - name: Install gotest
-      if: ${{ inputs.version != '' }}
+      if: ${{ inputs.version != 'gomod' }}
       shell: bash
       run: go install github.com/mvrahden/go-test/cmd/gotest@${{ inputs.version }}
 
@@ -57,7 +56,7 @@ runs:
         INPUT_GO_TEST_FLAGS: ${{ inputs.go-test-flags }}
         INPUT_VERSION: ${{ inputs.version }}
       run: |
-        if [ -n "$INPUT_VERSION" ]; then
+        if [ "$INPUT_VERSION" != "gomod" ]; then
           cmd=(gotest)
         else
           cmd=(go run github.com/mvrahden/go-test/cmd/gotest)

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,103 @@
+name: "Go Test Summary"
+description: "Run Go tests with failure-focused summary, GitHub annotations, and coverage reporting"
+
+branding:
+  icon: "check-circle"
+  color: "blue"
+
+inputs:
+  packages:
+    description: "Package patterns to test"
+    default: "./..."
+  race:
+    description: "Enable race detector"
+    default: "false"
+  coverage:
+    description: "Enable coverage profiling and reporting"
+    default: "false"
+  min-coverage:
+    description: "Minimum coverage percentage (0-100, fails if below)"
+    required: false
+  flags:
+    description: "Additional gotest flags (--double-dash style)"
+    required: false
+  go-test-flags:
+    description: "Additional go test flags (-single-dash style)"
+    required: false
+  version:
+    description: "gotest version to install (e.g. v1.0.0)"
+    default: "latest"
+
+outputs:
+  exit-code:
+    description: "Test process exit code"
+    value: ${{ steps.test.outputs.exit-code }}
+  coverage:
+    description: "Coverage percentage (empty if coverage not enabled)"
+    value: ${{ steps.test.outputs.coverage }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install gotest
+      shell: bash
+      run: go install github.com/mvrahden/go-test/cmd/gotest@${{ inputs.version }}
+
+    - name: Run tests
+      id: test
+      shell: bash
+      env:
+        INPUT_PACKAGES: ${{ inputs.packages }}
+        INPUT_RACE: ${{ inputs.race }}
+        INPUT_COVERAGE: ${{ inputs.coverage }}
+        INPUT_MIN_COVERAGE: ${{ inputs.min-coverage }}
+        INPUT_FLAGS: ${{ inputs.flags }}
+        INPUT_GO_TEST_FLAGS: ${{ inputs.go-test-flags }}
+      run: |
+        args=(summary --github)
+
+        cover_profile=""
+        if [ "$INPUT_COVERAGE" = "true" ]; then
+          cover_profile="$(mktemp -t gotest-cover-XXXXXX.out)"
+          args+=("--coverage=$cover_profile")
+        fi
+
+        if [ -n "$INPUT_MIN_COVERAGE" ]; then
+          args+=("--min=$INPUT_MIN_COVERAGE")
+        fi
+
+        if [ -n "$INPUT_FLAGS" ]; then
+          read -ra extra <<< "$INPUT_FLAGS"
+          args+=("${extra[@]}")
+        fi
+
+        read -ra pkgs <<< "$INPUT_PACKAGES"
+        args+=("${pkgs[@]}")
+
+        if [ "$INPUT_RACE" = "true" ]; then
+          args+=(-race)
+        fi
+
+        if [ -n "$cover_profile" ]; then
+          args+=("-coverprofile=$cover_profile")
+        fi
+
+        if [ -n "$INPUT_GO_TEST_FLAGS" ]; then
+          read -ra gtflags <<< "$INPUT_GO_TEST_FLAGS"
+          args+=("${gtflags[@]}")
+        fi
+
+        set +e
+        gotest "${args[@]}"
+        exit_code=$?
+        set -e
+
+        echo "exit-code=$exit_code" >> "$GITHUB_OUTPUT"
+
+        if [ -n "$cover_profile" ] && [ -f "$cover_profile" ]; then
+          cov=$(go tool cover -func="$cover_profile" | tail -1 | awk '{print $NF}' | sed 's/%//')
+          echo "coverage=$cov" >> "$GITHUB_OUTPUT"
+          rm -f "$cover_profile"
+        fi
+
+        exit "$exit_code"

--- a/cmd/gotest/args.go
+++ b/cmd/gotest/args.go
@@ -69,6 +69,7 @@ var knownSubcommands = map[string]bool{
 	"scaffold": true,
 	"migrate":  true,
 	"spec":     true,
+	"summary":  true,
 	"watch":    true,
 	"clean":    true,
 	"lint":     true,

--- a/cmd/gotest/cli.go
+++ b/cmd/gotest/cli.go
@@ -46,6 +46,8 @@ func main() {
 		os.Exit(runClean(inv))
 	case "spec":
 		os.Exit(runSpec(inv))
+	case "summary":
+		os.Exit(runSummary(inv))
 	case "watch":
 		os.Exit(runWatch(inv))
 	case "refactor":

--- a/cmd/gotest/flags.go
+++ b/cmd/gotest/flags.go
@@ -17,6 +17,7 @@ var gotestFlags = map[string]FlagKind{
 	"--no-color":         BoolFlag,
 	"--no-cache":         BoolFlag,
 	"--github":           BoolFlag,
+	"--coverage":         ValueFlag,
 	"--min":              ValueFlag,
 	"--setup-timeout":    ValueFlag,
 	"--debounce":         ValueFlag,
@@ -42,6 +43,7 @@ var summaryAllowed = flagSet(
 	"--debug", "--ci", "--update-snapshots", "--no-cache",
 	"--min", "--setup-timeout", "--timeout", "--parallel",
 	"--format", "--output", "--input", "--no-color", "--github",
+	"--coverage",
 )
 
 var watchAllowed = flagSet(

--- a/cmd/gotest/flags.go
+++ b/cmd/gotest/flags.go
@@ -16,6 +16,7 @@ var gotestFlags = map[string]FlagKind{
 	"--update-snapshots": BoolFlag,
 	"--no-color":         BoolFlag,
 	"--no-cache":         BoolFlag,
+	"--github":           BoolFlag,
 	"--min":              ValueFlag,
 	"--setup-timeout":    ValueFlag,
 	"--debounce":         ValueFlag,
@@ -35,6 +36,12 @@ var specAllowed = flagSet(
 	"--debug", "--ci", "--update-snapshots", "--no-cache",
 	"--min", "--setup-timeout", "--timeout", "--parallel",
 	"--format", "--output", "--input", "--no-color",
+)
+
+var summaryAllowed = flagSet(
+	"--debug", "--ci", "--update-snapshots", "--no-cache",
+	"--min", "--setup-timeout", "--timeout", "--parallel",
+	"--format", "--output", "--input", "--no-color", "--github",
 )
 
 var watchAllowed = flagSet(

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -208,6 +208,7 @@ Flags:
   --no-color              Disable ANSI color codes
   --github                GitHub CI mode: emit annotations and step summary
                           (auto-detected via $GITHUB_ACTIONS)
+  --coverage=<file>       Include coverage from profile in summary output
   --ci                    CI mode: fail on F_ prefixes, snapshot read-only
   --debug                 Keep generated overlay
   --update-snapshots      Regenerate snapshot files

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -27,6 +27,8 @@ func showHelp(topic string) {
 		printTestHelp()
 	case "spec":
 		printSpecHelp()
+	case "summary":
+		printSummaryHelp()
 	case "watch":
 		printWatchHelp()
 	case "discover":
@@ -64,6 +66,7 @@ Usage:
 
 Subcommands:
   spec        Render behavioral specification from test output
+  summary     Show failure-focused test summary for CI
   watch       Watch for file changes and re-run tests
   discover    Discover test suites and output JSON
   scaffold    Generate test suite skeleton
@@ -182,6 +185,47 @@ Examples:
   gotest spec --no-color --output=spec.txt ./...   Plain text for CI artifacts
   gotest spec --input=- < events.json              Render from piped JSON input
   gotest spec --format=json ./... -count=1         JSON tree, no caching
+`)
+}
+
+func printSummaryHelp() {
+	fmt.Print(`gotest summary — failure-focused test summary for CI
+
+Usage:
+  gotest summary [flags] [--] [go-test-flags] [packages...]
+  gotest summary --input=<file> [--format=<fmt>] [--output=<file>]
+
+Runs test suites and shows only failing tests with their error output.
+Designed for CI pipelines where the full spec tree is too verbose.
+
+When all tests pass, prints a single success line. When tests fail,
+prints each failure with its package, test path, and assertion output.
+
+Flags:
+  --format=<fmt>          Output format: terminal (default), md, json
+  --output=<file>         Write to file instead of stdout
+  --input=<file>          Read from saved JSON ("-" for stdin)
+  --no-color              Disable ANSI color codes
+  --github                GitHub CI mode: emit annotations and step summary
+                          (auto-detected via $GITHUB_ACTIONS)
+  --ci                    CI mode: fail on F_ prefixes, snapshot read-only
+  --debug                 Keep generated overlay
+  --update-snapshots      Regenerate snapshot files
+  --no-cache              Disable overlay cache, force fresh generation
+  --min=<pct>             Fail if coverage < pct% (0-100)
+  --setup-timeout=<dur>   Total budget for shared fixture setup (default: 2m, 0 to disable)
+  --timeout=<dur>         Global pipeline deadline (default: 15m, 0 to disable)
+
+GitHub CI mode (--github):
+  Emits ::error annotations for each failure, showing inline on PR diffs.
+  Writes a markdown summary to $GITHUB_STEP_SUMMARY.
+
+Examples:
+  gotest summary ./...                                Run and show failures only
+  gotest summary --github ./... -race                 CI pipeline with annotations
+  gotest summary --format=md --output=summary.md      Markdown failure report
+  gotest summary --input=- < events.json              Summarize from piped JSON
+  go test -json ./... | gotest summary --input=-      Filter plain go test output
 `)
 }
 

--- a/cmd/gotest/summary.go
+++ b/cmd/gotest/summary.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"slices"
+	"strings"
+
+	"github.com/mvrahden/go-test/internal/gotestgen"
+	"github.com/mvrahden/go-test/internal/gotestrunner"
+	"github.com/mvrahden/go-test/internal/gotestspec"
+)
+
+func runSummary(inv Invocation) int {
+	ownArgs, goTestArgs, err := SplitArgs(inv.DefaultArgs(), summaryAllowed)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+
+	format := extractStringFlag(ownArgs, "--format", "terminal")
+	output := extractStringFlag(ownArgs, "--output", "")
+	input := extractStringFlag(ownArgs, "--input", "")
+	noColor := hasFlag(ownArgs, "--no-color")
+	github := hasFlag(ownArgs, "--github") || os.Getenv("GITHUB_ACTIONS") == "true"
+
+	if input != "" {
+		return runSummaryFromInput(input, format, output, noColor, github)
+	}
+
+	setupTimeout, err := parseSetupTimeoutFlag(ownArgs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+	globalTimeout, err := parseGlobalTimeoutFlag(ownArgs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+	globalTimeout = resolveGlobalTimeout(globalTimeout)
+	minCoverage, err := parseMinFlag(ownArgs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+
+	parallel, err := parseParallelFlag(ownArgs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+	if parallel == 0 {
+		parallel = inv.Config.Parallel
+	}
+
+	var coverProfile string
+	if minCoverage > 0 {
+		for _, arg := range goTestArgs {
+			if v, ok := strings.CutPrefix(arg, "-coverprofile="); ok {
+				coverProfile = v
+			}
+		}
+		if coverProfile == "" {
+			f, ferr := os.CreateTemp("", "gotest-cover-*.out")
+			if ferr != nil {
+				fmt.Fprintf(os.Stderr, "FAIL: %s\n", ferr)
+				return 2
+			}
+			coverProfile = f.Name()
+			f.Close()
+			defer os.Remove(coverProfile)
+			goTestArgs = append(goTestArgs, "-coverprofile="+coverProfile)
+		}
+	}
+
+	patterns := ExtractPackagePatterns(goTestArgs)
+
+	cfg := ExecConfig{
+		GoTestArgs:      goTestArgs,
+		PackagePatterns: patterns,
+		SetupTimeout:    setupTimeout,
+		GlobalTimeout:   globalTimeout,
+		Debug:           slices.Contains(ownArgs, "--debug"),
+		CI:              slices.Contains(ownArgs, "--ci"),
+		UpdateSnapshots: slices.Contains(ownArgs, "--update-snapshots"),
+		NoCache:         slices.Contains(ownArgs, "--no-cache"),
+		Parallel:        parallel,
+	}
+
+	classified := gotestrunner.ClassifyGoTestArgs(goTestArgs)
+	loadFlags := gotestrunner.StripCoverBuildFlags(classified.BuildFlags)
+	loaded, err := gotestgen.LoadPackages(patterns, loadFlags)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+
+	if cfg.CI {
+		if code, err := enforceFocusGuard(loaded); err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+			return 2
+		} else if code != 0 {
+			return code
+		}
+	}
+
+	overlay, cleanup, err := gotestrunner.GenerateOverlay(loaded, cfg.Debug, cfg.NoCache)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+	defer cleanup()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), shutdownSignals...)
+	defer cancel()
+
+	if cfg.GlobalTimeout > 0 {
+		var timeoutCancel context.CancelFunc
+		ctx, timeoutCancel = context.WithTimeout(ctx, cfg.GlobalTimeout)
+		defer timeoutCancel()
+	}
+
+	result, err := gotestrunner.RunPipeline(ctx, gotestrunner.PipelineConfig{
+		GoTestArgs:      cfg.GoTestArgs,
+		SetupTimeout:    cfg.SetupTimeout,
+		UpdateSnapshots: cfg.UpdateSnapshots,
+		CI:              cfg.CI,
+		Parallel:        cfg.Parallel,
+		Streaming:       false,
+		OutputMode:      gotestrunner.RunCaptureJSON,
+	}, overlay)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+
+	code := result.ExitCode
+	if cfg.GlobalTimeout > 0 && ctx.Err() == context.DeadlineExceeded {
+		fmt.Fprintf(os.Stderr, "FAIL: global --timeout exceeded after %v\n", cfg.GlobalTimeout)
+		if code == 0 {
+			code = 1
+		}
+	}
+
+	events, err := gotestspec.ParseEvents(bytes.NewReader(result.CapturedJSON))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: parsing test events: %s\n", err)
+		return 2
+	}
+
+	tree := gotestspec.BuildTree(events)
+
+	writeSummaryOutput(tree, format, output, noColor, github)
+
+	if code == 0 && minCoverage > 0 && coverProfile != "" {
+		pct, err := readCoverageTotal(coverProfile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: reading coverage: %s\n", err)
+			return 2
+		}
+		if pct < float64(minCoverage) {
+			fmt.Fprintf(os.Stderr, "\nFAIL: %.1f%% coverage (minimum %d%%)\n", pct, minCoverage)
+			return 1
+		}
+	}
+
+	return code
+}
+
+func runSummaryFromInput(input, format, output string, noColor, github bool) int {
+	var r io.Reader
+	if input == "-" {
+		r = os.Stdin
+	} else {
+		f, err := os.Open(input)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: opening input file: %s\n", err)
+			return 2
+		}
+		defer f.Close()
+		r = f
+	}
+
+	events, err := gotestspec.ParseEvents(r)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: parsing test events: %s\n", err)
+		return 2
+	}
+
+	tree := gotestspec.BuildTree(events)
+
+	writeSummaryOutput(tree, format, output, noColor, github)
+
+	stats := gotestspec.CollectStats(tree)
+	if stats.Failed > 0 {
+		return 1
+	}
+	return 0
+}
+
+func writeSummaryOutput(tree []*gotestspec.Package, format, output string, noColor, github bool) {
+	var w io.Writer = os.Stdout
+	var closeFunc func()
+	if output != "" {
+		f, err := os.Create(output)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: creating output file: %s\n", err)
+			return
+		}
+		closeFunc = func() { f.Close() }
+		w = f
+	}
+	if closeFunc != nil {
+		defer closeFunc()
+	}
+
+	var renderOpts []gotestspec.RenderOption
+	if noColor {
+		renderOpts = append(renderOpts, gotestspec.WithNoColor())
+	}
+
+	switch format {
+	case "md", "markdown":
+		gotestspec.RenderMarkdownSummary(w, tree)
+	case "json":
+		gotestspec.RenderJSON(w, tree)
+	default:
+		gotestspec.RenderSummary(w, tree, renderOpts...)
+	}
+
+	if github {
+		modulePath := gotestspec.ReadModulePath(".")
+		annotations := gotestspec.CollectAnnotations(tree, modulePath)
+		gotestspec.WriteGitHubAnnotations(os.Stdout, annotations)
+
+		if summaryPath := os.Getenv("GITHUB_STEP_SUMMARY"); summaryPath != "" {
+			sf, err := os.OpenFile(summaryPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			if err == nil {
+				gotestspec.RenderMarkdownSummary(sf, tree)
+				sf.Close()
+			}
+		}
+	}
+}

--- a/cmd/gotest/summary.go
+++ b/cmd/gotest/summary.go
@@ -25,11 +25,12 @@ func runSummary(inv Invocation) int {
 	format := extractStringFlag(ownArgs, "--format", "terminal")
 	output := extractStringFlag(ownArgs, "--output", "")
 	input := extractStringFlag(ownArgs, "--input", "")
+	coverageProfile := extractStringFlag(ownArgs, "--coverage", "")
 	noColor := hasFlag(ownArgs, "--no-color")
 	github := hasFlag(ownArgs, "--github") || os.Getenv("GITHUB_ACTIONS") == "true"
 
 	if input != "" {
-		return runSummaryFromInput(input, format, output, noColor, github)
+		return runSummaryFromInput(input, format, output, coverageProfile, noColor, github)
 	}
 
 	setupTimeout, err := parseSetupTimeoutFlag(ownArgs)
@@ -155,7 +156,15 @@ func runSummary(inv Invocation) int {
 
 	tree := gotestspec.BuildTree(events)
 
-	writeSummaryOutput(tree, format, output, noColor, github)
+	if coverageProfile == "" {
+		for _, arg := range goTestArgs {
+			if v, ok := strings.CutPrefix(arg, "-coverprofile="); ok {
+				coverageProfile = v
+			}
+		}
+	}
+
+	writeSummaryOutput(tree, format, output, coverageProfile, noColor, github)
 
 	if code == 0 && minCoverage > 0 && coverProfile != "" {
 		pct, err := readCoverageTotal(coverProfile)
@@ -172,7 +181,7 @@ func runSummary(inv Invocation) int {
 	return code
 }
 
-func runSummaryFromInput(input, format, output string, noColor, github bool) int {
+func runSummaryFromInput(input, format, output, coverageProfile string, noColor, github bool) int {
 	var r io.Reader
 	if input == "-" {
 		r = os.Stdin
@@ -194,7 +203,7 @@ func runSummaryFromInput(input, format, output string, noColor, github bool) int
 
 	tree := gotestspec.BuildTree(events)
 
-	writeSummaryOutput(tree, format, output, noColor, github)
+	writeSummaryOutput(tree, format, output, coverageProfile, noColor, github)
 
 	stats := gotestspec.CollectStats(tree)
 	if stats.Failed > 0 {
@@ -203,7 +212,7 @@ func runSummaryFromInput(input, format, output string, noColor, github bool) int
 	return 0
 }
 
-func writeSummaryOutput(tree []*gotestspec.Package, format, output string, noColor, github bool) {
+func writeSummaryOutput(tree []*gotestspec.Package, format, output, coverageProfile string, noColor, github bool) {
 	var w io.Writer = os.Stdout
 	var closeFunc func()
 	if output != "" {
@@ -224,9 +233,18 @@ func writeSummaryOutput(tree []*gotestspec.Package, format, output string, noCol
 		renderOpts = append(renderOpts, gotestspec.WithNoColor())
 	}
 
+	if coverageProfile != "" {
+		report, err := gotestspec.ParseCoverageProfile(coverageProfile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: reading coverage profile: %s\n", err)
+		} else {
+			renderOpts = append(renderOpts, gotestspec.WithCoverage(report))
+		}
+	}
+
 	switch format {
 	case "md", "markdown":
-		gotestspec.RenderMarkdownSummary(w, tree)
+		gotestspec.RenderMarkdownSummary(w, tree, renderOpts...)
 	case "json":
 		gotestspec.RenderJSON(w, tree)
 	default:
@@ -241,7 +259,7 @@ func writeSummaryOutput(tree []*gotestspec.Package, format, output string, noCol
 		if summaryPath := os.Getenv("GITHUB_STEP_SUMMARY"); summaryPath != "" {
 			sf, err := os.OpenFile(summaryPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err == nil {
-				gotestspec.RenderMarkdownSummary(sf, tree)
+				gotestspec.RenderMarkdownSummary(sf, tree, renderOpts...)
 				sf.Close()
 			}
 		}

--- a/cmd/gotest/summary.go
+++ b/cmd/gotest/summary.go
@@ -49,6 +49,9 @@ func runSummary(inv Invocation) int {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2
 	}
+	if minCoverage == 0 {
+		minCoverage = inv.Config.MinCoverage
+	}
 
 	parallel, err := parseParallelFlag(ownArgs)
 	if err != nil {

--- a/docs/index.html
+++ b/docs/index.html
@@ -793,9 +793,9 @@
             <p>Spec View, Test Explorer, coverage, debug</p>
           </div>
           <div class="eco-item">
-            <strong>CI</strong>
-            <code>gotest --ci ./...</code>
-            <p>Coverage thresholds, safety checks, spec reports</p>
+            <strong>GitHub Action</strong>
+            <code>mvrahden/go-test@v1</code>
+            <p>PR annotations, step summaries, coverage reports</p>
           </div>
         </div>
       </div>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -419,6 +419,7 @@
         <li><a href="#configuration">Configuration</a></li>
         <li><a href="#coverage">Coverage</a></li>
         <li><a href="#cli">CLI Reference</a></li>
+        <li><a href="#ci-integration">CI Integration</a></li>
       </ol>
     </div>
 
@@ -959,6 +960,7 @@ percentage = covered / total</div>
           <tr><td><code>gotest ./...</code></td><td>Generate overlays and run tests. The default workflow.</td></tr>
           <tr><td><code>gotest watch ./...</code></td><td>Re-run on file changes. Only affected packages re-run.</td></tr>
           <tr><td><code>gotest spec ./...</code></td><td>Run tests and render the behavioral specification.</td></tr>
+          <tr><td><code>gotest summary ./...</code></td><td>Failure-focused summary for CI. Shows only failing tests with assertion output.</td></tr>
           <tr><td><code>gotest lint ./...</code></td><td>Static analysis for test suites.</td></tr>
           <tr><td><code>gotest scaffold ./pkg/user.Svc</code></td><td>Generate a suite skeleton from any Go type.</td></tr>
           <tr><td><code>gotest migrate ./...</code></td><td>Convert testify/suite tests automatically.</td></tr>
@@ -983,12 +985,100 @@ percentage = covered / total</div>
           <tr><td><code>--debug</code></td><td>Preserve overlays after the run for inspection.</td></tr>
           <tr><td><code>--setup-timeout=&lt;dur&gt;</code></td><td>Total budget for all shared fixture setup. Omit to let each fixture's own config govern. Use a negative value (e.g. <code>-1s</code>) to disable.</td></tr>
           <tr><td><code>--debounce=&lt;dur&gt;</code></td><td>Watch mode debounce interval (default 200ms).</td></tr>
-          <tr><td><code>--input=&lt;path&gt;</code></td><td>Read test output from file instead of running tests (<code>spec</code> command).</td></tr>
+          <tr><td><code>--input=&lt;path&gt;</code></td><td>Read test output from file instead of running tests (<code>spec</code>, <code>summary</code>).</td></tr>
+          <tr><td><code>--github</code></td><td>GitHub CI mode: emit <code>::error</code> annotations and write step summary (<code>summary</code> command). Auto-detected via <code>$GITHUB_ACTIONS</code>.</td></tr>
+          <tr><td><code>--coverage=&lt;file&gt;</code></td><td>Include coverage from profile in summary output (<code>summary</code> command).</td></tr>
         </tbody>
       </table>
 
       <div class="callout">
         Standard <code>go test</code> flags work unchanged: <code>-v</code>, <code>-race</code>, <code>-cover</code>, <code>-count</code>, <code>-run</code>, <code>-json</code>, <code>-short</code>, <code>-timeout</code>.
+      </div>
+    </section>
+
+    <!-- 10. CI Integration -->
+    <section class="ref-section" id="ci-integration">
+      <h2>CI Integration</h2>
+      <p class="lead">Failure-focused summaries, inline PR annotations, and coverage reports — out of the box.</p>
+
+      <h3>gotest summary</h3>
+      <p>The <code>summary</code> subcommand shows only failing tests with their assertion output, filtering out <code>=== RUN</code>, <code>=== CONT</code>, <code>--- PASS</code> noise. When all tests pass, it prints a single success line:</p>
+      <div class="code-block">
+        <div class="code-label">All tests pass</div>
+        <pre>147 tests passed (2.3s)
+Coverage: 82.4%</pre>
+      </div>
+      <div class="code-block">
+        <div class="code-label">Failures show assertion output only</div>
+        <pre>3 of 147 tests failed
+
+FAIL  pkg/foo TestValidateInput / empty string (12ms)
+      foo_test.go:42: expected error, got nil
+
+FAIL  pkg/bar TestProcessOrder / concurrent writes (1.2s)
+      bar_test.go:88:
+        expected: []string{"a", "b", "c"}
+             got: []string{"a", "c", "b"}</pre>
+      </div>
+
+      <p>In GitHub Actions, <code>--github</code> (auto-detected via <code>$GITHUB_ACTIONS</code>) emits <code>::error</code> annotations that appear inline on PR diffs and writes a markdown summary to the job summary panel.</p>
+
+      <h3>GitHub Action</h3>
+      <p>The repository includes a composite action at <code>mvrahden/go-test@v1</code> that wraps <code>gotest summary --github</code>:</p>
+      <div class="code-block">
+        <div class="code-label">.github/workflows/test.yml</div>
+        <pre>- uses: actions/checkout@v4
+- uses: actions/setup-go@v5
+  with:
+    go-version-file: go.mod
+
+- uses: mvrahden/go-test@v1
+  with:
+    packages: ./...
+    race: true
+    coverage: true
+    min-coverage: 80</pre>
+      </div>
+
+      <h3>Action inputs</h3>
+      <table class="ref-table">
+        <thead><tr><th>Input</th><th>Default</th><th>Description</th></tr></thead>
+        <tbody>
+          <tr><td><code>packages</code></td><td><code>./...</code></td><td>Package patterns to test.</td></tr>
+          <tr><td><code>race</code></td><td><code>false</code></td><td>Enable the race detector.</td></tr>
+          <tr><td><code>coverage</code></td><td><code>false</code></td><td>Enable coverage profiling and reporting.</td></tr>
+          <tr><td><code>min-coverage</code></td><td><em>none</em></td><td>Minimum coverage percentage (0–100). Fails the step if below.</td></tr>
+          <tr><td><code>flags</code></td><td><em>none</em></td><td>Additional gotest flags (<code>--double-dash</code> style).</td></tr>
+          <tr><td><code>go-test-flags</code></td><td><em>none</em></td><td>Additional go test flags (<code>-single-dash</code> style).</td></tr>
+          <tr><td><code>version</code></td><td><code>gomod</code></td><td>Version to install, or <code>gomod</code> to resolve from <code>go.mod</code>.</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Action outputs</h3>
+      <table class="ref-table">
+        <thead><tr><th>Output</th><th>Description</th></tr></thead>
+        <tbody>
+          <tr><td><code>exit-code</code></td><td>Test process exit code.</td></tr>
+          <tr><td><code>coverage</code></td><td>Coverage percentage (empty if coverage not enabled).</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Version resolution</h3>
+      <p>By default (<code>version: gomod</code>), the action runs <code>go&nbsp;run&nbsp;github.com/mvrahden/go-test/cmd/gotest</code>, which resolves the version pinned in your project's <code>go.mod</code>. This keeps the CLI version in sync with the library you already depend on — no version drift between CI and local development.</p>
+      <p>Set <code>version: latest</code> or a specific tag (e.g. <code>v1.2.0</code>) to install a standalone binary via <code>go install</code> instead. This is useful when your project doesn't depend on go-test as a library.</p>
+
+      <div class="callout">
+        To use the <code>gomod</code> default, ensure gotest is in your <code>go.mod</code>: use a <code>tool</code> directive (Go 1.24+) or add it via <code>go get github.com/mvrahden/go-test/cmd/gotest</code>.
+      </div>
+
+      <h3>Manual CI setup</h3>
+      <p>For non-GitHub CI systems, run <code>gotest summary</code> directly:</p>
+      <div class="code-block">
+        <pre>gotest summary ./... -race -coverprofile=coverage.out</pre>
+      </div>
+      <p>Or pipe from <code>go test -json</code> to summarize existing output without re-running tests:</p>
+      <div class="code-block">
+        <pre>go test -json ./... | gotest summary --input=-</pre>
       </div>
     </section>
   </div>

--- a/internal/gotestspec/annotations.go
+++ b/internal/gotestspec/annotations.go
@@ -1,0 +1,146 @@
+package gotestspec
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type Annotation struct {
+	File    string
+	Line    int
+	Title   string
+	Message string
+}
+
+func CollectAnnotations(packages []*Package, modulePath string) []Annotation {
+	failures := collectFailures(packages)
+	var annotations []Annotation
+
+	for _, f := range failures {
+		dir := packageDir(f.Package, modulePath)
+		title := strings.Join(f.Display, " / ")
+
+		file, line, msg := parseFirstLocation(filterOutput(f.Output))
+		if file == "" {
+			continue
+		}
+
+		if dir != "" {
+			file = dir + "/" + file
+		}
+
+		annotations = append(annotations, Annotation{
+			File:    file,
+			Line:    line,
+			Title:   title,
+			Message: msg,
+		})
+	}
+	return annotations
+}
+
+func WriteGitHubAnnotations(w io.Writer, annotations []Annotation) {
+	for _, a := range annotations {
+		msg := a.Message
+		if len(msg) > 1024 {
+			msg = msg[:1021] + "..."
+		}
+		msg = strings.ReplaceAll(msg, "\n", "%0A")
+		msg = strings.ReplaceAll(msg, "\r", "")
+
+		if a.Line > 0 {
+			fmt.Fprintf(w, "::error file=%s,line=%d,title=%s::%s\n",
+				a.File, a.Line, a.Title, msg)
+		} else {
+			fmt.Fprintf(w, "::error file=%s,title=%s::%s\n",
+				a.File, a.Title, msg)
+		}
+	}
+}
+
+func ReadModulePath(dir string) string {
+	f, err := os.Open(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if mod, ok := strings.CutPrefix(line, "module "); ok {
+			return strings.TrimSpace(mod)
+		}
+	}
+	_ = scanner.Err()
+	return ""
+}
+
+func packageDir(pkgPath, modulePath string) string {
+	if modulePath == "" {
+		return pkgPath
+	}
+	rel, ok := strings.CutPrefix(pkgPath, modulePath)
+	if !ok {
+		return pkgPath
+	}
+	return strings.TrimPrefix(rel, "/")
+}
+
+func parseFirstLocation(lines []string) (file string, line int, message string) {
+	for _, l := range lines {
+		f, ln, msg := parseFileLine(l)
+		if f != "" {
+			var allMsgs []string
+			if msg != "" {
+				allMsgs = append(allMsgs, msg)
+			}
+			for _, rest := range lines {
+				if rest == l {
+					continue
+				}
+				rf, _, rm := parseFileLine(rest)
+				if rf == "" && rm == "" {
+					allMsgs = append(allMsgs, rest)
+				} else if rm != "" {
+					allMsgs = append(allMsgs, rm)
+				}
+			}
+			return f, ln, strings.Join(allMsgs, "\n")
+		}
+	}
+
+	if len(lines) > 0 {
+		return "", 0, strings.Join(lines, "\n")
+	}
+	return "", 0, ""
+}
+
+func parseFileLine(s string) (file string, line int, message string) {
+	s = strings.TrimSpace(s)
+	if !strings.Contains(s, ".go:") {
+		return "", 0, ""
+	}
+
+	idx := strings.Index(s, ".go:")
+	fileEnd := idx + 3
+	file = s[:fileEnd]
+
+	rest := s[fileEnd+1:]
+	lineStr, after, ok := strings.Cut(rest, ":")
+	if !ok {
+		return "", 0, ""
+	}
+	ln, err := strconv.Atoi(lineStr)
+	if err != nil {
+		return "", 0, ""
+	}
+
+	message = strings.TrimSpace(after)
+	return file, ln, message
+}

--- a/internal/gotestspec/annotations.go
+++ b/internal/gotestspec/annotations.go
@@ -93,17 +93,14 @@ func packageDir(pkgPath, modulePath string) string {
 }
 
 func parseFirstLocation(lines []string) (file string, line int, message string) {
-	for _, l := range lines {
+	for i, l := range lines {
 		f, ln, msg := parseFileLine(l)
 		if f != "" {
 			var allMsgs []string
 			if msg != "" {
 				allMsgs = append(allMsgs, msg)
 			}
-			for _, rest := range lines {
-				if rest == l {
-					continue
-				}
+			for _, rest := range lines[i+1:] {
 				rf, _, rm := parseFileLine(rest)
 				if rf == "" && rm == "" {
 					allMsgs = append(allMsgs, rest)

--- a/internal/gotestspec/annotations_test.go
+++ b/internal/gotestspec/annotations_test.go
@@ -1,0 +1,218 @@
+package gotestspec //nolint:stdlib-test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseFileLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		file    string
+		line    int
+		message string
+	}{
+		{
+			name:    "standard format",
+			input:   "foo_test.go:42: expected 1, got 2",
+			file:    "foo_test.go",
+			line:    42,
+			message: "expected 1, got 2",
+		},
+		{
+			name:    "with leading whitespace",
+			input:   "    bar_test.go:15: timeout",
+			file:    "bar_test.go",
+			line:    15,
+			message: "timeout",
+		},
+		{
+			name:  "no file reference",
+			input: "some random output",
+		},
+		{
+			name:  "no line number",
+			input: "foo.go:abc: something",
+		},
+		{
+			name:    "nested path",
+			input:   "sub/dir/baz_test.go:99: failed",
+			file:    "sub/dir/baz_test.go",
+			line:    99,
+			message: "failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, line, msg := parseFileLine(tt.input)
+			if file != tt.file {
+				t.Errorf("file = %q, want %q", file, tt.file)
+			}
+			if line != tt.line {
+				t.Errorf("line = %d, want %d", line, tt.line)
+			}
+			if msg != tt.message {
+				t.Errorf("message = %q, want %q", msg, tt.message)
+			}
+		})
+	}
+}
+
+func TestPackageDir(t *testing.T) {
+	tests := []struct {
+		name       string
+		pkgPath    string
+		modulePath string
+		want       string
+	}{
+		{
+			name:       "strips module prefix",
+			pkgPath:    "github.com/user/repo/internal/foo",
+			modulePath: "github.com/user/repo",
+			want:       "internal/foo",
+		},
+		{
+			name:       "root package",
+			pkgPath:    "github.com/user/repo",
+			modulePath: "github.com/user/repo",
+			want:       "",
+		},
+		{
+			name:       "no module path",
+			pkgPath:    "github.com/user/repo/pkg",
+			modulePath: "",
+			want:       "github.com/user/repo/pkg",
+		},
+		{
+			name:       "different module",
+			pkgPath:    "github.com/other/repo/pkg",
+			modulePath: "github.com/user/repo",
+			want:       "github.com/other/repo/pkg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := packageDir(tt.pkgPath, tt.modulePath)
+			if got != tt.want {
+				t.Errorf("packageDir(%q, %q) = %q, want %q", tt.pkgPath, tt.modulePath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollectAnnotations(t *testing.T) {
+	packages := []*Package{{
+		Path: "github.com/user/repo/pkg/foo",
+		Nodes: []*Node{
+			{Kind: KindTest, Display: "Good", Status: StatusPass},
+			{
+				Kind:     KindTest,
+				Display:  "Bad",
+				Status:   StatusFail,
+				Duration: 12 * time.Millisecond,
+				Output:   []string{"    foo_test.go:42: expected 1, got 2\n"},
+			},
+		},
+	}}
+
+	annotations := CollectAnnotations(packages, "github.com/user/repo")
+
+	if len(annotations) != 1 {
+		t.Fatalf("expected 1 annotation, got %d", len(annotations))
+	}
+
+	a := annotations[0]
+	if a.File != "pkg/foo/foo_test.go" {
+		t.Errorf("file = %q, want %q", a.File, "pkg/foo/foo_test.go")
+	}
+	if a.Line != 42 {
+		t.Errorf("line = %d, want 42", a.Line)
+	}
+	if a.Title != "Bad" {
+		t.Errorf("title = %q, want %q", a.Title, "Bad")
+	}
+}
+
+func TestCollectAnnotations_NoFileReference(t *testing.T) {
+	packages := []*Package{{
+		Path: "p",
+		Nodes: []*Node{{
+			Kind:     KindTest,
+			Display:  "Broken",
+			Status:   StatusFail,
+			Duration: time.Millisecond,
+			Output:   []string{"panic: runtime error\n"},
+		}},
+	}}
+
+	annotations := CollectAnnotations(packages, "")
+	if len(annotations) != 0 {
+		t.Errorf("expected 0 annotations for output without file:line, got %d", len(annotations))
+	}
+}
+
+func TestWriteGitHubAnnotations(t *testing.T) {
+	annotations := []Annotation{
+		{
+			File:    "pkg/foo/foo_test.go",
+			Line:    42,
+			Title:   "TestFoo / validates input",
+			Message: "expected 1, got 2",
+		},
+		{
+			File:    "pkg/bar/bar_test.go",
+			Line:    0,
+			Title:   "TestBar",
+			Message: "timeout",
+		},
+	}
+
+	var buf bytes.Buffer
+	WriteGitHubAnnotations(&buf, annotations)
+	out := buf.String()
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 annotation lines, got %d: %s", len(lines), out)
+	}
+
+	if !strings.Contains(lines[0], "::error file=pkg/foo/foo_test.go,line=42") {
+		t.Errorf("first annotation wrong format: %s", lines[0])
+	}
+	if !strings.Contains(lines[0], "title=TestFoo / validates input") {
+		t.Errorf("first annotation missing title: %s", lines[0])
+	}
+	if !strings.Contains(lines[0], "::expected 1, got 2") {
+		t.Errorf("first annotation missing message: %s", lines[0])
+	}
+
+	if strings.Contains(lines[1], "line=") {
+		t.Errorf("second annotation should not have line when line=0: %s", lines[1])
+	}
+}
+
+func TestWriteGitHubAnnotations_TruncatesLongMessage(t *testing.T) {
+	long := strings.Repeat("x", 2000)
+	annotations := []Annotation{{
+		File:    "test.go",
+		Line:    1,
+		Title:   "T",
+		Message: long,
+	}}
+
+	var buf bytes.Buffer
+	WriteGitHubAnnotations(&buf, annotations)
+	out := buf.String()
+
+	if len(out) > 1200 {
+		t.Errorf("annotation should truncate long messages, got %d chars", len(out))
+	}
+	if !strings.Contains(out, "...") {
+		t.Error("truncated message should end with ...")
+	}
+}

--- a/internal/gotestspec/annotations_test.go
+++ b/internal/gotestspec/annotations_test.go
@@ -156,6 +156,40 @@ func TestCollectAnnotations_NoFileReference(t *testing.T) {
 	}
 }
 
+func TestCollectAnnotations_FiltersLogNoiseBeforeAssertion(t *testing.T) {
+	packages := []*Package{{
+		Path: "github.com/user/repo/pkg/foo",
+		Nodes: []*Node{{
+			Kind:     KindTest,
+			Display:  "Slow",
+			Status:   StatusFail,
+			Duration: 10 * time.Second,
+			Output: []string{
+				"    2026/06/25 18:10:03 INFO staging params.json bytes=2\n",
+				"    2026/06/25 18:10:03 INFO file stored successfully\n",
+				"    helpers.go:37: foo_test.go:74: Eventually failed after 10s:\n",
+				"    last failure:\n",
+				"    helpers.go:47: True failed:\n",
+				"    expected: true\n",
+				"    actual:   false\n",
+			},
+		}},
+	}}
+
+	annotations := CollectAnnotations(packages, "github.com/user/repo")
+	if len(annotations) != 1 {
+		t.Fatalf("expected 1 annotation, got %d", len(annotations))
+	}
+
+	a := annotations[0]
+	if strings.Contains(a.Message, "INFO") {
+		t.Errorf("annotation message should not contain log noise, got:\n%s", a.Message)
+	}
+	if !strings.Contains(a.Message, "True failed:") {
+		t.Errorf("annotation message should contain assertion output, got:\n%s", a.Message)
+	}
+}
+
 func TestWriteGitHubAnnotations(t *testing.T) {
 	annotations := []Annotation{
 		{

--- a/internal/gotestspec/annotations_test.go
+++ b/internal/gotestspec/annotations_test.go
@@ -168,10 +168,10 @@ func TestCollectAnnotations_FiltersLogNoiseBeforeAssertion(t *testing.T) {
 				"    2026/06/25 18:10:03 INFO staging params.json bytes=2\n",
 				"    2026/06/25 18:10:03 INFO file stored successfully\n",
 				"    helpers.go:37: foo_test.go:74: Eventually failed after 10s:\n",
-				"    last failure:\n",
-				"    helpers.go:47: True failed:\n",
-				"    expected: true\n",
-				"    actual:   false\n",
+				"        last failure:\n",
+				"        helpers.go:47: True failed:\n",
+				"            expected: true\n",
+				"            actual:   false\n",
 			},
 		}},
 	}}
@@ -185,8 +185,11 @@ func TestCollectAnnotations_FiltersLogNoiseBeforeAssertion(t *testing.T) {
 	if strings.Contains(a.Message, "INFO") {
 		t.Errorf("annotation message should not contain log noise, got:\n%s", a.Message)
 	}
-	if !strings.Contains(a.Message, "True failed:") {
-		t.Errorf("annotation message should contain assertion output, got:\n%s", a.Message)
+	if !strings.Contains(a.Message, "    last failure:") {
+		t.Errorf("annotation message should preserve relative indentation, got:\n%s", a.Message)
+	}
+	if !strings.Contains(a.Message, "        expected: true") {
+		t.Errorf("annotation message should preserve nested indentation, got:\n%s", a.Message)
 	}
 }
 

--- a/internal/gotestspec/coverage.go
+++ b/internal/gotestspec/coverage.go
@@ -1,0 +1,143 @@
+package gotestspec
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type CoverageReport struct {
+	Total    float64
+	Packages []PackageCoverage
+}
+
+type PackageCoverage struct {
+	Path       string
+	Percentage float64
+	Covered    int
+	Total      int
+}
+
+func ParseCoverageProfile(path string) (*CoverageReport, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return parseCoverageReader(f)
+}
+
+func parseCoverageReader(r io.Reader) (*CoverageReport, error) {
+	type pkgAccum struct {
+		covered int
+		total   int
+	}
+	pkgs := map[string]*pkgAccum{}
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "mode:") {
+			continue
+		}
+
+		file, stmts, count, err := parseCoverageLine(line)
+		if err != nil {
+			continue
+		}
+
+		pkg := coveragePackage(file)
+		acc := pkgs[pkg]
+		if acc == nil {
+			acc = &pkgAccum{}
+			pkgs[pkg] = acc
+		}
+		acc.total += stmts
+		if count > 0 {
+			acc.covered += stmts
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	var totalCovered, totalStmts int
+	result := make([]PackageCoverage, 0, len(pkgs))
+	for pkg, acc := range pkgs {
+		pct := 0.0
+		if acc.total > 0 {
+			pct = float64(acc.covered) / float64(acc.total) * 100
+		}
+		result = append(result, PackageCoverage{
+			Path:       pkg,
+			Percentage: pct,
+			Covered:    acc.covered,
+			Total:      acc.total,
+		})
+		totalCovered += acc.covered
+		totalStmts += acc.total
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Path < result[j].Path
+	})
+
+	totalPct := 0.0
+	if totalStmts > 0 {
+		totalPct = float64(totalCovered) / float64(totalStmts) * 100
+	}
+
+	return &CoverageReport{
+		Total:    totalPct,
+		Packages: result,
+	}, nil
+}
+
+// parseCoverageLine parses a Go coverage profile line.
+// Format: file:startLine.startCol,endLine.endCol numStatements count
+func parseCoverageLine(line string) (file string, stmts int, count int, err error) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return "", 0, 0, fmt.Errorf("empty line")
+	}
+
+	lastSpace := strings.LastIndex(line, " ")
+	if lastSpace < 0 {
+		return "", 0, 0, fmt.Errorf("invalid format")
+	}
+	count, err = strconv.Atoi(line[lastSpace+1:])
+	if err != nil {
+		return "", 0, 0, err
+	}
+	rest := line[:lastSpace]
+
+	lastSpace = strings.LastIndex(rest, " ")
+	if lastSpace < 0 {
+		return "", 0, 0, fmt.Errorf("invalid format")
+	}
+	stmts, err = strconv.Atoi(rest[lastSpace+1:])
+	if err != nil {
+		return "", 0, 0, err
+	}
+	rest = rest[:lastSpace]
+
+	colonIdx := strings.LastIndex(rest, ":")
+	if colonIdx < 0 {
+		return "", 0, 0, fmt.Errorf("invalid format")
+	}
+	file = rest[:colonIdx]
+
+	return file, stmts, count, nil
+}
+
+func coveragePackage(file string) string {
+	idx := strings.LastIndex(file, "/")
+	if idx < 0 {
+		return "."
+	}
+	return file[:idx]
+}

--- a/internal/gotestspec/coverage_test.go
+++ b/internal/gotestspec/coverage_test.go
@@ -1,0 +1,180 @@
+package gotestspec //nolint:stdlib-test
+
+import (
+	"bytes"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseCoverageReader(t *testing.T) {
+	profile := `mode: atomic
+github.com/user/repo/pkg/foo/foo.go:10.20,12.2 1 5
+github.com/user/repo/pkg/foo/foo.go:14.30,16.2 1 0
+github.com/user/repo/pkg/bar/bar.go:5.10,8.2 3 1
+github.com/user/repo/pkg/bar/bar.go:10.10,12.2 1 0
+`
+	report, err := parseCoverageReader(strings.NewReader(profile))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(report.Packages) != 2 {
+		t.Fatalf("expected 2 packages, got %d", len(report.Packages))
+	}
+
+	// Sorted by path
+	bar := report.Packages[0]
+	foo := report.Packages[1]
+
+	if bar.Path != "github.com/user/repo/pkg/bar" {
+		t.Errorf("bar path = %q", bar.Path)
+	}
+	if bar.Covered != 3 || bar.Total != 4 {
+		t.Errorf("bar covered/total = %d/%d, want 3/4", bar.Covered, bar.Total)
+	}
+	if math.Abs(bar.Percentage-75.0) > 0.1 {
+		t.Errorf("bar percentage = %.1f, want 75.0", bar.Percentage)
+	}
+
+	if foo.Path != "github.com/user/repo/pkg/foo" {
+		t.Errorf("foo path = %q", foo.Path)
+	}
+	if foo.Covered != 1 || foo.Total != 2 {
+		t.Errorf("foo covered/total = %d/%d, want 1/2", foo.Covered, foo.Total)
+	}
+	if math.Abs(foo.Percentage-50.0) > 0.1 {
+		t.Errorf("foo percentage = %.1f, want 50.0", foo.Percentage)
+	}
+
+	// Total: 4 covered / 6 total = 66.7%
+	if math.Abs(report.Total-66.7) > 0.1 {
+		t.Errorf("total = %.1f, want 66.7", report.Total)
+	}
+}
+
+func TestParseCoverageReader_Empty(t *testing.T) {
+	report, err := parseCoverageReader(strings.NewReader("mode: set\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Total != 0 {
+		t.Errorf("total = %.1f, want 0", report.Total)
+	}
+	if len(report.Packages) != 0 {
+		t.Errorf("expected 0 packages, got %d", len(report.Packages))
+	}
+}
+
+func TestParseCoverageLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		file  string
+		stmts int
+		count int
+		err   bool
+	}{
+		{
+			name:  "standard line",
+			input: "github.com/user/repo/foo.go:10.20,12.2 1 5",
+			file:  "github.com/user/repo/foo.go",
+			stmts: 1,
+			count: 5,
+		},
+		{
+			name:  "uncovered",
+			input: "pkg/bar.go:5.1,8.3 3 0",
+			file:  "pkg/bar.go",
+			stmts: 3,
+			count: 0,
+		},
+		{
+			name:  "empty line",
+			input: "",
+			err:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, stmts, count, err := parseCoverageLine(tt.input)
+			if tt.err {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if file != tt.file {
+				t.Errorf("file = %q, want %q", file, tt.file)
+			}
+			if stmts != tt.stmts {
+				t.Errorf("stmts = %d, want %d", stmts, tt.stmts)
+			}
+			if count != tt.count {
+				t.Errorf("count = %d, want %d", count, tt.count)
+			}
+		})
+	}
+}
+
+func TestRenderSummary_WithCoverage(t *testing.T) {
+	packages := []*Package{{
+		Path:     "p",
+		Duration: time.Second,
+		Nodes: []*Node{
+			{Kind: KindTest, Display: "A", Status: StatusPass},
+		},
+	}}
+
+	report := &CoverageReport{
+		Total: 82.4,
+		Packages: []PackageCoverage{
+			{Path: "p", Percentage: 82.4, Covered: 41, Total: 50},
+		},
+	}
+
+	var buf bytes.Buffer
+	RenderSummary(&buf, packages, WithNoColor(), WithCoverage(report))
+	out := buf.String()
+
+	if !strings.Contains(out, "Coverage: 82.4%") {
+		t.Errorf("expected coverage line, got:\n%s", out)
+	}
+}
+
+func TestRenderMarkdownSummary_WithCoverage(t *testing.T) {
+	packages := []*Package{{
+		Path:     "p",
+		Duration: time.Second,
+		Nodes: []*Node{
+			{Kind: KindTest, Display: "A", Status: StatusPass},
+		},
+	}}
+
+	report := &CoverageReport{
+		Total: 75.0,
+		Packages: []PackageCoverage{
+			{Path: "pkg/foo", Percentage: 90.0, Covered: 9, Total: 10},
+			{Path: "pkg/bar", Percentage: 60.0, Covered: 6, Total: 10},
+		},
+	}
+
+	var buf bytes.Buffer
+	RenderMarkdownSummary(&buf, packages, WithCoverage(report))
+	out := buf.String()
+
+	if !strings.Contains(out, "### Coverage: 75.0%") {
+		t.Errorf("expected coverage heading, got:\n%s", out)
+	}
+	if !strings.Contains(out, "| `pkg/foo` | 90.0% |") {
+		t.Errorf("expected foo row, got:\n%s", out)
+	}
+	if !strings.Contains(out, "| `pkg/bar` | 60.0% |") {
+		t.Errorf("expected bar row, got:\n%s", out)
+	}
+}

--- a/internal/gotestspec/summary.go
+++ b/internal/gotestspec/summary.go
@@ -1,0 +1,142 @@
+package gotestspec
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+type failure struct {
+	Package  string
+	Display  []string
+	Duration time.Duration
+	Output   []string
+}
+
+func collectFailures(packages []*Package) []failure {
+	var failures []failure
+	for _, pkg := range packages {
+		for _, node := range pkg.Nodes {
+			collectFailedLeaves(pkg.Path, node, nil, &failures)
+		}
+	}
+	return failures
+}
+
+func collectFailedLeaves(pkgPath string, n *Node, display []string, out *[]failure) {
+	cur := append(display, n.Display)
+
+	if len(n.Children) == 0 {
+		if n.Status == StatusFail {
+			d := make([]string, len(cur))
+			copy(d, cur)
+			*out = append(*out, failure{
+				Package:  pkgPath,
+				Display:  d,
+				Duration: n.Duration,
+				Output:   n.Output,
+			})
+		}
+		return
+	}
+
+	for _, child := range n.Children {
+		collectFailedLeaves(pkgPath, child, cur, out)
+	}
+}
+
+func totalDuration(packages []*Package) time.Duration {
+	var d time.Duration
+	for _, pkg := range packages {
+		d += pkg.Duration
+	}
+	return d
+}
+
+func RenderSummary(w io.Writer, packages []*Package, opts ...RenderOption) {
+	cfg := renderConfig{color: true}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	c := ansiColors
+	if !cfg.color {
+		c = noColors
+	}
+
+	stats := CollectStats(packages)
+	failures := collectFailures(packages)
+
+	if len(failures) == 0 {
+		fmt.Fprintf(w, "%s%d tests passed%s (%s)\n",
+			c.green, stats.Total(), c.reset,
+			formatDuration(totalDuration(packages)))
+		return
+	}
+
+	fmt.Fprintf(w, "%s%d of %d tests failed%s\n",
+		c.red, stats.Failed, stats.Total(), c.reset)
+
+	for _, f := range failures {
+		fmt.Fprintln(w)
+		displayPath := strings.Join(f.Display, " / ")
+		fmt.Fprintf(w, "%sFAIL%s  %s%s%s %s (%s)\n",
+			c.red, c.reset,
+			c.dim, f.Package, c.reset,
+			displayPath,
+			formatDuration(f.Duration))
+
+		for _, line := range filterOutput(f.Output) {
+			fmt.Fprintf(w, "      %s%s%s\n", c.red, line, c.reset)
+		}
+	}
+
+	fmt.Fprintln(w)
+	renderSummary(w, stats, c)
+}
+
+func RenderMarkdownSummary(w io.Writer, packages []*Package) {
+	stats := CollectStats(packages)
+	failures := collectFailures(packages)
+
+	if len(failures) == 0 {
+		fmt.Fprintf(w, "### All %d tests passed (%s)\n",
+			stats.Total(), formatDuration(totalDuration(packages)))
+		return
+	}
+
+	fmt.Fprintf(w, "### %d of %d tests failed\n", stats.Failed, stats.Total())
+
+	for _, f := range failures {
+		displayPath := strings.Join(f.Display, " / ")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "<details>\n<summary><b>%s</b> — %s (%s)</summary>\n\n",
+			f.Package, displayPath, formatDuration(f.Duration))
+
+		lines := filterOutput(f.Output)
+		if len(lines) > 0 {
+			for _, line := range lines {
+				fmt.Fprintf(w, "    %s\n", line)
+			}
+			fmt.Fprintln(w)
+		}
+
+		fmt.Fprintln(w, "</details>")
+	}
+
+	fmt.Fprintln(w)
+
+	fmt.Fprint(w, "---\n")
+	var parts []string
+	if stats.Suites > 0 {
+		parts = append(parts, fmt.Sprintf("%d suites", stats.Suites))
+	}
+	if stats.Behaviors > 0 {
+		parts = append(parts, fmt.Sprintf("%d behaviors", stats.Behaviors))
+	}
+	if stats.Tests > 0 {
+		parts = append(parts, fmt.Sprintf("%d stdlib tests", stats.Tests))
+	}
+	fmt.Fprintf(w, "%s: %d passed, %d failed, %d skipped\n",
+		strings.Join(parts, ", "), stats.Passed, stats.Failed, stats.Skipped)
+}

--- a/internal/gotestspec/summary.go
+++ b/internal/gotestspec/summary.go
@@ -71,6 +71,9 @@ func RenderSummary(w io.Writer, packages []*Package, opts ...RenderOption) {
 		fmt.Fprintf(w, "%s%d tests passed%s (%s)\n",
 			c.green, stats.Total(), c.reset,
 			formatDuration(totalDuration(packages)))
+		if cfg.coverage != nil {
+			fmt.Fprintf(w, "%sCoverage: %.1f%%%s\n", c.dim, cfg.coverage.Total, c.reset)
+		}
 		return
 	}
 
@@ -92,16 +95,27 @@ func RenderSummary(w io.Writer, packages []*Package, opts ...RenderOption) {
 	}
 
 	fmt.Fprintln(w)
+	if cfg.coverage != nil {
+		fmt.Fprintf(w, "%sCoverage: %.1f%%%s\n", c.dim, cfg.coverage.Total, c.reset)
+	}
 	renderSummary(w, stats, c)
 }
 
-func RenderMarkdownSummary(w io.Writer, packages []*Package) {
+func RenderMarkdownSummary(w io.Writer, packages []*Package, opts ...RenderOption) {
+	cfg := renderConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	stats := CollectStats(packages)
 	failures := collectFailures(packages)
 
 	if len(failures) == 0 {
 		fmt.Fprintf(w, "### All %d tests passed (%s)\n",
 			stats.Total(), formatDuration(totalDuration(packages)))
+		if cfg.coverage != nil {
+			renderMarkdownCoverage(w, cfg.coverage)
+		}
 		return
 	}
 
@@ -125,6 +139,9 @@ func RenderMarkdownSummary(w io.Writer, packages []*Package) {
 	}
 
 	fmt.Fprintln(w)
+	if cfg.coverage != nil {
+		renderMarkdownCoverage(w, cfg.coverage)
+	}
 
 	fmt.Fprint(w, "---\n")
 	var parts []string
@@ -139,4 +156,16 @@ func RenderMarkdownSummary(w io.Writer, packages []*Package) {
 	}
 	fmt.Fprintf(w, "%s: %d passed, %d failed, %d skipped\n",
 		strings.Join(parts, ", "), stats.Passed, stats.Failed, stats.Skipped)
+}
+
+func renderMarkdownCoverage(w io.Writer, report *CoverageReport) {
+	fmt.Fprintf(w, "### Coverage: %.1f%%\n\n", report.Total)
+	if len(report.Packages) > 1 {
+		fmt.Fprintln(w, "| Package | Coverage |")
+		fmt.Fprintln(w, "|---------|----------|")
+		for _, pkg := range report.Packages {
+			fmt.Fprintf(w, "| `%s` | %.1f%% |\n", pkg.Path, pkg.Percentage)
+		}
+		fmt.Fprintln(w)
+	}
 }

--- a/internal/gotestspec/summary_test.go
+++ b/internal/gotestspec/summary_test.go
@@ -1,0 +1,244 @@
+package gotestspec //nolint:stdlib-test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenderSummary_AllPass(t *testing.T) {
+	packages := []*Package{{
+		Path:     "example.com/pkg",
+		Duration: 2300 * time.Millisecond,
+		Nodes: []*Node{
+			{Kind: KindTest, Display: "Foo", Status: StatusPass, Duration: time.Second},
+			{Kind: KindTest, Display: "Bar", Status: StatusPass, Duration: time.Second},
+		},
+	}}
+
+	var buf bytes.Buffer
+	RenderSummary(&buf, packages, WithNoColor())
+	out := buf.String()
+
+	if !strings.Contains(out, "2 tests passed") {
+		t.Errorf("expected success line, got:\n%s", out)
+	}
+	if strings.Contains(out, "FAIL") {
+		t.Errorf("expected no FAIL in output:\n%s", out)
+	}
+}
+
+func TestRenderSummary_WithFailures(t *testing.T) {
+	packages := []*Package{{
+		Path: "example.com/pkg/foo",
+		Nodes: []*Node{{
+			Kind:    KindSuite,
+			Display: "UserService",
+			Children: []*Node{
+				{
+					Kind:    KindMethod,
+					Display: "Create",
+					Children: []*Node{
+						{
+							Kind:     KindBlock,
+							Display:  "returns ok",
+							Status:   StatusPass,
+							Duration: 5 * time.Millisecond,
+						},
+						{
+							Kind:     KindBlock,
+							Display:  "rejects empty name",
+							Status:   StatusFail,
+							Duration: 12 * time.Millisecond,
+							Output:   []string{"    user_test.go:42: expected error, got nil\n"},
+						},
+					},
+				},
+				{
+					Kind:     KindMethod,
+					Display:  "Delete",
+					Status:   StatusPass,
+					Duration: 3 * time.Millisecond,
+				},
+			},
+		}},
+	}}
+
+	var buf bytes.Buffer
+	RenderSummary(&buf, packages, WithNoColor())
+	out := buf.String()
+
+	if !strings.Contains(out, "1 of 3 tests failed") {
+		t.Errorf("expected failure count, got:\n%s", out)
+	}
+	if !strings.Contains(out, "FAIL") {
+		t.Errorf("expected FAIL label, got:\n%s", out)
+	}
+	if !strings.Contains(out, "UserService / Create / rejects empty name") {
+		t.Errorf("expected failure path, got:\n%s", out)
+	}
+	if !strings.Contains(out, "expected error, got nil") {
+		t.Errorf("expected error message, got:\n%s", out)
+	}
+	if strings.Contains(out, "returns ok") {
+		t.Errorf("passing tests should not appear in summary:\n%s", out)
+	}
+}
+
+func TestRenderSummary_FiltersNoise(t *testing.T) {
+	packages := []*Package{{
+		Path: "p",
+		Nodes: []*Node{{
+			Kind:     KindTest,
+			Display:  "Broken",
+			Status:   StatusFail,
+			Duration: time.Millisecond,
+			Output: []string{
+				"=== RUN   TestBroken\n",
+				"--- FAIL: TestBroken (0.00s)\n",
+				"    broken_test.go:10: assertion failed\n",
+			},
+		}},
+	}}
+
+	var buf bytes.Buffer
+	RenderSummary(&buf, packages, WithNoColor())
+	out := buf.String()
+
+	if !strings.Contains(out, "assertion failed") {
+		t.Errorf("expected assertion message, got:\n%s", out)
+	}
+	if strings.Contains(out, "=== RUN") {
+		t.Errorf("should filter === RUN noise:\n%s", out)
+	}
+	if strings.Contains(out, "--- FAIL") {
+		t.Errorf("should filter --- FAIL noise:\n%s", out)
+	}
+}
+
+func TestRenderSummary_MultiplePackages(t *testing.T) {
+	packages := []*Package{
+		{
+			Path: "pkg/a",
+			Nodes: []*Node{{
+				Kind:     KindTest,
+				Display:  "TestA",
+				Status:   StatusFail,
+				Duration: time.Millisecond,
+				Output:   []string{"    a_test.go:1: boom\n"},
+			}},
+		},
+		{
+			Path: "pkg/b",
+			Nodes: []*Node{{
+				Kind:     KindTest,
+				Display:  "TestB",
+				Status:   StatusFail,
+				Duration: time.Millisecond,
+				Output:   []string{"    b_test.go:2: crash\n"},
+			}},
+		},
+	}
+
+	var buf bytes.Buffer
+	RenderSummary(&buf, packages, WithNoColor())
+	out := buf.String()
+
+	if !strings.Contains(out, "pkg/a") {
+		t.Errorf("expected first package, got:\n%s", out)
+	}
+	if !strings.Contains(out, "pkg/b") {
+		t.Errorf("expected second package, got:\n%s", out)
+	}
+}
+
+func TestRenderMarkdownSummary_AllPass(t *testing.T) {
+	packages := []*Package{{
+		Path:     "p",
+		Duration: 500 * time.Millisecond,
+		Nodes: []*Node{
+			{Kind: KindTest, Display: "A", Status: StatusPass},
+			{Kind: KindTest, Display: "B", Status: StatusPass},
+		},
+	}}
+
+	var buf bytes.Buffer
+	RenderMarkdownSummary(&buf, packages)
+	out := buf.String()
+
+	if !strings.Contains(out, "All 2 tests passed") {
+		t.Errorf("expected success heading, got:\n%s", out)
+	}
+}
+
+func TestRenderMarkdownSummary_WithFailures(t *testing.T) {
+	packages := []*Package{{
+		Path: "pkg/foo",
+		Nodes: []*Node{
+			{Kind: KindTest, Display: "Good", Status: StatusPass},
+			{
+				Kind:     KindTest,
+				Display:  "Bad",
+				Status:   StatusFail,
+				Duration: 100 * time.Millisecond,
+				Output:   []string{"    foo_test.go:10: want 1, got 2\n"},
+			},
+		},
+	}}
+
+	var buf bytes.Buffer
+	RenderMarkdownSummary(&buf, packages)
+	out := buf.String()
+
+	if !strings.Contains(out, "1 of 2 tests failed") {
+		t.Errorf("expected failure heading, got:\n%s", out)
+	}
+	if !strings.Contains(out, "<details>") {
+		t.Errorf("expected collapsible section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "pkg/foo") {
+		t.Errorf("expected package name, got:\n%s", out)
+	}
+	if !strings.Contains(out, "want 1, got 2") {
+		t.Errorf("expected error output, got:\n%s", out)
+	}
+}
+
+func TestCollectFailures_DeepHierarchy(t *testing.T) {
+	packages := []*Package{{
+		Path: "p",
+		Nodes: []*Node{{
+			Kind:    KindSuite,
+			Display: "Suite",
+			Children: []*Node{{
+				Kind:    KindMethod,
+				Display: "Method",
+				Children: []*Node{
+					{
+						Kind:    KindBlock,
+						Display: "when valid",
+						Children: []*Node{
+							{Kind: KindBlock, Display: "returns ok", Status: StatusPass},
+							{Kind: KindBlock, Display: "logs event", Status: StatusFail, Output: []string{"err"}},
+						},
+					},
+					{Kind: KindBlock, Display: "when invalid", Status: StatusPass},
+				},
+			}},
+		}},
+	}}
+
+	failures := collectFailures(packages)
+
+	if len(failures) != 1 {
+		t.Fatalf("expected 1 failure, got %d", len(failures))
+	}
+
+	f := failures[0]
+	got := strings.Join(f.Display, " / ")
+	want := "Suite / Method / when valid / logs event"
+	if got != want {
+		t.Errorf("display path = %q, want %q", got, want)
+	}
+}

--- a/internal/gotestspec/terminal.go
+++ b/internal/gotestspec/terminal.go
@@ -23,13 +23,18 @@ var ansiColors = colors{
 var noColors = colors{}
 
 type renderConfig struct {
-	color bool
+	color    bool
+	coverage *CoverageReport
 }
 
 type RenderOption func(*renderConfig)
 
 func WithNoColor() RenderOption {
 	return func(c *renderConfig) { c.color = false }
+}
+
+func WithCoverage(report *CoverageReport) RenderOption {
+	return func(c *renderConfig) { c.coverage = report }
 }
 
 func RenderTerminal(w io.Writer, packages []*Package, opts ...RenderOption) {

--- a/internal/gotestspec/terminal.go
+++ b/internal/gotestspec/terminal.go
@@ -134,6 +134,13 @@ func formatDuration(d time.Duration) string {
 
 func renderErrorOutput(w io.Writer, output []string, depth int, c colors) {
 	indent := strings.Repeat("  ", depth)
+	for _, line := range filterOutput(output) {
+		fmt.Fprintf(w, "%s%s%s%s\n", indent, c.red, line, c.reset)
+	}
+}
+
+func filterOutput(output []string) []string {
+	var filtered []string
 	for _, line := range output {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
@@ -142,8 +149,9 @@ func renderErrorOutput(w io.Writer, output []string, depth int, c colors) {
 		if strings.HasPrefix(trimmed, "=== ") || strings.HasPrefix(trimmed, "--- ") {
 			continue
 		}
-		fmt.Fprintf(w, "%s%s%s%s\n", indent, c.red, trimmed, c.reset)
+		filtered = append(filtered, trimmed)
 	}
+	return filtered
 }
 
 func renderSummary(w io.Writer, stats Stats, c colors) {

--- a/internal/gotestspec/terminal.go
+++ b/internal/gotestspec/terminal.go
@@ -145,16 +145,36 @@ func renderErrorOutput(w io.Writer, output []string, depth int, c colors) {
 }
 
 func filterOutput(output []string) []string {
-	var filtered []string
+	var lines []string
 	for _, line := range output {
-		trimmed := strings.TrimSpace(line)
+		stripped := strings.TrimRight(line, " \t\n\r")
+		trimmed := strings.TrimSpace(stripped)
 		if trimmed == "" {
 			continue
 		}
 		if strings.HasPrefix(trimmed, "=== ") || strings.HasPrefix(trimmed, "--- ") {
 			continue
 		}
-		filtered = append(filtered, trimmed)
+		lines = append(lines, stripped)
+	}
+	if len(lines) == 0 {
+		return nil
+	}
+
+	minIndent := len(lines[0]) - len(strings.TrimLeft(lines[0], " \t"))
+	for _, line := range lines[1:] {
+		indent := len(line) - len(strings.TrimLeft(line, " \t"))
+		if indent < minIndent {
+			minIndent = indent
+		}
+	}
+	if minIndent == 0 {
+		return lines
+	}
+
+	filtered := make([]string, len(lines))
+	for i, line := range lines {
+		filtered[i] = line[minIndent:]
 	}
 	return filtered
 }


### PR DESCRIPTION
When tests fail in CI, the important output — assertion messages and failure reasons — is buried in thousands of lines of Go test framework noise. gotest summary shows only what failed and why.

- New gotest summary subcommand that filters test output down to failures only
- GitHub Action (mvrahden/go-test@v1) with inline PR annotations and step summaries
- Coverage profiling and per-package coverage reporting
- Resolves gotest version from go.mod by default; no version drift between local and CI