### PR TITLE
ci: update major version tag on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,20 @@ jobs:
         run: |
           gh release upload "${{ github.event.release.tag_name }}" gotest-*
 
+  update-major-tag:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update v1 tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          major="${tag%%.*}"
+          git tag -fa "$major" -m "$major"
+          git push origin "$major" --force
+
   extension:
     needs: build
     uses: ./.github/workflows/extension-release.yml


### PR DESCRIPTION
Automatically force-updates the v1 tag to point at the latest release, so users can reference uses: mvrahden/go-test@v1.