### PR TITLE
Use gotest action for CI test execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Lint
         run: go run ./cmd/gotest-lint ./... ./examples/...
       - name: Test (stdlib)
-        run: go test -ldflags=-checklinkname=0 -tags gotest_no_coverage_intercept -coverprofile=coverage-stdlib.out ./... -race
+        run: go test -ldflags=-checklinkname=0 -coverprofile=coverage-stdlib.out ./... -race
       - name: Test (suites)
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,11 @@ jobs:
         run: go work init . ./examples
       - name: Test (stdlib)
         run: go test -ldflags=-checklinkname=0 ./... -race
-      - name: Install gotest
-        run: go install ./cmd/gotest
       - name: Test (suites)
-        run: gotest ./... ./examples/... -race
+        uses: ./
+        with:
+          packages: "./... ./examples/..."
+          race: true
 
   test:
     runs-on: ubuntu-latest
@@ -63,24 +64,18 @@ jobs:
       - name: Test (stdlib)
         run: go test -ldflags=-checklinkname=0 -tags gotest_no_coverage_intercept -coverprofile=coverage-stdlib.out ./... -race
       - name: Test (suites)
-        run: go run ./cmd/gotest spec --no-color --min=40 --output=spec.txt ./... ./examples/... -race -coverprofile=coverage-suites.out
+        uses: ./
+        with:
+          packages: "./... ./examples/..."
+          race: true
+          min-coverage: 40
+          go-test-flags: "-coverprofile=coverage-suites.out"
       - name: Merge coverage
         run: |
-          # Merge stdlib + suite coverage profiles: dedup blocks, keep max hit count
           awk '
             FNR==1 && /^mode:/ { if(!mode){mode=$0}; next }
             { key=$1" "$2; if(!(key in max)||$3+0>max[key]+0){max[key]=$3+0;line[key]=$0} }
             END { print mode; n=asorti(line,sorted); for(i=1;i<=n;i++) print line[sorted[i]] }
           ' coverage-stdlib.out coverage-suites.out > coverage.out
-      - name: Summary
-        if: always()
-        run: |
-          if [ -f spec.txt ]; then
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            cat spec.txt >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-          fi
-          if [ -f coverage.out ]; then
-            pct=$(go tool cover -func=coverage.out | tail -1 | awk '{print $NF}')
-            echo "**Coverage: ${pct}**" >> "$GITHUB_STEP_SUMMARY"
-          fi
+          pct=$(go tool cover -func=coverage.out | tail -1 | awk '{print $NF}')
+          echo "**Combined coverage: ${pct}**" >> "$GITHUB_STEP_SUMMARY"

--- a/cmd/gotest/summary.go
+++ b/cmd/gotest/summary.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/mvrahden/go-test/internal/gotestgen"
 	"github.com/mvrahden/go-test/internal/gotestrunner"
@@ -129,6 +130,7 @@ func runSummary(inv Invocation) int {
 		defer timeoutCancel()
 	}
 
+	pipelineStart := time.Now()
 	result, err := gotestrunner.RunPipeline(ctx, gotestrunner.PipelineConfig{
 		GoTestArgs:      cfg.GoTestArgs,
 		SetupTimeout:    cfg.SetupTimeout,
@@ -167,7 +169,8 @@ func runSummary(inv Invocation) int {
 		}
 	}
 
-	writeSummaryOutput(tree, format, output, coverageProfile, noColor, github)
+	elapsed := time.Since(pipelineStart)
+	writeSummaryOutput(tree, format, output, coverageProfile, noColor, github, elapsed)
 
 	if code == 0 && minCoverage > 0 && coverProfile != "" {
 		pct, err := readCoverageTotal(coverProfile)
@@ -206,7 +209,7 @@ func runSummaryFromInput(input, format, output, coverageProfile string, noColor,
 
 	tree := gotestspec.BuildTree(events)
 
-	writeSummaryOutput(tree, format, output, coverageProfile, noColor, github)
+	writeSummaryOutput(tree, format, output, coverageProfile, noColor, github, 0)
 
 	stats := gotestspec.CollectStats(tree)
 	if stats.Failed > 0 {
@@ -215,7 +218,7 @@ func runSummaryFromInput(input, format, output, coverageProfile string, noColor,
 	return 0
 }
 
-func writeSummaryOutput(tree []*gotestspec.Package, format, output, coverageProfile string, noColor, github bool) {
+func writeSummaryOutput(tree []*gotestspec.Package, format, output, coverageProfile string, noColor, github bool, elapsed time.Duration) {
 	var w io.Writer = os.Stdout
 	var closeFunc func()
 	if output != "" {
@@ -232,6 +235,9 @@ func writeSummaryOutput(tree []*gotestspec.Package, format, output, coverageProf
 	}
 
 	var renderOpts []gotestspec.RenderOption
+	if elapsed > 0 {
+		renderOpts = append(renderOpts, gotestspec.WithElapsed(elapsed))
+	}
 	if noColor {
 		renderOpts = append(renderOpts, gotestspec.WithNoColor())
 	}

--- a/internal/gotestspec/summary.go
+++ b/internal/gotestspec/summary.go
@@ -54,6 +54,13 @@ func totalDuration(packages []*Package) time.Duration {
 	return d
 }
 
+func effectiveDuration(cfg renderConfig, packages []*Package) time.Duration {
+	if cfg.elapsed > 0 {
+		return cfg.elapsed
+	}
+	return totalDuration(packages)
+}
+
 func RenderSummary(w io.Writer, packages []*Package, opts ...RenderOption) {
 	cfg := renderConfig{color: true}
 	for _, o := range opts {
@@ -70,7 +77,7 @@ func RenderSummary(w io.Writer, packages []*Package, opts ...RenderOption) {
 	if len(failures) == 0 {
 		fmt.Fprintf(w, "%s%d tests passed%s (%s)\n",
 			c.green, stats.Total(), c.reset,
-			formatDuration(totalDuration(packages)))
+			formatDuration(effectiveDuration(cfg, packages)))
 		if cfg.coverage != nil {
 			fmt.Fprintf(w, "%sCoverage: %.1f%%%s\n", c.dim, cfg.coverage.Total, c.reset)
 		}
@@ -112,7 +119,7 @@ func RenderMarkdownSummary(w io.Writer, packages []*Package, opts ...RenderOptio
 
 	if len(failures) == 0 {
 		fmt.Fprintf(w, "### All %d tests passed (%s)\n",
-			stats.Total(), formatDuration(totalDuration(packages)))
+			stats.Total(), formatDuration(effectiveDuration(cfg, packages)))
 		if cfg.coverage != nil {
 			renderMarkdownCoverage(w, cfg.coverage)
 		}

--- a/internal/gotestspec/terminal.go
+++ b/internal/gotestspec/terminal.go
@@ -25,6 +25,7 @@ var noColors = colors{}
 type renderConfig struct {
 	color    bool
 	coverage *CoverageReport
+	elapsed  time.Duration
 }
 
 type RenderOption func(*renderConfig)
@@ -35,6 +36,10 @@ func WithNoColor() RenderOption {
 
 func WithCoverage(report *CoverageReport) RenderOption {
 	return func(c *renderConfig) { c.coverage = report }
+}
+
+func WithElapsed(d time.Duration) RenderOption {
+	return func(c *renderConfig) { c.elapsed = d }
 }
 
 func RenderTerminal(w io.Writer, packages []*Package, opts ...RenderOption) {


### PR DESCRIPTION
- Replace manual gotest invocations in CI with the mvrahden/go-test composite action
- Fix misleading total duration in summary output — was showing ~200s (sum of all packages running in parallel) instead of actual elapsed time (~50s)
- Remove unused build tag from stdlib test step