### PR TITLE
Detect and report unnecessary T escapes in test suites

### DIFF
--- a/cmd/gotest/gotest_suite_test.go
+++ b/cmd/gotest/gotest_suite_test.go
@@ -449,7 +449,7 @@ func (s *CmdGotestTestSuite) TestRunDiscover_SimpleSuite(t *gotest.T) {
 			it.T().Fatal(err)
 		}
 		if _, err := os.Stat(filepath.Join(absExamples, "go.mod")); err != nil {
-			it.T().Skipf("examples directory not found: %v", err)
+			it.Skipf("examples directory not found: %v", err)
 		}
 
 		loadResults, err := gotestgen.LoadPackages([]string{filepath.Join(absExamples, "cart")}, nil)
@@ -593,7 +593,7 @@ func (s *CmdGotestTestSuite) TestGenerateOverlay(t *gotest.T) {
 				it.T().Fatal(err)
 			}
 			if _, err := os.Stat(filepath.Join(absExamples, "go.mod")); err != nil {
-				it.T().Skipf("examples directory not found: %v", err)
+				it.Skipf("examples directory not found: %v", err)
 			}
 
 			loaded, err := gotestgen.LoadPackages([]string{filepath.Join(absExamples, "cart")}, nil)
@@ -660,7 +660,7 @@ func (s *CmdGotestTestSuite) TestGenerateOverlay(t *gotest.T) {
 			var allResults gotestgen.GenerateResults
 			allResults = append(allResults, results...)
 			if len(allResults) != 0 {
-				it.T().Skipf("expected 0 results for package without suites, got %d (package may have test suites)", len(allResults))
+				it.Skipf("expected 0 results for package without suites, got %d (package may have test suites)", len(allResults))
 			}
 		})
 	})
@@ -749,7 +749,7 @@ func (s *CmdGotestTestSuite) TestRunSpec_InputStdin(t *gotest.T) {
 			it.T().Fatal(err)
 		}
 		if _, err := os.Stat(filepath.Join(absExamples, "go.mod")); err != nil {
-			it.T().Skipf("examples directory not found: %v", err)
+			it.Skipf("examples directory not found: %v", err)
 		}
 
 		loaded, err := gotestgen.LoadPackages([]string{filepath.Join(absExamples, "cart")}, nil)

--- a/internal/gotestrunner/gotestrunner_process_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_process_suite_test.go
@@ -36,7 +36,7 @@ func (s *GotestrunnerProcessTestSuite) TestGracefulTermination(t *gotest.T) {
 				os.Exit(0)
 			}
 
-			marker := filepath.Join(it.T().TempDir(), "marker")
+			marker := filepath.Join(it.TempDir(), "marker")
 
 			cmd := exec.CommandContext(context.Background(), os.Args[0], //nolint:gosec // G204: test-only subprocess with hardcoded args
 				"-test.run=^TestGotestrunnerProcessTestSuite$/^TestGracefulTermination$")
@@ -94,7 +94,7 @@ func (s *GotestrunnerProcessTestSuite) TestTeardownBudget(t *gotest.T) {
 
 		w.When("valid duration", func(w *gotest.T) {
 			w.It("returns parsed duration", func(it *gotest.T) {
-				f := filepath.Join(it.T().TempDir(), "budget")
+				f := filepath.Join(it.TempDir(), "budget")
 				_ = os.WriteFile(f, []byte("2m30s\n"), 0600)
 				got := gotestrunner.ExportReadTeardownBudget(f)
 				want := 2*time.Minute + 30*time.Second
@@ -104,7 +104,7 @@ func (s *GotestrunnerProcessTestSuite) TestTeardownBudget(t *gotest.T) {
 
 		w.When("invalid duration", func(w *gotest.T) {
 			w.It("returns default", func(it *gotest.T) {
-				f := filepath.Join(it.T().TempDir(), "budget")
+				f := filepath.Join(it.TempDir(), "budget")
 				_ = os.WriteFile(f, []byte("not-a-duration"), 0600)
 				got := gotestrunner.ExportReadTeardownBudget(f)
 				gotest.Equal(it, gotestrunner.GracefulShutdownDelay, got)
@@ -113,7 +113,7 @@ func (s *GotestrunnerProcessTestSuite) TestTeardownBudget(t *gotest.T) {
 
 		w.When("zero duration", func(w *gotest.T) {
 			w.It("returns default", func(it *gotest.T) {
-				f := filepath.Join(it.T().TempDir(), "budget")
+				f := filepath.Join(it.TempDir(), "budget")
 				_ = os.WriteFile(f, []byte("0s"), 0600)
 				got := gotestrunner.ExportReadTeardownBudget(f)
 				gotest.Equal(it, gotestrunner.GracefulShutdownDelay, got)

--- a/internal/gotestrunner/gotestrunner_process_unix_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_process_unix_suite_test.go
@@ -153,7 +153,7 @@ func (s *GotestrunnerProcessTestSuite) TestProcessGroupTermination(t *gotest.T) 
 			err = syscall.Kill(pid, 0)
 			if err == nil {
 				_ = syscall.Kill(-pid, syscall.SIGKILL)
-				it.T().Errorf("process %d still alive after WaitDelay force-kill", pid)
+				it.Errorf("process %d still alive after WaitDelay force-kill", pid)
 			}
 		})
 	})
@@ -204,7 +204,7 @@ func (s *GotestrunnerProcessTestSuite) TestProcessGroupTermination(t *gotest.T) 
 			err = proc.Signal(syscall.Signal(0))
 			if err == nil {
 				_ = proc.Kill()
-				it.T().Errorf("grandchild process %d is still alive after context cancellation", childPID)
+				it.Errorf("grandchild process %d is still alive after context cancellation", childPID)
 			}
 		})
 	})

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -126,7 +126,7 @@ func (s *GotestrunnerTestSuite) TestCoverProfile(t *gotest.T) {
 	t.When("merging profiles", func(w *gotest.T) {
 		w.When("two profiles with overlapping blocks", func(w2 *gotest.T) {
 			w2.It("merges and sorts with max-count aggregation", func(it *gotest.T) {
-				dir := it.T().TempDir()
+				dir := it.TempDir()
 
 				writeProfile := func(name, content string) string {
 					p := filepath.Join(dir, name)
@@ -161,7 +161,7 @@ func (s *GotestrunnerTestSuite) TestCoverProfile(t *gotest.T) {
 
 		w.When("profile A has uncovered block not in profile B", func(w2 *gotest.T) {
 			w2.It("preserves uncovered blocks with count 0", func(it *gotest.T) {
-				dir := it.T().TempDir()
+				dir := it.TempDir()
 
 				writeProfile := func(name, content string) string {
 					p := filepath.Join(dir, name)
@@ -188,7 +188,7 @@ func (s *GotestrunnerTestSuite) TestCoverProfile(t *gotest.T) {
 
 		w.When("one profile is missing", func(w2 *gotest.T) {
 			w2.It("skips the missing file", func(it *gotest.T) {
-				dir := it.T().TempDir()
+				dir := it.TempDir()
 				p := filepath.Join(dir, "exists.out")
 				_ = os.WriteFile(p, []byte("mode: set\nfoo.go:1.2,3.4 1 1\n"), 0o600)
 
@@ -395,8 +395,8 @@ func (s *GotestrunnerTestSuite) TestOverlayCache(t *gotest.T) {
 
 	t.When("cache root resolution", func(w *gotest.T) {
 		w.It("respects GOTEST_CACHE_DIR env var", func(it *gotest.T) {
-			dir := it.T().TempDir()
-			it.T().Setenv(protocol.EnvCacheDir, dir)
+			dir := it.TempDir()
+			it.Setenv(protocol.EnvCacheDir, dir)
 
 			root, err := gotestrunner.ExportCacheRoot()
 			gotest.NoError(it, err)
@@ -404,7 +404,7 @@ func (s *GotestrunnerTestSuite) TestOverlayCache(t *gotest.T) {
 		})
 
 		w.It("falls back to UserCacheDir/gotest when env is unset", func(it *gotest.T) {
-			it.T().Setenv(protocol.EnvCacheDir, "")
+			it.Setenv(protocol.EnvCacheDir, "")
 
 			root, err := gotestrunner.ExportCacheRoot()
 			gotest.NoError(it, err)
@@ -415,8 +415,8 @@ func (s *GotestrunnerTestSuite) TestOverlayCache(t *gotest.T) {
 
 	t.When("writing to cache", func(w *gotest.T) {
 		w.It("creates valid overlay in cache directory", func(it *gotest.T) {
-			cacheDir := it.T().TempDir()
-			it.T().Setenv(protocol.EnvCacheDir, cacheDir)
+			cacheDir := it.TempDir()
+			it.Setenv(protocol.EnvCacheDir, cacheDir)
 
 			results := gotestgen.GenerateResults{
 				{AbsPath: "/fake/pkg/m", PTest: []byte("package m\n"), PXTest: []byte("package m_test\n")},
@@ -447,8 +447,8 @@ func (s *GotestrunnerTestSuite) TestOverlayCache(t *gotest.T) {
 		})
 
 		w.It("returns same directory on repeated calls (cache hit)", func(it *gotest.T) {
-			cacheDir := it.T().TempDir()
-			it.T().Setenv(protocol.EnvCacheDir, cacheDir)
+			cacheDir := it.TempDir()
+			it.Setenv(protocol.EnvCacheDir, cacheDir)
 
 			results := gotestgen.GenerateResults{
 				{AbsPath: "/fake/pkg/r", PTest: []byte("package r\n")},
@@ -464,8 +464,8 @@ func (s *GotestrunnerTestSuite) TestOverlayCache(t *gotest.T) {
 		})
 
 		w.It("falls back to tmpdir when noCache is true", func(it *gotest.T) {
-			cacheDir := it.T().TempDir()
-			it.T().Setenv(protocol.EnvCacheDir, cacheDir)
+			cacheDir := it.TempDir()
+			it.Setenv(protocol.EnvCacheDir, cacheDir)
 
 			results := gotestgen.GenerateResults{
 				{AbsPath: "/fake/pkg/nc", PTest: []byte("package nc\n")},
@@ -482,8 +482,8 @@ func (s *GotestrunnerTestSuite) TestOverlayCache(t *gotest.T) {
 
 	t.When("cleaning old cache entries", func(w *gotest.T) {
 		w.It("removes entries older than 7 days", func(it *gotest.T) {
-			cacheDir := it.T().TempDir()
-			it.T().Setenv(protocol.EnvCacheDir, cacheDir)
+			cacheDir := it.TempDir()
+			it.Setenv(protocol.EnvCacheDir, cacheDir)
 
 			overlaysDir := filepath.Join(cacheDir, "overlays")
 			_ = os.MkdirAll(overlaysDir, 0755)
@@ -780,7 +780,7 @@ func (s *GotestrunnerTestSuite) TestBuildSuiteCmd(t *gotest.T) {
 
 			goPath, err := exec.LookPath("go")
 			if err != nil {
-				it.T().Skip("go not in PATH")
+				it.Skipf("go not in PATH")
 			}
 			gotest.Equal(it, goPath, cmd.Path)
 		})
@@ -1578,31 +1578,31 @@ func (s *GotestrunnerTestSuite) TestResolveSetupTimeout(t *gotest.T) {
 func (s *GotestrunnerTestSuite) TestCIAutoDetection(t *gotest.T) {
 	t.When("auto-detecting CI from environment", func(w *gotest.T) {
 		w.It("sets CI when CI=true and GOTEST_CI is unset", func(it *gotest.T) {
-			it.T().Setenv("CI", "true")
-			it.T().Setenv(protocol.EnvCI, "")
+			it.Setenv("CI", "true")
+			it.Setenv(protocol.EnvCI, "")
 
 			cfg := gotestrunner.ExportAutoDetectCI(gotestrunner.PipelineConfig{})
 			gotest.True(it, cfg.CI)
 		})
 
 		w.It("does not override explicit --ci flag", func(it *gotest.T) {
-			it.T().Setenv("CI", "")
+			it.Setenv("CI", "")
 
 			cfg := gotestrunner.ExportAutoDetectCI(gotestrunner.PipelineConfig{CI: true})
 			gotest.True(it, cfg.CI)
 		})
 
 		w.It("respects GOTEST_CI=0 opt-out", func(it *gotest.T) {
-			it.T().Setenv("CI", "true")
-			it.T().Setenv(protocol.EnvCI, "0")
+			it.Setenv("CI", "true")
+			it.Setenv(protocol.EnvCI, "0")
 
 			cfg := gotestrunner.ExportAutoDetectCI(gotestrunner.PipelineConfig{})
 			gotest.False(it, cfg.CI)
 		})
 
 		w.It("stays off when neither CI nor GOTEST_CI is set", func(it *gotest.T) {
-			it.T().Setenv("CI", "")
-			it.T().Setenv(protocol.EnvCI, "")
+			it.Setenv("CI", "")
+			it.Setenv(protocol.EnvCI, "")
 
 			cfg := gotestrunner.ExportAutoDetectCI(gotestrunner.PipelineConfig{})
 			gotest.False(it, cfg.CI)
@@ -1622,8 +1622,8 @@ func (s *GotestrunnerTestSuite) TestCIAutoDetection(t *gotest.T) {
 		})
 
 		w.It("appends GOTEST_CI to base env when CI is true", func(it *gotest.T) {
-			it.T().Setenv("CI", "")
-			it.T().Setenv(protocol.EnvCI, "")
+			it.Setenv("CI", "")
+			it.Setenv(protocol.EnvCI, "")
 
 			env := gotestrunner.ExportBuildBaseEnv(gotestrunner.PipelineConfig{CI: true})
 			found := false
@@ -1668,7 +1668,7 @@ func (s *GotestrunnerTestSuite) TestSharedFixtureProcess(t *gotest.T) {
 
 	t.When("WriteStateFileForKeys", func(w *gotest.T) {
 		w.It("writes subset of state to file", func(it *gotest.T) {
-			tmpDir := it.T().TempDir()
+			tmpDir := it.TempDir()
 			proc := gotestrunner.ExportNewSharedFixtureProcess(tmpDir, map[string]json.RawMessage{
 				"pkg.Alpha": json.RawMessage(`{"Value":"a"}`),
 				"pkg.Beta":  json.RawMessage(`{"Value":"b"}`),

--- a/internal/gotestrunner/managed_process_suite_test.go
+++ b/internal/gotestrunner/managed_process_suite_test.go
@@ -53,7 +53,7 @@ func (s *ManagedProcessTestSuite) TestWaitWithGrace_ProcessExitsDuringGrace(t *g
 				os.Exit(0)
 			}
 
-			marker := filepath.Join(it.T().TempDir(), "started")
+			marker := filepath.Join(it.TempDir(), "started")
 
 			// Use a cancellable context for CommandContext so cmd.Cancel fires on cancel().
 			ctx, cancel := context.WithCancel(context.Background())
@@ -138,7 +138,7 @@ func (s *ManagedProcessTestSuite) TestWaitWithGrace_GraceBudget(t *gotest.T) {
 				os.Exit(0)
 			}
 
-			budgetFile := filepath.Join(it.T().TempDir(), "budget")
+			budgetFile := filepath.Join(it.TempDir(), "budget")
 			_ = os.WriteFile(budgetFile, []byte("300ms"), 0600)
 
 			cmd := exec.CommandContext(context.Background(), os.Args[0], //nolint:gosec // G204: test-only subprocess

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -336,24 +336,23 @@ func checkLifecyclePairs(pass *analysis.Pass, suites map[string]*suiteInfo) {
 // --- t-escape and suite rule detection ---
 
 type escapeConfig struct {
-	rule        Rule
-	message     string
-	suiteOnly   bool
-	skipClosure bool
-	canAutofix  bool
+	rule       Rule
+	message    string
+	suiteOnly  bool
+	canAutofix bool
 }
 
 var escapeConfigs = map[string]escapeConfig{
-	"Errorf":   {TEscape, "Errorf is available on gotest.T — unnecessary T escape", false, false, true},
-	"FailNow":  {TEscape, "FailNow is available on gotest.T — unnecessary T escape", false, false, true},
-	"Skipf":    {TEscape, "Skipf is available on gotest.T — unnecessary T escape", false, false, true},
-	"Setenv":   {TEscape, "Setenv is available on gotest.T — unnecessary T escape", false, false, true},
-	"TempDir":  {TEscape, "TempDir is available on gotest.T — unnecessary T escape", false, false, true},
-	"Skip":     {TEscape, "must use Skipf instead — unnecessary T escape", false, false, false},
-	"SkipNow":  {TEscape, "must use Skipf instead — unnecessary T escape", false, false, false},
-	"Cleanup":  {TEscape, "use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle", true, false, false},
-	"Parallel": {TEscape, "use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination", true, true, false},
-	"Run":      {TEscape, "use It or When instead — T.Run bypasses gotest wrapping", true, true, false},
+	"Errorf":   {TEscape, "Errorf is available on gotest.T — unnecessary T escape", false, true},
+	"FailNow":  {TEscape, "FailNow is available on gotest.T — unnecessary T escape", false, true},
+	"Skipf":    {TEscape, "Skipf is available on gotest.T — unnecessary T escape", false, true},
+	"Setenv":   {TEscape, "Setenv is available on gotest.T — unnecessary T escape", false, true},
+	"TempDir":  {TEscape, "TempDir is available on gotest.T — unnecessary T escape", false, true},
+	"Skip":     {TEscape, "must use Skipf instead — unnecessary T escape", false, false},
+	"SkipNow":  {TEscape, "must use Skipf instead — unnecessary T escape", false, false},
+	"Cleanup":  {TEscape, "use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle", true, false},
+	"Parallel": {TEscape, "use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination", true, false},
+	"Run":      {TEscape, "use It or When instead — T.Run bypasses gotest wrapping", true, false},
 }
 
 var gotestAssertionFuncs = map[string]bool{
@@ -404,30 +403,14 @@ func checkTEscape(pass *analysis.Pass, insp *inspector.Inspector, suites map[str
 			}
 		}
 
-		closureDepth := 0
-		var stack []ast.Node
-
 		ast.Inspect(fd.Body, func(n ast.Node) bool {
-			if n == nil {
-				top := stack[len(stack)-1]
-				stack = stack[:len(stack)-1]
-				if _, ok := top.(*ast.FuncLit); ok {
-					closureDepth--
-				}
-				return false
-			}
-			stack = append(stack, n)
-			if _, ok := n.(*ast.FuncLit); ok {
-				closureDepth++
-			}
-
 			switch node := n.(type) {
 			case *ast.AssignStmt:
 				trackTVarAssign(node, tVars, gotestTVars)
 			case *ast.CallExpr:
-				reportDirectEscape(pass, node, isSuiteMethod, closureDepth, tVars, reported)
+				reportDirectEscape(pass, node, isSuiteMethod, tVars, reported)
 				if isSuiteMethod {
-					collectInterproceduralEscape(node, closureDepth, tVars, gotestTVars, mr, &deferred)
+					collectInterproceduralEscape(node, tVars, gotestTVars, mr, &deferred)
 				}
 			}
 			return true
@@ -466,14 +449,14 @@ func trackTVarAssign(assign *ast.AssignStmt, tVars, gotestTVars map[string]bool)
 	}
 }
 
-func reportDirectEscape(pass *analysis.Pass, call *ast.CallExpr, isSuiteMethod bool, closureDepth int, tVars map[string]bool, reported map[token.Pos]bool) {
+func reportDirectEscape(pass *analysis.Pass, call *ast.CallExpr, isSuiteMethod bool, tVars map[string]bool, reported map[token.Pos]bool) {
 	sel, _ := call.Fun.(*ast.SelectorExpr)
 	if sel == nil {
 		return
 	}
 
 	if esc, ok := escapeConfigs[sel.Sel.Name]; ok {
-		if (!esc.suiteOnly || isSuiteMethod) && (!esc.skipClosure || closureDepth == 0) {
+		if !esc.suiteOnly || isSuiteMethod {
 			isDirect := isTMethodCall(sel.X)
 			isAlias := false
 			if !isDirect {
@@ -530,13 +513,10 @@ func reportDirectEscape(pass *analysis.Pass, call *ast.CallExpr, isSuiteMethod b
 	}
 }
 
-func collectInterproceduralEscape(call *ast.CallExpr, closureDepth int, tVars, gotestTVars map[string]bool, mr *methodReach, results *[]deferredReport) {
+func collectInterproceduralEscape(call *ast.CallExpr, tVars, gotestTVars map[string]bool, mr *methodReach, results *[]deferredReport) {
 	methods := mr.reachedMethods(call, tVars, gotestTVars)
 	for method, positions := range methods {
 		esc := escapeConfigs[method]
-		if esc.skipClosure && closureDepth > 0 {
-			continue
-		}
 		for pos := range positions {
 			*results = append(*results, deferredReport{esc.rule, pos, esc.message})
 		}

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -31,9 +31,6 @@ const (
 	TestSignature     Rule = "test-signature"
 	XLifecycle        Rule = "x-lifecycle"
 	AssertionSimplify Rule = "assertion-simplify"
-	SuiteCleanup      Rule = "suite-cleanup"
-	SuiteParallel     Rule = "suite-parallel"
-	SuiteSubtest      Rule = "suite-subtest"
 	TEscape           Rule = "t-escape"
 )
 
@@ -72,8 +69,6 @@ func run(pass *analysis.Pass) (any, error) {
 		checkMethods(pass, insp, suites)
 		checkFocusPrefixes(pass, suites)
 		checkLifecyclePairs(pass, suites)
-		checkSuiteCleanup(pass, insp, suites)
-		checkSuiteDirectCalls(pass, insp, suites)
 	}
 
 	checkOrphanedFiles(pass)
@@ -81,7 +76,7 @@ func run(pass *analysis.Pass) (any, error) {
 	checkTestifyImports(pass)
 	checkPollScope(pass, insp)
 	checkAssertionSimplify(pass, insp)
-	checkTEscape(pass, insp)
+	checkTEscape(pass, insp, suites)
 
 	return nil, nil
 }
@@ -338,135 +333,27 @@ func checkLifecyclePairs(pass *analysis.Pass, suites map[string]*suiteInfo) {
 	}
 }
 
-func checkSuiteCleanup(pass *analysis.Pass, insp *inspector.Inspector, suites map[string]*suiteInfo) {
-	cr := buildCleanupReach(pass, insp, 5)
+// --- t-escape and suite rule detection ---
 
-	insp.Preorder([]ast.Node{(*ast.FuncDecl)(nil)}, func(n ast.Node) {
-		fd := n.(*ast.FuncDecl)
-		if fd.Body == nil {
-			return
-		}
-
-		isSuiteMethod := false
-		if fd.Recv != nil && len(fd.Recv.List) > 0 {
-			recvName := receiverTypeName(fd.Recv)
-			if _, ok := suites[recvName]; ok {
-				isSuiteMethod = true
-			} else {
-				return
-			}
-		}
-
-		tVars := map[string]bool{}
-		gotestTVars := map[string]bool{}
-
-		if isSuiteMethod && fd.Type.Params != nil && len(fd.Type.Params.List) > 0 {
-			for _, name := range fd.Type.Params.List[0].Names {
-				gotestTVars[name.Name] = true
-			}
-		}
-
-		ast.Inspect(fd.Body, func(n ast.Node) bool {
-			switch node := n.(type) {
-			case *ast.AssignStmt:
-				for i, rhs := range node.Rhs {
-					if i >= len(node.Lhs) {
-						break
-					}
-					lhsId, ok := node.Lhs[i].(*ast.Ident)
-					if !ok {
-						continue
-					}
-					if isTMethodCall(rhs) {
-						tVars[lhsId.Name] = true
-						continue
-					}
-					if id, ok := rhs.(*ast.Ident); ok {
-						if tVars[id.Name] {
-							tVars[lhsId.Name] = true
-						}
-						if gotestTVars[id.Name] {
-							gotestTVars[lhsId.Name] = true
-						}
-					}
-				}
-			case *ast.CallExpr:
-				if isCleanupCall(node, tVars) {
-					reportCleanup(pass, node.Pos())
-					return true
-				}
-				if isSuiteMethod && cr.callPassesTaintedArg(node, tVars, gotestTVars) {
-					reportCleanup(pass, node.Pos())
-				}
-			}
-			return true
-		})
-	})
+type escapeConfig struct {
+	rule        Rule
+	message     string
+	suiteOnly   bool
+	skipClosure bool
+	canAutofix  bool
 }
 
-func reportCleanup(pass *analysis.Pass, pos token.Pos) {
-	report(pass, SuiteCleanup, pos,
-		"use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle")
-}
-
-func checkSuiteDirectCalls(pass *analysis.Pass, insp *inspector.Inspector, suites map[string]*suiteInfo) {
-	insp.Preorder([]ast.Node{(*ast.FuncDecl)(nil)}, func(n ast.Node) {
-		fd := n.(*ast.FuncDecl)
-		if fd.Body == nil || fd.Recv == nil || len(fd.Recv.List) == 0 {
-			return
-		}
-		recvName := receiverTypeName(fd.Recv)
-		if _, ok := suites[recvName]; !ok {
-			return
-		}
-
-		tVars := map[string]bool{}
-
-		ast.Inspect(fd.Body, func(n ast.Node) bool {
-			if _, ok := n.(*ast.FuncLit); ok {
-				return false
-			}
-			switch node := n.(type) {
-			case *ast.AssignStmt:
-				for i, rhs := range node.Rhs {
-					if i >= len(node.Lhs) {
-						break
-					}
-					if lhs, ok := node.Lhs[i].(*ast.Ident); ok && isTMethodCall(rhs) {
-						tVars[lhs.Name] = true
-					}
-				}
-			case *ast.CallExpr:
-				sel, ok := node.Fun.(*ast.SelectorExpr)
-				if !ok {
-					break
-				}
-				if !isTMethodCall(sel.X) {
-					if id, ok := sel.X.(*ast.Ident); !ok || !tVars[id.Name] {
-						break
-					}
-				}
-				switch sel.Sel.Name {
-				case "Parallel":
-					if len(node.Args) == 0 {
-						report(pass, SuiteParallel, node.Pos(),
-							"use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination")
-					}
-				case "Run":
-					if len(node.Args) >= 2 {
-						report(pass, SuiteSubtest, node.Pos(),
-							"use It or When instead — T.Run bypasses gotest wrapping")
-					}
-				}
-			}
-			return true
-		})
-	})
-}
-
-var tEscapeMethods = map[string]bool{
-	"Errorf": true, "FailNow": true,
-	"Skipf": true, "Setenv": true, "TempDir": true,
+var escapeConfigs = map[string]escapeConfig{
+	"Errorf":   {TEscape, "Errorf is available on gotest.T — unnecessary T escape", false, false, true},
+	"FailNow":  {TEscape, "FailNow is available on gotest.T — unnecessary T escape", false, false, true},
+	"Skipf":    {TEscape, "Skipf is available on gotest.T — unnecessary T escape", false, false, true},
+	"Setenv":   {TEscape, "Setenv is available on gotest.T — unnecessary T escape", false, false, true},
+	"TempDir":  {TEscape, "TempDir is available on gotest.T — unnecessary T escape", false, false, true},
+	"Skip":     {TEscape, "Skipf is available on gotest.T — unnecessary T escape", false, false, false},
+	"SkipNow":  {TEscape, "Skipf is available on gotest.T — unnecessary T escape", false, false, false},
+	"Cleanup":  {TEscape, "use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle", true, false, false},
+	"Parallel": {TEscape, "use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination", true, true, false},
+	"Run":      {TEscape, "use It or When instead — T.Run bypasses gotest wrapping", true, true, false},
 }
 
 var gotestAssertionFuncs = map[string]bool{
@@ -483,96 +370,156 @@ var gotestAssertionFuncs = map[string]bool{
 	"Eventually": true, "Consistently": true,
 }
 
-var tEscapeReportOnly = map[string]bool{
-	"Skip": true, "SkipNow": true,
-}
+func checkTEscape(pass *analysis.Pass, insp *inspector.Inspector, suites map[string]*suiteInfo) {
+	mr := buildMethodReach(pass, insp, 5)
 
-func checkTEscape(pass *analysis.Pass, insp *inspector.Inspector) {
 	insp.Preorder([]ast.Node{(*ast.FuncDecl)(nil)}, func(n ast.Node) {
 		fd := n.(*ast.FuncDecl)
 		if fd.Body == nil {
 			return
 		}
 
+		isSuiteMethod := false
+		if fd.Recv != nil && len(fd.Recv.List) > 0 {
+			recvName := receiverTypeName(fd.Recv)
+			_, isSuiteMethod = suites[recvName]
+		}
+
 		tVars := map[string]bool{}
+		gotestTVars := map[string]bool{}
+		if isSuiteMethod && fd.Type.Params != nil && len(fd.Type.Params.List) > 0 {
+			for _, name := range fd.Type.Params.List[0].Names {
+				gotestTVars[name.Name] = true
+			}
+		}
+
+		closureDepth := 0
+		var stack []ast.Node
 
 		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			if n == nil {
+				top := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				if _, ok := top.(*ast.FuncLit); ok {
+					closureDepth--
+				}
+				return false
+			}
+			stack = append(stack, n)
+			if _, ok := n.(*ast.FuncLit); ok {
+				closureDepth++
+			}
+
 			switch node := n.(type) {
 			case *ast.AssignStmt:
-				for i, rhs := range node.Rhs {
-					if i >= len(node.Lhs) {
-						break
-					}
-					if lhs, ok := node.Lhs[i].(*ast.Ident); ok && isTMethodCall(rhs) {
-						tVars[lhs.Name] = true
-					}
-				}
+				trackTVarAssign(node, tVars, gotestTVars)
 			case *ast.CallExpr:
-				reportTEscape(pass, node, tVars)
+				reportEscape(pass, node, isSuiteMethod, closureDepth, tVars, gotestTVars, mr)
 			}
 			return true
 		})
 	})
 }
 
-func reportTEscape(pass *analysis.Pass, call *ast.CallExpr, tVars map[string]bool) {
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok {
-		return
-	}
-
-	if tEscapeMethods[sel.Sel.Name] || tEscapeReportOnly[sel.Sel.Name] {
-		isDirect := isTMethodCall(sel.X)
-		isAlias := false
-		if !isDirect {
-			if id, ok := sel.X.(*ast.Ident); ok && tVars[id.Name] {
-				isAlias = true
+func trackTVarAssign(assign *ast.AssignStmt, tVars, gotestTVars map[string]bool) {
+	for i, rhs := range assign.Rhs {
+		if i >= len(assign.Lhs) {
+			break
+		}
+		lhsId, ok := assign.Lhs[i].(*ast.Ident)
+		if !ok {
+			continue
+		}
+		if isTMethodCall(rhs) {
+			tVars[lhsId.Name] = true
+			continue
+		}
+		if id, ok := rhs.(*ast.Ident); ok {
+			if tVars[id.Name] {
+				tVars[lhsId.Name] = true
+			}
+			if gotestTVars[id.Name] {
+				gotestTVars[lhsId.Name] = true
 			}
 		}
-		if isDirect || isAlias {
-			if tEscapeReportOnly[sel.Sel.Name] {
-				report(pass, TEscape, call.Pos(),
-					"Skipf is available on gotest.T — unnecessary T escape")
-				return
+	}
+}
+
+func reportEscape(pass *analysis.Pass, call *ast.CallExpr, isSuiteMethod bool, closureDepth int, tVars, gotestTVars map[string]bool, mr *methodReach) {
+	sel, _ := call.Fun.(*ast.SelectorExpr)
+
+	if sel != nil {
+		if cfg, ok := escapeConfigs[sel.Sel.Name]; ok {
+			if (!cfg.suiteOnly || isSuiteMethod) && (!cfg.skipClosure || closureDepth == 0) {
+				isDirect := isTMethodCall(sel.X)
+				isAlias := false
+				if !isDirect {
+					if id, ok := sel.X.(*ast.Ident); ok && tVars[id.Name] {
+						isAlias = true
+					}
+				}
+				if isDirect || isAlias {
+					if cfg.canAutofix && isDirect {
+						inner := sel.X.(*ast.CallExpr)
+						innerSel := inner.Fun.(*ast.SelectorExpr)
+						reportWithFix(pass, cfg.rule, call.Pos(),
+							[]analysis.SuggestedFix{{
+								Message: fmt.Sprintf("call %s directly", sel.Sel.Name),
+								TextEdits: []analysis.TextEdit{{
+									Pos:     innerSel.X.End(),
+									End:     inner.End(),
+									NewText: []byte(""),
+								}},
+							}},
+							"%s", cfg.message)
+					} else {
+						report(pass, cfg.rule, call.Pos(), "%s", cfg.message)
+					}
+					return
+				}
 			}
-			if isDirect {
-				inner := sel.X.(*ast.CallExpr)
+		}
+
+		if gotestAssertionFuncs[sel.Sel.Name] && isGotestPkgRef(pass, sel.X) && len(call.Args) > 0 {
+			arg := call.Args[0]
+			if inner, ok := arg.(*ast.CallExpr); ok && isTMethodCall(inner) {
 				innerSel := inner.Fun.(*ast.SelectorExpr)
-				reportWithFix(pass, TEscape, call.Pos(),
+				reportWithFix(pass, TEscape, inner.Pos(),
 					[]analysis.SuggestedFix{{
-						Message: fmt.Sprintf("call %s directly", sel.Sel.Name),
+						Message: "pass gotest.T directly",
 						TextEdits: []analysis.TextEdit{{
 							Pos:     innerSel.X.End(),
 							End:     inner.End(),
 							NewText: []byte(""),
 						}},
 					}},
-					"%s is available on gotest.T — unnecessary T escape", sel.Sel.Name)
-			} else {
-				report(pass, TEscape, call.Pos(),
-					"%s is available on gotest.T — unnecessary T escape", sel.Sel.Name)
+					"pass gotest.T directly to %s — unnecessary T escape", sel.Sel.Name)
+				return
 			}
-			return
+			if id, ok := arg.(*ast.Ident); ok && tVars[id.Name] {
+				report(pass, TEscape, arg.Pos(),
+					"pass gotest.T directly to %s — unnecessary T escape", sel.Sel.Name)
+				return
+			}
 		}
 	}
 
-	if gotestAssertionFuncs[sel.Sel.Name] && isGotestPkgRef(pass, sel.X) && len(call.Args) > 0 {
-		arg := call.Args[0]
-		if inner, ok := arg.(*ast.CallExpr); ok && isTMethodCall(inner) {
-			innerSel := inner.Fun.(*ast.SelectorExpr)
-			reportWithFix(pass, TEscape, inner.Pos(),
-				[]analysis.SuggestedFix{{
-					Message: "pass gotest.T directly",
-					TextEdits: []analysis.TextEdit{{
-						Pos:     innerSel.X.End(),
-						End:     inner.End(),
-						NewText: []byte(""),
-					}},
-				}},
-				"pass gotest.T directly to %s — unnecessary T escape", sel.Sel.Name)
-		} else if id, ok := arg.(*ast.Ident); ok && tVars[id.Name] {
-			report(pass, TEscape, arg.Pos(),
-				"pass gotest.T directly to %s — unnecessary T escape", sel.Sel.Name)
+	if isSuiteMethod {
+		methods := mr.reachedMethods(call, tVars, gotestTVars)
+		reported := map[Rule]bool{}
+		for method := range methods {
+			cfg := escapeConfigs[method]
+			if !cfg.suiteOnly {
+				continue
+			}
+			if cfg.skipClosure && closureDepth > 0 {
+				continue
+			}
+			if reported[cfg.rule] {
+				continue
+			}
+			reported[cfg.rule] = true
+			report(pass, cfg.rule, call.Pos(), "%s", cfg.message)
 		}
 	}
 }
@@ -593,21 +540,21 @@ func isGotestPkgRef(pass *analysis.Pass, expr ast.Expr) bool {
 	return pkgName.Imported().Path() == "github.com/mvrahden/go-test/pkg/gotest"
 }
 
-// --- cleanup reachability analysis ---
+// --- interprocedural method reachability ---
 
-// cleanupReach tracks which function parameters transitively lead to a
-// .Cleanup() call, enabling interprocedural detection across helper chains.
-type cleanupReach struct {
+// methodReach tracks which function parameters transitively lead to calls
+// of flagged methods, enabling interprocedural detection across helper chains.
+type methodReach struct {
 	pass      *analysis.Pass
 	funcDecls map[types.Object]*ast.FuncDecl
-	params    map[*ast.FuncDecl]map[int]bool
+	params    map[*ast.FuncDecl]map[int]map[string]bool
 }
 
-func buildCleanupReach(pass *analysis.Pass, insp *inspector.Inspector, maxDepth int) *cleanupReach {
-	cr := &cleanupReach{
+func buildMethodReach(pass *analysis.Pass, insp *inspector.Inspector, maxDepth int) *methodReach {
+	mr := &methodReach{
 		pass:      pass,
 		funcDecls: map[types.Object]*ast.FuncDecl{},
-		params:    map[*ast.FuncDecl]map[int]bool{},
+		params:    map[*ast.FuncDecl]map[int]map[string]bool{},
 	}
 
 	insp.Preorder([]ast.Node{(*ast.FuncDecl)(nil)}, func(n ast.Node) {
@@ -616,17 +563,18 @@ func buildCleanupReach(pass *analysis.Pass, insp *inspector.Inspector, maxDepth 
 			return
 		}
 		if obj := pass.TypesInfo.Defs[fd.Name]; obj != nil {
-			cr.funcDecls[obj] = fd
+			mr.funcDecls[obj] = fd
 		}
 	})
 
-	for _, fd := range cr.funcDecls {
-		cr.scanDirect(fd)
+	for _, fd := range mr.funcDecls {
+		mr.scanDirect(fd)
 	}
-	for round := 0; round < maxDepth; round++ {
+	for round := range maxDepth {
+		_ = round
 		changed := false
-		for _, fd := range cr.funcDecls {
-			if cr.propagate(fd) {
+		for _, fd := range mr.funcDecls {
+			if mr.propagate(fd) {
 				changed = true
 			}
 		}
@@ -635,21 +583,24 @@ func buildCleanupReach(pass *analysis.Pass, insp *inspector.Inspector, maxDepth 
 		}
 	}
 
-	return cr
+	return mr
 }
 
-func (cr *cleanupReach) mark(fd *ast.FuncDecl, paramIdx int) bool {
-	if cr.params[fd] == nil {
-		cr.params[fd] = map[int]bool{}
+func (mr *methodReach) mark(fd *ast.FuncDecl, paramIdx int, method string) bool {
+	if mr.params[fd] == nil {
+		mr.params[fd] = map[int]map[string]bool{}
 	}
-	if cr.params[fd][paramIdx] {
+	if mr.params[fd][paramIdx] == nil {
+		mr.params[fd][paramIdx] = map[string]bool{}
+	}
+	if mr.params[fd][paramIdx][method] {
 		return false
 	}
-	cr.params[fd][paramIdx] = true
+	mr.params[fd][paramIdx][method] = true
 	return true
 }
 
-func (cr *cleanupReach) resolveCallee(call *ast.CallExpr) *ast.FuncDecl {
+func (mr *methodReach) resolveCallee(call *ast.CallExpr) *ast.FuncDecl {
 	var ident *ast.Ident
 	switch fn := call.Fun.(type) {
 	case *ast.Ident:
@@ -660,16 +611,14 @@ func (cr *cleanupReach) resolveCallee(call *ast.CallExpr) *ast.FuncDecl {
 	if ident == nil {
 		return nil
 	}
-	obj := cr.pass.TypesInfo.Uses[ident]
+	obj := mr.pass.TypesInfo.Uses[ident]
 	if obj == nil {
 		return nil
 	}
-	return cr.funcDecls[obj]
+	return mr.funcDecls[obj]
 }
 
-// scanDirect finds parameters that have .Cleanup() called on them directly
-// (including via .T() and variable aliases).
-func (cr *cleanupReach) scanDirect(fd *ast.FuncDecl) {
+func (mr *methodReach) scanDirect(fd *ast.FuncDecl) {
 	aliases := flattenParams(fd.Type.Params)
 	if len(aliases) == 0 {
 		return
@@ -681,20 +630,23 @@ func (cr *cleanupReach) scanDirect(fd *ast.FuncDecl) {
 			trackParamFlow(node, aliases)
 		case *ast.CallExpr:
 			sel, ok := node.Fun.(*ast.SelectorExpr)
-			if !ok || sel.Sel.Name != "Cleanup" {
+			if !ok {
 				break
 			}
+			if _, ok := escapeConfigs[sel.Sel.Name]; !ok {
+				break
+			}
+			method := sel.Sel.Name
 			if id, ok := sel.X.(*ast.Ident); ok {
 				if idx, ok := aliases[id.Name]; ok {
-					cr.mark(fd, idx)
+					mr.mark(fd, idx, method)
 				}
 			}
-			if innerCall, ok := sel.X.(*ast.CallExpr); ok && len(innerCall.Args) == 0 {
-				if innerSel, ok := innerCall.Fun.(*ast.SelectorExpr); ok && innerSel.Sel.Name == "T" {
-					if id, ok := innerSel.X.(*ast.Ident); ok {
-						if idx, ok := aliases[id.Name]; ok {
-							cr.mark(fd, idx)
-						}
+			if isTMethodCall(sel.X) {
+				innerSel := sel.X.(*ast.CallExpr).Fun.(*ast.SelectorExpr)
+				if id, ok := innerSel.X.(*ast.Ident); ok {
+					if idx, ok := aliases[id.Name]; ok {
+						mr.mark(fd, idx, method)
 					}
 				}
 			}
@@ -703,9 +655,7 @@ func (cr *cleanupReach) scanDirect(fd *ast.FuncDecl) {
 	})
 }
 
-// propagate marks parameters that flow into cleanup-reaching parameters
-// of called functions (one round of fixed-point iteration).
-func (cr *cleanupReach) propagate(fd *ast.FuncDecl) bool {
+func (mr *methodReach) propagate(fd *ast.FuncDecl) bool {
 	aliases := flattenParams(fd.Type.Params)
 	if len(aliases) == 0 {
 		return false
@@ -717,21 +667,24 @@ func (cr *cleanupReach) propagate(fd *ast.FuncDecl) bool {
 		case *ast.AssignStmt:
 			trackParamFlow(node, aliases)
 		case *ast.CallExpr:
-			callee := cr.resolveCallee(node)
+			callee := mr.resolveCallee(node)
 			if callee == nil {
 				break
 			}
-			calleeReach := cr.params[callee]
+			calleeReach := mr.params[callee]
 			if len(calleeReach) == 0 {
 				break
 			}
 			for argIdx, arg := range node.Args {
-				if !calleeReach[argIdx] {
+				methods := calleeReach[argIdx]
+				if len(methods) == 0 {
 					continue
 				}
 				if idx := exprToParamIdx(arg, aliases); idx >= 0 {
-					if cr.mark(fd, idx) {
-						changed = true
+					for method := range methods {
+						if mr.mark(fd, idx, method) {
+							changed = true
+						}
 					}
 				}
 			}
@@ -741,29 +694,37 @@ func (cr *cleanupReach) propagate(fd *ast.FuncDecl) bool {
 	return changed
 }
 
-func (cr *cleanupReach) callPassesTaintedArg(call *ast.CallExpr, tVars, gotestTVars map[string]bool) bool {
-	callee := cr.resolveCallee(call)
+func (mr *methodReach) reachedMethods(call *ast.CallExpr, tVars, gotestTVars map[string]bool) map[string]bool {
+	callee := mr.resolveCallee(call)
 	if callee == nil {
-		return false
+		return nil
 	}
-	calleeReach := cr.params[callee]
+	calleeReach := mr.params[callee]
 	if len(calleeReach) == 0 {
-		return false
+		return nil
 	}
+	var methods map[string]bool
 	for argIdx, arg := range call.Args {
-		if !calleeReach[argIdx] {
+		argMethods := calleeReach[argIdx]
+		if len(argMethods) == 0 {
 			continue
 		}
-		if isTMethodCall(arg) {
-			return true
+		tainted := isTMethodCall(arg)
+		if !tainted {
+			if id, ok := arg.(*ast.Ident); ok {
+				tainted = tVars[id.Name] || gotestTVars[id.Name]
+			}
 		}
-		if id, ok := arg.(*ast.Ident); ok {
-			if tVars[id.Name] || gotestTVars[id.Name] {
-				return true
+		if tainted {
+			if methods == nil {
+				methods = map[string]bool{}
+			}
+			for m := range argMethods {
+				methods[m] = true
 			}
 		}
 	}
-	return false
+	return methods
 }
 
 // flattenParams returns a map from parameter name to its flattened index.
@@ -838,20 +799,6 @@ func isTMethodCall(expr ast.Expr) bool {
 	}
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	return ok && sel.Sel.Name == "T"
-}
-
-func isCleanupCall(call *ast.CallExpr, tVars map[string]bool) bool {
-	sel, ok := call.Fun.(*ast.SelectorExpr)
-	if !ok || sel.Sel.Name != "Cleanup" {
-		return false
-	}
-	if innerCall, ok := sel.X.(*ast.CallExpr); ok && isTMethodCall(innerCall) {
-		return true
-	}
-	if id, ok := sel.X.(*ast.Ident); ok && tVars[id.Name] {
-		return true
-	}
-	return false
 }
 
 func checkOrphanedFiles(pass *analysis.Pass) {

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"go/types"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -30,6 +31,7 @@ const (
 	TestSignature     Rule = "test-signature"
 	XLifecycle        Rule = "x-lifecycle"
 	AssertionSimplify Rule = "assertion-simplify"
+	SuiteCleanup      Rule = "suite-cleanup"
 )
 
 // SkippableRules is the set of rules that support opt-out via skip flags.
@@ -67,6 +69,7 @@ func run(pass *analysis.Pass) (any, error) {
 		checkMethods(pass, insp, suites)
 		checkFocusPrefixes(pass, suites)
 		checkLifecyclePairs(pass, suites)
+		checkSuiteCleanup(pass, insp, suites)
 	}
 
 	checkOrphanedFiles(pass)
@@ -328,6 +331,338 @@ func checkLifecyclePairs(pass *analysis.Pass, suites map[string]*suiteInfo) {
 			report(pass, LifecyclePair, s.pos, "suite %s has BeforeAll but no AfterAll — resources may leak", s.name)
 		}
 	}
+}
+
+func checkSuiteCleanup(pass *analysis.Pass, insp *inspector.Inspector, suites map[string]*suiteInfo) {
+	cr := buildCleanupReach(pass, insp, 5)
+
+	insp.Preorder([]ast.Node{(*ast.FuncDecl)(nil)}, func(n ast.Node) {
+		fd := n.(*ast.FuncDecl)
+		if fd.Body == nil {
+			return
+		}
+
+		isSuiteMethod := false
+		if fd.Recv != nil && len(fd.Recv.List) > 0 {
+			recvName := receiverTypeName(fd.Recv)
+			if _, ok := suites[recvName]; ok {
+				isSuiteMethod = true
+			} else {
+				return
+			}
+		}
+
+		tVars := map[string]bool{}
+		gotestTVars := map[string]bool{}
+
+		if isSuiteMethod && fd.Type.Params != nil && len(fd.Type.Params.List) > 0 {
+			for _, name := range fd.Type.Params.List[0].Names {
+				gotestTVars[name.Name] = true
+			}
+		}
+
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.AssignStmt:
+				for i, rhs := range node.Rhs {
+					if i >= len(node.Lhs) {
+						break
+					}
+					lhsId, ok := node.Lhs[i].(*ast.Ident)
+					if !ok {
+						continue
+					}
+					if isTMethodCall(rhs) {
+						tVars[lhsId.Name] = true
+						continue
+					}
+					if id, ok := rhs.(*ast.Ident); ok {
+						if tVars[id.Name] {
+							tVars[lhsId.Name] = true
+						}
+						if gotestTVars[id.Name] {
+							gotestTVars[lhsId.Name] = true
+						}
+					}
+				}
+			case *ast.CallExpr:
+				if isCleanupCall(node, tVars) {
+					reportCleanup(pass, node.Pos())
+					return true
+				}
+				if isSuiteMethod && cr.callPassesTaintedArg(node, tVars, gotestTVars) {
+					reportCleanup(pass, node.Pos())
+				}
+			}
+			return true
+		})
+	})
+}
+
+func reportCleanup(pass *analysis.Pass, pos token.Pos) {
+	report(pass, SuiteCleanup, pos,
+		"use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle")
+}
+
+// --- cleanup reachability analysis ---
+
+// cleanupReach tracks which function parameters transitively lead to a
+// .Cleanup() call, enabling interprocedural detection across helper chains.
+type cleanupReach struct {
+	pass      *analysis.Pass
+	funcDecls map[types.Object]*ast.FuncDecl
+	params    map[*ast.FuncDecl]map[int]bool
+}
+
+func buildCleanupReach(pass *analysis.Pass, insp *inspector.Inspector, maxDepth int) *cleanupReach {
+	cr := &cleanupReach{
+		pass:      pass,
+		funcDecls: map[types.Object]*ast.FuncDecl{},
+		params:    map[*ast.FuncDecl]map[int]bool{},
+	}
+
+	insp.Preorder([]ast.Node{(*ast.FuncDecl)(nil)}, func(n ast.Node) {
+		fd := n.(*ast.FuncDecl)
+		if fd.Body == nil || fd.Name == nil {
+			return
+		}
+		if obj := pass.TypesInfo.Defs[fd.Name]; obj != nil {
+			cr.funcDecls[obj] = fd
+		}
+	})
+
+	for _, fd := range cr.funcDecls {
+		cr.scanDirect(fd)
+	}
+	for round := 0; round < maxDepth; round++ {
+		changed := false
+		for _, fd := range cr.funcDecls {
+			if cr.propagate(fd) {
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
+	return cr
+}
+
+func (cr *cleanupReach) mark(fd *ast.FuncDecl, paramIdx int) bool {
+	if cr.params[fd] == nil {
+		cr.params[fd] = map[int]bool{}
+	}
+	if cr.params[fd][paramIdx] {
+		return false
+	}
+	cr.params[fd][paramIdx] = true
+	return true
+}
+
+func (cr *cleanupReach) resolveCallee(call *ast.CallExpr) *ast.FuncDecl {
+	var ident *ast.Ident
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		ident = fn
+	case *ast.SelectorExpr:
+		ident = fn.Sel
+	}
+	if ident == nil {
+		return nil
+	}
+	obj := cr.pass.TypesInfo.Uses[ident]
+	if obj == nil {
+		return nil
+	}
+	return cr.funcDecls[obj]
+}
+
+// scanDirect finds parameters that have .Cleanup() called on them directly
+// (including via .T() and variable aliases).
+func (cr *cleanupReach) scanDirect(fd *ast.FuncDecl) {
+	aliases := flattenParams(fd.Type.Params)
+	if len(aliases) == 0 {
+		return
+	}
+
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			trackParamFlow(node, aliases)
+		case *ast.CallExpr:
+			sel, ok := node.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Cleanup" {
+				break
+			}
+			if id, ok := sel.X.(*ast.Ident); ok {
+				if idx, ok := aliases[id.Name]; ok {
+					cr.mark(fd, idx)
+				}
+			}
+			if innerCall, ok := sel.X.(*ast.CallExpr); ok && len(innerCall.Args) == 0 {
+				if innerSel, ok := innerCall.Fun.(*ast.SelectorExpr); ok && innerSel.Sel.Name == "T" {
+					if id, ok := innerSel.X.(*ast.Ident); ok {
+						if idx, ok := aliases[id.Name]; ok {
+							cr.mark(fd, idx)
+						}
+					}
+				}
+			}
+		}
+		return true
+	})
+}
+
+// propagate marks parameters that flow into cleanup-reaching parameters
+// of called functions (one round of fixed-point iteration).
+func (cr *cleanupReach) propagate(fd *ast.FuncDecl) bool {
+	aliases := flattenParams(fd.Type.Params)
+	if len(aliases) == 0 {
+		return false
+	}
+
+	changed := false
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			trackParamFlow(node, aliases)
+		case *ast.CallExpr:
+			callee := cr.resolveCallee(node)
+			if callee == nil {
+				break
+			}
+			calleeReach := cr.params[callee]
+			if len(calleeReach) == 0 {
+				break
+			}
+			for argIdx, arg := range node.Args {
+				if !calleeReach[argIdx] {
+					continue
+				}
+				if idx := exprToParamIdx(arg, aliases); idx >= 0 {
+					if cr.mark(fd, idx) {
+						changed = true
+					}
+				}
+			}
+		}
+		return true
+	})
+	return changed
+}
+
+func (cr *cleanupReach) callPassesTaintedArg(call *ast.CallExpr, tVars, gotestTVars map[string]bool) bool {
+	callee := cr.resolveCallee(call)
+	if callee == nil {
+		return false
+	}
+	calleeReach := cr.params[callee]
+	if len(calleeReach) == 0 {
+		return false
+	}
+	for argIdx, arg := range call.Args {
+		if !calleeReach[argIdx] {
+			continue
+		}
+		if isTMethodCall(arg) {
+			return true
+		}
+		if id, ok := arg.(*ast.Ident); ok {
+			if tVars[id.Name] || gotestTVars[id.Name] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// flattenParams returns a map from parameter name to its flattened index.
+func flattenParams(params *ast.FieldList) map[string]int {
+	if params == nil {
+		return nil
+	}
+	m := map[string]int{}
+	idx := 0
+	for _, field := range params.List {
+		for _, name := range field.Names {
+			m[name.Name] = idx
+			idx++
+		}
+	}
+	return m
+}
+
+// trackParamFlow extends the alias map for direct assignments (x := param)
+// and .T() calls (x := param.T()).
+func trackParamFlow(assign *ast.AssignStmt, aliases map[string]int) {
+	for i, rhs := range assign.Rhs {
+		if i >= len(assign.Lhs) {
+			break
+		}
+		lhsId, ok := assign.Lhs[i].(*ast.Ident)
+		if !ok {
+			continue
+		}
+		if id, ok := rhs.(*ast.Ident); ok {
+			if idx, ok := aliases[id.Name]; ok {
+				aliases[lhsId.Name] = idx
+			}
+			continue
+		}
+		if call, ok := rhs.(*ast.CallExpr); ok && isTMethodCall(call) {
+			if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+				if id, ok := sel.X.(*ast.Ident); ok {
+					if idx, ok := aliases[id.Name]; ok {
+						aliases[lhsId.Name] = idx
+					}
+				}
+			}
+		}
+	}
+}
+
+// exprToParamIdx returns the parameter index if the expression is a
+// parameter/alias ident or a .T() call on one. Returns -1 otherwise.
+func exprToParamIdx(expr ast.Expr, aliases map[string]int) int {
+	if id, ok := expr.(*ast.Ident); ok {
+		if idx, ok := aliases[id.Name]; ok {
+			return idx
+		}
+	}
+	if call, ok := expr.(*ast.CallExpr); ok && isTMethodCall(call) {
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+			if id, ok := sel.X.(*ast.Ident); ok {
+				if idx, ok := aliases[id.Name]; ok {
+					return idx
+				}
+			}
+		}
+	}
+	return -1
+}
+
+func isTMethodCall(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) != 0 {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "T"
+}
+
+func isCleanupCall(call *ast.CallExpr, tVars map[string]bool) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Cleanup" {
+		return false
+	}
+	if innerCall, ok := sel.X.(*ast.CallExpr); ok && isTMethodCall(innerCall) {
+		return true
+	}
+	if id, ok := sel.X.(*ast.Ident); ok && tVars[id.Name] {
+		return true
+	}
+	return false
 }
 
 func checkOrphanedFiles(pass *analysis.Pass) {

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -349,8 +349,8 @@ var escapeConfigs = map[string]escapeConfig{
 	"Skipf":    {TEscape, "Skipf is available on gotest.T — unnecessary T escape", false, false, true},
 	"Setenv":   {TEscape, "Setenv is available on gotest.T — unnecessary T escape", false, false, true},
 	"TempDir":  {TEscape, "TempDir is available on gotest.T — unnecessary T escape", false, false, true},
-	"Skip":     {TEscape, "Skipf is available on gotest.T — unnecessary T escape", false, false, false},
-	"SkipNow":  {TEscape, "Skipf is available on gotest.T — unnecessary T escape", false, false, false},
+	"Skip":     {TEscape, "must use Skipf instead — unnecessary T escape", false, false, false},
+	"SkipNow":  {TEscape, "must use Skipf instead — unnecessary T escape", false, false, false},
 	"Cleanup":  {TEscape, "use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle", true, false, false},
 	"Parallel": {TEscape, "use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination", true, true, false},
 	"Run":      {TEscape, "use It or When instead — T.Run bypasses gotest wrapping", true, true, false},
@@ -370,8 +370,16 @@ var gotestAssertionFuncs = map[string]bool{
 	"Eventually": true, "Consistently": true,
 }
 
+type deferredReport struct {
+	rule    Rule
+	pos     token.Pos
+	message string
+}
+
 func checkTEscape(pass *analysis.Pass, insp *inspector.Inspector, suites map[string]*suiteInfo) {
 	mr := buildMethodReach(pass, insp, 5)
+	reported := map[token.Pos]bool{}
+	var deferred []deferredReport
 
 	insp.Preorder([]ast.Node{(*ast.FuncDecl)(nil)}, func(n ast.Node) {
 		fd := n.(*ast.FuncDecl)
@@ -381,15 +389,18 @@ func checkTEscape(pass *analysis.Pass, insp *inspector.Inspector, suites map[str
 
 		isSuiteMethod := false
 		if fd.Recv != nil && len(fd.Recv.List) > 0 {
-			recvName := receiverTypeName(fd.Recv)
-			_, isSuiteMethod = suites[recvName]
+			_, isSuiteMethod = suites[receiverTypeName(fd.Recv)]
 		}
 
 		tVars := map[string]bool{}
 		gotestTVars := map[string]bool{}
-		if isSuiteMethod && fd.Type.Params != nil && len(fd.Type.Params.List) > 0 {
-			for _, name := range fd.Type.Params.List[0].Names {
-				gotestTVars[name.Name] = true
+		if isSuiteMethod && fd.Type.Params != nil {
+			for _, field := range fd.Type.Params.List {
+				if isGotestTType(pass, field) {
+					for _, name := range field.Names {
+						gotestTVars[name.Name] = true
+					}
+				}
 			}
 		}
 
@@ -414,11 +425,21 @@ func checkTEscape(pass *analysis.Pass, insp *inspector.Inspector, suites map[str
 			case *ast.AssignStmt:
 				trackTVarAssign(node, tVars, gotestTVars)
 			case *ast.CallExpr:
-				reportEscape(pass, node, isSuiteMethod, closureDepth, tVars, gotestTVars, mr)
+				reportDirectEscape(pass, node, isSuiteMethod, closureDepth, tVars, reported)
+				if isSuiteMethod {
+					collectInterproceduralEscape(node, closureDepth, tVars, gotestTVars, mr, &deferred)
+				}
 			}
 			return true
 		})
 	})
+
+	for _, d := range deferred {
+		if !reported[d.pos] {
+			reported[d.pos] = true
+			report(pass, d.rule, d.pos, "%s", d.message)
+		}
+	}
 }
 
 func trackTVarAssign(assign *ast.AssignStmt, tVars, gotestTVars map[string]bool) {
@@ -445,84 +466,84 @@ func trackTVarAssign(assign *ast.AssignStmt, tVars, gotestTVars map[string]bool)
 	}
 }
 
-func reportEscape(pass *analysis.Pass, call *ast.CallExpr, isSuiteMethod bool, closureDepth int, tVars, gotestTVars map[string]bool, mr *methodReach) {
+func reportDirectEscape(pass *analysis.Pass, call *ast.CallExpr, isSuiteMethod bool, closureDepth int, tVars map[string]bool, reported map[token.Pos]bool) {
 	sel, _ := call.Fun.(*ast.SelectorExpr)
+	if sel == nil {
+		return
+	}
 
-	if sel != nil {
-		if cfg, ok := escapeConfigs[sel.Sel.Name]; ok {
-			if (!cfg.suiteOnly || isSuiteMethod) && (!cfg.skipClosure || closureDepth == 0) {
-				isDirect := isTMethodCall(sel.X)
-				isAlias := false
-				if !isDirect {
-					if id, ok := sel.X.(*ast.Ident); ok && tVars[id.Name] {
-						isAlias = true
-					}
+	if esc, ok := escapeConfigs[sel.Sel.Name]; ok {
+		if (!esc.suiteOnly || isSuiteMethod) && (!esc.skipClosure || closureDepth == 0) {
+			isDirect := isTMethodCall(sel.X)
+			isAlias := false
+			if !isDirect {
+				if id, ok := sel.X.(*ast.Ident); ok && tVars[id.Name] {
+					isAlias = true
 				}
-				if isDirect || isAlias {
-					if cfg.canAutofix && isDirect {
-						inner := sel.X.(*ast.CallExpr)
-						innerSel := inner.Fun.(*ast.SelectorExpr)
-						reportWithFix(pass, cfg.rule, call.Pos(),
-							[]analysis.SuggestedFix{{
-								Message: fmt.Sprintf("call %s directly", sel.Sel.Name),
-								TextEdits: []analysis.TextEdit{{
-									Pos:     innerSel.X.End(),
-									End:     inner.End(),
-									NewText: []byte(""),
-								}},
+			}
+			if isDirect || isAlias {
+				reported[call.Pos()] = true
+				if esc.canAutofix && isDirect {
+					inner := sel.X.(*ast.CallExpr)
+					innerSel := inner.Fun.(*ast.SelectorExpr)
+					reportWithFix(pass, esc.rule, call.Pos(),
+						[]analysis.SuggestedFix{{
+							Message: fmt.Sprintf("call %s directly", sel.Sel.Name),
+							TextEdits: []analysis.TextEdit{{
+								Pos:     innerSel.X.End(),
+								End:     inner.End(),
+								NewText: []byte(""),
 							}},
-							"%s", cfg.message)
-					} else {
-						report(pass, cfg.rule, call.Pos(), "%s", cfg.message)
-					}
-					return
-				}
-			}
-		}
-
-		if gotestAssertionFuncs[sel.Sel.Name] && isGotestPkgRef(pass, sel.X) && len(call.Args) > 0 {
-			arg := call.Args[0]
-			if inner, ok := arg.(*ast.CallExpr); ok && isTMethodCall(inner) {
-				innerSel := inner.Fun.(*ast.SelectorExpr)
-				reportWithFix(pass, TEscape, inner.Pos(),
-					[]analysis.SuggestedFix{{
-						Message: "pass gotest.T directly",
-						TextEdits: []analysis.TextEdit{{
-							Pos:     innerSel.X.End(),
-							End:     inner.End(),
-							NewText: []byte(""),
 						}},
-					}},
-					"pass gotest.T directly to %s — unnecessary T escape", sel.Sel.Name)
-				return
-			}
-			if id, ok := arg.(*ast.Ident); ok && tVars[id.Name] {
-				report(pass, TEscape, arg.Pos(),
-					"pass gotest.T directly to %s — unnecessary T escape", sel.Sel.Name)
+						"%s", esc.message)
+				} else {
+					report(pass, esc.rule, call.Pos(), "%s", esc.message)
+				}
 				return
 			}
 		}
 	}
 
-	if isSuiteMethod {
-		methods := mr.reachedMethods(call, tVars, gotestTVars)
-		reported := map[Rule]bool{}
-		for method := range methods {
-			cfg := escapeConfigs[method]
-			if !cfg.suiteOnly {
-				continue
-			}
-			if cfg.skipClosure && closureDepth > 0 {
-				continue
-			}
-			if reported[cfg.rule] {
-				continue
-			}
-			reported[cfg.rule] = true
-			report(pass, cfg.rule, call.Pos(), "%s", cfg.message)
+	if gotestAssertionFuncs[sel.Sel.Name] && isGotestPkgRef(pass, sel.X) && len(call.Args) > 0 {
+		arg := call.Args[0]
+		if inner, ok := arg.(*ast.CallExpr); ok && isTMethodCall(inner) {
+			reported[inner.Pos()] = true
+			innerSel := inner.Fun.(*ast.SelectorExpr)
+			reportWithFix(pass, TEscape, inner.Pos(),
+				[]analysis.SuggestedFix{{
+					Message: "pass gotest.T directly",
+					TextEdits: []analysis.TextEdit{{
+						Pos:     innerSel.X.End(),
+						End:     inner.End(),
+						NewText: []byte(""),
+					}},
+				}},
+				"pass gotest.T directly to %s — unnecessary T escape", sel.Sel.Name)
+			return
+		}
+		if id, ok := arg.(*ast.Ident); ok && tVars[id.Name] {
+			reported[arg.Pos()] = true
+			report(pass, TEscape, arg.Pos(),
+				"pass gotest.T directly to %s — unnecessary T escape", sel.Sel.Name)
+			return
 		}
 	}
 }
+
+func collectInterproceduralEscape(call *ast.CallExpr, closureDepth int, tVars, gotestTVars map[string]bool, mr *methodReach, results *[]deferredReport) {
+	methods := mr.reachedMethods(call, tVars, gotestTVars)
+	for method, positions := range methods {
+		esc := escapeConfigs[method]
+		if esc.skipClosure && closureDepth > 0 {
+			continue
+		}
+		for pos := range positions {
+			*results = append(*results, deferredReport{esc.rule, pos, esc.message})
+		}
+	}
+}
+
+const gotestImportPath = "github.com/mvrahden/go-test/pkg/gotest"
 
 func isGotestPkgRef(pass *analysis.Pass, expr ast.Expr) bool {
 	id, ok := expr.(*ast.Ident)
@@ -537,24 +558,48 @@ func isGotestPkgRef(pass *analysis.Pass, expr ast.Expr) bool {
 	if !ok {
 		return false
 	}
-	return pkgName.Imported().Path() == "github.com/mvrahden/go-test/pkg/gotest"
+	return pkgName.Imported().Path() == gotestImportPath
+}
+
+func isGotestTType(pass *analysis.Pass, field *ast.Field) bool {
+	typ := pass.TypesInfo.TypeOf(field.Type)
+	if typ == nil {
+		return false
+	}
+	ptr, ok := typ.(*types.Pointer)
+	if !ok {
+		return false
+	}
+	named, ok := ptr.Elem().(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj.Name() == "T" && obj.Pkg() != nil && obj.Pkg().Path() == gotestImportPath
 }
 
 // --- interprocedural method reachability ---
+
+type callEdge struct {
+	callee *ast.FuncDecl
+	args   map[int]int // call arg position → caller's param index
+}
 
 // methodReach tracks which function parameters transitively lead to calls
 // of flagged methods, enabling interprocedural detection across helper chains.
 type methodReach struct {
 	pass      *analysis.Pass
 	funcDecls map[types.Object]*ast.FuncDecl
-	params    map[*ast.FuncDecl]map[int]map[string]bool
+	params    map[*ast.FuncDecl]map[int]map[string]map[token.Pos]bool
+	edges     map[*ast.FuncDecl][]callEdge
 }
 
 func buildMethodReach(pass *analysis.Pass, insp *inspector.Inspector, maxDepth int) *methodReach {
 	mr := &methodReach{
 		pass:      pass,
 		funcDecls: map[types.Object]*ast.FuncDecl{},
-		params:    map[*ast.FuncDecl]map[int]map[string]bool{},
+		params:    map[*ast.FuncDecl]map[int]map[string]map[token.Pos]bool{},
+		edges:     map[*ast.FuncDecl][]callEdge{},
 	}
 
 	insp.Preorder([]ast.Node{(*ast.FuncDecl)(nil)}, func(n ast.Node) {
@@ -570,15 +615,8 @@ func buildMethodReach(pass *analysis.Pass, insp *inspector.Inspector, maxDepth i
 	for _, fd := range mr.funcDecls {
 		mr.scanDirect(fd)
 	}
-	for round := range maxDepth {
-		_ = round
-		changed := false
-		for _, fd := range mr.funcDecls {
-			if mr.propagate(fd) {
-				changed = true
-			}
-		}
-		if !changed {
+	for range maxDepth {
+		if !mr.propagate() {
 			break
 		}
 	}
@@ -586,17 +624,20 @@ func buildMethodReach(pass *analysis.Pass, insp *inspector.Inspector, maxDepth i
 	return mr
 }
 
-func (mr *methodReach) mark(fd *ast.FuncDecl, paramIdx int, method string) bool {
+func (mr *methodReach) mark(fd *ast.FuncDecl, paramIdx int, method string, pos token.Pos) bool {
 	if mr.params[fd] == nil {
-		mr.params[fd] = map[int]map[string]bool{}
+		mr.params[fd] = map[int]map[string]map[token.Pos]bool{}
 	}
 	if mr.params[fd][paramIdx] == nil {
-		mr.params[fd][paramIdx] = map[string]bool{}
+		mr.params[fd][paramIdx] = map[string]map[token.Pos]bool{}
 	}
-	if mr.params[fd][paramIdx][method] {
+	if mr.params[fd][paramIdx][method] == nil {
+		mr.params[fd][paramIdx][method] = map[token.Pos]bool{}
+	}
+	if mr.params[fd][paramIdx][method][pos] {
 		return false
 	}
-	mr.params[fd][paramIdx][method] = true
+	mr.params[fd][paramIdx][method][pos] = true
 	return true
 }
 
@@ -630,24 +671,33 @@ func (mr *methodReach) scanDirect(fd *ast.FuncDecl) {
 			trackParamFlow(node, aliases)
 		case *ast.CallExpr:
 			sel, ok := node.Fun.(*ast.SelectorExpr)
-			if !ok {
-				break
-			}
-			if _, ok := escapeConfigs[sel.Sel.Name]; !ok {
-				break
-			}
-			method := sel.Sel.Name
-			if id, ok := sel.X.(*ast.Ident); ok {
-				if idx, ok := aliases[id.Name]; ok {
-					mr.mark(fd, idx, method)
+			if ok {
+				if _, ok := escapeConfigs[sel.Sel.Name]; ok {
+					method := sel.Sel.Name
+					if id, ok := sel.X.(*ast.Ident); ok {
+						if idx, ok := aliases[id.Name]; ok {
+							mr.mark(fd, idx, method, node.Pos())
+						}
+					}
+					if isTMethodCall(sel.X) {
+						innerSel := sel.X.(*ast.CallExpr).Fun.(*ast.SelectorExpr)
+						if id, ok := innerSel.X.(*ast.Ident); ok {
+							if idx, ok := aliases[id.Name]; ok {
+								mr.mark(fd, idx, method, node.Pos())
+							}
+						}
+					}
 				}
 			}
-			if isTMethodCall(sel.X) {
-				innerSel := sel.X.(*ast.CallExpr).Fun.(*ast.SelectorExpr)
-				if id, ok := innerSel.X.(*ast.Ident); ok {
-					if idx, ok := aliases[id.Name]; ok {
-						mr.mark(fd, idx, method)
+			if callee := mr.resolveCallee(node); callee != nil {
+				edge := callEdge{callee: callee, args: map[int]int{}}
+				for argIdx, arg := range node.Args {
+					if idx := exprToParamIdx(arg, aliases); idx >= 0 {
+						edge.args[argIdx] = idx
 					}
+				}
+				if len(edge.args) > 0 {
+					mr.edges[fd] = append(mr.edges[fd], edge)
 				}
 			}
 		}
@@ -655,46 +705,29 @@ func (mr *methodReach) scanDirect(fd *ast.FuncDecl) {
 	})
 }
 
-func (mr *methodReach) propagate(fd *ast.FuncDecl) bool {
-	aliases := flattenParams(fd.Type.Params)
-	if len(aliases) == 0 {
-		return false
-	}
-
+func (mr *methodReach) propagate() bool {
 	changed := false
-	ast.Inspect(fd.Body, func(n ast.Node) bool {
-		switch node := n.(type) {
-		case *ast.AssignStmt:
-			trackParamFlow(node, aliases)
-		case *ast.CallExpr:
-			callee := mr.resolveCallee(node)
-			if callee == nil {
-				break
-			}
-			calleeReach := mr.params[callee]
+	for fd, edges := range mr.edges {
+		for _, edge := range edges {
+			calleeReach := mr.params[edge.callee]
 			if len(calleeReach) == 0 {
-				break
+				continue
 			}
-			for argIdx, arg := range node.Args {
-				methods := calleeReach[argIdx]
-				if len(methods) == 0 {
-					continue
-				}
-				if idx := exprToParamIdx(arg, aliases); idx >= 0 {
-					for method := range methods {
-						if mr.mark(fd, idx, method) {
+			for argIdx, callerParamIdx := range edge.args {
+				for method, positions := range calleeReach[argIdx] {
+					for pos := range positions {
+						if mr.mark(fd, callerParamIdx, method, pos) {
 							changed = true
 						}
 					}
 				}
 			}
 		}
-		return true
-	})
+	}
 	return changed
 }
 
-func (mr *methodReach) reachedMethods(call *ast.CallExpr, tVars, gotestTVars map[string]bool) map[string]bool {
+func (mr *methodReach) reachedMethods(call *ast.CallExpr, tVars, gotestTVars map[string]bool) map[string]map[token.Pos]bool {
 	callee := mr.resolveCallee(call)
 	if callee == nil {
 		return nil
@@ -703,7 +736,7 @@ func (mr *methodReach) reachedMethods(call *ast.CallExpr, tVars, gotestTVars map
 	if len(calleeReach) == 0 {
 		return nil
 	}
-	var methods map[string]bool
+	var methods map[string]map[token.Pos]bool
 	for argIdx, arg := range call.Args {
 		argMethods := calleeReach[argIdx]
 		if len(argMethods) == 0 {
@@ -717,10 +750,15 @@ func (mr *methodReach) reachedMethods(call *ast.CallExpr, tVars, gotestTVars map
 		}
 		if tainted {
 			if methods == nil {
-				methods = map[string]bool{}
+				methods = map[string]map[token.Pos]bool{}
 			}
-			for m := range argMethods {
-				methods[m] = true
+			for method, positions := range argMethods {
+				if methods[method] == nil {
+					methods[method] = map[token.Pos]bool{}
+				}
+				for pos := range positions {
+					methods[method][pos] = true
+				}
 			}
 		}
 	}
@@ -735,6 +773,10 @@ func flattenParams(params *ast.FieldList) map[string]int {
 	m := map[string]int{}
 	idx := 0
 	for _, field := range params.List {
+		if len(field.Names) == 0 {
+			idx++
+			continue
+		}
 		for _, name := range field.Names {
 			m[name.Name] = idx
 			idx++

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -32,6 +32,9 @@ const (
 	XLifecycle        Rule = "x-lifecycle"
 	AssertionSimplify Rule = "assertion-simplify"
 	SuiteCleanup      Rule = "suite-cleanup"
+	SuiteParallel     Rule = "suite-parallel"
+	SuiteSubtest      Rule = "suite-subtest"
+	TEscape           Rule = "t-escape"
 )
 
 // SkippableRules is the set of rules that support opt-out via skip flags.
@@ -70,6 +73,7 @@ func run(pass *analysis.Pass) (any, error) {
 		checkFocusPrefixes(pass, suites)
 		checkLifecyclePairs(pass, suites)
 		checkSuiteCleanup(pass, insp, suites)
+		checkSuiteDirectCalls(pass, insp, suites)
 	}
 
 	checkOrphanedFiles(pass)
@@ -77,6 +81,7 @@ func run(pass *analysis.Pass) (any, error) {
 	checkTestifyImports(pass)
 	checkPollScope(pass, insp)
 	checkAssertionSimplify(pass, insp)
+	checkTEscape(pass, insp)
 
 	return nil, nil
 }
@@ -402,6 +407,190 @@ func checkSuiteCleanup(pass *analysis.Pass, insp *inspector.Inspector, suites ma
 func reportCleanup(pass *analysis.Pass, pos token.Pos) {
 	report(pass, SuiteCleanup, pos,
 		"use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle")
+}
+
+func checkSuiteDirectCalls(pass *analysis.Pass, insp *inspector.Inspector, suites map[string]*suiteInfo) {
+	insp.Preorder([]ast.Node{(*ast.FuncDecl)(nil)}, func(n ast.Node) {
+		fd := n.(*ast.FuncDecl)
+		if fd.Body == nil || fd.Recv == nil || len(fd.Recv.List) == 0 {
+			return
+		}
+		recvName := receiverTypeName(fd.Recv)
+		if _, ok := suites[recvName]; !ok {
+			return
+		}
+
+		tVars := map[string]bool{}
+
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			if _, ok := n.(*ast.FuncLit); ok {
+				return false
+			}
+			switch node := n.(type) {
+			case *ast.AssignStmt:
+				for i, rhs := range node.Rhs {
+					if i >= len(node.Lhs) {
+						break
+					}
+					if lhs, ok := node.Lhs[i].(*ast.Ident); ok && isTMethodCall(rhs) {
+						tVars[lhs.Name] = true
+					}
+				}
+			case *ast.CallExpr:
+				sel, ok := node.Fun.(*ast.SelectorExpr)
+				if !ok {
+					break
+				}
+				if !isTMethodCall(sel.X) {
+					if id, ok := sel.X.(*ast.Ident); !ok || !tVars[id.Name] {
+						break
+					}
+				}
+				switch sel.Sel.Name {
+				case "Parallel":
+					if len(node.Args) == 0 {
+						report(pass, SuiteParallel, node.Pos(),
+							"use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination")
+					}
+				case "Run":
+					if len(node.Args) >= 2 {
+						report(pass, SuiteSubtest, node.Pos(),
+							"use It or When instead — T.Run bypasses gotest wrapping")
+					}
+				}
+			}
+			return true
+		})
+	})
+}
+
+var tEscapeMethods = map[string]bool{
+	"Errorf": true, "FailNow": true,
+	"Skipf": true, "Setenv": true, "TempDir": true,
+}
+
+var gotestAssertionFuncs = map[string]bool{
+	"True": true, "False": true,
+	"Equal": true, "NotEqual": true,
+	"Greater": true, "GreaterOrEqual": true,
+	"Less": true, "LessOrEqual": true,
+	"Zero": true, "NotZero": true,
+	"Empty": true, "NotEmpty": true,
+	"Len": true, "Contains": true, "NotContains": true,
+	"NoError": true, "Error": true,
+	"ErrorIs": true, "ErrorContains": true,
+	"Regexp": true, "MatchSnapshot": true,
+	"Eventually": true, "Consistently": true,
+}
+
+var tEscapeReportOnly = map[string]bool{
+	"Skip": true, "SkipNow": true,
+}
+
+func checkTEscape(pass *analysis.Pass, insp *inspector.Inspector) {
+	insp.Preorder([]ast.Node{(*ast.FuncDecl)(nil)}, func(n ast.Node) {
+		fd := n.(*ast.FuncDecl)
+		if fd.Body == nil {
+			return
+		}
+
+		tVars := map[string]bool{}
+
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.AssignStmt:
+				for i, rhs := range node.Rhs {
+					if i >= len(node.Lhs) {
+						break
+					}
+					if lhs, ok := node.Lhs[i].(*ast.Ident); ok && isTMethodCall(rhs) {
+						tVars[lhs.Name] = true
+					}
+				}
+			case *ast.CallExpr:
+				reportTEscape(pass, node, tVars)
+			}
+			return true
+		})
+	})
+}
+
+func reportTEscape(pass *analysis.Pass, call *ast.CallExpr, tVars map[string]bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+
+	if tEscapeMethods[sel.Sel.Name] || tEscapeReportOnly[sel.Sel.Name] {
+		isDirect := isTMethodCall(sel.X)
+		isAlias := false
+		if !isDirect {
+			if id, ok := sel.X.(*ast.Ident); ok && tVars[id.Name] {
+				isAlias = true
+			}
+		}
+		if isDirect || isAlias {
+			if tEscapeReportOnly[sel.Sel.Name] {
+				report(pass, TEscape, call.Pos(),
+					"Skipf is available on gotest.T — unnecessary T escape")
+				return
+			}
+			if isDirect {
+				inner := sel.X.(*ast.CallExpr)
+				innerSel := inner.Fun.(*ast.SelectorExpr)
+				reportWithFix(pass, TEscape, call.Pos(),
+					[]analysis.SuggestedFix{{
+						Message: fmt.Sprintf("call %s directly", sel.Sel.Name),
+						TextEdits: []analysis.TextEdit{{
+							Pos:     innerSel.X.End(),
+							End:     inner.End(),
+							NewText: []byte(""),
+						}},
+					}},
+					"%s is available on gotest.T — unnecessary T escape", sel.Sel.Name)
+			} else {
+				report(pass, TEscape, call.Pos(),
+					"%s is available on gotest.T — unnecessary T escape", sel.Sel.Name)
+			}
+			return
+		}
+	}
+
+	if gotestAssertionFuncs[sel.Sel.Name] && isGotestPkgRef(pass, sel.X) && len(call.Args) > 0 {
+		arg := call.Args[0]
+		if inner, ok := arg.(*ast.CallExpr); ok && isTMethodCall(inner) {
+			innerSel := inner.Fun.(*ast.SelectorExpr)
+			reportWithFix(pass, TEscape, inner.Pos(),
+				[]analysis.SuggestedFix{{
+					Message: "pass gotest.T directly",
+					TextEdits: []analysis.TextEdit{{
+						Pos:     innerSel.X.End(),
+						End:     inner.End(),
+						NewText: []byte(""),
+					}},
+				}},
+				"pass gotest.T directly to %s — unnecessary T escape", sel.Sel.Name)
+		} else if id, ok := arg.(*ast.Ident); ok && tVars[id.Name] {
+			report(pass, TEscape, arg.Pos(),
+				"pass gotest.T directly to %s — unnecessary T escape", sel.Sel.Name)
+		}
+	}
+}
+
+func isGotestPkgRef(pass *analysis.Pass, expr ast.Expr) bool {
+	id, ok := expr.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	obj := pass.TypesInfo.Uses[id]
+	if obj == nil {
+		return false
+	}
+	pkgName, ok := obj.(*types.PkgName)
+	if !ok {
+		return false
+	}
+	return pkgName.Imported().Path() == "github.com/mvrahden/go-test/pkg/gotest"
 }
 
 // --- cleanup reachability analysis ---

--- a/internal/lint/lint_suite_test.go
+++ b/internal/lint/lint_suite_test.go
@@ -46,6 +46,12 @@ func (s *LintTestSuite) TestAnalyzer(t *gotest.T) {
 		})
 	})
 
+	t.When("suite cleanup", func(w *gotest.T) {
+		w.It("detects .T().Cleanup in suite methods", func(it *gotest.T) {
+			analysistest.Run(it.T(), testdata, lint.Analyzer, "withcleanup")
+		})
+	})
+
 	t.When("file-level nolint", func(w *gotest.T) {
 		w.It("respects file-level nolint", func(it *gotest.T) {
 			analysistest.Run(it.T(), testdata, lint.Analyzer, "withnolint_file")

--- a/internal/lint/lint_suite_test.go
+++ b/internal/lint/lint_suite_test.go
@@ -52,6 +52,18 @@ func (s *LintTestSuite) TestAnalyzer(t *gotest.T) {
 		})
 	})
 
+	t.When("suite direct calls", func(w *gotest.T) {
+		w.It("detects T.Parallel and T.Run in suite methods", func(it *gotest.T) {
+			analysistest.Run(it.T(), testdata, lint.Analyzer, "withdirectcalls")
+		})
+	})
+
+	t.When("t escape", func(w *gotest.T) {
+		w.It("detects unnecessary .T() escape and applies fixes", func(it *gotest.T) {
+			analysistest.RunWithSuggestedFixes(it.T(), testdata, lint.Analyzer, "withtescape")
+		})
+	})
+
 	t.When("file-level nolint", func(w *gotest.T) {
 		w.It("respects file-level nolint", func(it *gotest.T) {
 			analysistest.Run(it.T(), testdata, lint.Analyzer, "withnolint_file")

--- a/internal/lint/testdata/src/github.com/mvrahden/go-test/pkg/gotest/gotest.go
+++ b/internal/lint/testdata/src/github.com/mvrahden/go-test/pkg/gotest/gotest.go
@@ -1,6 +1,9 @@
 package gotest
 
-import "time"
+import (
+	"testing"
+	"time"
+)
 
 type R struct{}
 
@@ -14,6 +17,7 @@ type T struct{}
 
 func (t *T) Errorf(string, ...any) {}
 func (t *T) FailNow()              {}
+func (t *T) T() *testing.T         { return nil }
 
 type testingT interface {
 	Errorf(format string, args ...any)

--- a/internal/lint/testdata/src/github.com/mvrahden/go-test/pkg/gotest/gotest.go
+++ b/internal/lint/testdata/src/github.com/mvrahden/go-test/pkg/gotest/gotest.go
@@ -15,7 +15,7 @@ func (r *R) Message() string       { return "" }
 
 type T struct{}
 
-func (t *T) Errorf(string, ...any)  {}
+func (t *T) Errorf(string, ...any) {}
 func (t *T) FailNow()              {}
 func (t *T) Skipf(string, ...any)  {}
 func (t *T) Setenv(string, string) {}

--- a/internal/lint/testdata/src/github.com/mvrahden/go-test/pkg/gotest/gotest.go
+++ b/internal/lint/testdata/src/github.com/mvrahden/go-test/pkg/gotest/gotest.go
@@ -15,9 +15,14 @@ func (r *R) Message() string       { return "" }
 
 type T struct{}
 
-func (t *T) Errorf(string, ...any) {}
+func (t *T) Errorf(string, ...any)  {}
 func (t *T) FailNow()              {}
+func (t *T) Skipf(string, ...any)  {}
+func (t *T) Setenv(string, string) {}
+func (t *T) TempDir() string       { return "" }
 func (t *T) T() *testing.T         { return nil }
+func (t *T) It(string, func(*T))   {}
+func (t *T) When(string, func(*T)) {}
 
 type testingT interface {
 	Errorf(format string, args ...any)

--- a/internal/lint/testdata/src/sample/gotest_psuite_test.go
+++ b/internal/lint/testdata/src/sample/gotest_psuite_test.go
@@ -1,1 +1,1 @@
-package sample // want `generated file gotest_psuite_test\.go should not be checked into version control`
+package sample // want `generated file gotest_psuite_test.go should not be checked into version control`

--- a/internal/lint/testdata/src/sample/sample_test.go
+++ b/internal/lint/testdata/src/sample/sample_test.go
@@ -8,43 +8,43 @@ import (
 
 type UserServiceTestSuite struct{}
 
-func (s *UserServiceTestSuite) TestCreate()                                  {} // want `test method UserServiceTestSuite\.TestCreate has wrong signature`
+func (s *UserServiceTestSuite) TestCreate()                                  {} // want `test method UserServiceTestSuite.TestCreate has wrong signature`
 func (s *UserServiceTestSuite) TestCorrectSig(t *gotest.T)                   {}
 func (s *UserServiceTestSuite) TestContextualSig(t *gotest.T, ctx *struct{}) {}
 func (s *UserServiceTestSuite) TestStdlibSig(t *testing.T)                   {}
 func (s *UserServiceTestSuite) TestStdlibCtxSig(t *testing.T, ctx *struct{}) {}
 func (s *UserServiceTestSuite) BeforeAll()                                   {}
 func (s *UserServiceTestSuite) AfterAll()                                    {}
-func (s *UserServiceTestSuite) X_AfterEach()                                 {} // want `X_ prefix on lifecycle hook UserServiceTestSuite\.X_AfterEach has no effect`
+func (s *UserServiceTestSuite) X_AfterEach()                                 {} // want `X_ prefix on lifecycle hook UserServiceTestSuite.X_AfterEach has no effect`
 func (s *UserServiceTestSuite) BeforreAll()                                  {} // want `method BeforreAll on suite UserServiceTestSuite is similar to lifecycle hook BeforeAll`
-func (s UserServiceTestSuite) TestByValue()                                  {} // want `suite method UserServiceTestSuite\.TestByValue should use a pointer receiver` `test method UserServiceTestSuite\.TestByValue has wrong signature`
-func (s *UserServiceTestSuite) F_TestFocused()                               {} // want `focused method UserServiceTestSuite\.F_TestFocused should not be committed` `test method UserServiceTestSuite\.F_TestFocused has wrong signature`
+func (s UserServiceTestSuite) TestByValue()                                  {} // want `suite method UserServiceTestSuite.TestByValue should use a pointer receiver` `test method UserServiceTestSuite.TestByValue has wrong signature`
+func (s *UserServiceTestSuite) F_TestFocused()                               {} // want `focused method UserServiceTestSuite.F_TestFocused should not be committed` `test method UserServiceTestSuite.F_TestFocused has wrong signature`
 
 type F_OrderTestSuite struct{} // want `focused suite F_OrderTestSuite should not be committed`
 
-func (s *F_OrderTestSuite) TestList() {} // want `test method F_OrderTestSuite\.TestList has wrong signature`
+func (s *F_OrderTestSuite) TestList() {} // want `test method F_OrderTestSuite.TestList has wrong signature`
 
 type PaymentTestSuite struct{} // want `suite PaymentTestSuite has BeforeAll but no AfterAll`
 
-func (s *PaymentTestSuite) TestCharge() {} // want `test method PaymentTestSuite\.TestCharge has wrong signature`
+func (s *PaymentTestSuite) TestCharge() {} // want `test method PaymentTestSuite.TestCharge has wrong signature`
 func (s *PaymentTestSuite) BeforeAll()  {}
 
 // X_ prefix is allowed — skip markers don't hide other tests behind a green CI run.
 type X_InactiveTestSuite struct{}
 
-func (s *X_InactiveTestSuite) TestSkipped() {} // want `test method X_InactiveTestSuite\.TestSkipped has wrong signature`
+func (s *X_InactiveTestSuite) TestSkipped() {} // want `test method X_InactiveTestSuite.TestSkipped has wrong signature`
 
 // Generic suite with single type param — pointer receiver must be recognized.
 type TypedTestSuite[T any] struct{}
 
-func (s *TypedTestSuite[T]) TestTyped()            {} // want `test method TypedTestSuite\.TestTyped has wrong signature`
-func (s TypedTestSuite[T]) TestTypedByValue()      {} // want `suite method TypedTestSuite\.TestTypedByValue should use a pointer receiver` `test method TypedTestSuite\.TestTypedByValue has wrong signature`
-func (s *TypedTestSuite[T]) F_TestFocusedGeneric() {} // want `focused method TypedTestSuite\.F_TestFocusedGeneric should not be committed` `test method TypedTestSuite\.F_TestFocusedGeneric has wrong signature`
+func (s *TypedTestSuite[T]) TestTyped()            {} // want `test method TypedTestSuite.TestTyped has wrong signature`
+func (s TypedTestSuite[T]) TestTypedByValue()      {} // want `suite method TypedTestSuite.TestTypedByValue should use a pointer receiver` `test method TypedTestSuite.TestTypedByValue has wrong signature`
+func (s *TypedTestSuite[T]) F_TestFocusedGeneric() {} // want `focused method TypedTestSuite.F_TestFocusedGeneric should not be committed` `test method TypedTestSuite.F_TestFocusedGeneric has wrong signature`
 
 // Generic suite with multiple type params — pointer receiver must be recognized.
 type PairTestSuite[K comparable, V any] struct{}
 
-func (s *PairTestSuite[K, V]) TestPair()       {} // want `test method PairTestSuite\.TestPair has wrong signature`
-func (s PairTestSuite[K, V]) TestPairByValue() {} // want `suite method PairTestSuite\.TestPairByValue should use a pointer receiver` `test method PairTestSuite\.TestPairByValue has wrong signature`
+func (s *PairTestSuite[K, V]) TestPair()       {} // want `test method PairTestSuite.TestPair has wrong signature`
+func (s PairTestSuite[K, V]) TestPairByValue() {} // want `suite method PairTestSuite.TestPairByValue should use a pointer receiver` `test method PairTestSuite.TestPairByValue has wrong signature`
 
 func TestStdlib(t *testing.T) {} // want `stdlib test TestStdlib — consider using a gotest suite`

--- a/internal/lint/testdata/src/withcleanup/withcleanup_test.go
+++ b/internal/lint/testdata/src/withcleanup/withcleanup_test.go
@@ -23,20 +23,33 @@ func (s *ResourceTestSuite) TestIndirectCleanup(t *gotest.T) {
 }
 
 func (s *ResourceTestSuite) TestHelperTestingT(t *gotest.T) {
-	helperDirect(t.T()) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+	helperDirect(t.T())
 }
 
 func (s *ResourceTestSuite) TestHelperTestingTIndirect(t *gotest.T) {
 	tt := t.T()
-	helperDirect(tt) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+	helperDirect(tt)
 }
 
 func (s *ResourceTestSuite) TestNestedHelpers(t *gotest.T) {
-	helperNested(t.T()) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+	helperNested(t.T())
 }
 
 func (s *ResourceTestSuite) TestGoTestTWrapper(t *gotest.T) {
-	wrapperGoTestT(t) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+	wrapperGoTestT(t)
+}
+
+func (s *ResourceTestSuite) TestHelperCleanupSecondParam(t *gotest.T) {
+	helperCleanupSecondParam("ctx", t.T())
+}
+
+func (s *ResourceTestSuite) TestDeepNestedCleanup(t *gotest.T) {
+	deepOuterCleanup(t.T())
+}
+
+func (s *ResourceTestSuite) TestMethodHelperCleanup(t *gotest.T) {
+	var h cleanupHelper
+	h.doCleanup(t.T())
 }
 
 func (s *ResourceTestSuite) TestNoCleanup(t *gotest.T) {
@@ -52,17 +65,41 @@ func helperGoTestT(t *gotest.T) { //nolint:unused
 	t.T().Cleanup(func() {})
 }
 
-// Helper with *testing.T — .Cleanup() caught only via transitive analysis.
-func helperDirect(t *testing.T) {
+// Standalone functions must not be flagged for suite-only rules.
+func standaloneCleanup(t *testing.T) { //nolint:unused
 	t.Cleanup(func() {})
 }
 
-// Nested chain: passes *testing.T to helperDirect.
+func helperDirect(t *testing.T) {
+	t.Cleanup(func() {}) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+}
+
 func helperNested(t *testing.T) {
 	helperDirect(t)
 }
 
-// Takes *gotest.T, bridges to *testing.T helper via .T().
 func wrapperGoTestT(t *gotest.T) {
 	helperDirect(t.T())
+}
+
+func helperCleanupSecondParam(name string, t *testing.T) {
+	t.Cleanup(func() {}) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+}
+
+func deepLeafCleanup(t *testing.T) {
+	t.Cleanup(func() {}) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+}
+
+func deepMiddleCleanup(t *testing.T) {
+	deepLeafCleanup(t)
+}
+
+func deepOuterCleanup(t *testing.T) {
+	deepMiddleCleanup(t)
+}
+
+type cleanupHelper struct{}
+
+func (h *cleanupHelper) doCleanup(t *testing.T) {
+	t.Cleanup(func() {}) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
 }

--- a/internal/lint/testdata/src/withcleanup/withcleanup_test.go
+++ b/internal/lint/testdata/src/withcleanup/withcleanup_test.go
@@ -46,9 +46,10 @@ func (s *ResourceTestSuite) TestNoCleanup(t *gotest.T) {
 func (s *ResourceTestSuite) BeforeEach() {}
 func (s *ResourceTestSuite) AfterEach()  {}
 
-// Helper with *gotest.T — .T().Cleanup() caught by direct detection.
+// Helper with *gotest.T — not flagged directly; only call sites in suite
+// methods are flagged via interprocedural analysis.
 func helperGoTestT(t *gotest.T) { //nolint:unused
-	t.T().Cleanup(func() {}) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+	t.T().Cleanup(func() {})
 }
 
 // Helper with *testing.T — .Cleanup() caught only via transitive analysis.

--- a/internal/lint/testdata/src/withcleanup/withcleanup_test.go
+++ b/internal/lint/testdata/src/withcleanup/withcleanup_test.go
@@ -1,0 +1,67 @@
+package withcleanup
+
+import (
+	"testing"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type ResourceTestSuite struct{}
+
+func (s *ResourceTestSuite) TestDirectCleanup(t *gotest.T) {
+	t.T().Cleanup(func() {}) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+}
+
+func (s *ResourceTestSuite) TestMultipleCleanups(t *gotest.T) {
+	t.T().Cleanup(func() {}) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+	t.T().Cleanup(func() {}) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+}
+
+func (s *ResourceTestSuite) TestIndirectCleanup(t *gotest.T) {
+	tt := t.T()
+	tt.Cleanup(func() {}) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+}
+
+func (s *ResourceTestSuite) TestHelperTestingT(t *gotest.T) {
+	helperDirect(t.T()) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+}
+
+func (s *ResourceTestSuite) TestHelperTestingTIndirect(t *gotest.T) {
+	tt := t.T()
+	helperDirect(tt) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+}
+
+func (s *ResourceTestSuite) TestNestedHelpers(t *gotest.T) {
+	helperNested(t.T()) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+}
+
+func (s *ResourceTestSuite) TestGoTestTWrapper(t *gotest.T) {
+	wrapperGoTestT(t) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+}
+
+func (s *ResourceTestSuite) TestNoCleanup(t *gotest.T) {
+	gotest.True(t, true)
+}
+
+func (s *ResourceTestSuite) BeforeEach() {}
+func (s *ResourceTestSuite) AfterEach()  {}
+
+// Helper with *gotest.T — .T().Cleanup() caught by direct detection.
+func helperGoTestT(t *gotest.T) { //nolint:unused
+	t.T().Cleanup(func() {}) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
+}
+
+// Helper with *testing.T — .Cleanup() caught only via transitive analysis.
+func helperDirect(t *testing.T) {
+	t.Cleanup(func() {})
+}
+
+// Nested chain: passes *testing.T to helperDirect.
+func helperNested(t *testing.T) {
+	helperDirect(t)
+}
+
+// Takes *gotest.T, bridges to *testing.T helper via .T().
+func wrapperGoTestT(t *gotest.T) {
+	helperDirect(t.T())
+}

--- a/internal/lint/testdata/src/withdirectcalls/withdirectcalls_test.go
+++ b/internal/lint/testdata/src/withdirectcalls/withdirectcalls_test.go
@@ -40,9 +40,103 @@ func (s *DirectCallTestSuite) TestRunInClosure(t *gotest.T) {
 	}
 }
 
+func (s *DirectCallTestSuite) TestHelperParallel(t *gotest.T) {
+	helperParallel(t.T())
+}
+
+func (s *DirectCallTestSuite) TestHelperRun(t *gotest.T) {
+	helperRun(t.T())
+}
+
+func (s *DirectCallTestSuite) TestHelperGotestParallel(t *gotest.T) {
+	helperGotestParallel(t)
+}
+
+func (s *DirectCallTestSuite) TestHelperGotestRun(t *gotest.T) {
+	helperGotestRun(t)
+}
+
+func (s *DirectCallTestSuite) TestChainedParallel(t *gotest.T) {
+	wrapperParallel(t)
+}
+
+func (s *DirectCallTestSuite) TestHelperParallelSecondParam(t *gotest.T) {
+	helperParallelSecondParam("ctx", t.T())
+}
+
+func (s *DirectCallTestSuite) TestDeepChainParallel(t *gotest.T) {
+	deepOuterParallel(t.T())
+}
+
+func (s *DirectCallTestSuite) TestMethodHelperParallel(t *gotest.T) {
+	var h parallelHelper
+	h.doParallel(t.T())
+}
+
+func (s *DirectCallTestSuite) TestHelperParallelInClosureScope(t *gotest.T) {
+	_ = func() {
+		helperParallelClosureOnly(t.T())
+	}
+}
+
 func (s *DirectCallTestSuite) TestClean(t *gotest.T) {
 	gotest.True(t, true)
 }
 
 func (s *DirectCallTestSuite) BeforeEach() {}
 func (s *DirectCallTestSuite) AfterEach()  {}
+
+func helperParallel(t *testing.T) {
+	t.Parallel() // want `use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination`
+}
+
+func helperRun(t *testing.T) {
+	t.Run("sub", func(st *testing.T) {}) // want `use It or When instead — T.Run bypasses gotest wrapping`
+}
+
+func helperGotestParallel(t *gotest.T) {
+	t.T().Parallel() // want `use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination`
+}
+
+func helperGotestRun(t *gotest.T) {
+	t.T().Run("sub", func(st *testing.T) {}) // want `use It or When instead — T.Run bypasses gotest wrapping`
+}
+
+func wrapperParallel(t *gotest.T) {
+	helperParallel(t.T())
+}
+
+// Standalone functions must not be flagged for suite-only rules.
+func standaloneParallel(t *testing.T) { //nolint:unused
+	t.Parallel()
+}
+
+func standaloneRun(t *testing.T) { //nolint:unused
+	t.Run("sub", func(st *testing.T) {})
+}
+
+func helperParallelSecondParam(name string, t *testing.T) {
+	t.Parallel() // want `use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination`
+}
+
+func deepLeafParallel(t *testing.T) {
+	t.Parallel() // want `use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination`
+}
+
+func deepMiddleParallel(t *testing.T) {
+	deepLeafParallel(t)
+}
+
+func deepOuterParallel(t *testing.T) {
+	deepMiddleParallel(t)
+}
+
+type parallelHelper struct{}
+
+func (h *parallelHelper) doParallel(t *testing.T) {
+	t.Parallel() // want `use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination`
+}
+
+func helperParallelClosureOnly(t *testing.T) {
+	t.Parallel()
+}

--- a/internal/lint/testdata/src/withdirectcalls/withdirectcalls_test.go
+++ b/internal/lint/testdata/src/withdirectcalls/withdirectcalls_test.go
@@ -26,17 +26,15 @@ func (s *DirectCallTestSuite) TestRunIndirect(t *gotest.T) {
 	tt.Run("sub", func(st *testing.T) {}) // want `use It or When instead — T.Run bypasses gotest wrapping`
 }
 
-// Parallel inside closure is OK — scoped to subtest
 func (s *DirectCallTestSuite) TestParallelInClosure(t *gotest.T) {
 	_ = func() {
-		t.T().Parallel()
+		t.T().Parallel() // want `use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination`
 	}
 }
 
-// Run inside closure is OK — likely inside It/When callback
 func (s *DirectCallTestSuite) TestRunInClosure(t *gotest.T) {
 	_ = func() {
-		t.T().Run("sub", func(st *testing.T) {})
+		t.T().Run("sub", func(st *testing.T) {}) // want `use It or When instead — T.Run bypasses gotest wrapping`
 	}
 }
 
@@ -138,5 +136,5 @@ func (h *parallelHelper) doParallel(t *testing.T) {
 }
 
 func helperParallelClosureOnly(t *testing.T) {
-	t.Parallel()
+	t.Parallel() // want `use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination`
 }

--- a/internal/lint/testdata/src/withdirectcalls/withdirectcalls_test.go
+++ b/internal/lint/testdata/src/withdirectcalls/withdirectcalls_test.go
@@ -1,0 +1,48 @@
+package withdirectcalls
+
+import (
+	"testing"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type DirectCallTestSuite struct{}
+
+func (s *DirectCallTestSuite) TestParallelDirect(t *gotest.T) {
+	t.T().Parallel() // want `use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination`
+}
+
+func (s *DirectCallTestSuite) TestParallelIndirect(t *gotest.T) {
+	tt := t.T()
+	tt.Parallel() // want `use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination`
+}
+
+func (s *DirectCallTestSuite) TestRunDirect(t *gotest.T) {
+	t.T().Run("sub", func(st *testing.T) {}) // want `use It or When instead — T.Run bypasses gotest wrapping`
+}
+
+func (s *DirectCallTestSuite) TestRunIndirect(t *gotest.T) {
+	tt := t.T()
+	tt.Run("sub", func(st *testing.T) {}) // want `use It or When instead — T.Run bypasses gotest wrapping`
+}
+
+// Parallel inside closure is OK — scoped to subtest
+func (s *DirectCallTestSuite) TestParallelInClosure(t *gotest.T) {
+	_ = func() {
+		t.T().Parallel()
+	}
+}
+
+// Run inside closure is OK — likely inside It/When callback
+func (s *DirectCallTestSuite) TestRunInClosure(t *gotest.T) {
+	_ = func() {
+		t.T().Run("sub", func(st *testing.T) {})
+	}
+}
+
+func (s *DirectCallTestSuite) TestClean(t *gotest.T) {
+	gotest.True(t, true)
+}
+
+func (s *DirectCallTestSuite) BeforeEach() {}
+func (s *DirectCallTestSuite) AfterEach()  {}

--- a/internal/lint/testdata/src/withsimplify/withsimplify_test.go
+++ b/internal/lint/testdata/src/withsimplify/withsimplify_test.go
@@ -79,11 +79,11 @@ func TestTrueLen(t *testing.T) {
 
 func TestTrueCalls(t *testing.T) {
 	s := "hello world"
-	gotest.True(t, strings.Contains(s, "hello"))    // want `use Contains instead of True for strings\.Contains call`
-	gotest.True(t, errors.Is(errors.New("x"), nil)) // want `use ErrorIs instead of True for errors\.Is call`
+	gotest.True(t, strings.Contains(s, "hello"))    // want `use Contains instead of True for strings.Contains call`
+	gotest.True(t, errors.Is(errors.New("x"), nil)) // want `use ErrorIs instead of True for errors.Is call`
 	re := regexp.MustCompile(".*")
 	gotest.True(t, re.MatchString("hello")) // want `use Regexp instead of True for MatchString call`
-	gotest.True(t, reflect.DeepEqual(1, 2)) // want `use Equal instead of True for reflect\.DeepEqual call`
+	gotest.True(t, reflect.DeepEqual(1, 2)) // want `use Equal instead of True for reflect.DeepEqual call`
 }
 
 // === True with negation ===
@@ -93,7 +93,7 @@ func TestTrueNegation(t *testing.T) {
 	gotest.True(t, !b) // want `use False instead of True for negation`
 
 	s := "hello"
-	gotest.True(t, !strings.Contains(s, "z")) // want `use NotContains instead of True for negated strings\.Contains call`
+	gotest.True(t, !strings.Contains(s, "z")) // want `use NotContains instead of True for negated strings.Contains call`
 }
 
 // === False with binary comparisons ===
@@ -160,8 +160,8 @@ func TestFalseLen(t *testing.T) {
 
 func TestFalseCalls(t *testing.T) {
 	s := "hello world"
-	gotest.False(t, strings.Contains(s, "xyz")) // want `use NotContains instead of False for strings\.Contains call`
-	gotest.False(t, reflect.DeepEqual(1, 2))    // want `use NotEqual instead of False for reflect\.DeepEqual call`
+	gotest.False(t, strings.Contains(s, "xyz")) // want `use NotContains instead of False for strings.Contains call`
+	gotest.False(t, reflect.DeepEqual(1, 2))    // want `use NotEqual instead of False for reflect.DeepEqual call`
 }
 
 // === False with negation ===
@@ -171,7 +171,7 @@ func TestFalseNegation(t *testing.T) {
 	gotest.False(t, !b) // want `use True instead of False for negation`
 
 	s := "hello"
-	gotest.False(t, !strings.Contains(s, "h")) // want `use Contains instead of False for negated strings\.Contains call`
+	gotest.False(t, !strings.Contains(s, "h")) // want `use Contains instead of False for negated strings.Contains call`
 }
 
 // === Equal with special values ===
@@ -299,7 +299,7 @@ func TestZeroError(t *testing.T) {
 
 func TestContainsErrMsg(t *testing.T) {
 	err := errors.New("something failed")
-	gotest.Contains(t, err.Error(), "failed") // want `use ErrorContains instead of Contains for err\.Error\(\) contains check`
+	gotest.Contains(t, err.Error(), "failed") // want `use ErrorContains instead of Contains for err.Error\(\) contains check`
 }
 
 // === Correct usage — no diagnostics ===

--- a/internal/lint/testdata/src/withsimplify/withsimplify_test.go.golden
+++ b/internal/lint/testdata/src/withsimplify/withsimplify_test.go.golden
@@ -77,11 +77,11 @@ func TestTrueLen(t *testing.T) {
 
 func TestTrueCalls(t *testing.T) {
 	s := "hello world"
-	gotest.Contains(t, s, "hello")          // want `use Contains instead of True for strings\.Contains call`
-	gotest.ErrorIs(t, errors.New("x"), nil) // want `use ErrorIs instead of True for errors\.Is call`
+	gotest.Contains(t, s, "hello")          // want `use Contains instead of True for strings.Contains call`
+	gotest.ErrorIs(t, errors.New("x"), nil) // want `use ErrorIs instead of True for errors.Is call`
 	re := regexp.MustCompile(".*")
 	gotest.Regexp(t, re, "hello") // want `use Regexp instead of True for MatchString call`
-	gotest.Equal(t, 1, 2)         // want `use Equal instead of True for reflect\.DeepEqual call`
+	gotest.Equal(t, 1, 2)         // want `use Equal instead of True for reflect.DeepEqual call`
 }
 
 // === True with negation ===
@@ -91,7 +91,7 @@ func TestTrueNegation(t *testing.T) {
 	gotest.False(t, b) // want `use False instead of True for negation`
 
 	s := "hello"
-	gotest.NotContains(t, s, "z") // want `use NotContains instead of True for negated strings\.Contains call`
+	gotest.NotContains(t, s, "z") // want `use NotContains instead of True for negated strings.Contains call`
 }
 
 // === False with binary comparisons ===
@@ -158,8 +158,8 @@ func TestFalseLen(t *testing.T) {
 
 func TestFalseCalls(t *testing.T) {
 	s := "hello world"
-	gotest.NotContains(t, s, "xyz") // want `use NotContains instead of False for strings\.Contains call`
-	gotest.NotEqual(t, 1, 2)        // want `use NotEqual instead of False for reflect\.DeepEqual call`
+	gotest.NotContains(t, s, "xyz") // want `use NotContains instead of False for strings.Contains call`
+	gotest.NotEqual(t, 1, 2)        // want `use NotEqual instead of False for reflect.DeepEqual call`
 }
 
 // === False with negation ===
@@ -169,7 +169,7 @@ func TestFalseNegation(t *testing.T) {
 	gotest.True(t, b) // want `use True instead of False for negation`
 
 	s := "hello"
-	gotest.Contains(t, s, "h") // want `use Contains instead of False for negated strings\.Contains call`
+	gotest.Contains(t, s, "h") // want `use Contains instead of False for negated strings.Contains call`
 }
 
 // === Equal with special values ===
@@ -297,7 +297,7 @@ func TestZeroError(t *testing.T) {
 
 func TestContainsErrMsg(t *testing.T) {
 	err := errors.New("something failed")
-	gotest.ErrorContains(t, err, "failed") // want `use ErrorContains instead of Contains for err\.Error\(\) contains check`
+	gotest.ErrorContains(t, err, "failed") // want `use ErrorContains instead of Contains for err.Error\(\) contains check`
 }
 
 // === Correct usage — no diagnostics ===

--- a/internal/lint/testdata/src/withtescape/withtescape_test.go
+++ b/internal/lint/testdata/src/withtescape/withtescape_test.go
@@ -1,6 +1,8 @@
 package withtescape
 
 import (
+	"testing"
+
 	"github.com/mvrahden/go-test/pkg/gotest"
 )
 
@@ -9,8 +11,8 @@ type EscapeTestSuite struct{}
 func (s *EscapeTestSuite) TestMethodEscape(t *gotest.T) {
 	t.T().Errorf("msg")          // want `Errorf is available on gotest.T — unnecessary T escape`
 	t.T().FailNow()              // want `FailNow is available on gotest.T — unnecessary T escape`
-	t.T().Skip()                 // want `Skipf is available on gotest.T — unnecessary T escape`
-	t.T().SkipNow()              // want `Skipf is available on gotest.T — unnecessary T escape`
+	t.T().Skip()                 // want `must use Skipf instead — unnecessary T escape`
+	t.T().SkipNow()              // want `must use Skipf instead — unnecessary T escape`
 	t.T().Skipf("reason")        // want `Skipf is available on gotest.T — unnecessary T escape`
 	t.T().Setenv("KEY", "VALUE") // want `Setenv is available on gotest.T — unnecessary T escape`
 	_ = t.T().TempDir()          // want `TempDir is available on gotest.T — unnecessary T escape`
@@ -19,8 +21,8 @@ func (s *EscapeTestSuite) TestMethodEscape(t *gotest.T) {
 func (s *EscapeTestSuite) TestAliasEscape(t *gotest.T) {
 	tt := t.T()
 	tt.Errorf("msg")      // want `Errorf is available on gotest.T — unnecessary T escape`
-	tt.Skip()             // want `Skipf is available on gotest.T — unnecessary T escape`
-	tt.SkipNow()          // want `Skipf is available on gotest.T — unnecessary T escape`
+	tt.Skip()             // want `must use Skipf instead — unnecessary T escape`
+	tt.SkipNow()          // want `must use Skipf instead — unnecessary T escape`
 	gotest.True(tt, true) // want `pass gotest.T directly to True — unnecessary T escape`
 }
 
@@ -37,6 +39,95 @@ func (s *EscapeTestSuite) TestNoEscape(t *gotest.T) {
 func (s *EscapeTestSuite) BeforeEach() {}
 func (s *EscapeTestSuite) AfterEach()  {}
 
+func (s *EscapeTestSuite) TestInterproceduralTestingT(t *gotest.T) {
+	helperErrorf(t.T())
+}
+
+func (s *EscapeTestSuite) TestInterproceduralGotestT(t *gotest.T) {
+	helperGotestErrorf(t)
+}
+
+func (s *EscapeTestSuite) TestInterproceduralChain(t *gotest.T) {
+	wrapperErrorf(t)
+}
+
+func (s *EscapeTestSuite) TestInterproceduralMultiMethod(t *gotest.T) {
+	helperMultiMethod(t.T())
+}
+
+func (s *EscapeTestSuite) TestInterproceduralNonFirstParam(t *gotest.T) {
+	helperNonFirstParam("ctx", t.T())
+}
+
+func (s *EscapeTestSuite) TestInterproceduralDeepChain(t *gotest.T) {
+	deepOuterErrorf(t.T())
+}
+
+func (s *EscapeTestSuite) TestInterproceduralMethodHelper(t *gotest.T) {
+	var h escapeHelper
+	h.doErrorf(t.T())
+}
+
 func standaloneEscape(t *gotest.T) { //nolint:unused
 	t.T().Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
+}
+
+func standaloneAssertionEscape(t *gotest.T) { //nolint:unused
+	gotest.True(t.T(), true) // want `pass gotest.T directly to True — unnecessary T escape`
+}
+
+// Standalone functions must not be flagged for suite-only rules.
+func standaloneCleanup(t *gotest.T) { //nolint:unused
+	t.T().Cleanup(func() {})
+}
+
+func standaloneParallel(t *gotest.T) { //nolint:unused
+	t.T().Parallel()
+}
+
+func standaloneRun(t *gotest.T) { //nolint:unused
+	t.T().Run("sub", func(st *testing.T) {})
+}
+
+func helperErrorf(t *testing.T) {
+	t.Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
+}
+
+func helperGotestErrorf(t *gotest.T) {
+	t.T().Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
+}
+
+func wrapperErrorf(t *gotest.T) {
+	helperErrorf(t.T())
+}
+
+func helperMultiMethod(t *testing.T) {
+	t.FailNow()              // want `FailNow is available on gotest.T — unnecessary T escape`
+	t.Skip()                 // want `must use Skipf instead — unnecessary T escape`
+	t.SkipNow()              // want `must use Skipf instead — unnecessary T escape`
+	t.Skipf("reason")        // want `Skipf is available on gotest.T — unnecessary T escape`
+	t.Setenv("KEY", "VALUE") // want `Setenv is available on gotest.T — unnecessary T escape`
+	_ = t.TempDir()          // want `TempDir is available on gotest.T — unnecessary T escape`
+}
+
+func helperNonFirstParam(name string, t *testing.T) {
+	t.Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
+}
+
+func deepLeafErrorf(t *testing.T) {
+	t.Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
+}
+
+func deepMiddleErrorf(t *testing.T) {
+	deepLeafErrorf(t)
+}
+
+func deepOuterErrorf(t *testing.T) {
+	deepMiddleErrorf(t)
+}
+
+type escapeHelper struct{}
+
+func (h *escapeHelper) doErrorf(t *testing.T) {
+	t.Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
 }

--- a/internal/lint/testdata/src/withtescape/withtescape_test.go
+++ b/internal/lint/testdata/src/withtescape/withtescape_test.go
@@ -1,0 +1,42 @@
+package withtescape
+
+import (
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type EscapeTestSuite struct{}
+
+func (s *EscapeTestSuite) TestMethodEscape(t *gotest.T) {
+	t.T().Errorf("msg")          // want `Errorf is available on gotest.T — unnecessary T escape`
+	t.T().FailNow()              // want `FailNow is available on gotest.T — unnecessary T escape`
+	t.T().Skip()                 // want `Skipf is available on gotest.T — unnecessary T escape`
+	t.T().SkipNow()              // want `Skipf is available on gotest.T — unnecessary T escape`
+	t.T().Skipf("reason")        // want `Skipf is available on gotest.T — unnecessary T escape`
+	t.T().Setenv("KEY", "VALUE") // want `Setenv is available on gotest.T — unnecessary T escape`
+	_ = t.T().TempDir()          // want `TempDir is available on gotest.T — unnecessary T escape`
+}
+
+func (s *EscapeTestSuite) TestAliasEscape(t *gotest.T) {
+	tt := t.T()
+	tt.Errorf("msg")      // want `Errorf is available on gotest.T — unnecessary T escape`
+	tt.Skip()             // want `Skipf is available on gotest.T — unnecessary T escape`
+	tt.SkipNow()          // want `Skipf is available on gotest.T — unnecessary T escape`
+	gotest.True(tt, true) // want `pass gotest.T directly to True — unnecessary T escape`
+}
+
+func (s *EscapeTestSuite) TestAssertionEscape(t *gotest.T) {
+	gotest.True(t.T(), true)  // want `pass gotest.T directly to True — unnecessary T escape`
+	gotest.Equal(t.T(), 1, 2) // want `pass gotest.T directly to Equal — unnecessary T escape`
+}
+
+func (s *EscapeTestSuite) TestNoEscape(t *gotest.T) {
+	t.Errorf("msg")
+	gotest.True(t, true)
+}
+
+func (s *EscapeTestSuite) BeforeEach() {}
+func (s *EscapeTestSuite) AfterEach()  {}
+
+func standaloneEscape(t *gotest.T) { //nolint:unused
+	t.T().Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
+}

--- a/internal/lint/testdata/src/withtescape/withtescape_test.go.golden
+++ b/internal/lint/testdata/src/withtescape/withtescape_test.go.golden
@@ -1,6 +1,8 @@
 package withtescape
 
 import (
+	"testing"
+
 	"github.com/mvrahden/go-test/pkg/gotest"
 )
 
@@ -9,8 +11,8 @@ type EscapeTestSuite struct{}
 func (s *EscapeTestSuite) TestMethodEscape(t *gotest.T) {
 	t.Errorf("msg")          // want `Errorf is available on gotest.T — unnecessary T escape`
 	t.FailNow()              // want `FailNow is available on gotest.T — unnecessary T escape`
-	t.T().Skip()             // want `Skipf is available on gotest.T — unnecessary T escape`
-	t.T().SkipNow()          // want `Skipf is available on gotest.T — unnecessary T escape`
+	t.T().Skip()             // want `must use Skipf instead — unnecessary T escape`
+	t.T().SkipNow()          // want `must use Skipf instead — unnecessary T escape`
 	t.Skipf("reason")        // want `Skipf is available on gotest.T — unnecessary T escape`
 	t.Setenv("KEY", "VALUE") // want `Setenv is available on gotest.T — unnecessary T escape`
 	_ = t.TempDir()          // want `TempDir is available on gotest.T — unnecessary T escape`
@@ -19,8 +21,8 @@ func (s *EscapeTestSuite) TestMethodEscape(t *gotest.T) {
 func (s *EscapeTestSuite) TestAliasEscape(t *gotest.T) {
 	tt := t.T()
 	tt.Errorf("msg")      // want `Errorf is available on gotest.T — unnecessary T escape`
-	tt.Skip()             // want `Skipf is available on gotest.T — unnecessary T escape`
-	tt.SkipNow()          // want `Skipf is available on gotest.T — unnecessary T escape`
+	tt.Skip()             // want `must use Skipf instead — unnecessary T escape`
+	tt.SkipNow()          // want `must use Skipf instead — unnecessary T escape`
 	gotest.True(tt, true) // want `pass gotest.T directly to True — unnecessary T escape`
 }
 
@@ -37,6 +39,95 @@ func (s *EscapeTestSuite) TestNoEscape(t *gotest.T) {
 func (s *EscapeTestSuite) BeforeEach() {}
 func (s *EscapeTestSuite) AfterEach()  {}
 
+func (s *EscapeTestSuite) TestInterproceduralTestingT(t *gotest.T) {
+	helperErrorf(t.T())
+}
+
+func (s *EscapeTestSuite) TestInterproceduralGotestT(t *gotest.T) {
+	helperGotestErrorf(t)
+}
+
+func (s *EscapeTestSuite) TestInterproceduralChain(t *gotest.T) {
+	wrapperErrorf(t)
+}
+
+func (s *EscapeTestSuite) TestInterproceduralMultiMethod(t *gotest.T) {
+	helperMultiMethod(t.T())
+}
+
+func (s *EscapeTestSuite) TestInterproceduralNonFirstParam(t *gotest.T) {
+	helperNonFirstParam("ctx", t.T())
+}
+
+func (s *EscapeTestSuite) TestInterproceduralDeepChain(t *gotest.T) {
+	deepOuterErrorf(t.T())
+}
+
+func (s *EscapeTestSuite) TestInterproceduralMethodHelper(t *gotest.T) {
+	var h escapeHelper
+	h.doErrorf(t.T())
+}
+
 func standaloneEscape(t *gotest.T) { //nolint:unused
+	t.Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
+}
+
+func standaloneAssertionEscape(t *gotest.T) { //nolint:unused
+	gotest.True(t, true) // want `pass gotest.T directly to True — unnecessary T escape`
+}
+
+// Standalone functions must not be flagged for suite-only rules.
+func standaloneCleanup(t *gotest.T) { //nolint:unused
+	t.T().Cleanup(func() {})
+}
+
+func standaloneParallel(t *gotest.T) { //nolint:unused
+	t.T().Parallel()
+}
+
+func standaloneRun(t *gotest.T) { //nolint:unused
+	t.T().Run("sub", func(st *testing.T) {})
+}
+
+func helperErrorf(t *testing.T) {
+	t.Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
+}
+
+func helperGotestErrorf(t *gotest.T) {
+	t.Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
+}
+
+func wrapperErrorf(t *gotest.T) {
+	helperErrorf(t.T())
+}
+
+func helperMultiMethod(t *testing.T) {
+	t.FailNow()              // want `FailNow is available on gotest.T — unnecessary T escape`
+	t.Skip()                 // want `must use Skipf instead — unnecessary T escape`
+	t.SkipNow()              // want `must use Skipf instead — unnecessary T escape`
+	t.Skipf("reason")        // want `Skipf is available on gotest.T — unnecessary T escape`
+	t.Setenv("KEY", "VALUE") // want `Setenv is available on gotest.T — unnecessary T escape`
+	_ = t.TempDir()          // want `TempDir is available on gotest.T — unnecessary T escape`
+}
+
+func helperNonFirstParam(name string, t *testing.T) {
+	t.Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
+}
+
+func deepLeafErrorf(t *testing.T) {
+	t.Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
+}
+
+func deepMiddleErrorf(t *testing.T) {
+	deepLeafErrorf(t)
+}
+
+func deepOuterErrorf(t *testing.T) {
+	deepMiddleErrorf(t)
+}
+
+type escapeHelper struct{}
+
+func (h *escapeHelper) doErrorf(t *testing.T) {
 	t.Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
 }

--- a/internal/lint/testdata/src/withtescape/withtescape_test.go.golden
+++ b/internal/lint/testdata/src/withtescape/withtescape_test.go.golden
@@ -1,0 +1,42 @@
+package withtescape
+
+import (
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type EscapeTestSuite struct{}
+
+func (s *EscapeTestSuite) TestMethodEscape(t *gotest.T) {
+	t.Errorf("msg")          // want `Errorf is available on gotest.T — unnecessary T escape`
+	t.FailNow()              // want `FailNow is available on gotest.T — unnecessary T escape`
+	t.T().Skip()             // want `Skipf is available on gotest.T — unnecessary T escape`
+	t.T().SkipNow()          // want `Skipf is available on gotest.T — unnecessary T escape`
+	t.Skipf("reason")        // want `Skipf is available on gotest.T — unnecessary T escape`
+	t.Setenv("KEY", "VALUE") // want `Setenv is available on gotest.T — unnecessary T escape`
+	_ = t.TempDir()          // want `TempDir is available on gotest.T — unnecessary T escape`
+}
+
+func (s *EscapeTestSuite) TestAliasEscape(t *gotest.T) {
+	tt := t.T()
+	tt.Errorf("msg")      // want `Errorf is available on gotest.T — unnecessary T escape`
+	tt.Skip()             // want `Skipf is available on gotest.T — unnecessary T escape`
+	tt.SkipNow()          // want `Skipf is available on gotest.T — unnecessary T escape`
+	gotest.True(tt, true) // want `pass gotest.T directly to True — unnecessary T escape`
+}
+
+func (s *EscapeTestSuite) TestAssertionEscape(t *gotest.T) {
+	gotest.True(t, true)  // want `pass gotest.T directly to True — unnecessary T escape`
+	gotest.Equal(t, 1, 2) // want `pass gotest.T directly to Equal — unnecessary T escape`
+}
+
+func (s *EscapeTestSuite) TestNoEscape(t *gotest.T) {
+	t.Errorf("msg")
+	gotest.True(t, true)
+}
+
+func (s *EscapeTestSuite) BeforeEach() {}
+func (s *EscapeTestSuite) AfterEach()  {}
+
+func standaloneEscape(t *gotest.T) { //nolint:unused
+	t.Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
+}

--- a/pkg/gotest/snapshot_suite_test.go
+++ b/pkg/gotest/snapshot_suite_test.go
@@ -14,12 +14,17 @@ import (
 )
 
 // SnapshotGroupingTestSuite tests grouped snapshot file creation with per-subtest sections.
-type SnapshotGroupingTestSuite struct{}
+type SnapshotGroupingTestSuite struct{ snapPath string }
+
+func (s *SnapshotGroupingTestSuite) BeforeEach(_ *gotest.T) {
+	s.snapPath = filepath.Join("testdata", "__snapshots__", "TestSnapshotGroupingTestSuite_ext.snap")
+}
+
+func (s *SnapshotGroupingTestSuite) AfterEach(_ *gotest.T) { os.Remove(s.snapPath) }
 
 func (s *SnapshotGroupingTestSuite) TestMatchSnapshotGrouping(t *gotest.T) {
-	t.T().Setenv(protocol.EnvCI, "0")
+	t.Setenv(protocol.EnvCI, "0")
 	snapDir := filepath.Join("testdata", "__snapshots__")
-	t.T().Cleanup(func() { os.Remove(filepath.Join(snapDir, "TestSnapshotGroupingTestSuite_ext.snap")) })
 
 	t.When("subtests write snapshots", func(w *gotest.T) {
 		w.It("creates a file with named sections per subtest", func(it *gotest.T) {
@@ -71,12 +76,16 @@ func (s *SnapshotGroupingTestSuite) TestMatchSnapshotGrouping(t *gotest.T) {
 }
 
 // SnapshotConcurrencyTestSuite tests concurrent snapshot writes from parallel subtests.
-type SnapshotConcurrencyTestSuite struct{}
+type SnapshotConcurrencyTestSuite struct{ snapPath string }
+
+func (s *SnapshotConcurrencyTestSuite) BeforeEach(_ *gotest.T) {
+	s.snapPath = filepath.Join("testdata", "__snapshots__", "TestSnapshotConcurrencyTestSuite_ext.snap")
+}
+
+func (s *SnapshotConcurrencyTestSuite) AfterEach(_ *gotest.T) { os.Remove(s.snapPath) }
 
 func (s *SnapshotConcurrencyTestSuite) TestMatchSnapshotConcurrency(t *gotest.T) {
-	t.T().Setenv(protocol.EnvCI, "0")
-	snapDir := filepath.Join("testdata", "__snapshots__")
-	t.T().Cleanup(func() { os.Remove(filepath.Join(snapDir, "TestSnapshotConcurrencyTestSuite_ext.snap")) })
+	t.Setenv(protocol.EnvCI, "0")
 
 	t.When("multiple goroutines write concurrently", func(w *gotest.T) {
 		for i := range 10 {
@@ -89,12 +98,17 @@ func (s *SnapshotConcurrencyTestSuite) TestMatchSnapshotConcurrency(t *gotest.T)
 }
 
 // SnapshotUpdateTestSuite tests snapshot update mode via GOTEST_UPDATE_SNAPSHOTS.
-type SnapshotUpdateTestSuite struct{}
+type SnapshotUpdateTestSuite struct{ snapPath string }
+
+func (s *SnapshotUpdateTestSuite) BeforeEach(_ *gotest.T) {
+	s.snapPath = filepath.Join("testdata", "__snapshots__", "TestSnapshotUpdateTestSuite_ext.snap")
+}
+
+func (s *SnapshotUpdateTestSuite) AfterEach(_ *gotest.T) { os.Remove(s.snapPath) }
 
 func (s *SnapshotUpdateTestSuite) TestMatchSnapshotUpdate(t *gotest.T) {
-	t.T().Setenv(protocol.EnvCI, "0")
+	t.Setenv(protocol.EnvCI, "0")
 	snapDir := filepath.Join("testdata", "__snapshots__")
-	t.T().Cleanup(func() { os.Remove(filepath.Join(snapDir, "TestSnapshotUpdateTestSuite_ext.snap")) })
 
 	t.When("GOTEST_UPDATE_SNAPSHOTS is set", func(w *gotest.T) {
 		w.It("replaces original content with updated content and removes the old value", func(it *gotest.T) {
@@ -105,7 +119,7 @@ func (s *SnapshotUpdateTestSuite) TestMatchSnapshotUpdate(t *gotest.T) {
 			gotest.NoError(it, err)
 			gotest.Contains(it, string(data), "original-value")
 
-			it.T().Setenv(protocol.EnvUpdateSnapshots, "1")
+			it.Setenv(protocol.EnvUpdateSnapshots, "1")
 			gotest.MatchSnapshot(it, "updated-value")
 
 			data, err = os.ReadFile(snapPath)
@@ -132,12 +146,17 @@ func (m snapshotJSONMarshaler) MarshalJSON() ([]byte, error) { return json.Marsh
 type snapshotNamedString string
 
 // SnapshotTestSuite tests snapshot matching, custom naming, and value serialization.
-type SnapshotTestSuite struct{}
+type SnapshotTestSuite struct{ snapPath string }
+
+func (s *SnapshotTestSuite) BeforeEach(_ *gotest.T) {
+	s.snapPath = filepath.Join("testdata", "__snapshots__", "TestSnapshotTestSuite_ext.snap")
+}
+
+func (s *SnapshotTestSuite) AfterEach(_ *gotest.T) { os.Remove(s.snapPath) }
 
 func (s *SnapshotTestSuite) TestMatchSnapshot(t *gotest.T) {
-	t.T().Setenv(protocol.EnvCI, "0")
+	t.Setenv(protocol.EnvCI, "0")
 	snapDir := filepath.Join("testdata", "__snapshots__")
-	t.T().Cleanup(func() { os.Remove(filepath.Join(snapDir, "TestSnapshotTestSuite_ext.snap")) })
 
 	t.When("no snapshot exists", func(w *gotest.T) {
 		w.It("creates a grouped snapshot file on first run", func(it *gotest.T) {
@@ -172,7 +191,7 @@ func (s *SnapshotTestSuite) TestMatchSnapshot(t *gotest.T) {
 		w.It("overwrites the existing snapshot", func(it *gotest.T) {
 			gotest.MatchSnapshot(it, "original")
 
-			it.T().Setenv(protocol.EnvUpdateSnapshots, "1")
+			it.Setenv(protocol.EnvUpdateSnapshots, "1")
 			gotest.MatchSnapshot(it, "updated")
 
 			snapPath := filepath.Join(snapDir, "TestSnapshotTestSuite_ext.snap")
@@ -185,11 +204,9 @@ func (s *SnapshotTestSuite) TestMatchSnapshot(t *gotest.T) {
 }
 
 func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
-	t.T().Setenv(protocol.EnvCI, "0")
+	t.Setenv(protocol.EnvCI, "0")
 	snapDir := filepath.Join("testdata", "__snapshots__")
-
 	snapPath := filepath.Join(snapDir, "TestSnapshotTestSuite_ext.snap")
-	t.T().Cleanup(func() { os.Remove(snapPath) })
 
 	t.When("value is a string", func(w *gotest.T) {
 		w.It("snapshots the string directly", func(it *gotest.T) {

--- a/pkg/gotest/snapshot_suite_test.go
+++ b/pkg/gotest/snapshot_suite_test.go
@@ -90,7 +90,7 @@ func (s *SnapshotConcurrencyTestSuite) TestMatchSnapshotConcurrency(t *gotest.T)
 	t.When("multiple goroutines write concurrently", func(w *gotest.T) {
 		for i := range 10 {
 			w.It(fmt.Sprintf("goroutine %d writes its value", i), func(it *gotest.T) {
-				it.T().Parallel()
+				it.T().Parallel() //nolint:t-escape
 				gotest.MatchSnapshot(it, fmt.Sprintf("concurrent-value-%d", i))
 			})
 		}

--- a/pkg/gotest/t.go
+++ b/pkg/gotest/t.go
@@ -50,6 +50,18 @@ func (t *T) FailNow() {
 	t.t.FailNow()
 }
 
+func (t *T) Skipf(format string, args ...any) {
+	t.t.Skipf(format, args...)
+}
+
+func (t *T) Setenv(key, value string) {
+	t.t.Setenv(key, value)
+}
+
+func (t *T) TempDir() string {
+	return t.t.TempDir()
+}
+
 //go:noinline
 func execTestFn(testFn func(it *T), it *T) { testFn(it) }
 

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -33,7 +33,7 @@ func (s *E2ETestSuite) BeforeAll(t *gotest.T) {
 	absRoot, err := filepath.Abs("../..")
 	gotest.NoError(t, err)
 
-	binDir := t.T().TempDir()
+	binDir := t.TempDir()
 	binaryName := "gotest"
 	if runtime.GOOS == "windows" {
 		binaryName += ".exe"
@@ -44,7 +44,7 @@ func (s *E2ETestSuite) BeforeAll(t *gotest.T) {
 	out, err := cmd.CombinedOutput()
 	gotest.NoError(t, err, "build gotest binary: %s", string(out))
 
-	s.workDir = t.T().TempDir()
+	s.workDir = t.TempDir()
 	testutils.CopyModuleUnderTestToTmp(t.T(), s.workDir, "../..", testutils.DefaultExcludePaths...)
 	testutils.ActivateTests(t.T(), s.workDir)
 	testutils.HackGoWork(t.T(), s.workDir)
@@ -53,7 +53,7 @@ func (s *E2ETestSuite) BeforeAll(t *gotest.T) {
 func (s *E2ETestSuite) AfterAll(t *gotest.T) {}
 
 func (s *E2ETestSuite) TestT(t *gotest.T) {
-	tmp := t.T().TempDir()
+	tmp := t.TempDir()
 	excludedPaths := append(append([]string(nil), testutils.DefaultExcludePaths...),
 		"pkg/gotest/assertions_suite_test.go",
 		"pkg/gotest/config_suite_test.go",

--- a/tests/sharedfixture/sharedfixture_suite_test.go
+++ b/tests/sharedfixture/sharedfixture_suite_test.go
@@ -20,7 +20,13 @@ import (
 
 // SharedFixtureIntegrationTestSuite tests shared fixture lifecycle integration
 // with real package loading, code generation, and binary execution.
-type SharedFixtureIntegrationTestSuite struct{}
+type SharedFixtureIntegrationTestSuite struct{ tmpDir string }
+
+func (s *SharedFixtureIntegrationTestSuite) AfterEach(_ *gotest.T) {
+	if s.tmpDir != "" {
+		os.RemoveAll(s.tmpDir)
+	}
+}
 
 func (s *SharedFixtureIntegrationTestSuite) TestSharedFixtureIntegration(t *gotest.T) {
 	standalonePattern := "github.com/mvrahden/go-test/tests/sharedfixture/standalone/..."
@@ -67,15 +73,14 @@ func (s *SharedFixtureIntegrationTestSuite) TestSharedFixtureIntegration(t *gote
 		})
 	})
 
-	tmpDir, err := gotestrunner.WriteOverlay(allResults)
+	s.tmpDir, err = gotestrunner.WriteOverlay(allResults)
 	gotest.NoError(t, err)
-	t.T().Cleanup(func() { os.RemoveAll(tmpDir) })
 
 	t.When("SetupSubprocess", func(w *gotest.T) {
 		setupSrc, err := gotestgen.GenerateSharedSetup(allSharedFixtures)
 		gotest.NoError(w, err)
 
-		sharedDir := filepath.Join(tmpDir, "shared")
+		sharedDir := filepath.Join(s.tmpDir, "shared")
 		gotest.NoError(w, os.MkdirAll(sharedDir, 0755))
 		setupFile := filepath.Join(sharedDir, "setup.go")
 		gotest.NoError(w, os.WriteFile(setupFile, setupSrc, 0600))
@@ -171,7 +176,7 @@ func (s *SharedFixtureIntegrationTestSuite) TestSharedFixtureIntegration(t *gote
 		})
 
 		w.It("RunTests", func(it *gotest.T) {
-			overlayFlag := "-overlay=" + filepath.Join(tmpDir, "overlay.json")
+			overlayFlag := "-overlay=" + filepath.Join(s.tmpDir, "overlay.json")
 			goTestArgs := []string{
 				overlayFlag, "-v",
 				standalonePattern,
@@ -187,7 +192,7 @@ func (s *SharedFixtureIntegrationTestSuite) TestSharedFixtureIntegration(t *gote
 		})
 
 		w.It("RunSpecJSON", func(it *gotest.T) {
-			overlayFlag := "-overlay=" + filepath.Join(tmpDir, "overlay.json")
+			overlayFlag := "-overlay=" + filepath.Join(s.tmpDir, "overlay.json")
 			goTestArgs := []string{
 				overlayFlag,
 				standalonePattern,


### PR DESCRIPTION
Adds a new lint rule that catches test code reaching for the raw *testing.T when *gotest.T already provides the same functionality. This covers methods like Errorf, Skip, Cleanup, Parallel, Run, and assertion helpers; both when called directly and when buried inside helper function chains. The linter auto-fixes the straightforward cases and flags the rest with actionable messages.