### PR TITLE
Add blog articles

### DIFF
--- a/docs/blog/code-generation-not-reflection.html
+++ b/docs/blog/code-generation-not-reflection.html
@@ -1,0 +1,677 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Code Generation, Not Reflection: How gotest Discovers Your Tests | gotest blog</title>
+  <meta name="description" content="Most Go test frameworks use reflection to find suites at runtime. gotest takes a different approach: AST-based code generation with overlay filesystem injection.">
+  <meta name="keywords" content="go code generation, golang ast, go test reflection, go overlay filesystem, gotest generate, go test framework design">
+
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://mvrahden.github.io/go-test/blog/code-generation-not-reflection.html">
+  <meta property="og:title" content="Code Generation, Not Reflection: How gotest Discovers Your Tests">
+  <meta property="og:description" content="Most Go test frameworks use reflection to find suites at runtime. gotest takes a different approach: AST-based code generation with overlay filesystem injection.">
+  <meta property="og:image" content="https://mvrahden.github.io/go-test/static/gopher.png">
+  <meta property="og:image:width" content="1024">
+  <meta property="og:image:height" content="572">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Code Generation, Not Reflection: How gotest Discovers Your Tests">
+  <meta name="twitter:description" content="Most Go test frameworks use reflection to find suites at runtime. gotest takes a different approach: AST-based code generation with overlay filesystem injection.">
+  <meta name="twitter:image" content="https://mvrahden.github.io/go-test/static/gopher.png">
+
+  <link rel="icon" type="image/png" href="../static/logo.png">
+  <link rel="canonical" href="https://mvrahden.github.io/go-test/blog/code-generation-not-reflection.html">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7WHJ67Z1J0"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-7WHJ67Z1J0');
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "Code Generation, Not Reflection: How gotest Discovers Your Tests",
+    "description": "Most Go test frameworks use reflection to find suites at runtime. gotest takes a different approach: AST-based code generation with overlay filesystem injection.",
+    "url": "https://mvrahden.github.io/go-test/blog/code-generation-not-reflection.html",
+    "datePublished": "2026-07-09",
+    "author": {
+      "@type": "Person",
+      "name": "Menno van Rahden",
+      "url": "https://github.com/mvrahden"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "gotest",
+      "url": "https://mvrahden.github.io/go-test/"
+    },
+    "isPartOf": {
+      "@type": "Blog",
+      "name": "gotest blog",
+      "url": "https://mvrahden.github.io/go-test/blog/"
+    },
+    "programmingLanguage": "Go"
+  }
+  </script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --cyan: #00ADD8;
+      --cyan-dark: #007d9c;
+      --bg: #ffffff;
+      --bg-alt: #f6f8fa;
+      --bg-dark: #0d1117;
+      --bg-dark-alt: #161b22;
+      --text: #24292f;
+      --text-secondary: #656d76;
+      --text-on-dark: #e6edf3;
+      --text-dimmed: #8b949e;
+      --border: #d0d7de;
+      --green: #3fb950;
+      --amber: #d29922;
+      --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', Consolas, 'Liberation Mono', monospace;
+      --max-w: 740px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d1117;
+        --bg-alt: #161b22;
+        --bg-dark: #010409;
+        --bg-dark-alt: #0d1117;
+        --text: #e6edf3;
+        --text-secondary: #8b949e;
+        --border: #30363d;
+      }
+    }
+
+    html { scroll-behavior: smooth; height: 100%; }
+
+    body {
+      font-family: var(--font-sans);
+      color: var(--text);
+      background: var(--bg);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      min-height: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .article { flex: 1; }
+
+    a { color: var(--cyan-dark); text-decoration: none; }
+    @media (prefers-color-scheme: dark) { a { color: var(--cyan); } }
+    a:hover { text-decoration: underline; }
+
+    /* ===== Nav ===== */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(8px);
+    }
+    .nav-inner {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 0.75rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .nav-brand {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 700;
+      font-size: 1.125rem;
+      color: var(--text);
+      text-decoration: none;
+    }
+    .nav-brand:hover { text-decoration: none; }
+    .nav-brand img { width: 28px; height: 28px; border-radius: 50%; }
+    .nav-links { display: flex; gap: 1.25rem; font-size: 0.9rem; align-items: center; }
+    .nav-links a { color: var(--text-secondary); }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+    .nav-links .nav-ref {
+      padding: 0.25rem 0.65rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-weight: 600;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-links .nav-ref:hover { background: var(--bg-alt); }
+    .nav-links .star-btn { font-size: 0.85rem; }
+    .star-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.3rem 0.7rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-weight: 600;
+      text-decoration: none;
+      transition: all 0.15s;
+      font-size: 0.8rem;
+    }
+    .star-btn:hover { background: var(--bg-alt); text-decoration: none; }
+    .star-btn .star-icon { color: #e3b341; }
+    .star-count { font-weight: 400; color: var(--text-dimmed); }
+
+    /* ===== Article ===== */
+    .article {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 0 1.5rem;
+    }
+
+    .article-header {
+      padding: 3.5rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 2.5rem;
+    }
+    .article-header .back {
+      display: inline-block;
+      font-size: 0.85rem;
+      color: var(--text-dimmed);
+      margin-bottom: 1.5rem;
+    }
+    .article-header .back:hover { color: var(--text-secondary); }
+    .article-header h1 {
+      font-size: 2.25rem;
+      font-weight: 800;
+      letter-spacing: -0.025em;
+      line-height: 1.2;
+      margin-bottom: 1rem;
+    }
+    .article-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.85rem;
+      color: var(--text-dimmed);
+    }
+    .article-meta .tag {
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+    }
+
+    /* ===== Article Body ===== */
+    .article-body {
+      padding-bottom: 3rem;
+    }
+    .article-body p {
+      font-size: 1.1rem;
+      line-height: 1.75;
+      margin-bottom: 1.5rem;
+    }
+    .article-body h2 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      margin-top: 3rem;
+      margin-bottom: 1rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--border);
+    }
+    .article-body h2:first-child {
+      margin-top: 0;
+      padding-top: 0;
+      border-top: none;
+    }
+    .article-body h3 {
+      font-size: 1.2rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+    }
+    .article-body ul, .article-body ol {
+      margin-bottom: 1.5rem;
+      padding-left: 1.5rem;
+    }
+    .article-body li {
+      font-size: 1.05rem;
+      line-height: 1.7;
+      margin-bottom: 0.4rem;
+    }
+    .article-body strong { font-weight: 600; }
+
+    .article-body code {
+      font-family: var(--font-mono);
+      font-size: 0.88em;
+      padding: 0.15em 0.4em;
+      border-radius: 4px;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+    }
+
+    .article-body blockquote {
+      border-left: 3px solid var(--cyan);
+      padding: 0.75rem 1.25rem;
+      margin: 1.5rem 0;
+      background: var(--bg-alt);
+      border-radius: 0 6px 6px 0;
+    }
+    .article-body blockquote p {
+      font-size: 1.05rem;
+      margin-bottom: 0;
+      color: var(--text-secondary);
+    }
+
+    /* Code blocks */
+    .code-block {
+      background: #161b22;
+      border-radius: 8px;
+      border: 1px solid #30363d;
+      margin: 1.5rem 0;
+      overflow: hidden;
+    }
+    .code-label {
+      display: block;
+      padding: 0.5rem 1.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--text-dimmed);
+      border-bottom: 1px solid #30363d;
+      background: #1c2128;
+    }
+    .code-block pre {
+      padding: 1.25rem 1.5rem;
+      overflow-x: auto;
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      line-height: 1.65;
+      color: #e6edf3;
+    }
+    .code-block pre code {
+      font-family: inherit;
+      font-size: inherit;
+      padding: 0;
+      border: none;
+      background: none;
+      border-radius: 0;
+      color: inherit;
+    }
+
+    .kw { color: #ff7b72; }
+    .fn { color: #d2a8ff; }
+    .str { color: #a5d6ff; }
+    .cm { color: #8b949e; }
+    .tp { color: #79c0ff; }
+
+    /* Diagram */
+    .diagram {
+      margin: 1.5rem 0;
+      padding: 1.5rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      line-height: 1.8;
+      overflow-x: auto;
+      text-align: center;
+      color: var(--text-secondary);
+    }
+
+    /* CTA section */
+    .cta {
+      margin: 2.5rem 0;
+      padding: 2rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      text-align: center;
+    }
+    .cta p {
+      margin-bottom: 1rem;
+    }
+    .cta .install-cmd {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 0.75rem 1rem;
+      font-family: var(--font-mono);
+      font-size: 0.9rem;
+      max-width: 100%;
+      overflow-x: auto;
+    }
+    .cta .install-cmd code {
+      white-space: nowrap;
+      color: var(--text);
+    }
+    .cta .install-cmd button {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.3rem 0.5rem;
+      cursor: pointer;
+      color: var(--text-secondary);
+      font-size: 0.8rem;
+      flex-shrink: 0;
+      transition: all 0.15s;
+    }
+    .cta .install-cmd button:hover { background: var(--border); }
+    .cta-links {
+      margin-top: 1rem;
+      font-size: 0.9rem;
+      display: flex;
+      justify-content: center;
+      gap: 1.5rem;
+    }
+
+    /* ===== Footer ===== */
+    footer {
+      background: var(--bg-dark);
+      color: var(--text-dimmed);
+      padding: 2.5rem 1.5rem;
+      text-align: center;
+      font-size: 0.85rem;
+    }
+    footer a { color: var(--text-on-dark); }
+    footer a:hover { color: var(--cyan); }
+    .footer-links {
+      display: flex;
+      justify-content: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .footer-copy { color: #484f58; font-size: 0.8rem; }
+
+    /* ===== Responsive ===== */
+    @media (max-width: 640px) {
+      .article-header h1 { font-size: 1.75rem; }
+      .article-body p { font-size: 1.05rem; }
+    }
+    @media (max-width: 480px) {
+      .nav-links { gap: 0.75rem; font-size: 0.8rem; }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-inner">
+      <a href="../" class="nav-brand">
+        <img src="../static/logo.png" alt="gotest logo" width="28" height="28">
+        gotest
+      </a>
+      <div class="nav-links">
+        <a href="./">Blog</a>
+        <a href="../reference.html" class="nav-ref">Reference</a>
+        <a href="https://github.com/mvrahden/go-test" class="star-btn"><span class="star-icon">&#9734;</span> Star<span class="star-count" id="star-count"></span></a>
+        <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="article">
+    <header class="article-header">
+      <a href="./" class="back">&larr; All posts</a>
+      <h1>Code Generation, Not Reflection: How gotest Discovers Your Tests</h1>
+      <div class="article-meta">
+        <time datetime="2026-07-09">July 9, 2026</time>
+        <span>&middot;</span>
+        <span>11 min read</span>
+        <span class="tag">Internals</span>
+      </div>
+    </header>
+
+    <div class="article-body">
+
+      <p>Every Go test framework that supports suites needs to solve the same problem: how do you connect a struct full of test methods to the <code>go test</code> runner? The runner only knows about top-level <code>func Test*(t *testing.T)</code> functions. Your suite is a struct with methods. Something has to bridge the gap.</p>
+
+      <p>Most frameworks use reflection. gotest uses code generation. This post explains why, and what the code generation pipeline actually does.</p>
+
+      <h2>The reflection approach</h2>
+
+      <p>In a reflection-based framework like testify/suite, the bridge looks like this:</p>
+
+      <div class="code-block">
+        <pre><code><span class="kw">func</span> <span class="fn">TestUserSuite</span>(t *<span class="tp">testing.T</span>) {
+    suite.Run(t, <span class="kw">new</span>(UserSuite))
+}</code></pre>
+      </div>
+
+      <p>You write a <code>func Test*</code> that the runner can find, and inside it you call <code>suite.Run</code>, which uses the <code>reflect</code> package to:</p>
+
+      <ol>
+        <li>Enumerate all methods on <code>UserSuite</code></li>
+        <li>Filter for methods starting with <code>Test</code></li>
+        <li>Call each one as a subtest via <code>t.Run</code></li>
+        <li>Look for <code>SetupTest</code>, <code>TearDownTest</code>, etc. and call them at the right time</li>
+      </ol>
+
+      <p>This works. But it has costs:</p>
+
+      <ul>
+        <li><strong>Boilerplate.</strong> Every suite needs a <code>func Test*(t *testing.T) { suite.Run(t, new(MySuite)) }</code> wrapper. It's the same line every time, but you have to write it.</li>
+        <li><strong>Runtime discovery.</strong> Method lookup happens when the test runs, not when it compiles. A typo in a lifecycle method name (<code>SetUpTest</code> instead of <code>SetupTest</code>) silently does nothing.</li>
+        <li><strong>Opaque wiring.</strong> The connection between your struct and the test runner is hidden inside <code>suite.Run</code>. You can't inspect the generated subtests, set breakpoints on the lifecycle logic, or see what gets called in what order without reading the framework source.</li>
+      </ul>
+
+      <h2>The code generation approach</h2>
+
+      <p>gotest takes a different path. Instead of discovering tests at runtime with reflection, it discovers them at build time by reading your source code's AST (abstract syntax tree). Then it generates the bridge code that a developer would otherwise write by hand.</p>
+
+      <p>The pipeline has three stages:</p>
+
+      <div class="diagram">
+AST discovery &rarr; code generation &rarr; overlay injection
+      </div>
+
+      <h3>Stage 1: AST discovery</h3>
+
+      <p>gotest uses Go's <code>go/parser</code> and <code>go/ast</code> packages to walk your source files. It looks for naming conventions:</p>
+
+      <ul>
+        <li><strong>Structs ending in <code>TestSuite</code></strong>: recognized as test suites</li>
+        <li><strong>Methods starting with <code>Test</code></strong> on suite types: recognized as test cases</li>
+        <li><strong><code>BeforeEach</code>, <code>AfterEach</code>, <code>BeforeAll</code>, <code>AfterAll</code></strong>: recognized as lifecycle hooks</li>
+        <li><strong>Structs ending in <code>Fixture</code></strong>: recognized as package fixtures</li>
+        <li><strong>Structs ending in <code>SharedFixture</code></strong>: recognized as cross-package fixtures</li>
+      </ul>
+
+      <p>This is purely static analysis. No code runs. No <code>reflect</code> import. The AST walker reads struct declarations and method signatures from the parse tree, the same way a linter would.</p>
+
+      <p>The key advantage: errors are caught before your tests run. If a lifecycle method has the wrong signature, say <code>BeforeEach()</code> with no parameters instead of <code>BeforeEach(t *gotest.T)</code>, gotest reports the error at generation time with the file and line number, not as a silent no-op at runtime.</p>
+
+      <h3>Stage 2: Code generation</h3>
+
+      <p>From the AST analysis, gotest generates a <code>gotest_psuite_test.go</code> file for each package that contains suites. Here's what gets generated for a simple suite:</p>
+
+      <div class="code-block">
+        <span class="code-label">your code</span>
+        <pre><code><span class="kw">type</span> <span class="tp">UserServiceTestSuite</span> <span class="kw">struct</span> {
+    svc *UserService
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserServiceTestSuite</span>) <span class="fn">BeforeEach</span>(t *<span class="tp">gotest.T</span>) {
+    s.svc = NewUserService()
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserServiceTestSuite</span>) <span class="fn">TestCreate</span>(t *<span class="tp">gotest.T</span>) { <span class="cm">/* ... */</span> }
+<span class="kw">func</span> (s *<span class="tp">UserServiceTestSuite</span>) <span class="fn">TestDelete</span>(t *<span class="tp">gotest.T</span>) { <span class="cm">/* ... */</span> }</code></pre>
+      </div>
+
+      <div class="code-block">
+        <span class="code-label">generated bridge (simplified)</span>
+        <pre><code><span class="kw">func</span> <span class="fn">TestUserServiceTestSuite</span>(t *<span class="tp">testing.T</span>) {
+    s := &amp;UserServiceTestSuite{}
+
+    t.Run(<span class="str">"TestCreate"</span>, <span class="kw">func</span>(t *<span class="tp">testing.T</span>) {
+        s.BeforeEach(gotest.NewT(t))
+        s.TestCreate(gotest.NewT(t))
+    })
+
+    t.Run(<span class="str">"TestDelete"</span>, <span class="kw">func</span>(t *<span class="tp">testing.T</span>) {
+        s.BeforeEach(gotest.NewT(t))
+        s.TestDelete(gotest.NewT(t))
+    })
+}</code></pre>
+      </div>
+
+      <p>The generated code is what you'd write by hand if you were wiring up the suite yourself: a top-level <code>func Test*</code> that creates the struct, then runs each test method as a subtest with the lifecycle hooks in the right places.</p>
+
+      <p>For suites with fixtures, the generated code also includes fixture initialization with proper DAG ordering, <code>sync.Once</code> semantics for one-time setup, and <code>t.Cleanup</code> registration for teardown.</p>
+
+      <h3>Stage 3: Overlay injection</h3>
+
+      <p>Here's the part that makes code generation practical: the generated files never touch your source tree.</p>
+
+      <p>Go 1.16 introduced the <code>-overlay</code> flag for the <code>go</code> toolchain. It takes a JSON file that maps virtual file paths to actual file paths on disk. When the compiler encounters a file reference, it checks the overlay map first. This means a file can appear to exist at <code>pkg/user/gotest_psuite_test.go</code> while actually living in a temp directory.</p>
+
+      <div class="code-block">
+        <span class="code-label">overlay.json</span>
+        <pre><code>{
+  <span class="str">"Replace"</span>: {
+    <span class="str">"pkg/user/gotest_psuite_test.go"</span>: <span class="str">"/tmp/gotest-overlay/0/gotest_psuite_test.go"</span>,
+    <span class="str">"pkg/order/gotest_psuite_test.go"</span>: <span class="str">"/tmp/gotest-overlay/1/gotest_psuite_test.go"</span>
+  }
+}</code></pre>
+      </div>
+
+      <p>gotest writes the generated files to a content-addressable cache directory, creates the overlay JSON, and passes it to <code>go test -overlay=overlay.json</code>. After the run, nothing is left behind. Your source directory stays clean, your git status stays unchanged, and pull requests don't include generated code.</p>
+
+      <p>The cache uses SHA-256 hashing of the generated content. If you run tests twice without changing any suite code, the second run reuses the cached overlay; no regeneration needed.</p>
+
+      <h2>What you gain</h2>
+
+      <p>The code generation approach has several concrete advantages over reflection:</p>
+
+      <h3>Compile-time errors</h3>
+
+      <p>If your <code>BeforeEach</code> method takes <code>(ctx context.Context)</code> instead of <code>(t *gotest.T)</code>, gotest tells you at generation time:</p>
+
+      <div class="code-block">
+        <pre><code>user_test.go:12: BeforeEach: expected signature func(t *gotest.T), got func(ctx context.Context)</code></pre>
+      </div>
+
+      <p>With reflection, this would either panic at runtime or, worse, silently skip the hook because the framework doesn't recognize the method signature.</p>
+
+      <h3>Inspectable output</h3>
+
+      <p>You can run <code>gotest generate ./...</code> to write the generated files to disk and read them. The generated code is standard Go; you can set breakpoints in it, step through the lifecycle logic, and see exactly what gets called in what order. There's no framework magic at runtime, just direct method calls.</p>
+
+      <h3>No registration ceremony</h3>
+
+      <p>With reflection-based frameworks, every suite needs a top-level <code>func Test*</code> that calls <code>suite.Run</code>. With code generation, the bridge function is generated automatically. You write the suite struct and its methods, and that's it.</p>
+
+      <div class="code-block">
+        <span class="code-label">reflection-based (every suite needs this)</span>
+        <pre><code><span class="kw">func</span> <span class="fn">TestUserSuite</span>(t *<span class="tp">testing.T</span>) {
+    suite.Run(t, <span class="kw">new</span>(UserSuite))
+}</code></pre>
+      </div>
+
+      <div class="code-block">
+        <span class="code-label">code generation (nothing to write)</span>
+        <pre><code><span class="cm">// The bridge is generated. Just write your suite.</span></code></pre>
+      </div>
+
+      <h3>Zero runtime overhead</h3>
+
+      <p>The generated code compiles to direct function calls. No <code>reflect.ValueOf</code>, no <code>reflect.Method</code>, no interface dispatch. At test execution time, there's no framework code in the call stack: just your suite methods being called directly.</p>
+
+      <h2>The pipeline in practice</h2>
+
+      <p>When you run <code>gotest ./...</code>, the full pipeline executes automatically:</p>
+
+      <ol>
+        <li><strong>Load packages</strong>: discover which packages match the pattern</li>
+        <li><strong>AST discovery</strong>: walk source files for suites, fixtures, lifecycle hooks</li>
+        <li><strong>Validate</strong>: check method signatures, fixture consistency, dependency cycles</li>
+        <li><strong>Generate</strong>: produce bridge code for each package</li>
+        <li><strong>Cache</strong>: write generated files to the content-addressable cache</li>
+        <li><strong>Overlay</strong>: create the overlay JSON mapping</li>
+        <li><strong>Compile &amp; run</strong>: invoke <code>go test -overlay=...</code></li>
+      </ol>
+
+      <p>Steps 1&ndash;6 are fast; they operate on parse trees, not compiled code. And with caching, steps 4&ndash;6 are skipped entirely on repeat runs if the source hasn't changed.</p>
+
+      <p>For large projects, gotest also uses streaming compilation: test packages start running as soon as they're compiled, without waiting for all packages to finish compiling. This overlaps compilation time with execution time, reducing wall-clock duration for multi-package test runs.</p>
+
+      <h2>Inspecting the generated code</h2>
+
+      <p>If you're curious about what gotest generates for your project, you can write the files to disk:</p>
+
+      <div class="code-block">
+        <pre><code><span class="cm"># Write generated files alongside your source</span>
+gotest generate ./...
+
+<span class="cm"># Look at what was generated</span>
+cat pkg/user/gotest_psuite_test.go
+
+<span class="cm"># Clean up when done</span>
+gotest clean</code></pre>
+      </div>
+
+      <p>The generated files are standard Go test files. They import your package, reference your types, and call your methods. Reading them is the most direct way to understand what the framework does, because the framework <em>is</em> the generated code.</p>
+
+      <h2>The trade-off</h2>
+
+      <p>Code generation isn't free. It adds a build step: the AST discovery and generation that runs before <code>go test</code>. If you run <code>go test</code> directly without <code>gotest</code>, you'll get a compilation error because the generated bridge file doesn't exist.</p>
+
+      <p>This is a deliberate design choice. A missing generated file produces a clear compiler error that tells you what to do. The alternative, silently doing nothing when the bridge is absent, would be worse.</p>
+
+      <p>The code generation approach aligns with Go's broader philosophy: explicit over implicit, compile-time over runtime, readable code over framework magic. The generated code is what a careful developer would write by hand. gotest just writes it for you.</p>
+
+      <div class="cta">
+        <p><strong>Try gotest on your next project.</strong></p>
+        <div class="install-cmd">
+          <code>go install github.com/mvrahden/go-test/cmd/gotest@latest</code>
+          <button onclick="navigator.clipboard.writeText('go install github.com/mvrahden/go-test/cmd/gotest@latest').then(()=>{this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)})" aria-label="Copy install command">Copy</button>
+        </div>
+        <div class="cta-links">
+          <a href="../reference.html">Reference</a>
+          <a href="https://github.com/mvrahden/go-test">GitHub</a>
+          <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+  <footer>
+    <div class="footer-links">
+      <a href="../">Home</a>
+      <a href="https://github.com/mvrahden/go-test">GitHub</a>
+      <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
+      <a href="../reference.html">Reference</a>
+      <a href="./">Blog</a>
+      <a href="https://github.com/mvrahden/go-test/blob/main/LICENSE">MIT License</a>
+    </div>
+    <p class="footer-copy">Built for Go developers who want tests that explain themselves.</p>
+  </footer>
+  <script>
+  fetch('https://api.github.com/repos/mvrahden/go-test')
+    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(d => {
+      if (d.stargazers_count >= 10) {
+        document.getElementById('star-count').textContent = ` ${d.stargazers_count}`;
+      }
+    })
+    .catch(() => {});
+  </script>
+</body>
+</html>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -266,6 +266,17 @@
 
     <article class="post-entry">
       <div class="post-entry-meta">
+        <time datetime="2026-07-06">July 6, 2026</time>
+        <span>&middot;</span>
+        <span>10 min read</span>
+        <span class="tag">Patterns</span>
+      </div>
+      <h2><a href="organizing-go-tests.html">Organizing Go Tests Beyond <code>func TestX</code></a></h2>
+      <p class="excerpt">Go's testing simplicity is a feature. Until your project outgrows it. A look at why flat test functions, table-driven tests, and subtests each solve part of the problem, and what happens when you need all three at once.</p>
+    </article>
+
+    <article class="post-entry">
+      <div class="post-entry-meta">
         <time datetime="2026-07-05">July 5, 2026</time>
         <span>&middot;</span>
         <span>8 min read</span>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -266,6 +266,17 @@
 
     <article class="post-entry">
       <div class="post-entry-meta">
+        <time datetime="2026-07-07">July 7, 2026</time>
+        <span>&middot;</span>
+        <span>12 min read</span>
+        <span class="tag">Patterns</span>
+      </div>
+      <h2><a href="test-fixtures-in-go.html">Test Fixtures in Go: Patterns That Scale</a></h2>
+      <p class="excerpt">Every growing Go project needs shared test infrastructure: databases, caches, containers. A look at fixture patterns from global vars to DAG-based lifecycle management.</p>
+    </article>
+
+    <article class="post-entry">
+      <div class="post-entry-meta">
         <time datetime="2026-07-06">July 6, 2026</time>
         <span>&middot;</span>
         <span>10 min read</span>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -266,6 +266,17 @@
 
     <article class="post-entry">
       <div class="post-entry-meta">
+        <time datetime="2026-07-09">July 9, 2026</time>
+        <span>&middot;</span>
+        <span>11 min read</span>
+        <span class="tag">Internals</span>
+      </div>
+      <h2><a href="code-generation-not-reflection.html">Code Generation, Not Reflection: How gotest Discovers Your Tests</a></h2>
+      <p class="excerpt">Most Go test frameworks use reflection to find suites at runtime. gotest takes a different approach: AST-based code generation with overlay filesystem injection.</p>
+    </article>
+
+    <article class="post-entry">
+      <div class="post-entry-meta">
         <time datetime="2026-07-08">July 8, 2026</time>
         <span>&middot;</span>
         <span>9 min read</span>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Blog | gotest</title>
+  <meta name="description" content="Articles on Go testing patterns, test suite design, and specification-driven development. From the makers of gotest.">
+  <meta name="keywords" content="go testing blog, golang test patterns, go test suites, bdd golang, specification driven testing">
+
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://mvrahden.github.io/go-test/blog/">
+  <meta property="og:title" content="Blog | gotest">
+  <meta property="og:description" content="Articles on Go testing patterns, test suite design, and specification-driven development.">
+  <meta property="og:image" content="https://mvrahden.github.io/go-test/static/gopher.png">
+  <meta property="og:image:width" content="1024">
+  <meta property="og:image:height" content="572">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Blog | gotest">
+  <meta name="twitter:description" content="Articles on Go testing patterns, test suite design, and specification-driven development.">
+  <meta name="twitter:image" content="https://mvrahden.github.io/go-test/static/gopher.png">
+
+  <link rel="icon" type="image/png" href="../static/logo.png">
+  <link rel="canonical" href="https://mvrahden.github.io/go-test/blog/">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7WHJ67Z1J0"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-7WHJ67Z1J0');
+  </script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --cyan: #00ADD8;
+      --cyan-dark: #007d9c;
+      --bg: #ffffff;
+      --bg-alt: #f6f8fa;
+      --bg-dark: #0d1117;
+      --bg-dark-alt: #161b22;
+      --text: #24292f;
+      --text-secondary: #656d76;
+      --text-on-dark: #e6edf3;
+      --text-dimmed: #8b949e;
+      --border: #d0d7de;
+      --green: #3fb950;
+      --amber: #d29922;
+      --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', Consolas, 'Liberation Mono', monospace;
+      --max-w: 1080px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d1117;
+        --bg-alt: #161b22;
+        --bg-dark: #010409;
+        --bg-dark-alt: #0d1117;
+        --text: #e6edf3;
+        --text-secondary: #8b949e;
+        --border: #30363d;
+      }
+    }
+
+    html { scroll-behavior: smooth; height: 100%; }
+
+    body {
+      font-family: var(--font-sans);
+      color: var(--text);
+      background: var(--bg);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      min-height: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .post-list { flex: 1; }
+
+    a { color: var(--cyan-dark); text-decoration: none; }
+    @media (prefers-color-scheme: dark) { a { color: var(--cyan); } }
+    a:hover { text-decoration: underline; }
+
+    /* ===== Nav ===== */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(8px);
+    }
+    .nav-inner {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 0.75rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .nav-brand {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 700;
+      font-size: 1.125rem;
+      color: var(--text);
+      text-decoration: none;
+    }
+    .nav-brand:hover { text-decoration: none; }
+    .nav-brand img { width: 28px; height: 28px; border-radius: 50%; }
+    .nav-links { display: flex; gap: 1.25rem; font-size: 0.9rem; align-items: center; }
+    .nav-links a { color: var(--text-secondary); }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+    .nav-links .nav-ref {
+      padding: 0.25rem 0.65rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-weight: 600;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-links .nav-ref:hover { background: var(--bg-alt); }
+    .nav-links .star-btn { font-size: 0.85rem; }
+    .star-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.3rem 0.7rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-weight: 600;
+      text-decoration: none;
+      transition: all 0.15s;
+      font-size: 0.8rem;
+    }
+    .star-btn:hover { background: var(--bg-alt); text-decoration: none; }
+    .star-btn .star-icon { color: #e3b341; }
+    .star-count { font-weight: 400; color: var(--text-dimmed); }
+
+    /* ===== Page Header ===== */
+    .page-header {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 4rem 1.5rem 2rem;
+    }
+    .page-header h1 {
+      font-size: 2.5rem;
+      font-weight: 800;
+      letter-spacing: -0.02em;
+      margin-bottom: 0.5rem;
+    }
+    .page-header p {
+      font-size: 1.15rem;
+      color: var(--text-secondary);
+    }
+
+    /* ===== Post List ===== */
+    .post-list {
+      max-width: 820px;
+      margin: 0 auto;
+      padding: 0 1.5rem 4rem;
+    }
+    .post-entry {
+      padding: 2rem 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .post-entry:first-child {
+      border-top: 1px solid var(--border);
+    }
+    .post-entry-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.85rem;
+      color: var(--text-dimmed);
+      margin-bottom: 0.5rem;
+    }
+    .post-entry-meta .tag {
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+    }
+    .post-entry h2 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      margin-bottom: 0.5rem;
+      line-height: 1.3;
+    }
+    .post-entry h2 a {
+      color: var(--text);
+    }
+    .post-entry h2 a:hover {
+      color: var(--cyan-dark);
+      text-decoration: none;
+    }
+    @media (prefers-color-scheme: dark) {
+      .post-entry h2 a:hover { color: var(--cyan); }
+    }
+    .post-entry .excerpt {
+      color: var(--text-secondary);
+      font-size: 1.05rem;
+      line-height: 1.6;
+    }
+
+    /* ===== Footer ===== */
+    footer {
+      background: var(--bg-dark);
+      color: var(--text-dimmed);
+      padding: 2.5rem 1.5rem;
+      text-align: center;
+      font-size: 0.85rem;
+    }
+    footer a { color: var(--text-on-dark); }
+    footer a:hover { color: var(--cyan); }
+    .footer-links {
+      display: flex;
+      justify-content: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .footer-copy { color: #484f58; font-size: 0.8rem; }
+
+    /* ===== Responsive ===== */
+    @media (max-width: 640px) {
+      .page-header { padding: 2.5rem 1.5rem 1.5rem; }
+      .page-header h1 { font-size: 2rem; }
+    }
+    @media (max-width: 480px) {
+      .nav-links { gap: 0.75rem; font-size: 0.8rem; }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-inner">
+      <a href="../" class="nav-brand">
+        <img src="../static/logo.png" alt="gotest logo" width="28" height="28">
+        gotest
+      </a>
+      <div class="nav-links">
+        <a href="../">Home</a>
+        <a href="../reference.html" class="nav-ref">Reference</a>
+        <a href="https://github.com/mvrahden/go-test" class="star-btn"><span class="star-icon">&#9734;</span> Star<span class="star-count" id="star-count"></span></a>
+        <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code</a>
+      </div>
+    </div>
+  </nav>
+
+  <header class="page-header">
+    <h1>Blog</h1>
+    <p>Thinking about Go testing: patterns, trade-offs, and the ideas behind gotest.</p>
+  </header>
+
+  <main class="post-list">
+
+    <article class="post-entry">
+      <div class="post-entry-meta">
+        <time datetime="2026-07-05">July 5, 2026</time>
+        <span>&middot;</span>
+        <span>8 min read</span>
+        <span class="tag">Philosophy</span>
+      </div>
+      <h2><a href="why-gotest.html">Why gotest Exists</a></h2>
+      <p class="excerpt">Go's testing package is one of the best things about the language. But it leaves gaps that every growing project eventually hits. The motivation behind gotest and the five principles that shaped its design.</p>
+    </article>
+
+  </main>
+
+  <footer>
+    <div class="footer-links">
+      <a href="../">Home</a>
+      <a href="https://github.com/mvrahden/go-test">GitHub</a>
+      <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
+      <a href="../reference.html">Reference</a>
+      <a href="https://github.com/mvrahden/go-test/blob/main/LICENSE">MIT License</a>
+    </div>
+    <p class="footer-copy">Built for Go developers who want tests that explain themselves.</p>
+  </footer>
+  <script>
+  fetch('https://api.github.com/repos/mvrahden/go-test')
+    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(d => {
+      if (d.stargazers_count >= 10) {
+        document.getElementById('star-count').textContent = ` ${d.stargazers_count}`;
+      }
+    })
+    .catch(() => {});
+  </script>
+</body>
+</html>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -266,6 +266,17 @@
 
     <article class="post-entry">
       <div class="post-entry-meta">
+        <time datetime="2026-07-08">July 8, 2026</time>
+        <span>&middot;</span>
+        <span>9 min read</span>
+        <span class="tag">Testing</span>
+      </div>
+      <h2><a href="readable-tests-with-bdd.html">Readable Tests with BDD-Style Go</a></h2>
+      <p class="excerpt">Test names like TestCreateUser_WhenEmailInvalid_ReturnsError are hard to scan. BDD-style labeled subtests and spec output turn your tests into living documentation.</p>
+    </article>
+
+    <article class="post-entry">
+      <div class="post-entry-meta">
         <time datetime="2026-07-07">July 7, 2026</time>
         <span>&middot;</span>
         <span>12 min read</span>

--- a/docs/blog/organizing-go-tests.html
+++ b/docs/blog/organizing-go-tests.html
@@ -1,0 +1,837 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Organizing Go Tests Beyond func TestX | gotest blog</title>
+  <meta name="description" content="Go's testing simplicity is a feature. Until your project outgrows it. A look at flat test functions, table-driven tests, subtests, and suites, and how code generation changes the equation.">
+  <meta name="keywords" content="go test organization, golang test structure, go test suites, go testing best practices, testify alternative, go bdd, go test lifecycle">
+
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://mvrahden.github.io/go-test/blog/organizing-go-tests.html">
+  <meta property="og:title" content="Organizing Go Tests Beyond func TestX">
+  <meta property="og:description" content="Go's testing simplicity is a feature. Until your project outgrows it. A look at flat test functions, table-driven tests, subtests, and suites.">
+  <meta property="og:image" content="https://mvrahden.github.io/go-test/static/gopher.png">
+  <meta property="og:image:width" content="1024">
+  <meta property="og:image:height" content="572">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Organizing Go Tests Beyond func TestX">
+  <meta name="twitter:description" content="Go's testing simplicity is a feature. Until your project outgrows it. Flat functions, table tests, subtests, and suites, and what code generation changes.">
+  <meta name="twitter:image" content="https://mvrahden.github.io/go-test/static/gopher.png">
+
+  <link rel="icon" type="image/png" href="../static/logo.png">
+  <link rel="canonical" href="https://mvrahden.github.io/go-test/blog/organizing-go-tests.html">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7WHJ67Z1J0"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-7WHJ67Z1J0');
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "Organizing Go Tests Beyond func TestX",
+    "description": "Go's testing simplicity is a feature. Until your project outgrows it. A progression through flat functions, table-driven tests, subtests, and suites.",
+    "url": "https://mvrahden.github.io/go-test/blog/organizing-go-tests.html",
+    "datePublished": "2026-07-06",
+    "author": {
+      "@type": "Person",
+      "name": "Menno van Rahden",
+      "url": "https://github.com/mvrahden"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "gotest",
+      "url": "https://mvrahden.github.io/go-test/"
+    },
+    "isPartOf": {
+      "@type": "Blog",
+      "name": "gotest blog",
+      "url": "https://mvrahden.github.io/go-test/blog/"
+    },
+    "programmingLanguage": "Go"
+  }
+  </script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --cyan: #00ADD8;
+      --cyan-dark: #007d9c;
+      --bg: #ffffff;
+      --bg-alt: #f6f8fa;
+      --bg-dark: #0d1117;
+      --bg-dark-alt: #161b22;
+      --text: #24292f;
+      --text-secondary: #656d76;
+      --text-on-dark: #e6edf3;
+      --text-dimmed: #8b949e;
+      --border: #d0d7de;
+      --green: #3fb950;
+      --amber: #d29922;
+      --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', Consolas, 'Liberation Mono', monospace;
+      --max-w: 740px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d1117;
+        --bg-alt: #161b22;
+        --bg-dark: #010409;
+        --bg-dark-alt: #0d1117;
+        --text: #e6edf3;
+        --text-secondary: #8b949e;
+        --border: #30363d;
+      }
+    }
+
+    html { scroll-behavior: smooth; height: 100%; }
+
+    body {
+      font-family: var(--font-sans);
+      color: var(--text);
+      background: var(--bg);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      min-height: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .article { flex: 1; }
+
+    a { color: var(--cyan-dark); text-decoration: none; }
+    @media (prefers-color-scheme: dark) { a { color: var(--cyan); } }
+    a:hover { text-decoration: underline; }
+
+    /* ===== Nav ===== */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(8px);
+    }
+    .nav-inner {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 0.75rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .nav-brand {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 700;
+      font-size: 1.125rem;
+      color: var(--text);
+      text-decoration: none;
+    }
+    .nav-brand:hover { text-decoration: none; }
+    .nav-brand img { width: 28px; height: 28px; border-radius: 50%; }
+    .nav-links { display: flex; gap: 1.25rem; font-size: 0.9rem; align-items: center; }
+    .nav-links a { color: var(--text-secondary); }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+    .nav-links .nav-ref {
+      padding: 0.25rem 0.65rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-weight: 600;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-links .nav-ref:hover { background: var(--bg-alt); }
+    .nav-links .star-btn { font-size: 0.85rem; }
+    .star-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.3rem 0.7rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-weight: 600;
+      text-decoration: none;
+      transition: all 0.15s;
+      font-size: 0.8rem;
+    }
+    .star-btn:hover { background: var(--bg-alt); text-decoration: none; }
+    .star-btn .star-icon { color: #e3b341; }
+    .star-count { font-weight: 400; color: var(--text-dimmed); }
+
+    /* ===== Article ===== */
+    .article {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 0 1.5rem;
+    }
+
+    .article-header {
+      padding: 3.5rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 2.5rem;
+    }
+    .article-header .back {
+      display: inline-block;
+      font-size: 0.85rem;
+      color: var(--text-dimmed);
+      margin-bottom: 1.5rem;
+    }
+    .article-header .back:hover { color: var(--text-secondary); }
+    .article-header h1 {
+      font-size: 2.25rem;
+      font-weight: 800;
+      letter-spacing: -0.025em;
+      line-height: 1.2;
+      margin-bottom: 1rem;
+    }
+    .article-header h1 code {
+      font-size: 0.85em;
+      font-weight: 700;
+      color: var(--cyan-dark);
+    }
+    @media (prefers-color-scheme: dark) {
+      .article-header h1 code { color: var(--cyan); }
+    }
+    .article-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.85rem;
+      color: var(--text-dimmed);
+    }
+    .article-meta .tag {
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+    }
+
+    /* ===== Article Body ===== */
+    .article-body {
+      padding-bottom: 3rem;
+    }
+    .article-body p {
+      font-size: 1.1rem;
+      line-height: 1.75;
+      margin-bottom: 1.5rem;
+    }
+    .article-body h2 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      margin-top: 3rem;
+      margin-bottom: 1rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--border);
+    }
+    .article-body h2:first-child {
+      margin-top: 0;
+      padding-top: 0;
+      border-top: none;
+    }
+    .article-body h3 {
+      font-size: 1.2rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+    }
+    .article-body ul, .article-body ol {
+      margin-bottom: 1.5rem;
+      padding-left: 1.5rem;
+    }
+    .article-body li {
+      font-size: 1.05rem;
+      line-height: 1.7;
+      margin-bottom: 0.4rem;
+    }
+    .article-body strong { font-weight: 600; }
+
+    .article-body code {
+      font-family: var(--font-mono);
+      font-size: 0.88em;
+      padding: 0.15em 0.4em;
+      border-radius: 4px;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+    }
+    @media (prefers-color-scheme: dark) {
+      .article-body code { background: var(--bg-alt); }
+    }
+
+    .article-body blockquote {
+      border-left: 3px solid var(--cyan);
+      padding: 0.75rem 1.25rem;
+      margin: 1.5rem 0;
+      background: var(--bg-alt);
+      border-radius: 0 6px 6px 0;
+    }
+    .article-body blockquote p {
+      font-size: 1.05rem;
+      margin-bottom: 0;
+      color: var(--text-secondary);
+    }
+
+    /* Code blocks */
+    .code-block {
+      background: #161b22;
+      border-radius: 8px;
+      border: 1px solid #30363d;
+      margin: 1.5rem 0;
+      overflow: hidden;
+    }
+    .code-label {
+      display: block;
+      padding: 0.5rem 1.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--text-dimmed);
+      border-bottom: 1px solid #30363d;
+      background: #1c2128;
+    }
+    .code-block pre {
+      padding: 1.25rem 1.5rem;
+      overflow-x: auto;
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      line-height: 1.65;
+      color: #e6edf3;
+    }
+    .code-block pre code {
+      font-family: inherit;
+      font-size: inherit;
+      padding: 0;
+      border: none;
+      background: none;
+      border-radius: 0;
+      color: inherit;
+    }
+
+    /* Minimal syntax hints */
+    .kw { color: #ff7b72; }
+    .fn { color: #d2a8ff; }
+    .str { color: #a5d6ff; }
+    .cm { color: #8b949e; }
+    .tp { color: #79c0ff; }
+
+    /* Terminal block (for spec output) */
+    .terminal {
+      margin: 1.5rem 0;
+      background: #161b22;
+      border-radius: 8px;
+      border: 1px solid #30363d;
+      overflow: hidden;
+    }
+    .terminal-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 10px 14px;
+      background: #1c2128;
+      border-bottom: 1px solid #30363d;
+    }
+    .terminal-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+    }
+    .terminal-dot.r { background: #f85149; }
+    .terminal-dot.y { background: #d29922; }
+    .terminal-dot.g { background: #3fb950; }
+    .terminal-title {
+      margin-left: 6px;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--text-dimmed);
+    }
+    .terminal-body {
+      padding: 1.25rem 1.5rem;
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      line-height: 1.7;
+      color: var(--text-on-dark);
+      overflow-x: auto;
+    }
+    .t-prompt { color: var(--text-dimmed); }
+    .t-cmd { color: var(--cyan); }
+    .t-suite { color: #f0f6fc; font-weight: 600; }
+    .t-test { color: #f0f6fc; font-weight: 600; }
+    .t-when { color: var(--text-dimmed); }
+    .t-pass { color: var(--green); }
+    .t-time { color: #484f58; }
+    .t-summary { color: var(--text-dimmed); border-top: 1px solid #21262d; display: block; padding-top: 0.75rem; margin-top: 0.5rem; }
+
+    /* Side-by-side comparison */
+    .compare {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+      margin: 1.5rem 0;
+    }
+    .compare .code-block { margin: 0; }
+    @media (max-width: 720px) {
+      .compare { grid-template-columns: 1fr; }
+    }
+
+    /* CTA section */
+    .cta {
+      margin: 2.5rem 0;
+      padding: 2rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      text-align: center;
+    }
+    .cta p {
+      margin-bottom: 1rem;
+    }
+    .cta .install-cmd {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 0.75rem 1rem;
+      font-family: var(--font-mono);
+      font-size: 0.9rem;
+      max-width: 100%;
+      overflow-x: auto;
+    }
+    .cta .install-cmd code {
+      white-space: nowrap;
+      color: var(--text);
+    }
+    .cta .install-cmd button {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.3rem 0.5rem;
+      cursor: pointer;
+      color: var(--text-secondary);
+      font-size: 0.8rem;
+      flex-shrink: 0;
+      transition: all 0.15s;
+    }
+    .cta .install-cmd button:hover { background: var(--border); }
+    .cta-links {
+      margin-top: 1rem;
+      font-size: 0.9rem;
+      display: flex;
+      justify-content: center;
+      gap: 1.5rem;
+    }
+
+    /* ===== Footer ===== */
+    footer {
+      background: var(--bg-dark);
+      color: var(--text-dimmed);
+      padding: 2.5rem 1.5rem;
+      text-align: center;
+      font-size: 0.85rem;
+    }
+    footer a { color: var(--text-on-dark); }
+    footer a:hover { color: var(--cyan); }
+    .footer-links {
+      display: flex;
+      justify-content: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .footer-copy { color: #484f58; font-size: 0.8rem; }
+
+    /* ===== Responsive ===== */
+    @media (max-width: 640px) {
+      .article-header h1 { font-size: 1.75rem; }
+      .article-body p { font-size: 1.05rem; }
+    }
+    @media (max-width: 480px) {
+      .nav-links { gap: 0.75rem; font-size: 0.8rem; }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-inner">
+      <a href="../" class="nav-brand">
+        <img src="../static/logo.png" alt="gotest logo" width="28" height="28">
+        gotest
+      </a>
+      <div class="nav-links">
+        <a href="./">Blog</a>
+        <a href="../reference.html" class="nav-ref">Reference</a>
+        <a href="https://github.com/mvrahden/go-test" class="star-btn"><span class="star-icon">&#9734;</span> Star<span class="star-count" id="star-count"></span></a>
+        <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="article">
+    <header class="article-header">
+      <a href="./" class="back">&larr; All posts</a>
+      <h1>Organizing Go Tests Beyond <code>func TestX</code></h1>
+      <div class="article-meta">
+        <time datetime="2026-07-06">July 6, 2026</time>
+        <span>&middot;</span>
+        <span>10 min read</span>
+        <span class="tag">Patterns</span>
+      </div>
+    </header>
+
+    <div class="article-body">
+
+      <p>Go's testing package is deliberately simple. No annotations, no test classes, no dependency injection: just functions that start with <code>Test</code> and a <code>*testing.T</code>. This simplicity is one of Go's genuine strengths. But it creates a gap that every growing project eventually falls into.</p>
+
+      <p>This post walks through the progression most Go projects follow as their test suites grow: flat functions, table-driven tests, subtests, and suites. Each solves a real problem. Each leaves something on the table. Understanding that progression makes it easier to see where your own project sits, and what it might need next.</p>
+
+      <h2>Flat functions: where everyone starts</h2>
+
+      <p>A new Go project's test file usually looks like this:</p>
+
+      <div class="code-block">
+        <span class="code-label">user_service_test.go</span>
+        <pre><code><span class="kw">func</span> <span class="fn">TestCreateUser</span>(t *<span class="tp">testing.T</span>) {
+    db := setupTestDB(t)
+    err := db.CreateUser(User{Name: <span class="str">"Alice"</span>, Email: <span class="str">"alice@example.com"</span>})
+    <span class="kw">if</span> err != <span class="kw">nil</span> {
+        t.Fatalf(<span class="str">"expected no error, got %v"</span>, err)
+    }
+}
+
+<span class="kw">func</span> <span class="fn">TestCreateUserDuplicateEmail</span>(t *<span class="tp">testing.T</span>) {
+    db := setupTestDB(t)
+    db.CreateUser(User{Name: <span class="str">"Alice"</span>, Email: <span class="str">"alice@example.com"</span>})
+    err := db.CreateUser(User{Name: <span class="str">"Bob"</span>, Email: <span class="str">"alice@example.com"</span>})
+    <span class="kw">if</span> err == <span class="kw">nil</span> {
+        t.Fatal(<span class="str">"expected error for duplicate email"</span>)
+    }
+}
+
+<span class="kw">func</span> <span class="fn">TestGetUser</span>(t *<span class="tp">testing.T</span>) {
+    db := setupTestDB(t)
+    db.CreateUser(User{Name: <span class="str">"Alice"</span>, Email: <span class="str">"alice@example.com"</span>})
+    user, err := db.GetUser(<span class="str">"alice@example.com"</span>)
+    <span class="kw">if</span> err != <span class="kw">nil</span> {
+        t.Fatalf(<span class="str">"expected no error, got %v"</span>, err)
+    }
+    <span class="kw">if</span> user.Name != <span class="str">"Alice"</span> {
+        t.Errorf(<span class="str">"expected Alice, got %s"</span>, user.Name)
+    }
+}
+
+<span class="kw">func</span> <span class="fn">TestGetUserNotFound</span>(t *<span class="tp">testing.T</span>) {
+    db := setupTestDB(t)
+    _, err := db.GetUser(<span class="str">"nobody@example.com"</span>)
+    <span class="kw">if</span> err == <span class="kw">nil</span> {
+        t.Fatal(<span class="str">"expected error for missing user"</span>)
+    }
+}
+
+<span class="kw">func</span> <span class="fn">TestDeleteUser</span>(t *<span class="tp">testing.T</span>) {
+    db := setupTestDB(t)
+    db.CreateUser(User{Name: <span class="str">"Alice"</span>, Email: <span class="str">"alice@example.com"</span>})
+    err := db.DeleteUser(<span class="str">"alice@example.com"</span>)
+    <span class="kw">if</span> err != <span class="kw">nil</span> {
+        t.Fatalf(<span class="str">"expected no error, got %v"</span>, err)
+    }
+}</code></pre>
+      </div>
+
+      <p>Five functions, and <code>setupTestDB(t)</code> appears in every one. There's no visible relationship between the "create" tests and the "get" tests; they're just an alphabetical list. Assertions are manual <code>if</code>/<code>t.Fatal</code> checks with inconsistent formatting.</p>
+
+      <p>This works fine at 10 test functions. At 50, you're scrolling to find what you need. At 200, you're <code>grep</code>-ing your own test files.</p>
+
+      <h2>Table-driven tests: less code, same structure</h2>
+
+      <p>The first escape hatch most Go developers reach for is the table-driven pattern:</p>
+
+      <div class="code-block">
+        <pre><code><span class="kw">func</span> <span class="fn">TestCreateUser</span>(t *<span class="tp">testing.T</span>) {
+    tests := []<span class="kw">struct</span> {
+        name    <span class="tp">string</span>
+        user    User
+        wantErr <span class="tp">bool</span>
+    }{
+        {<span class="str">"valid user"</span>, User{Name: <span class="str">"Alice"</span>, Email: <span class="str">"alice@example.com"</span>}, <span class="kw">false</span>},
+        {<span class="str">"missing name"</span>, User{Email: <span class="str">"alice@example.com"</span>}, <span class="kw">true</span>},
+        {<span class="str">"invalid email"</span>, User{Name: <span class="str">"Alice"</span>, Email: <span class="str">"not-an-email"</span>}, <span class="kw">true</span>},
+    }
+
+    <span class="kw">for</span> _, tt := <span class="kw">range</span> tests {
+        t.Run(tt.name, <span class="kw">func</span>(t *<span class="tp">testing.T</span>) {
+            db := setupTestDB(t)
+            err := db.CreateUser(tt.user)
+            <span class="kw">if</span> (err != <span class="kw">nil</span>) != tt.wantErr {
+                t.Errorf(<span class="str">"CreateUser() error = %v, wantErr %v"</span>, err, tt.wantErr)
+            }
+        })
+    }
+}</code></pre>
+      </div>
+
+      <p>Better. Less repetition within a group of related cases. <code>t.Run</code> gives each case a name so failures point to the right row.</p>
+
+      <p>But table-driven tests solve repetition, not organization. <code>TestCreateUser</code> and <code>TestGetUser</code> and <code>TestDeleteUser</code> are still unrelated flat functions sitting in a file together. And the pattern starts to strain when cases need different assertion logic: the struct grows fields like <code>wantCode</code>, <code>wantBody</code>, <code>setupFn</code>, <code>checkFn</code>, and the table becomes harder to read than the tests it replaced.</p>
+
+      <h2>Subtests: hierarchy without lifecycle</h2>
+
+      <p>Go 1.7 introduced <code>t.Run</code>, and with it came the ability to nest tests:</p>
+
+      <div class="code-block">
+        <pre><code><span class="kw">func</span> <span class="fn">TestUserService</span>(t *<span class="tp">testing.T</span>) {
+    db := setupTestDB(t)
+    t.Cleanup(<span class="kw">func</span>() { db.Close() })
+
+    t.Run(<span class="str">"Create"</span>, <span class="kw">func</span>(t *<span class="tp">testing.T</span>) {
+        t.Run(<span class="str">"valid user"</span>, <span class="kw">func</span>(t *<span class="tp">testing.T</span>) {
+            err := db.CreateUser(User{Name: <span class="str">"Alice"</span>})
+            <span class="kw">if</span> err != <span class="kw">nil</span> {
+                t.Fatal(err)
+            }
+        })
+        t.Run(<span class="str">"duplicate email"</span>, <span class="kw">func</span>(t *<span class="tp">testing.T</span>) {
+            err := db.CreateUser(User{Name: <span class="str">"Alice"</span>})
+            <span class="cm">// this fails: Create/valid_user already inserted Alice</span>
+            <span class="kw">if</span> err == <span class="kw">nil</span> {
+                t.Fatal(<span class="str">"expected error"</span>)
+            }
+        })
+    })
+
+    t.Run(<span class="str">"Delete"</span>, <span class="kw">func</span>(t *<span class="tp">testing.T</span>) {
+        err := db.DeleteUser(<span class="str">"alice@example.com"</span>)
+        <span class="cm">// depends on what Create tests left behind</span>
+        <span class="kw">if</span> err != <span class="kw">nil</span> {
+            t.Fatal(err)
+        }
+    })
+}</code></pre>
+      </div>
+
+      <p>Now there's visible structure: <code>TestUserService/Create/valid_user</code> reads like a path. But this pattern has real problems:</p>
+
+      <ul>
+        <li><strong>Shared state leaks across subtests.</strong> The <code>db</code> variable is shared between "Create" and "Delete." If the "Create" subtests modify the database, "Delete" inherits that state. Tests become order-dependent.</li>
+        <li><strong>No per-group lifecycle.</strong> There's no way to reset <code>db</code> before each subtest. <code>t.Cleanup</code> runs once, at the end. You'd need to call <code>setupTestDB(t)</code> inside every leaf <code>t.Run</code>, which brings back the repetition you were trying to eliminate.</li>
+        <li><strong>Closures stack up fast.</strong> Three levels of nesting means three levels of <code>func(t *testing.T) {</code>. At scale, the indentation alone makes the file hard to navigate.</li>
+        <li><strong>Parallelism is manual.</strong> Want to run subtests in parallel? You need <code>t.Parallel()</code> in every leaf, and careful synchronization on the shared <code>db</code>.</li>
+      </ul>
+
+      <p>Subtests give you hierarchy. They don't give you lifecycle.</p>
+
+      <h2>What a suite actually provides</h2>
+
+      <p>The pattern most projects eventually need is a <strong>test suite</strong>: a group of tests organized around a single subject, with lifecycle hooks that guarantee each test starts from a known state.</p>
+
+      <p>A suite gives you four things that flat functions and subtests don't:</p>
+
+      <ol>
+        <li><strong>Grouping by subject.</strong> All tests for <code>UserService</code> live on one struct.</li>
+        <li><strong>Lifecycle hooks.</strong> <code>BeforeEach</code> runs before every test, so each test gets fresh state.</li>
+        <li><strong>Isolation.</strong> Test methods can't accidentally share state through closures.</li>
+        <li><strong>Discoverability.</strong> The struct name tells you what's under test. Methods tell you what it does.</li>
+      </ol>
+
+      <p>In Go, the most established suite framework is <code>testify/suite</code>:</p>
+
+      <div class="code-block">
+        <span class="code-label">testify/suite approach</span>
+        <pre><code><span class="kw">type</span> <span class="tp">UserServiceSuite</span> <span class="kw">struct</span> {
+    suite.Suite
+    db *TestDB
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserServiceSuite</span>) <span class="fn">SetupTest</span>() {
+    s.db = setupTestDB(s.T())
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserServiceSuite</span>) <span class="fn">TearDownTest</span>() {
+    s.db.Close()
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserServiceSuite</span>) <span class="fn">TestCreateUser</span>() {
+    err := s.db.CreateUser(User{Name: <span class="str">"Alice"</span>})
+    s.NoError(err)
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserServiceSuite</span>) <span class="fn">TestCreateUserDuplicate</span>() {
+    s.db.CreateUser(User{Name: <span class="str">"Alice"</span>, Email: <span class="str">"a@b.com"</span>})
+    err := s.db.CreateUser(User{Name: <span class="str">"Bob"</span>, Email: <span class="str">"a@b.com"</span>})
+    s.Error(err)
+}
+
+<span class="kw">func</span> <span class="fn">TestUserServiceSuite</span>(t *<span class="tp">testing.T</span>) {
+    suite.Run(t, <span class="kw">new</span>(UserServiceSuite))
+}
+</code></pre>
+      </div>
+
+      <p>This solves the organizational problem. <code>SetupTest</code> runs before each test method. State lives on the struct, not in closures. Each method is a self-contained test.</p>
+
+      <p>But it comes with trade-offs:</p>
+
+      <ul>
+        <li><strong>Reflection-based discovery.</strong> <code>suite.Run</code> uses <code>reflect</code> to find and invoke test methods at runtime. That means test failures don't always map cleanly to stack traces, and refactoring tools can't always follow the call chain.</li>
+        <li><strong>Runtime dependency.</strong> Your test binary imports <code>github.com/stretchr/testify</code>, a third-party module with its own release cycle and transitive dependencies.</li>
+        <li><strong>Framework coupling.</strong> Every suite must embed <code>suite.Suite</code>. Every assertion goes through <code>s.NoError</code>, <code>s.Equal</code>, methods on the embedded struct, not type-safe generic functions.</li>
+        <li><strong>No BDD structure.</strong> Test methods are flat; there's no equivalent of "when X, it should Y" nesting within a method.</li>
+      </ul>
+
+      <h2>A different angle: suites as a compile-time concern</h2>
+
+      <p>Here's the observation that changes the equation: <strong>the suite pattern is an organizational concern, not a runtime concern.</strong></p>
+
+      <p>What suites need at runtime is ordinary Go code: <code>t.Run</code> calls, <code>t.Cleanup</code> calls, struct initialization. Everything the stdlib already provides. The reason frameworks like testify/suite use reflection is to <em>discover</em> test methods and <em>wire up</em> lifecycle hooks. But discovery and wiring are compile-time activities. They can happen before <code>go test</code> runs.</p>
+
+      <p>That's the approach <a href="https://github.com/mvrahden/go-test">gotest</a> takes. You write test suites as plain Go structs with naming conventions. A code generator reads your source, discovers the structure, and generates the lifecycle wiring that you'd write by hand. What runs is standard <code>go test</code>. No reflection. No framework orchestration at runtime.</p>
+
+      <div class="code-block">
+        <span class="code-label">gotest approach</span>
+        <pre><code><span class="kw">type</span> <span class="tp">UserServiceTestSuite</span> <span class="kw">struct</span> {
+    db *TestDB
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserServiceTestSuite</span>) <span class="fn">BeforeEach</span>(t *<span class="tp">gotest.T</span>) {
+    s.db = setupTestDB(t)
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserServiceTestSuite</span>) <span class="fn">TestCreateUser</span>(t *<span class="tp">gotest.T</span>) {
+    t.When(<span class="str">"the input is valid"</span>, <span class="kw">func</span>(w *<span class="tp">gotest.T</span>) {
+        err := s.db.CreateUser(User{Name: <span class="str">"Alice"</span>, Email: <span class="str">"alice@example.com"</span>})
+
+        w.It(<span class="str">"succeeds without error"</span>, <span class="kw">func</span>(it *<span class="tp">gotest.T</span>) {
+            gotest.NoError(it, err)
+        })
+    })
+
+    t.When(<span class="str">"the email already exists"</span>, <span class="kw">func</span>(w *<span class="tp">gotest.T</span>) {
+        s.db.CreateUser(User{Name: <span class="str">"Alice"</span>, Email: <span class="str">"alice@example.com"</span>})
+        err := s.db.CreateUser(User{Name: <span class="str">"Bob"</span>, Email: <span class="str">"alice@example.com"</span>})
+
+        w.It(<span class="str">"returns an error"</span>, <span class="kw">func</span>(it *<span class="tp">gotest.T</span>) {
+            gotest.Error(it, err)
+        })
+    })
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserServiceTestSuite</span>) <span class="fn">TestDeleteUser</span>(t *<span class="tp">gotest.T</span>) {
+    t.When(<span class="str">"the user exists"</span>, <span class="kw">func</span>(w *<span class="tp">gotest.T</span>) {
+        s.db.CreateUser(User{Name: <span class="str">"Alice"</span>, Email: <span class="str">"alice@example.com"</span>})
+        err := s.db.DeleteUser(<span class="str">"alice@example.com"</span>)
+
+        w.It(<span class="str">"succeeds without error"</span>, <span class="kw">func</span>(it *<span class="tp">gotest.T</span>) {
+            gotest.NoError(it, err)
+        })
+    })
+}</code></pre>
+      </div>
+
+      <p>A few things to notice:</p>
+
+      <ul>
+        <li><strong>No framework embedding.</strong> The struct has only your fields. No <code>suite.Suite</code>, no interface to satisfy.</li>
+        <li><strong>Lifecycle via naming conventions.</strong> <code>BeforeEach</code> is recognized by name. It runs before every <code>Test*</code> method, giving each test a fresh <code>db</code>.</li>
+        <li><strong>BDD structure inside methods.</strong> <code>t.When</code> and <code>t.It</code> create labeled subtests via <code>t.Run</code>. They're just method calls: no DSL, no magic.</li>
+        <li><strong>Type-safe assertions.</strong> <code>gotest.NoError</code>, <code>gotest.Equal</code>, and others are generic functions. Pass the wrong type and the compiler catches it.</li>
+      </ul>
+
+      <p>Running <code>gotest ./...</code> generates the <code>t.Run</code> nesting, lifecycle calls, and process isolation behind the scenes, then invokes <code>go test</code>. The generated code is injected via Go's <code>-overlay</code> flag; it never touches your source tree.</p>
+
+      <h2>Tests that explain themselves</h2>
+
+      <p>There's a useful consequence of this structure. Because test methods, <code>When</code> blocks, and <code>It</code> blocks all have descriptive names, gotest can render them as a behavioral specification:</p>
+
+      <div class="terminal">
+        <div class="terminal-header">
+          <span class="terminal-dot r"></span>
+          <span class="terminal-dot y"></span>
+          <span class="terminal-dot g"></span>
+          <span class="terminal-title">gotest spec ./...</span>
+        </div>
+        <pre class="terminal-body"><span class="t-prompt">$</span> <span class="t-cmd">gotest spec ./...</span>
+
+<span class="t-suite">UserService</span>
+  <span class="t-test">CreateUser</span>
+    <span class="t-when">when the input is valid</span>
+      <span class="t-pass">&#10003;</span> succeeds without error <span class="t-time">(5ms)</span>
+    <span class="t-when">when the email already exists</span>
+      <span class="t-pass">&#10003;</span> returns an error <span class="t-time">(&lt;1ms)</span>
+  <span class="t-test">DeleteUser</span>
+    <span class="t-when">when the user exists</span>
+      <span class="t-pass">&#10003;</span> succeeds without error <span class="t-time">(3ms)</span>
+<span class="t-summary">1 suite, 3 behaviors: <span class="t-pass">3 passed</span>, 0 failed, 0 skipped</span></pre>
+      </div>
+
+      <p>This isn't generated documentation; it's a direct rendering of your test structure. If a test is missing, the spec has a gap. If a test fails, the spec shows it. The test <em>is</em> the specification.</p>
+
+      <p>This spec output is also machine-readable. <code>gotest spec --format json</code> produces structured JSON that you can feed into documentation pipelines, AI-assisted workflows, or CI reporting.</p>
+
+      <h2>Where this leaves you</h2>
+
+      <p>Every Go project moves through a progression:</p>
+
+      <ol>
+        <li><strong>Flat functions.</strong> Simple, but no organization.</li>
+        <li><strong>Table-driven tests.</strong> Reduce repetition within a group.</li>
+        <li><strong>Subtests.</strong> Add hierarchy, but no lifecycle.</li>
+        <li><strong>Suites.</strong> Add lifecycle, grouping, and isolation.</li>
+      </ol>
+
+      <p>The question at step 4 is how you get suites. Runtime reflection (testify/suite) works and is battle-tested. Compile-time code generation (gotest) gives you the same organizational benefits with type safety, no reflection, and BDD structure, at the cost of a code generation step.</p>
+
+      <p>Neither is universally right. But if you've been writing Go tests long enough to feel the limits of flat functions and subtests, it's worth understanding the trade-offs. The test structure you choose is the one you'll read, debug, and maintain for the life of the project.</p>
+
+      <div class="cta">
+        <p><strong>Try gotest on your next project.</strong></p>
+        <div class="install-cmd">
+          <code>go install github.com/mvrahden/go-test/cmd/gotest@latest</code>
+          <button onclick="navigator.clipboard.writeText('go install github.com/mvrahden/go-test/cmd/gotest@latest').then(()=>{this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)})" aria-label="Copy install command">Copy</button>
+        </div>
+        <div class="cta-links">
+          <a href="../reference.html">Reference</a>
+          <a href="https://github.com/mvrahden/go-test">GitHub</a>
+          <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+  <footer>
+    <div class="footer-links">
+      <a href="../">Home</a>
+      <a href="https://github.com/mvrahden/go-test">GitHub</a>
+      <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
+      <a href="../reference.html">Reference</a>
+      <a href="./">Blog</a>
+      <a href="https://github.com/mvrahden/go-test/blob/main/LICENSE">MIT License</a>
+    </div>
+    <p class="footer-copy">Built for Go developers who want tests that explain themselves.</p>
+  </footer>
+  <script>
+  fetch('https://api.github.com/repos/mvrahden/go-test')
+    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(d => {
+      if (d.stargazers_count >= 10) {
+        document.getElementById('star-count').textContent = ` ${d.stargazers_count}`;
+      }
+    })
+    .catch(() => {});
+  </script>
+</body>
+</html>

--- a/docs/blog/readable-tests-with-bdd.html
+++ b/docs/blog/readable-tests-with-bdd.html
@@ -1,0 +1,782 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Readable Tests with BDD-Style Go | gotest blog</title>
+  <meta name="description" content="Test names like TestCreateUser_WhenEmailInvalid_ReturnsError are hard to scan. BDD-style labeled subtests and spec output turn your tests into living documentation.">
+  <meta name="keywords" content="go bdd testing, golang behavior driven development, go test readable output, go test subtests, gotest spec, go test documentation">
+
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://mvrahden.github.io/go-test/blog/readable-tests-with-bdd.html">
+  <meta property="og:title" content="Readable Tests with BDD-Style Go">
+  <meta property="og:description" content="Test names like TestCreateUser_WhenEmailInvalid_ReturnsError are hard to scan. BDD-style labeled subtests and spec output turn your tests into living documentation.">
+  <meta property="og:image" content="https://mvrahden.github.io/go-test/static/gopher.png">
+  <meta property="og:image:width" content="1024">
+  <meta property="og:image:height" content="572">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Readable Tests with BDD-Style Go">
+  <meta name="twitter:description" content="Test names like TestCreateUser_WhenEmailInvalid_ReturnsError are hard to scan. BDD-style labeled subtests and spec output turn your tests into living documentation.">
+  <meta name="twitter:image" content="https://mvrahden.github.io/go-test/static/gopher.png">
+
+  <link rel="icon" type="image/png" href="../static/logo.png">
+  <link rel="canonical" href="https://mvrahden.github.io/go-test/blog/readable-tests-with-bdd.html">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7WHJ67Z1J0"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-7WHJ67Z1J0');
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "Readable Tests with BDD-Style Go",
+    "description": "Test names like TestCreateUser_WhenEmailInvalid_ReturnsError are hard to scan. BDD-style labeled subtests and spec output turn your tests into living documentation.",
+    "url": "https://mvrahden.github.io/go-test/blog/readable-tests-with-bdd.html",
+    "datePublished": "2026-07-08",
+    "author": {
+      "@type": "Person",
+      "name": "Menno van Rahden",
+      "url": "https://github.com/mvrahden"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "gotest",
+      "url": "https://mvrahden.github.io/go-test/"
+    },
+    "isPartOf": {
+      "@type": "Blog",
+      "name": "gotest blog",
+      "url": "https://mvrahden.github.io/go-test/blog/"
+    },
+    "programmingLanguage": "Go"
+  }
+  </script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --cyan: #00ADD8;
+      --cyan-dark: #007d9c;
+      --bg: #ffffff;
+      --bg-alt: #f6f8fa;
+      --bg-dark: #0d1117;
+      --bg-dark-alt: #161b22;
+      --text: #24292f;
+      --text-secondary: #656d76;
+      --text-on-dark: #e6edf3;
+      --text-dimmed: #8b949e;
+      --border: #d0d7de;
+      --green: #3fb950;
+      --amber: #d29922;
+      --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', Consolas, 'Liberation Mono', monospace;
+      --max-w: 740px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d1117;
+        --bg-alt: #161b22;
+        --bg-dark: #010409;
+        --bg-dark-alt: #0d1117;
+        --text: #e6edf3;
+        --text-secondary: #8b949e;
+        --border: #30363d;
+      }
+    }
+
+    html { scroll-behavior: smooth; height: 100%; }
+
+    body {
+      font-family: var(--font-sans);
+      color: var(--text);
+      background: var(--bg);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      min-height: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .article { flex: 1; }
+
+    a { color: var(--cyan-dark); text-decoration: none; }
+    @media (prefers-color-scheme: dark) { a { color: var(--cyan); } }
+    a:hover { text-decoration: underline; }
+
+    /* ===== Nav ===== */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(8px);
+    }
+    .nav-inner {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 0.75rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .nav-brand {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 700;
+      font-size: 1.125rem;
+      color: var(--text);
+      text-decoration: none;
+    }
+    .nav-brand:hover { text-decoration: none; }
+    .nav-brand img { width: 28px; height: 28px; border-radius: 50%; }
+    .nav-links { display: flex; gap: 1.25rem; font-size: 0.9rem; align-items: center; }
+    .nav-links a { color: var(--text-secondary); }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+    .nav-links .nav-ref {
+      padding: 0.25rem 0.65rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-weight: 600;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-links .nav-ref:hover { background: var(--bg-alt); }
+    .nav-links .star-btn { font-size: 0.85rem; }
+    .star-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.3rem 0.7rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-weight: 600;
+      text-decoration: none;
+      transition: all 0.15s;
+      font-size: 0.8rem;
+    }
+    .star-btn:hover { background: var(--bg-alt); text-decoration: none; }
+    .star-btn .star-icon { color: #e3b341; }
+    .star-count { font-weight: 400; color: var(--text-dimmed); }
+
+    /* ===== Article ===== */
+    .article {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 0 1.5rem;
+    }
+
+    .article-header {
+      padding: 3.5rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 2.5rem;
+    }
+    .article-header .back {
+      display: inline-block;
+      font-size: 0.85rem;
+      color: var(--text-dimmed);
+      margin-bottom: 1.5rem;
+    }
+    .article-header .back:hover { color: var(--text-secondary); }
+    .article-header h1 {
+      font-size: 2.25rem;
+      font-weight: 800;
+      letter-spacing: -0.025em;
+      line-height: 1.2;
+      margin-bottom: 1rem;
+    }
+    .article-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.85rem;
+      color: var(--text-dimmed);
+    }
+    .article-meta .tag {
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+    }
+
+    /* ===== Article Body ===== */
+    .article-body {
+      padding-bottom: 3rem;
+    }
+    .article-body p {
+      font-size: 1.1rem;
+      line-height: 1.75;
+      margin-bottom: 1.5rem;
+    }
+    .article-body h2 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      margin-top: 3rem;
+      margin-bottom: 1rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--border);
+    }
+    .article-body h2:first-child {
+      margin-top: 0;
+      padding-top: 0;
+      border-top: none;
+    }
+    .article-body h3 {
+      font-size: 1.2rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+    }
+    .article-body ul, .article-body ol {
+      margin-bottom: 1.5rem;
+      padding-left: 1.5rem;
+    }
+    .article-body li {
+      font-size: 1.05rem;
+      line-height: 1.7;
+      margin-bottom: 0.4rem;
+    }
+    .article-body strong { font-weight: 600; }
+
+    .article-body code {
+      font-family: var(--font-mono);
+      font-size: 0.88em;
+      padding: 0.15em 0.4em;
+      border-radius: 4px;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+    }
+
+    .article-body blockquote {
+      border-left: 3px solid var(--cyan);
+      padding: 0.75rem 1.25rem;
+      margin: 1.5rem 0;
+      background: var(--bg-alt);
+      border-radius: 0 6px 6px 0;
+    }
+    .article-body blockquote p {
+      font-size: 1.05rem;
+      margin-bottom: 0;
+      color: var(--text-secondary);
+    }
+
+    /* Code blocks */
+    .code-block {
+      background: #161b22;
+      border-radius: 8px;
+      border: 1px solid #30363d;
+      margin: 1.5rem 0;
+      overflow: hidden;
+    }
+    .code-label {
+      display: block;
+      padding: 0.5rem 1.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--text-dimmed);
+      border-bottom: 1px solid #30363d;
+      background: #1c2128;
+    }
+    .code-block pre {
+      padding: 1.25rem 1.5rem;
+      overflow-x: auto;
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      line-height: 1.65;
+      color: #e6edf3;
+    }
+    .code-block pre code {
+      font-family: inherit;
+      font-size: inherit;
+      padding: 0;
+      border: none;
+      background: none;
+      border-radius: 0;
+      color: inherit;
+    }
+
+    .kw { color: #ff7b72; }
+    .fn { color: #d2a8ff; }
+    .str { color: #a5d6ff; }
+    .cm { color: #8b949e; }
+    .tp { color: #79c0ff; }
+
+    /* Spec output visualization */
+    .spec-block {
+      background: #0d1117;
+      border-radius: 8px;
+      border: 1px solid #30363d;
+      margin: 1.5rem 0;
+      overflow: hidden;
+    }
+    .spec-label {
+      display: block;
+      padding: 0.5rem 1.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--text-dimmed);
+      border-bottom: 1px solid #30363d;
+      background: #1c2128;
+    }
+    .spec-block pre {
+      padding: 1.25rem 1.5rem;
+      overflow-x: auto;
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      line-height: 1.8;
+      color: #e6edf3;
+    }
+    .t-suite { color: #f0f6fc; font-weight: 600; }
+    .t-test { color: #f0f6fc; font-weight: 600; }
+    .t-when { color: var(--text-dimmed); }
+    .t-pass { color: var(--green); }
+    .t-fail { color: #f85149; }
+    .t-time { color: #484f58; }
+    .t-summary { color: var(--text-dimmed); border-top: 1px solid #21262d; display: block; padding-top: 0.75rem; margin-top: 0.5rem; }
+
+    /* go test output visualization */
+    .gotest-block {
+      background: #161b22;
+      border-radius: 8px;
+      border: 1px solid #30363d;
+      margin: 1.5rem 0;
+      overflow: hidden;
+    }
+    .gotest-label {
+      display: block;
+      padding: 0.5rem 1.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--text-dimmed);
+      border-bottom: 1px solid #30363d;
+      background: #1c2128;
+    }
+    .gotest-block pre {
+      padding: 1.25rem 1.5rem;
+      overflow-x: auto;
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      line-height: 1.65;
+      color: #8b949e;
+    }
+
+    /* CTA section */
+    .cta {
+      margin: 2.5rem 0;
+      padding: 2rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      text-align: center;
+    }
+    .cta p {
+      margin-bottom: 1rem;
+    }
+    .cta .install-cmd {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 0.75rem 1rem;
+      font-family: var(--font-mono);
+      font-size: 0.9rem;
+      max-width: 100%;
+      overflow-x: auto;
+    }
+    .cta .install-cmd code {
+      white-space: nowrap;
+      color: var(--text);
+    }
+    .cta .install-cmd button {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.3rem 0.5rem;
+      cursor: pointer;
+      color: var(--text-secondary);
+      font-size: 0.8rem;
+      flex-shrink: 0;
+      transition: all 0.15s;
+    }
+    .cta .install-cmd button:hover { background: var(--border); }
+    .cta-links {
+      margin-top: 1rem;
+      font-size: 0.9rem;
+      display: flex;
+      justify-content: center;
+      gap: 1.5rem;
+    }
+
+    /* ===== Footer ===== */
+    footer {
+      background: var(--bg-dark);
+      color: var(--text-dimmed);
+      padding: 2.5rem 1.5rem;
+      text-align: center;
+      font-size: 0.85rem;
+    }
+    footer a { color: var(--text-on-dark); }
+    footer a:hover { color: var(--cyan); }
+    .footer-links {
+      display: flex;
+      justify-content: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .footer-copy { color: #484f58; font-size: 0.8rem; }
+
+    /* ===== Responsive ===== */
+    @media (max-width: 640px) {
+      .article-header h1 { font-size: 1.75rem; }
+      .article-body p { font-size: 1.05rem; }
+    }
+    @media (max-width: 480px) {
+      .nav-links { gap: 0.75rem; font-size: 0.8rem; }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-inner">
+      <a href="../" class="nav-brand">
+        <img src="../static/logo.png" alt="gotest logo" width="28" height="28">
+        gotest
+      </a>
+      <div class="nav-links">
+        <a href="./">Blog</a>
+        <a href="../reference.html" class="nav-ref">Reference</a>
+        <a href="https://github.com/mvrahden/go-test" class="star-btn"><span class="star-icon">&#9734;</span> Star<span class="star-count" id="star-count"></span></a>
+        <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="article">
+    <header class="article-header">
+      <a href="./" class="back">&larr; All posts</a>
+      <h1>Readable Tests with BDD-Style Go</h1>
+      <div class="article-meta">
+        <time datetime="2026-07-08">July 8, 2026</time>
+        <span>&middot;</span>
+        <span>9 min read</span>
+        <span class="tag">Testing</span>
+      </div>
+    </header>
+
+    <div class="article-body">
+
+      <p>When a test fails in CI, the first thing you read is its name. And for most Go projects, that name looks like this:</p>
+
+      <div class="gotest-block">
+        <span class="gotest-label">go test -v output</span>
+        <pre>=== RUN   TestCreateUser_WhenEmailInvalid_ReturnsError
+--- FAIL: TestCreateUser_WhenEmailInvalid_ReturnsError (0.01s)</pre>
+      </div>
+
+      <p>You can decode it. <code>TestCreateUser</code> is the subject, <code>WhenEmailInvalid</code> is the condition, <code>ReturnsError</code> is the expectation. But it takes a moment. And when you're scanning twenty failures across five packages, those moments add up.</p>
+
+      <p>This post looks at why Go test output is hard to read at scale, how BDD-style structure helps, and what it takes to turn test runs into something that reads like a specification.</p>
+
+      <h2>The naming problem</h2>
+
+      <p>Go's test runner requires test function names to start with <code>Test</code> and use CamelCase or underscores. This forces you to encode three separate ideas, namely the subject, the condition, and the expectation, into a single identifier:</p>
+
+      <div class="code-block">
+        <pre><code><span class="kw">func</span> <span class="fn">TestCreateUser_WhenEmailInvalid_ReturnsError</span>(t *<span class="tp">testing.T</span>) { ... }
+<span class="kw">func</span> <span class="fn">TestCreateUser_WhenEmailAlreadyExists_ReturnsDuplicate</span>(t *<span class="tp">testing.T</span>) { ... }
+<span class="kw">func</span> <span class="fn">TestCreateUser_WhenInputValid_CreatesUser</span>(t *<span class="tp">testing.T</span>) { ... }
+<span class="kw">func</span> <span class="fn">TestCreateUser_WhenInputValid_SendsWelcomeEmail</span>(t *<span class="tp">testing.T</span>) { ... }
+<span class="kw">func</span> <span class="fn">TestDeleteUser_WhenUserExists_SoftDeletes</span>(t *<span class="tp">testing.T</span>) { ... }
+<span class="kw">func</span> <span class="fn">TestDeleteUser_WhenUserNotFound_ReturnsNotFound</span>(t *<span class="tp">testing.T</span>) { ... }</code></pre>
+      </div>
+
+      <p>Six test functions, but the structure is invisible. You have to read every name to understand that there are two subjects (<code>CreateUser</code> and <code>DeleteUser</code>), three conditions for create, two for delete, and that two of the create expectations share the same condition.</p>
+
+      <p>Subtests improve this somewhat:</p>
+
+      <div class="code-block">
+        <pre><code><span class="kw">func</span> <span class="fn">TestCreateUser</span>(t *<span class="tp">testing.T</span>) {
+    t.Run(<span class="str">"when email is invalid"</span>, <span class="kw">func</span>(t *<span class="tp">testing.T</span>) {
+        t.Run(<span class="str">"returns error"</span>, <span class="kw">func</span>(t *<span class="tp">testing.T</span>) {
+            <span class="cm">// ...</span>
+        })
+    })
+    t.Run(<span class="str">"when input is valid"</span>, <span class="kw">func</span>(t *<span class="tp">testing.T</span>) {
+        t.Run(<span class="str">"creates the user"</span>, <span class="kw">func</span>(t *<span class="tp">testing.T</span>) {
+            <span class="cm">// ...</span>
+        })
+    })
+}</code></pre>
+      </div>
+
+      <p>The code itself is more structured. But the output isn't:</p>
+
+      <div class="gotest-block">
+        <span class="gotest-label">go test -v output</span>
+        <pre>=== RUN   TestCreateUser
+=== RUN   TestCreateUser/when_email_is_invalid
+=== RUN   TestCreateUser/when_email_is_invalid/returns_error
+--- PASS: TestCreateUser/when_email_is_invalid/returns_error (0.00s)
+--- PASS: TestCreateUser/when_email_is_invalid (0.00s)
+=== RUN   TestCreateUser/when_input_is_valid
+=== RUN   TestCreateUser/when_input_is_valid/creates_the_user
+--- PASS: TestCreateUser/when_input_is_valid/creates_the_user (0.01s)
+--- PASS: TestCreateUser/when_input_is_valid (0.01s)
+--- PASS: TestCreateUser (0.02s)
+PASS</pre>
+      </div>
+
+      <p>Every subtest name is repeated three times: once in <code>=== RUN</code>, again in its own <code>--- PASS</code>, and again in its parent's <code>--- PASS</code>. The nesting is encoded by slash-separated paths, not indentation. For a single test function with four subtests, that's twelve lines of output. Scale to a real test suite and the signal-to-noise ratio collapses.</p>
+
+      <h2>What BDD structure looks like</h2>
+
+      <p>Behavior-driven development (BDD) introduces a simple idea: describe <em>what</em> a system does in terms of <em>contexts</em> and <em>expectations</em>. A test for a user service might read:</p>
+
+      <blockquote>
+        <p>UserService &rarr; Create &rarr; when email is valid &rarr; creates the user</p>
+      </blockquote>
+
+      <p>The structure is always the same: subject, behavior, context, expectation. Each level adds specificity. The key insight is that contexts and expectations are separate concepts; they shouldn't be jammed into a single function name.</p>
+
+      <p>In gotest, two methods on <code>*gotest.T</code> express this structure:</p>
+
+      <ul>
+        <li><code>t.When(label, fn)</code>: establishes a context. "When the email is invalid," "when the user already exists."</li>
+        <li><code>t.It(label, fn)</code>: states an expectation. "It creates the user," "it returns an error."</li>
+      </ul>
+
+      <p>Both are thin wrappers around <code>t.Run</code>; they create standard Go subtests. The difference is semantic: <code>When</code> is for conditions, <code>It</code> is for assertions. Here's what the user service example looks like:</p>
+
+      <div class="code-block">
+        <span class="code-label">service_test.go</span>
+        <pre><code><span class="kw">type</span> <span class="tp">UserServiceTestSuite</span> <span class="kw">struct</span> {
+    svc *UserService
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserServiceTestSuite</span>) <span class="fn">TestCreate</span>(t *<span class="tp">gotest.T</span>) {
+    t.When(<span class="str">"email is valid"</span>, <span class="kw">func</span>(w *<span class="tp">gotest.T</span>) {
+        user := User{Name: <span class="str">"Alice"</span>, Email: <span class="str">"alice@example.com"</span>}
+        err := s.svc.Create(user)
+
+        w.It(<span class="str">"creates the user"</span>, <span class="kw">func</span>(it *<span class="tp">gotest.T</span>) {
+            gotest.NoError(it, err)
+        })
+        w.It(<span class="str">"sends a welcome email"</span>, <span class="kw">func</span>(it *<span class="tp">gotest.T</span>) {
+            gotest.Equal(it, s.svc.EmailsSent(), 1)
+        })
+    })
+
+    t.When(<span class="str">"email already exists"</span>, <span class="kw">func</span>(w *<span class="tp">gotest.T</span>) {
+        _ = s.svc.Create(User{Email: <span class="str">"bob@example.com"</span>})
+        err := s.svc.Create(User{Email: <span class="str">"bob@example.com"</span>})
+
+        w.It(<span class="str">"returns ErrDuplicate"</span>, <span class="kw">func</span>(it *<span class="tp">gotest.T</span>) {
+            gotest.ErrorIs(it, err, ErrDuplicate)
+        })
+    })
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserServiceTestSuite</span>) <span class="fn">TestDelete</span>(t *<span class="tp">gotest.T</span>) {
+    t.It(<span class="str">"soft-deletes the user"</span>, <span class="kw">func</span>(it *<span class="tp">gotest.T</span>) {
+        s.svc.Create(User{Email: <span class="str">"charlie@example.com"</span>})
+        err := s.svc.Delete(<span class="str">"charlie@example.com"</span>)
+        gotest.NoError(it, err)
+    })
+}</code></pre>
+      </div>
+
+      <p>A few things to notice:</p>
+
+      <ul>
+        <li><strong>Setup runs inside <code>When</code> blocks.</strong> The condition and its setup live together. <code>When("email already exists", ...)</code> creates the duplicate inside the block, not in a separate fixture.</li>
+        <li><strong>Multiple <code>It</code> blocks per <code>When</code>.</strong> "creates the user" and "sends a welcome email" share the same setup but assert different things.</li>
+        <li><strong>Suite and method names carry meaning.</strong> <code>UserServiceTestSuite</code> becomes the subject. <code>TestCreate</code> becomes the behavior. <code>When</code>/<code>It</code> provide context and expectation.</li>
+        <li><strong>You can skip <code>When</code>.</strong> <code>TestDelete</code> goes straight to <code>It</code> because the test doesn't need a conditional context.</li>
+      </ul>
+
+      <h2>Tests as specification output</h2>
+
+      <p>The structure in the code is only half the value. The other half is what you see when the tests run. <code>gotest spec</code> transforms the test output into an indented tree:</p>
+
+      <div class="spec-block">
+        <span class="spec-label">gotest spec ./...</span>
+        <pre><span class="t-suite">UserService</span>
+  <span class="t-test">Create</span>
+    <span class="t-when">when email is valid</span>
+      <span class="t-pass">&#10003;</span> creates the user <span class="t-time">(8ms)</span>
+      <span class="t-pass">&#10003;</span> sends a welcome email <span class="t-time">(120ms)</span>
+    <span class="t-when">when email already exists</span>
+      <span class="t-pass">&#10003;</span> returns ErrDuplicate <span class="t-time">(&lt;1ms)</span>
+  <span class="t-test">Delete</span>
+    <span class="t-pass">&#10003;</span> soft-deletes the user <span class="t-time">(5ms)</span>
+
+<span class="t-summary">1 suite, 4 passed in 0.34s</span></pre>
+      </div>
+
+      <p>Compare this with the <code>go test -v</code> output for the same tests. The spec output is:</p>
+
+      <ul>
+        <li><strong>8 lines</strong> instead of 20+. No repetition, no <code>=== RUN</code> / <code>--- PASS</code> noise.</li>
+        <li><strong>Hierarchical.</strong> 2-space indentation shows structure at a glance. Suite name is bold. Method names are bold. Contexts are dimmed. Expectations get checkmarks.</li>
+        <li><strong>Human-readable names.</strong> <code>UserServiceTestSuite</code> becomes "UserService" (suffix stripped). <code>TestCreate</code> becomes "Create" (prefix stripped). No CamelCase, no underscores.</li>
+      </ul>
+
+      <p>When a test fails, the tree structure tells you exactly where:</p>
+
+      <div class="spec-block">
+        <span class="spec-label">gotest spec ./...</span>
+        <pre><span class="t-suite">UserService</span>
+  <span class="t-test">Create</span>
+    <span class="t-when">when email is valid</span>
+      <span class="t-pass">&#10003;</span> creates the user <span class="t-time">(8ms)</span>
+      <span class="t-fail">&#10007;</span> sends a welcome email <span class="t-time">(120ms)</span>
+    <span class="t-when">when email already exists</span>
+      <span class="t-pass">&#10003;</span> returns ErrDuplicate <span class="t-time">(&lt;1ms)</span>
+
+<span class="t-summary">1 suite, 2 passed, <span class="t-fail">1 failed</span> in 0.34s</span></pre>
+      </div>
+
+      <p>The red cross at "sends a welcome email" under "when email is valid" is a sentence: <em>UserService Create, when email is valid, fails to send a welcome email.</em> You know what's broken without reading any code.</p>
+
+      <h2>When and It can nest arbitrarily</h2>
+
+      <p>Both <code>When</code> and <code>It</code> delegate to <code>t.Run</code>, so they nest to any depth. This is useful when a single context has sub-conditions:</p>
+
+      <div class="code-block">
+        <pre><code><span class="kw">func</span> (s *<span class="tp">OrderServiceTestSuite</span>) <span class="fn">TestCheckout</span>(t *<span class="tp">gotest.T</span>) {
+    t.When(<span class="str">"the cart is not empty"</span>, <span class="kw">func</span>(w *<span class="tp">gotest.T</span>) {
+        w.When(<span class="str">"payment succeeds"</span>, <span class="kw">func</span>(w *<span class="tp">gotest.T</span>) {
+            w.It(<span class="str">"creates an order"</span>, <span class="kw">func</span>(it *<span class="tp">gotest.T</span>) {
+                <span class="cm">// ...</span>
+            })
+            w.It(<span class="str">"clears the cart"</span>, <span class="kw">func</span>(it *<span class="tp">gotest.T</span>) {
+                <span class="cm">// ...</span>
+            })
+        })
+        w.When(<span class="str">"payment fails"</span>, <span class="kw">func</span>(w *<span class="tp">gotest.T</span>) {
+            w.It(<span class="str">"does not create an order"</span>, <span class="kw">func</span>(it *<span class="tp">gotest.T</span>) {
+                <span class="cm">// ...</span>
+            })
+        })
+    })
+}</code></pre>
+      </div>
+
+      <p>The spec output reflects the nesting:</p>
+
+      <div class="spec-block">
+        <span class="spec-label">gotest spec ./...</span>
+        <pre><span class="t-suite">OrderService</span>
+  <span class="t-test">Checkout</span>
+    <span class="t-when">when the cart is not empty</span>
+      <span class="t-when">when payment succeeds</span>
+        <span class="t-pass">&#10003;</span> creates an order <span class="t-time">(12ms)</span>
+        <span class="t-pass">&#10003;</span> clears the cart <span class="t-time">(3ms)</span>
+      <span class="t-when">when payment fails</span>
+        <span class="t-pass">&#10003;</span> does not create an order <span class="t-time">(2ms)</span>
+
+<span class="t-summary">1 suite, 3 passed in 0.21s</span></pre>
+      </div>
+
+      <p>Each level of <code>When</code> narrows the context. The spec reads as a decision tree: checkout, when the cart is not empty, when payment succeeds, creates an order. You can trace any path from root to leaf and get a complete behavioral statement.</p>
+
+      <h2>The spec command</h2>
+
+      <p><code>gotest spec</code> works by running <code>gotest test</code> with <code>-json</code> output, then transforming the structured test events into the indented tree. It accepts the same package patterns as <code>go test</code>:</p>
+
+      <div class="code-block">
+        <pre><code><span class="cm"># spec output for all packages</span>
+gotest spec ./...
+
+<span class="cm"># verbose mode: show durations for passing tests</span>
+gotest spec -v ./...
+
+<span class="cm"># filter by test name</span>
+gotest spec --run UserService ./...
+
+<span class="cm"># disable color for CI logs</span>
+gotest spec --no-color ./...</code></pre>
+      </div>
+
+      <p>The rendering strips naming conventions automatically:</p>
+
+      <ul>
+        <li><code>UserServiceTestSuite</code> &rarr; <strong>UserService</strong> (drops <code>TestSuite</code> suffix)</li>
+        <li><code>TestCreate</code> &rarr; <strong>Create</strong> (drops <code>Test</code> prefix)</li>
+        <li>Underscores in <code>When</code>/<code>It</code> labels &rarr; spaces</li>
+      </ul>
+
+      <p>Suite and method names are bold. Contexts are dimmed. Passing expectations get a green checkmark, failing ones a red cross. The summary line at the bottom shows total counts and duration.</p>
+
+      <h2>Tests that document themselves</h2>
+
+      <p>The deeper value of spec output is that it doubles as documentation. When someone new joins the team and asks "what does the order service do?", you can point them at <code>gotest spec ./pkg/order/...</code> instead of a wiki page that's three sprints out of date.</p>
+
+      <p>The spec output stays accurate because it's generated from the tests. If the behavior changes, the tests change, and the spec reflects it. There's no separate document to keep in sync.</p>
+
+      <p>This works best when test names are written as behavioral descriptions rather than implementation details. Compare:</p>
+
+      <ul>
+        <li><strong>Implementation-focused:</strong> <code>t.It("calls repository.Save", ...)</code></li>
+        <li><strong>Behavior-focused:</strong> <code>t.It("persists the user", ...)</code></li>
+      </ul>
+
+      <p>The first tells you what the code does internally. The second tells you what the system does for its users. When the spec output reads like a behavioral contract, you've turned your test suite into a living specification.</p>
+
+      <div class="cta">
+        <p><strong>Try gotest spec on your next project.</strong></p>
+        <div class="install-cmd">
+          <code>go install github.com/mvrahden/go-test/cmd/gotest@latest</code>
+          <button onclick="navigator.clipboard.writeText('go install github.com/mvrahden/go-test/cmd/gotest@latest').then(()=>{this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)})" aria-label="Copy install command">Copy</button>
+        </div>
+        <div class="cta-links">
+          <a href="../reference.html">Reference</a>
+          <a href="https://github.com/mvrahden/go-test">GitHub</a>
+          <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+  <footer>
+    <div class="footer-links">
+      <a href="../">Home</a>
+      <a href="https://github.com/mvrahden/go-test">GitHub</a>
+      <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
+      <a href="../reference.html">Reference</a>
+      <a href="./">Blog</a>
+      <a href="https://github.com/mvrahden/go-test/blob/main/LICENSE">MIT License</a>
+    </div>
+    <p class="footer-copy">Built for Go developers who want tests that explain themselves.</p>
+  </footer>
+  <script>
+  fetch('https://api.github.com/repos/mvrahden/go-test')
+    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(d => {
+      if (d.stargazers_count >= 10) {
+        document.getElementById('star-count').textContent = ` ${d.stargazers_count}`;
+      }
+    })
+    .catch(() => {});
+  </script>
+</body>
+</html>

--- a/docs/blog/test-fixtures-in-go.html
+++ b/docs/blog/test-fixtures-in-go.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Test Fixtures in Go: Patterns That Scale | gotest blog</title>
+  <meta name="description" content="Every growing Go project needs shared test infrastructure: databases, caches, containers. A look at fixture patterns from global vars to DAG-based lifecycle management.">
+  <meta name="keywords" content="go test fixtures, golang test setup, go testing database, go test containers, go test lifecycle, go test shared state, gotest fixtures">
+
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://mvrahden.github.io/go-test/blog/test-fixtures-in-go.html">
+  <meta property="og:title" content="Test Fixtures in Go: Patterns That Scale">
+  <meta property="og:description" content="Every growing Go project needs shared test infrastructure. A look at fixture patterns from global vars to DAG-based lifecycle management.">
+  <meta property="og:image" content="https://mvrahden.github.io/go-test/static/gopher.png">
+  <meta property="og:image:width" content="1024">
+  <meta property="og:image:height" content="572">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Test Fixtures in Go: Patterns That Scale">
+  <meta name="twitter:description" content="Every growing Go project needs shared test infrastructure. A look at fixture patterns from global vars to DAG-based lifecycle management.">
+  <meta name="twitter:image" content="https://mvrahden.github.io/go-test/static/gopher.png">
+
+  <link rel="icon" type="image/png" href="../static/logo.png">
+  <link rel="canonical" href="https://mvrahden.github.io/go-test/blog/test-fixtures-in-go.html">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7WHJ67Z1J0"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-7WHJ67Z1J0');
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "Test Fixtures in Go: Patterns That Scale",
+    "description": "Every growing Go project needs shared test infrastructure: databases, caches, containers. A look at fixture patterns from global vars to DAG-based lifecycle management.",
+    "url": "https://mvrahden.github.io/go-test/blog/test-fixtures-in-go.html",
+    "datePublished": "2026-07-07",
+    "author": {
+      "@type": "Person",
+      "name": "Menno van Rahden",
+      "url": "https://github.com/mvrahden"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "gotest",
+      "url": "https://mvrahden.github.io/go-test/"
+    },
+    "isPartOf": {
+      "@type": "Blog",
+      "name": "gotest blog",
+      "url": "https://mvrahden.github.io/go-test/blog/"
+    },
+    "programmingLanguage": "Go"
+  }
+  </script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --cyan: #00ADD8;
+      --cyan-dark: #007d9c;
+      --bg: #ffffff;
+      --bg-alt: #f6f8fa;
+      --bg-dark: #0d1117;
+      --bg-dark-alt: #161b22;
+      --text: #24292f;
+      --text-secondary: #656d76;
+      --text-on-dark: #e6edf3;
+      --text-dimmed: #8b949e;
+      --border: #d0d7de;
+      --green: #3fb950;
+      --amber: #d29922;
+      --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', Consolas, 'Liberation Mono', monospace;
+      --max-w: 740px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d1117;
+        --bg-alt: #161b22;
+        --bg-dark: #010409;
+        --bg-dark-alt: #0d1117;
+        --text: #e6edf3;
+        --text-secondary: #8b949e;
+        --border: #30363d;
+      }
+    }
+
+    html { scroll-behavior: smooth; height: 100%; }
+
+    body {
+      font-family: var(--font-sans);
+      color: var(--text);
+      background: var(--bg);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      min-height: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .article { flex: 1; }
+
+    a { color: var(--cyan-dark); text-decoration: none; }
+    @media (prefers-color-scheme: dark) { a { color: var(--cyan); } }
+    a:hover { text-decoration: underline; }
+
+    /* ===== Nav ===== */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(8px);
+    }
+    .nav-inner {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 0.75rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .nav-brand {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 700;
+      font-size: 1.125rem;
+      color: var(--text);
+      text-decoration: none;
+    }
+    .nav-brand:hover { text-decoration: none; }
+    .nav-brand img { width: 28px; height: 28px; border-radius: 50%; }
+    .nav-links { display: flex; gap: 1.25rem; font-size: 0.9rem; align-items: center; }
+    .nav-links a { color: var(--text-secondary); }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+    .nav-links .nav-ref {
+      padding: 0.25rem 0.65rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-weight: 600;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-links .nav-ref:hover { background: var(--bg-alt); }
+    .nav-links .star-btn { font-size: 0.85rem; }
+    .star-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.3rem 0.7rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-weight: 600;
+      text-decoration: none;
+      transition: all 0.15s;
+      font-size: 0.8rem;
+    }
+    .star-btn:hover { background: var(--bg-alt); text-decoration: none; }
+    .star-btn .star-icon { color: #e3b341; }
+    .star-count { font-weight: 400; color: var(--text-dimmed); }
+
+    /* ===== Article ===== */
+    .article {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 0 1.5rem;
+    }
+
+    .article-header {
+      padding: 3.5rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 2.5rem;
+    }
+    .article-header .back {
+      display: inline-block;
+      font-size: 0.85rem;
+      color: var(--text-dimmed);
+      margin-bottom: 1.5rem;
+    }
+    .article-header .back:hover { color: var(--text-secondary); }
+    .article-header h1 {
+      font-size: 2.25rem;
+      font-weight: 800;
+      letter-spacing: -0.025em;
+      line-height: 1.2;
+      margin-bottom: 1rem;
+    }
+    .article-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.85rem;
+      color: var(--text-dimmed);
+    }
+    .article-meta .tag {
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+    }
+
+    /* ===== Article Body ===== */
+    .article-body {
+      padding-bottom: 3rem;
+    }
+    .article-body p {
+      font-size: 1.1rem;
+      line-height: 1.75;
+      margin-bottom: 1.5rem;
+    }
+    .article-body h2 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      margin-top: 3rem;
+      margin-bottom: 1rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--border);
+    }
+    .article-body h2:first-child {
+      margin-top: 0;
+      padding-top: 0;
+      border-top: none;
+    }
+    .article-body h3 {
+      font-size: 1.2rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+    }
+    .article-body ul, .article-body ol {
+      margin-bottom: 1.5rem;
+      padding-left: 1.5rem;
+    }
+    .article-body li {
+      font-size: 1.05rem;
+      line-height: 1.7;
+      margin-bottom: 0.4rem;
+    }
+    .article-body strong { font-weight: 600; }
+
+    .article-body code {
+      font-family: var(--font-mono);
+      font-size: 0.88em;
+      padding: 0.15em 0.4em;
+      border-radius: 4px;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+    }
+
+    .article-body blockquote {
+      border-left: 3px solid var(--cyan);
+      padding: 0.75rem 1.25rem;
+      margin: 1.5rem 0;
+      background: var(--bg-alt);
+      border-radius: 0 6px 6px 0;
+    }
+    .article-body blockquote p {
+      font-size: 1.05rem;
+      margin-bottom: 0;
+      color: var(--text-secondary);
+    }
+
+    /* Code blocks */
+    .code-block {
+      background: #161b22;
+      border-radius: 8px;
+      border: 1px solid #30363d;
+      margin: 1.5rem 0;
+      overflow: hidden;
+    }
+    .code-label {
+      display: block;
+      padding: 0.5rem 1.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--text-dimmed);
+      border-bottom: 1px solid #30363d;
+      background: #1c2128;
+    }
+    .code-block pre {
+      padding: 1.25rem 1.5rem;
+      overflow-x: auto;
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      line-height: 1.65;
+      color: #e6edf3;
+    }
+    .code-block pre code {
+      font-family: inherit;
+      font-size: inherit;
+      padding: 0;
+      border: none;
+      background: none;
+      border-radius: 0;
+      color: inherit;
+    }
+
+    .kw { color: #ff7b72; }
+    .fn { color: #d2a8ff; }
+    .str { color: #a5d6ff; }
+    .cm { color: #8b949e; }
+    .tp { color: #79c0ff; }
+
+    /* Diagram */
+    .diagram {
+      margin: 1.5rem 0;
+      padding: 1.5rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      line-height: 1.8;
+      overflow-x: auto;
+      text-align: center;
+      color: var(--text-secondary);
+    }
+
+    /* CTA section */
+    .cta {
+      margin: 2.5rem 0;
+      padding: 2rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      text-align: center;
+    }
+    .cta p {
+      margin-bottom: 1rem;
+    }
+    .cta .install-cmd {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 0.75rem 1rem;
+      font-family: var(--font-mono);
+      font-size: 0.9rem;
+      max-width: 100%;
+      overflow-x: auto;
+    }
+    .cta .install-cmd code {
+      white-space: nowrap;
+      color: var(--text);
+    }
+    .cta .install-cmd button {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.3rem 0.5rem;
+      cursor: pointer;
+      color: var(--text-secondary);
+      font-size: 0.8rem;
+      flex-shrink: 0;
+      transition: all 0.15s;
+    }
+    .cta .install-cmd button:hover { background: var(--border); }
+    .cta-links {
+      margin-top: 1rem;
+      font-size: 0.9rem;
+      display: flex;
+      justify-content: center;
+      gap: 1.5rem;
+    }
+
+    /* ===== Footer ===== */
+    footer {
+      background: var(--bg-dark);
+      color: var(--text-dimmed);
+      padding: 2.5rem 1.5rem;
+      text-align: center;
+      font-size: 0.85rem;
+    }
+    footer a { color: var(--text-on-dark); }
+    footer a:hover { color: var(--cyan); }
+    .footer-links {
+      display: flex;
+      justify-content: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .footer-copy { color: #484f58; font-size: 0.8rem; }
+
+    /* ===== Responsive ===== */
+    @media (max-width: 640px) {
+      .article-header h1 { font-size: 1.75rem; }
+      .article-body p { font-size: 1.05rem; }
+    }
+    @media (max-width: 480px) {
+      .nav-links { gap: 0.75rem; font-size: 0.8rem; }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-inner">
+      <a href="../" class="nav-brand">
+        <img src="../static/logo.png" alt="gotest logo" width="28" height="28">
+        gotest
+      </a>
+      <div class="nav-links">
+        <a href="./">Blog</a>
+        <a href="../reference.html" class="nav-ref">Reference</a>
+        <a href="https://github.com/mvrahden/go-test" class="star-btn"><span class="star-icon">&#9734;</span> Star<span class="star-count" id="star-count"></span></a>
+        <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="article">
+    <header class="article-header">
+      <a href="./" class="back">&larr; All posts</a>
+      <h1>Test Fixtures in Go: Patterns That Scale</h1>
+      <div class="article-meta">
+        <time datetime="2026-07-07">July 7, 2026</time>
+        <span>&middot;</span>
+        <span>12 min read</span>
+        <span class="tag">Patterns</span>
+      </div>
+    </header>
+
+    <div class="article-body">
+
+      <p>Most Go projects eventually need shared test infrastructure: a database connection, a message queue, a container that takes seconds to start. The stdlib doesn't have a built-in answer for this. So every team invents its own fixture pattern, and most of those patterns stop working at some point.</p>
+
+      <p>This post looks at the common approaches, where each one breaks down, and what a fixture system needs to handle the cases that real projects run into.</p>
+
+      <h2>The problem</h2>
+
+      <p>A test fixture is any shared resource that tests depend on. The simplest example: a database that multiple test functions query. The fixture problem is about lifecycle: when does the database get created, when does it get torn down, and how do you make sure tests don't step on each other?</p>
+
+      <p>The challenge grows along two axes:</p>
+
+      <ul>
+        <li><strong>Cost.</strong> Some fixtures are cheap (an in-memory map). Others are expensive (spinning up a Postgres container). Expensive fixtures can't be created per-test; you need to share them.</li>
+        <li><strong>Scope.</strong> Some fixtures belong to one test file. Others are shared across an entire package. Some need to be shared across multiple packages. Each scope has different lifecycle requirements.</li>
+      </ul>
+
+      <h2>Pattern 1: Global variables</h2>
+
+      <p>The most common first approach:</p>
+
+      <div class="code-block">
+        <pre><code><span class="kw">var</span> testDB *sql.DB
+
+<span class="kw">func</span> <span class="fn">TestMain</span>(m *<span class="tp">testing.M</span>) {
+    <span class="kw">var</span> err <span class="tp">error</span>
+    testDB, err = sql.Open(<span class="str">"postgres"</span>, os.Getenv(<span class="str">"TEST_DB_URL"</span>))
+    <span class="kw">if</span> err != <span class="kw">nil</span> {
+        log.Fatal(err)
+    }
+    <span class="kw">defer</span> testDB.Close()
+    os.Exit(m.Run())
+}
+
+<span class="kw">func</span> <span class="fn">TestCreateUser</span>(t *<span class="tp">testing.T</span>) {
+    _, err := testDB.Exec(<span class="str">"INSERT INTO users ..."</span>)
+    <span class="cm">// ...</span>
+}
+
+<span class="kw">func</span> <span class="fn">TestListUsers</span>(t *<span class="tp">testing.T</span>) {
+    rows, err := testDB.Query(<span class="str">"SELECT * FROM users"</span>)
+    <span class="cm">// depends on what TestCreateUser left behind</span>
+}</code></pre>
+      </div>
+
+      <p><code>TestMain</code> is Go's package-level setup hook: it runs once before any tests in the package. The database connection lives in a global variable that every test function can access.</p>
+
+      <p>This works until it doesn't:</p>
+
+      <ul>
+        <li><strong>Tests share state.</strong> <code>TestListUsers</code> sees rows that <code>TestCreateUser</code> inserted. Tests become order-dependent. Add <code>t.Parallel()</code> and they become race-condition-dependent.</li>
+        <li><strong>Teardown is fragile.</strong> If any test panics, <code>defer testDB.Close()</code> might not run. If <code>TestMain</code> itself fails, the process exits with no cleanup.</li>
+        <li><strong>One fixture per package.</strong> <code>TestMain</code> can only be defined once. Need a database <em>and</em> a cache? Everything goes into one function.</li>
+        <li><strong>No per-test reset.</strong> There's no hook to truncate tables between tests. You'd need to write that into every test function manually.</li>
+      </ul>
+
+      <h2>Pattern 2: Helper functions</h2>
+
+      <p>The next step is to wrap fixture creation in a helper:</p>
+
+      <div class="code-block">
+        <pre><code><span class="kw">func</span> <span class="fn">setupTestDB</span>(t *<span class="tp">testing.T</span>) *sql.DB {
+    t.Helper()
+    db, err := sql.Open(<span class="str">"postgres"</span>, os.Getenv(<span class="str">"TEST_DB_URL"</span>))
+    <span class="kw">if</span> err != <span class="kw">nil</span> {
+        t.Fatal(err)
+    }
+    t.Cleanup(<span class="kw">func</span>() { db.Close() })
+    <span class="kw">return</span> db
+}
+
+<span class="kw">func</span> <span class="fn">TestCreateUser</span>(t *<span class="tp">testing.T</span>) {
+    db := setupTestDB(t)
+    <span class="cm">// db is fresh for this test</span>
+}
+
+<span class="kw">func</span> <span class="fn">TestListUsers</span>(t *<span class="tp">testing.T</span>) {
+    db := setupTestDB(t)
+    <span class="cm">// db is fresh for this test too</span>
+}</code></pre>
+      </div>
+
+      <p>Better. Each test gets its own connection. <code>t.Cleanup</code> handles teardown even if the test panics. No shared state between tests.</p>
+
+      <p>But the cost problem is back: if the fixture is expensive (a container, a schema migration, a seed dataset), creating it per-test is too slow. And if you add caching to amortize the cost, say a <code>sync.Once</code> around the container startup, you've reinvented the global variable pattern with extra steps.</p>
+
+      <h2>Pattern 3: Struct-based fixtures with sync.Once</h2>
+
+      <p>A more structured approach uses a struct to hold the fixture state and <code>sync.Once</code> to ensure one-time initialization:</p>
+
+      <div class="code-block">
+        <pre><code><span class="kw">type</span> <span class="tp">DBFixture</span> <span class="kw">struct</span> {
+    once <span class="tp">sync.Once</span>
+    db   *<span class="tp">sql.DB</span>
+    err  <span class="tp">error</span>
+}
+
+<span class="kw">func</span> (f *<span class="tp">DBFixture</span>) <span class="fn">Get</span>(t *<span class="tp">testing.T</span>) *<span class="tp">sql.DB</span> {
+    t.Helper()
+    f.once.Do(<span class="kw">func</span>() {
+        f.db, f.err = sql.Open(<span class="str">"postgres"</span>, os.Getenv(<span class="str">"TEST_DB_URL"</span>))
+    })
+    <span class="kw">if</span> f.err != <span class="kw">nil</span> {
+        t.Fatal(f.err)
+    }
+    <span class="kw">return</span> f.db
+}
+
+<span class="kw">var</span> dbFixture DBFixture
+
+<span class="kw">func</span> <span class="fn">TestCreateUser</span>(t *<span class="tp">testing.T</span>) {
+    db := dbFixture.Get(t)
+    <span class="cm">// ...</span>
+}</code></pre>
+      </div>
+
+      <p>This solves the cost problem: the database is created once and shared. But it still has the state-leaking problem (tests share the same database), and teardown is still unclear: when does the database get closed? <code>sync.Once</code> has no corresponding "undo."</p>
+
+      <p>More fundamentally, none of these patterns handle <strong>fixture dependencies</strong>. What if your test needs a database <em>and</em> a cache, and the cache needs the database connection to configure itself? Now you need to manage initialization order, and that's where hand-rolled patterns start to collapse.</p>
+
+      <h2>What fixtures actually need</h2>
+
+      <p>Looking at the patterns above, a fixture system needs to handle four concerns:</p>
+
+      <ol>
+        <li><strong>Lifecycle hooks.</strong> Setup and teardown at both the suite level (once) and the test level (per-test). Fixtures that take <code>context.Context</code> and return <code>error</code>, so expensive operations can be cancelled and failures can be handled.</li>
+        <li><strong>Dependency ordering.</strong> If fixture B depends on fixture A, A's setup must complete before B's begins. Teardown runs in reverse order. This is a DAG (directed acyclic graph) problem.</li>
+        <li><strong>Scope control.</strong> Some fixtures are package-scoped (shared across suites in one package). Some are shared across multiple packages. The fixture system needs to understand these scopes.</li>
+        <li><strong>Isolation.</strong> Per-test hooks that reset state between test methods, so tests don't inherit side effects from each other.</li>
+      </ol>
+
+      <h2>Fixtures as structs with lifecycle conventions</h2>
+
+      <p>In <a href="https://github.com/mvrahden/go-test">gotest</a>, a fixture is a struct with naming conventions, the same pattern used for test suites. A struct whose name ends in <code>Fixture</code> is recognized as a package-scoped fixture. Its lifecycle methods are discovered by name:</p>
+
+      <div class="code-block">
+        <span class="code-label">fixtures.go</span>
+        <pre><code><span class="kw">type</span> <span class="tp">DatabaseFixture</span> <span class="kw">struct</span> {
+    DB *sql.DB
+}
+
+<span class="kw">func</span> (f *<span class="tp">DatabaseFixture</span>) <span class="fn">FixtureConfig</span>() <span class="tp">gotest.FixtureConfig</span> {
+    <span class="kw">return</span> gotest.ContainerFixtureConfig()  <span class="cm">// 5m timeout, 1 retry</span>
+}
+
+<span class="kw">func</span> (f *<span class="tp">DatabaseFixture</span>) <span class="fn">BeforeAll</span>(_ <span class="tp">context.Context</span>) <span class="tp">error</span> {
+    <span class="kw">var</span> err <span class="tp">error</span>
+    f.DB, err = sql.Open(<span class="str">"postgres"</span>, os.Getenv(<span class="str">"TEST_DB_URL"</span>))
+    <span class="kw">return</span> err
+}
+
+<span class="kw">func</span> (f *<span class="tp">DatabaseFixture</span>) <span class="fn">AfterAll</span>(_ <span class="tp">context.Context</span>) <span class="tp">error</span> {
+    <span class="kw">return</span> f.DB.Close()
+}
+
+<span class="kw">func</span> (f *<span class="tp">DatabaseFixture</span>) <span class="fn">BeforeEach</span>(_ <span class="tp">context.Context</span>) <span class="tp">error</span> {
+    _, err := f.DB.Exec(<span class="str">"TRUNCATE users, orders"</span>)
+    <span class="kw">return</span> err
+}</code></pre>
+      </div>
+
+      <p>A few things to notice:</p>
+
+      <ul>
+        <li><strong>Lifecycle methods take <code>context.Context</code> and return <code>error</code>.</strong> This is different from suite lifecycle hooks (which take <code>*gotest.T</code>). Fixtures represent infrastructure; they need cancellation and error propagation.</li>
+        <li><strong><code>BeforeAll</code>/<code>AfterAll</code></strong> run once for the package. The database is opened once and closed once.</li>
+        <li><strong><code>BeforeEach</code></strong> runs before every test method in every suite that uses this fixture. Tables get truncated, so each test starts clean.</li>
+        <li><strong><code>FixtureConfig</code></strong> controls timeout and retry behavior. <code>ContainerFixtureConfig()</code> gives a 5-minute timeout with one retry, appropriate for infrastructure that might need time to start.</li>
+      </ul>
+
+      <h2>Suites consume fixtures by referencing them</h2>
+
+      <p>A suite declares its fixture dependency by including it as a pointer field:</p>
+
+      <div class="code-block">
+        <span class="code-label">suite_test.go</span>
+        <pre><code><span class="kw">type</span> <span class="tp">UserRepositoryTestSuite</span> <span class="kw">struct</span> {
+    DB   *DatabaseFixture
+    repo *userRepository
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserRepositoryTestSuite</span>) <span class="fn">BeforeEach</span>(t *<span class="tp">gotest.T</span>) {
+    s.repo = newUserRepository(s.DB.DB)
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserRepositoryTestSuite</span>) <span class="fn">TestCreateUser</span>(t *<span class="tp">gotest.T</span>) {
+    t.When(<span class="str">"the input is valid"</span>, <span class="kw">func</span>(w *<span class="tp">gotest.T</span>) {
+        err := s.repo.Create(User{Name: <span class="str">"Alice"</span>})
+
+        w.It(<span class="str">"succeeds"</span>, <span class="kw">func</span>(it *<span class="tp">gotest.T</span>) {
+            gotest.NoError(it, err)
+        })
+    })
+}</code></pre>
+      </div>
+
+      <p>The field <code>DB *DatabaseFixture</code> is the entire dependency declaration. gotest sees the pointer to a <code>Fixture</code>-suffixed type and wires it up automatically. By the time <code>BeforeEach</code> runs on the suite, the fixture's <code>BeforeAll</code> has already completed and <code>s.DB.DB</code> is a live database connection.</p>
+
+      <p>The lifecycle order for each test method is:</p>
+
+      <ol>
+        <li>Fixture <code>BeforeEach</code>: truncate tables</li>
+        <li>Suite <code>BeforeEach</code>: create repository</li>
+        <li>Test method: run the test</li>
+        <li>Suite <code>AfterEach</code></li>
+        <li>Fixture <code>AfterEach</code></li>
+      </ol>
+
+      <p>If multiple suites in the same package reference <code>*DatabaseFixture</code>, they all share the same instance. <code>BeforeAll</code> runs once for the package, not once per suite.</p>
+
+      <h2>Fixture dependencies form a DAG</h2>
+
+      <p>Fixtures can depend on other fixtures. A cache fixture that needs a database connection declares the dependency the same way, as a pointer field:</p>
+
+      <div class="code-block">
+        <pre><code><span class="kw">type</span> <span class="tp">CacheFixture</span> <span class="kw">struct</span> {
+    DB    *DatabaseFixture  <span class="cm">// depends on DatabaseFixture</span>
+    Cache *redis.Client
+}
+
+<span class="kw">func</span> (f *<span class="tp">CacheFixture</span>) <span class="fn">BeforeAll</span>(_ <span class="tp">context.Context</span>) <span class="tp">error</span> {
+    f.Cache = redis.NewClient(&amp;redis.Options{Addr: <span class="str">"localhost:6379"</span>})
+    <span class="cm">// f.DB.DB is already initialized. DatabaseFixture.BeforeAll ran first</span>
+    <span class="kw">return</span> f.Cache.Ping(context.Background()).Err()
+}</code></pre>
+      </div>
+
+      <p>gotest resolves these dependencies into a directed acyclic graph and runs <code>BeforeAll</code> in topological order. Independent fixtures (no dependency between them) initialize concurrently. Teardown runs in reverse topological order.</p>
+
+      <div class="diagram">
+DatabaseFixture.BeforeAll &rarr; CacheFixture.BeforeAll &rarr; tests run &rarr; CacheFixture.AfterAll &rarr; DatabaseFixture.AfterAll
+      </div>
+
+      <p>This scales to arbitrary depth. If a third fixture depends on the cache, it slots into the graph naturally. You never manually coordinate initialization order; the dependency pointers encode it.</p>
+
+      <h2>The cross-package problem</h2>
+
+      <p>Everything above works within a single package. But <code>go test</code> runs each package as a <strong>separate OS process</strong>. There is no shared memory between <code>pkg/user</code> and <code>pkg/order</code>. They are different binaries, running in different processes, with different address spaces.</p>
+
+      <p>This means none of the patterns above can share a fixture across packages:</p>
+
+      <ul>
+        <li><strong><code>TestMain</code></strong> runs once per package, not once per test run. Five packages that need Postgres means five containers started, five schema migrations run.</li>
+        <li><strong><code>sync.Once</code></strong> is a per-process primitive. It does not cross process boundaries.</li>
+        <li><strong>Helper packages</strong> like <code>testutil.GetDB()</code> get imported by each package independently. Each one initializes its own connection in its own process.</li>
+      </ul>
+
+      <p>The stdlib has no answer for this. Most teams fall back to external orchestration: a Makefile or CI script starts the database before <code>go test</code>, passes the DSN through an environment variable, and each package's <code>TestMain</code> connects independently. It works, but the fixture lifecycle lives outside of Go, in shell scripts, docker-compose files, or CI configuration. The test code cannot express "I need a Postgres instance" as a dependency; it can only assume one already exists.</p>
+
+      <h2>Sharing fixtures across packages</h2>
+
+      <p>gotest has <strong>shared fixtures</strong> for this: structs whose name ends in <code>SharedFixture</code>. A shared fixture runs in its own subprocess, once for the entire test run. Its state is serialized as JSON and transferred to every test package that needs it.</p>
+
+      <div class="code-block">
+        <span class="code-label">shared_fixtures.go</span>
+        <pre><code><span class="kw">type</span> <span class="tp">PostgresSharedFixture</span> <span class="kw">struct</span> {
+    DSN    <span class="tp">string</span>   <span class="cm">// serialized: transferred to test packages</span>
+    conn   *sql.DB  <span class="cm">// local: reconstructed by Hydrate</span>
+}
+
+<span class="kw">func</span> (f *<span class="tp">PostgresSharedFixture</span>) <span class="fn">BeforeAll</span>(_ <span class="tp">context.Context</span>) <span class="tp">error</span> {
+    <span class="cm">// start container, run migrations</span>
+    f.DSN = <span class="str">"postgres://localhost:5432/testdb"</span>
+    <span class="kw">var</span> err <span class="tp">error</span>
+    f.conn, err = sql.Open(<span class="str">"postgres"</span>, f.DSN)
+    <span class="kw">return</span> err
+}
+
+<span class="kw">func</span> (f *<span class="tp">PostgresSharedFixture</span>) <span class="fn">AfterAll</span>(_ <span class="tp">context.Context</span>) <span class="tp">error</span> {
+    f.conn.Close()
+    <span class="cm">// stop container</span>
+    <span class="kw">return</span> <span class="kw">nil</span>
+}
+
+<span class="kw">func</span> (f *<span class="tp">PostgresSharedFixture</span>) <span class="fn">Hydrate</span>(_ <span class="tp">context.Context</span>) <span class="tp">error</span> {
+    <span class="kw">var</span> err <span class="tp">error</span>
+    f.conn, err = sql.Open(<span class="str">"postgres"</span>, f.DSN)
+    <span class="kw">return</span> err
+}
+
+<span class="kw">func</span> (f *<span class="tp">PostgresSharedFixture</span>) <span class="fn">Dehydrate</span>(_ <span class="tp">context.Context</span>) <span class="tp">error</span> {
+    <span class="kw">return</span> f.conn.Close()
+}</code></pre>
+      </div>
+
+      <p>The key concept is the split between <strong>transfer fields</strong> and <strong>local fields</strong>:</p>
+
+      <ul>
+        <li><strong>Transfer fields</strong> (<code>DSN</code>) are exported and serialized as JSON. They cross process boundaries.</li>
+        <li><strong>Local fields</strong> (<code>conn</code>) are unexported or assigned in <code>Hydrate</code>. They represent resources that can't be serialized: connections, file handles, goroutines.</li>
+      </ul>
+
+      <p><code>Hydrate</code> runs in each test package's process after the JSON state is deserialized. It reconstructs the non-serializable resources from the transferred data. <code>Dehydrate</code> cleans up those local resources when the test package finishes.</p>
+
+      <h2>Where this leaves you</h2>
+
+      <p>Every fixture pattern represents a trade-off between simplicity, cost, and isolation:</p>
+
+      <ul>
+        <li><strong>Global variables</strong> are simple but share state and have fragile teardown.</li>
+        <li><strong>Helper functions</strong> isolate well but duplicate expensive setup.</li>
+        <li><strong>sync.Once wrappers</strong> amortize cost but reintroduce shared state and have no lifecycle management.</li>
+        <li><strong>All of the above</strong> are confined to a single package. None can share a database or container across the process boundary that <code>go test</code> puts between packages.</li>
+      </ul>
+
+      <p>A struct-based fixture system with lifecycle hooks, dependency ordering, scope control, and serialization-based shared fixtures addresses all four concerns. The fixture is created once (cheap), torn down reliably (lifecycle hooks with context and error handling), each test gets a clean slate (per-test hooks), and expensive infrastructure like databases and containers can be shared across the process boundaries that <code>go test</code> puts between packages.</p>
+
+      <p>The important part isn't the specific implementation. It is recognizing that fixture management is a graph problem. Once you have more than two fixtures that depend on each other, manual coordination becomes a liability. A system that resolves dependencies, enforces initialization order, handles teardown in reverse, and bridges the cross-package process boundary is worth the upfront investment.</p>
+
+      <div class="cta">
+        <p><strong>Try gotest fixtures on your next project.</strong></p>
+        <div class="install-cmd">
+          <code>go install github.com/mvrahden/go-test/cmd/gotest@latest</code>
+          <button onclick="navigator.clipboard.writeText('go install github.com/mvrahden/go-test/cmd/gotest@latest').then(()=>{this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)})" aria-label="Copy install command">Copy</button>
+        </div>
+        <div class="cta-links">
+          <a href="../reference.html">Reference</a>
+          <a href="https://github.com/mvrahden/go-test">GitHub</a>
+          <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+  <footer>
+    <div class="footer-links">
+      <a href="../">Home</a>
+      <a href="https://github.com/mvrahden/go-test">GitHub</a>
+      <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
+      <a href="../reference.html">Reference</a>
+      <a href="./">Blog</a>
+      <a href="https://github.com/mvrahden/go-test/blob/main/LICENSE">MIT License</a>
+    </div>
+    <p class="footer-copy">Built for Go developers who want tests that explain themselves.</p>
+  </footer>
+  <script>
+  fetch('https://api.github.com/repos/mvrahden/go-test')
+    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(d => {
+      if (d.stargazers_count >= 10) {
+        document.getElementById('star-count').textContent = ` ${d.stargazers_count}`;
+      }
+    })
+    .catch(() => {});
+  </script>
+</body>
+</html>

--- a/docs/blog/why-gotest.html
+++ b/docs/blog/why-gotest.html
@@ -1,0 +1,618 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Why gotest Exists | gotest blog</title>
+  <meta name="description" content="Go's testing package is one of the best things about the language. But it leaves gaps that every growing project eventually hits. gotest fills those gaps with code generation, naming conventions, and zero runtime dependencies.">
+  <meta name="keywords" content="gotest motivation, go testing framework, golang test suite, go test code generation, testify alternative, go testing principles">
+
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://mvrahden.github.io/go-test/blog/why-gotest.html">
+  <meta property="og:title" content="Why gotest Exists">
+  <meta property="og:description" content="Go's testing package is one of the best things about the language. But it leaves gaps that every growing project eventually hits.">
+  <meta property="og:image" content="https://mvrahden.github.io/go-test/static/gopher.png">
+  <meta property="og:image:width" content="1024">
+  <meta property="og:image:height" content="572">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Why gotest Exists">
+  <meta name="twitter:description" content="Go's testing package is one of the best things about the language. But it leaves gaps that every growing project eventually hits.">
+  <meta name="twitter:image" content="https://mvrahden.github.io/go-test/static/gopher.png">
+
+  <link rel="icon" type="image/png" href="../static/logo.png">
+  <link rel="canonical" href="https://mvrahden.github.io/go-test/blog/why-gotest.html">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-7WHJ67Z1J0"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-7WHJ67Z1J0');
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "Why gotest Exists",
+    "description": "Go's testing package is one of the best things about the language. But it leaves gaps that every growing project eventually hits. gotest fills those gaps with code generation, naming conventions, and zero runtime dependencies.",
+    "url": "https://mvrahden.github.io/go-test/blog/why-gotest.html",
+    "datePublished": "2026-07-05",
+    "author": {
+      "@type": "Person",
+      "name": "Menno van Rahden",
+      "url": "https://github.com/mvrahden"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "gotest",
+      "url": "https://mvrahden.github.io/go-test/"
+    },
+    "isPartOf": {
+      "@type": "Blog",
+      "name": "gotest blog",
+      "url": "https://mvrahden.github.io/go-test/blog/"
+    },
+    "programmingLanguage": "Go"
+  }
+  </script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --cyan: #00ADD8;
+      --cyan-dark: #007d9c;
+      --bg: #ffffff;
+      --bg-alt: #f6f8fa;
+      --bg-dark: #0d1117;
+      --bg-dark-alt: #161b22;
+      --text: #24292f;
+      --text-secondary: #656d76;
+      --text-on-dark: #e6edf3;
+      --text-dimmed: #8b949e;
+      --border: #d0d7de;
+      --green: #3fb950;
+      --amber: #d29922;
+      --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', Consolas, 'Liberation Mono', monospace;
+      --max-w: 740px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d1117;
+        --bg-alt: #161b22;
+        --bg-dark: #010409;
+        --bg-dark-alt: #0d1117;
+        --text: #e6edf3;
+        --text-secondary: #8b949e;
+        --border: #30363d;
+      }
+    }
+
+    html { scroll-behavior: smooth; height: 100%; }
+
+    body {
+      font-family: var(--font-sans);
+      color: var(--text);
+      background: var(--bg);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      min-height: 100%;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .article { flex: 1; }
+
+    a { color: var(--cyan-dark); text-decoration: none; }
+    @media (prefers-color-scheme: dark) { a { color: var(--cyan); } }
+    a:hover { text-decoration: underline; }
+
+    /* ===== Nav ===== */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      backdrop-filter: blur(8px);
+    }
+    .nav-inner {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 0.75rem 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .nav-brand {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 700;
+      font-size: 1.125rem;
+      color: var(--text);
+      text-decoration: none;
+    }
+    .nav-brand:hover { text-decoration: none; }
+    .nav-brand img { width: 28px; height: 28px; border-radius: 50%; }
+    .nav-links { display: flex; gap: 1.25rem; font-size: 0.9rem; align-items: center; }
+    .nav-links a { color: var(--text-secondary); }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+    .nav-links .nav-ref {
+      padding: 0.25rem 0.65rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-weight: 600;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-links .nav-ref:hover { background: var(--bg-alt); }
+    .nav-links .star-btn { font-size: 0.85rem; }
+    .star-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      padding: 0.3rem 0.7rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-weight: 600;
+      text-decoration: none;
+      transition: all 0.15s;
+      font-size: 0.8rem;
+    }
+    .star-btn:hover { background: var(--bg-alt); text-decoration: none; }
+    .star-btn .star-icon { color: #e3b341; }
+    .star-count { font-weight: 400; color: var(--text-dimmed); }
+
+    /* ===== Article ===== */
+    .article {
+      max-width: var(--max-w);
+      margin: 0 auto;
+      padding: 0 1.5rem;
+    }
+
+    .article-header {
+      padding: 3.5rem 0 2rem;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 2.5rem;
+    }
+    .article-header .back {
+      display: inline-block;
+      font-size: 0.85rem;
+      color: var(--text-dimmed);
+      margin-bottom: 1.5rem;
+    }
+    .article-header .back:hover { color: var(--text-secondary); }
+    .article-header h1 {
+      font-size: 2.25rem;
+      font-weight: 800;
+      letter-spacing: -0.025em;
+      line-height: 1.2;
+      margin-bottom: 1rem;
+    }
+    .article-header h1 code {
+      font-size: 0.85em;
+      font-weight: 700;
+      color: var(--cyan-dark);
+    }
+    @media (prefers-color-scheme: dark) {
+      .article-header h1 code { color: var(--cyan); }
+    }
+    .article-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.85rem;
+      color: var(--text-dimmed);
+    }
+    .article-meta .tag {
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      font-size: 0.75rem;
+      color: var(--text-secondary);
+    }
+
+    /* ===== Article Body ===== */
+    .article-body {
+      padding-bottom: 3rem;
+    }
+    .article-body p {
+      font-size: 1.1rem;
+      line-height: 1.75;
+      margin-bottom: 1.5rem;
+    }
+    .article-body h2 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+      margin-top: 3rem;
+      margin-bottom: 1rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--border);
+    }
+    .article-body h2:first-child {
+      margin-top: 0;
+      padding-top: 0;
+      border-top: none;
+    }
+    .article-body h3 {
+      font-size: 1.2rem;
+      font-weight: 600;
+      margin-top: 2rem;
+      margin-bottom: 0.75rem;
+    }
+    .article-body ul, .article-body ol {
+      margin-bottom: 1.5rem;
+      padding-left: 1.5rem;
+    }
+    .article-body li {
+      font-size: 1.05rem;
+      line-height: 1.7;
+      margin-bottom: 0.4rem;
+    }
+    .article-body strong { font-weight: 600; }
+
+    .article-body code {
+      font-family: var(--font-mono);
+      font-size: 0.88em;
+      padding: 0.15em 0.4em;
+      border-radius: 4px;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+    }
+    @media (prefers-color-scheme: dark) {
+      .article-body code { background: var(--bg-alt); }
+    }
+
+    .article-body blockquote {
+      border-left: 3px solid var(--cyan);
+      padding: 0.75rem 1.25rem;
+      margin: 1.5rem 0;
+      background: var(--bg-alt);
+      border-radius: 0 6px 6px 0;
+    }
+    .article-body blockquote p {
+      font-size: 1.05rem;
+      margin-bottom: 0;
+      color: var(--text-secondary);
+    }
+
+    /* Code blocks */
+    .code-block {
+      background: #161b22;
+      border-radius: 8px;
+      border: 1px solid #30363d;
+      margin: 1.5rem 0;
+      overflow: hidden;
+    }
+    .code-label {
+      display: block;
+      padding: 0.5rem 1.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--text-dimmed);
+      border-bottom: 1px solid #30363d;
+      background: #1c2128;
+    }
+    .code-block pre {
+      padding: 1.25rem 1.5rem;
+      overflow-x: auto;
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      line-height: 1.65;
+      color: #e6edf3;
+    }
+    .code-block pre code {
+      font-family: inherit;
+      font-size: inherit;
+      padding: 0;
+      border: none;
+      background: none;
+      border-radius: 0;
+      color: inherit;
+    }
+
+    /* Minimal syntax hints */
+    .kw { color: #ff7b72; }
+    .fn { color: #d2a8ff; }
+    .str { color: #a5d6ff; }
+    .cm { color: #8b949e; }
+    .tp { color: #79c0ff; }
+
+    /* CTA section */
+    .cta {
+      margin: 2.5rem 0;
+      padding: 2rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      text-align: center;
+    }
+    .cta p {
+      margin-bottom: 1rem;
+    }
+    .cta .install-cmd {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.75rem;
+      background: var(--bg-alt);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 0.75rem 1rem;
+      font-family: var(--font-mono);
+      font-size: 0.9rem;
+      max-width: 100%;
+      overflow-x: auto;
+    }
+    .cta .install-cmd code {
+      white-space: nowrap;
+      color: var(--text);
+    }
+    .cta .install-cmd button {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.3rem 0.5rem;
+      cursor: pointer;
+      color: var(--text-secondary);
+      font-size: 0.8rem;
+      flex-shrink: 0;
+      transition: all 0.15s;
+    }
+    .cta .install-cmd button:hover { background: var(--border); }
+    .cta-links {
+      margin-top: 1rem;
+      font-size: 0.9rem;
+      display: flex;
+      justify-content: center;
+      gap: 1.5rem;
+    }
+
+    /* ===== Footer ===== */
+    footer {
+      background: var(--bg-dark);
+      color: var(--text-dimmed);
+      padding: 2.5rem 1.5rem;
+      text-align: center;
+      font-size: 0.85rem;
+    }
+    footer a { color: var(--text-on-dark); }
+    footer a:hover { color: var(--cyan); }
+    .footer-links {
+      display: flex;
+      justify-content: center;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .footer-copy { color: #484f58; font-size: 0.8rem; }
+
+    /* ===== Responsive ===== */
+    @media (max-width: 640px) {
+      .article-header h1 { font-size: 1.75rem; }
+      .article-body p { font-size: 1.05rem; }
+    }
+    @media (max-width: 480px) {
+      .nav-links { gap: 0.75rem; font-size: 0.8rem; }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="nav-inner">
+      <a href="../" class="nav-brand">
+        <img src="../static/logo.png" alt="gotest logo" width="28" height="28">
+        gotest
+      </a>
+      <div class="nav-links">
+        <a href="./">Blog</a>
+        <a href="../reference.html" class="nav-ref">Reference</a>
+        <a href="https://github.com/mvrahden/go-test" class="star-btn"><span class="star-icon">&#9734;</span> Star<span class="star-count" id="star-count"></span></a>
+        <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code</a>
+      </div>
+    </div>
+  </nav>
+
+  <main class="article">
+    <header class="article-header">
+      <a href="./" class="back">&larr; All posts</a>
+      <h1>Why gotest Exists</h1>
+      <div class="article-meta">
+        <time datetime="2026-07-05">July 5, 2026</time>
+        <span>&middot;</span>
+        <span>8 min read</span>
+        <span class="tag">Philosophy</span>
+      </div>
+    </header>
+
+    <div class="article-body">
+
+      <p>Go's <code>testing</code> package is one of the best things about the language. No framework to install. No annotations to learn. Write a function that starts with <code>Test</code>, accept a <code>*testing.T</code>, and run <code>go test</code>. It works, and it scales further than most people expect.</p>
+
+      <p>But it does leave gaps. Not because the design is wrong, but because <code>testing</code> is deliberately minimal. It gives you a test runner and an assertion-free <code>T</code> type. Everything else is left to the developer: organizing tests into groups, managing setup and teardown, sharing expensive infrastructure, expressing what a test <em>means</em> rather than just what it does.</p>
+
+      <p>gotest exists to fill those gaps without replacing what works. This post explains the problems it targets, the principles behind its design, and why those principles lead to code generation rather than a runtime framework.</p>
+
+      <h2>The gaps</h2>
+
+      <p>Most Go projects hit the same set of problems as their test suite grows past a few dozen files:</p>
+
+      <ul>
+        <li><strong>No structural grouping.</strong> The stdlib gives you <code>func TestX</code> and <code>t.Run</code> for subtests. But subtests are closures inside flat functions, not first-class groups. If you have 30 test functions for <code>UserService</code> and 20 for <code>OrderService</code> in the same package, they are an alphabetical list. There is no way to say "these tests belong together" at the structural level.</li>
+        <li><strong>No lifecycle hooks.</strong> There is no built-in "run this before each test" or "run this once before the suite." <code>TestMain</code> gives you one entry point per package, but it runs before all tests and has no per-test granularity. <code>t.Cleanup</code> runs after a test, but there is no corresponding setup hook.</li>
+        <li><strong>No fixture management.</strong> If three test functions need a Postgres container, each one either starts its own (slow) or they share a package-level variable (fragile). The stdlib has no concept of "this resource has a lifecycle and these tests depend on it."</li>
+        <li><strong>No cross-package sharing.</strong> <code>go test</code> runs each package as a separate OS process. There is no way for <code>pkg/user</code> and <code>pkg/order</code> to share a database container through Go code. Most teams fall back to Makefiles or CI scripts to start infrastructure before running tests.</li>
+        <li><strong>No structure in output.</strong> Test names like <code>TestCreateUser_WhenEmailInvalid_ReturnsError</code> encode meaning in underscores. But <code>go test -v</code> renders them as flat lines. There is no hierarchical view that shows what a test suite covers at a glance.</li>
+      </ul>
+
+      <p>These are not theoretical concerns. They are the reasons most Go projects beyond a certain size end up either adopting a framework like testify/suite or building an ad-hoc system of helper functions, global variables, and <code>TestMain</code> orchestration.</p>
+
+      <h2>What existing frameworks do</h2>
+
+      <p>testify/suite is the most widely used answer to these problems. It gives you struct-based test suites with <code>SetupTest</code>/<code>TearDownTest</code> lifecycle hooks, and it works. But it makes trade-offs that gotest is designed to avoid:</p>
+
+      <ul>
+        <li><strong>Runtime reflection.</strong> testify/suite discovers test methods with <code>reflect</code> at runtime. A typo in a lifecycle method name (<code>SetUpTest</code> instead of <code>SetupTest</code>) silently does nothing. The wrong method signature silently does nothing. You find out when your test passes for the wrong reason, not when you compile.</li>
+        <li><strong>Registration boilerplate.</strong> Every suite needs a <code>func TestX(t *testing.T) { suite.Run(t, new(MySuite)) }</code> wrapper. It is one line, but it is one line per suite that exists only to satisfy the framework.</li>
+        <li><strong>Framework coupling.</strong> Every suite must embed <code>suite.Suite</code>. Assertions go through <code>s.Equal</code>, <code>s.NoError</code>, which are methods on the embedded struct, not standalone functions. Removing the framework means rewriting every assertion in every test.</li>
+        <li><strong>No fixture graph.</strong> testify/suite has no concept of fixture dependencies. If suite A and suite B both need a database, and the database needs a container, the developer manages that wiring manually.</li>
+      </ul>
+
+      <p>testify/suite is a good tool. gotest is not a reaction against it. But looking at the trade-offs above, they are not independent problems. They share a root cause.</p>
+
+      <h2>A different starting point</h2>
+
+      <p>testify/suite discovers tests at runtime through reflection. Once you choose reflection, the rest follows: you need a base type to reflect on (framework coupling), the developer must connect each suite to the test runner (registration boilerplate), and method signatures cannot be validated until the code actually runs (silent failures).</p>
+
+      <p>gotest asks a different question: what if discovery happens before the tests run? The suite struct is already in the source code. The method names are already there. A tool that reads Go source files can find everything reflection finds, without running any code, and produce the bridge functions that connect suites to <code>go test</code>. If that tool runs at build time, everything it produces is ordinary Go.</p>
+
+      <p>That premise shaped five design principles. They are not aspirations; they are constraints that every feature in gotest must satisfy.</p>
+
+      <h2>Principle 1: Standard Go output, always</h2>
+
+      <p>Every generated test is a <code>func Test*(t *testing.T)</code>. Every line of output is standard <code>go test</code> output. Every CI system, IDE, coverage tool, and profiler works unchanged.</p>
+
+      <p>This is the highest-priority principle, and the others are subordinate to it. gotest does not replace <code>go test</code>. It generates the bridge code that connects your suite structs to <code>go test</code>'s entry point convention. What actually runs is <code>go test</code>, with standard <code>func Test*(t *testing.T)</code> functions that the generator produced.</p>
+
+      <p>This means there is no lock-in at the output level. CI pipelines that parse <code>go test -json</code> output do not need to know gotest exists. Coverage tools see standard Go test functions. Race detector, profiler, debugger: all unchanged. The generated code is the same code a careful developer would write by hand; gotest automates the wiring, not the execution.</p>
+
+      <h2>Principle 2: The naming IS the API</h2>
+
+      <p>gotest has no configuration files, no struct tags, no annotations, and no registration calls. The entire API is naming conventions:</p>
+
+      <ul>
+        <li>A struct whose name ends in <code>TestSuite</code> is a test suite.</li>
+        <li>A method whose name starts with <code>Test</code> is a test case.</li>
+        <li>A method named <code>BeforeEach</code> runs before every test.</li>
+        <li>A struct whose name ends in <code>Fixture</code> is a package fixture.</li>
+        <li>A struct whose name ends in <code>SharedFixture</code> is a cross-package shared fixture.</li>
+        <li>A method prefixed with <code>F_</code> is focused (only focused tests run). A method prefixed with <code>X_</code> is excluded.</li>
+      </ul>
+
+      <p>The goal is that a developer reads the naming conventions once and never opens documentation again. If you can read Go, you can read a gotest suite. There is nothing to decode, no interface to look up, no config to cross-reference.</p>
+
+      <p>In practice, a suite looks like this:</p>
+
+      <div class="code-block">
+        <span class="code-label">user_test.go</span>
+        <pre><code><span class="kw">type</span> <span class="tp">UserServiceTestSuite</span> <span class="kw">struct</span> {
+    db   *sql.DB
+    svc  *UserService
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserServiceTestSuite</span>) <span class="fn">BeforeEach</span>(t *<span class="tp">gotest.T</span>) {
+    s.db = setupTestDB(t.T())
+    s.svc = NewUserService(s.db)
+}
+
+<span class="kw">func</span> (s *<span class="tp">UserServiceTestSuite</span>) <span class="fn">TestCreate</span>(t *<span class="tp">gotest.T</span>) {
+    t.When(<span class="str">"email is valid"</span>, <span class="kw">func</span>(w *<span class="tp">gotest.T</span>) {
+        w.It(<span class="str">"creates the user"</span>, <span class="kw">func</span>(it *<span class="tp">gotest.T</span>) {
+            err := s.svc.Create(<span class="str">"alice@example.com"</span>)
+            gotest.NoError(it, err)
+        })
+    })
+}</code></pre>
+      </div>
+
+      <p>There is no registration call, no embedded base type, no interface to implement. The struct name ends in <code>TestSuite</code>, so the generator recognizes it. The method name starts with <code>Test</code>, so it becomes a test case. <code>BeforeEach</code> runs before every test method. Everything else is plain Go.</p>
+
+      <p>The code generator reads these source files with <code>go/parser</code>, walks the AST looking for the naming patterns, and produces the lifecycle wiring. Discovery is purely static: no code runs during the generation step.</p>
+
+      <h2>Principle 3: Zero runtime cost</h2>
+
+      <p>At test execution time, there is no framework orchestration code in your call stack. The only runtime component is the thin <code>gotest.T</code> wrapper that provides <code>When</code>/<code>It</code> methods and standalone assertion functions like <code>gotest.Equal</code>. Everything else is generated: struct initialization, <code>t.Run</code> calls, <code>t.Cleanup</code> calls, direct method invocations. No reflection, no interface dispatch, no type assertions.</p>
+
+      <p>This has practical consequences. Stack traces point to your code, not to framework internals. Refactoring tools can follow the call chain because every call is a direct call. The <code>gotest</code> package that your tests import is a thin layer of helper types and functions; it has no transitive dependencies beyond the standard library.</p>
+
+      <p>The code generator runs before <code>go test</code> and produces Go source files. Those files are injected via Go's <code>-overlay</code> flag, a built-in mechanism that maps virtual file paths to real files on disk. The compiler sees the generated files; your source directory does not. After the run, nothing is left behind. Your <code>git status</code> stays clean.</p>
+
+      <p>This extends to isolation. Each suite runs in its own OS process — a generated test binary, compiled and executed separately. A panicking test in one suite cannot crash another. Memory is isolated by the OS, not by convention. Goroutine leaks, global state mutations, and port conflicts stay contained to the process that caused them.</p>
+
+      <p>This structural isolation is what makes suite-level parallelism safe by default: suites run concurrently without any opt-in, because they cannot interfere with each other.</p>
+
+      <h2>Principle 4: Invisible until needed</h2>
+
+      <p>A developer who has never heard of gotest can read a test suite struct and understand what it does. The struct has fields, methods with descriptive names, and assertions that are standalone function calls. There is nothing to decode.</p>
+
+      <p>A developer who runs <code>go test</code> directly (without the CLI) gets a compilation error for the missing generated file, not silent wrong behavior. The error is clear and points to the solution.</p>
+
+      <p>And a developer who decides to stop using gotest can look at the generated code to see exactly what to write by hand. The generated file is a complete, readable Go test file. It is not a binary artifact or a compressed intermediate representation. It is the code you would have written yourself if you had the patience.</p>
+
+      <h2>Principle 5: Adopt incrementally, eject freely</h2>
+
+      <p>Existing <code>func Test*</code> tests coexist with suites in the same package. You do not need to convert everything at once. A single suite can live next to 50 flat test functions, and <code>gotest</code> handles both.</p>
+
+      <p>Ejecting is real work, but it is straightforward work. You replace <code>*gotest.T</code> parameters with <code>*testing.T</code>, swap gotest assertions for your preferred alternative, and write the <code>func Test*</code> entry points that the generator was producing for you. The generated code shows exactly what those entry points look like. There is no data to migrate, no configuration to unwind, no runtime state to reconstruct.</p>
+
+      <p>This is a deliberate contrast with frameworks that require embedding a base type or implementing an interface. Those create a structural dependency: your test code <em>is</em> framework code. With gotest, your test code is Go code that happens to follow naming conventions. The conventions are what the tool reads; they are not what the code depends on.</p>
+
+      <h2>Why code generation</h2>
+
+      <p>The principles above point toward code generation almost by necessity. If you want no reflection, you need a static discovery step. If you want standard <code>go test</code> output, you need standard test functions. If you want naming conventions instead of interfaces, you need a tool that reads source code and produces source code.</p>
+
+      <p>Code generation also solves the error-reporting problem that plagues reflection-based frameworks. If a lifecycle method has the wrong signature, the code generator rejects it at generation time with a clear error message, file name, and line number. With reflection, the method is silently ignored at runtime. You discover the problem when your <code>BeforeEach</code> never runs and your tests pass for the wrong reason.</p>
+
+      <p>The overlay filesystem injection is what makes this practical. Without it, code generation would mean generated files in your source tree: files to <code>.gitignore</code>, files that clutter your editor, files that go stale if you forget to regenerate. The <code>-overlay</code> flag removes all of that. The generated code exists only during the test run, in a content-addressable cache that handles invalidation automatically.</p>
+
+      <h2>What follows from this</h2>
+
+      <p>These principles are not abstract. They directly shaped every feature in gotest:</p>
+
+      <ul>
+        <li><strong>Test suites</strong> are plain structs with <code>TestSuite</code> suffix, not types that embed a framework base. Lifecycle hooks are methods with conventional names, not interface implementations. <a href="organizing-go-tests.html">More on organizing tests.</a></li>
+        <li><strong>Fixtures</strong> are structs with <code>Fixture</code> suffix. Dependencies between fixtures are expressed as pointer fields, forming a DAG that the generator resolves automatically. Shared fixtures cross the process boundary through JSON serialization. <a href="test-fixtures-in-go.html">More on fixtures.</a></li>
+        <li><strong>BDD structure</strong> uses <code>t.When()</code> and <code>t.It()</code> method calls that map directly to <code>t.Run</code>. The <code>gotest spec</code> command renders this structure as a behavioral specification, because the hierarchy is already there in the test code. <a href="readable-tests-with-bdd.html">More on BDD-style tests.</a></li>
+        <li><strong>AST-based discovery</strong> uses <code>go/parser</code> to read source files without importing or compiling them. This keeps the generation step fast and means the generator never executes user code. <a href="code-generation-not-reflection.html">More on code generation.</a></li>
+      </ul>
+
+      <p>Each of these deserves a deeper look. The common thread is the same: gotest is not trying to replace Go's testing model. It is trying to generate the code that Go's testing model requires you to write by hand once your project outgrows flat functions and subtests.</p>
+
+      <div class="cta">
+        <p><strong>Try gotest on your next project.</strong></p>
+        <div class="install-cmd">
+          <code>go install github.com/mvrahden/go-test/cmd/gotest@latest</code>
+          <button onclick="navigator.clipboard.writeText('go install github.com/mvrahden/go-test/cmd/gotest@latest').then(()=>{this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)})" aria-label="Copy install command">Copy</button>
+        </div>
+        <div class="cta-links">
+          <a href="../reference.html">Reference</a>
+          <a href="https://github.com/mvrahden/go-test">GitHub</a>
+          <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
+        </div>
+      </div>
+
+    </div>
+  </main>
+
+  <footer>
+    <div class="footer-links">
+      <a href="../">Home</a>
+      <a href="https://github.com/mvrahden/go-test">GitHub</a>
+      <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
+      <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
+      <a href="../reference.html">Reference</a>
+      <a href="./">Blog</a>
+      <a href="https://github.com/mvrahden/go-test/blob/main/LICENSE">MIT License</a>
+    </div>
+    <p class="footer-copy">Built for Go developers who want tests that explain themselves.</p>
+  </footer>
+  <script>
+  fetch('https://api.github.com/repos/mvrahden/go-test')
+    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(d => {
+      if (d.stargazers_count >= 10) {
+        document.getElementById('star-count').textContent = ` ${d.stargazers_count}`;
+      }
+    })
+    .catch(() => {});
+  </script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -572,11 +572,12 @@
 <body>
   <nav>
     <div class="nav-inner">
-      <a href="/" class="nav-brand">
+      <a href="./" class="nav-brand">
         <img src="static/logo.png" alt="gotest logo" width="28" height="28">
         gotest
       </a>
       <div class="nav-links">
+        <a href="blog/">Blog</a>
         <a href="reference.html" class="nav-ref">Reference</a>
         <a href="https://github.com/mvrahden/go-test" class="star-btn"><span class="star-icon">&#9734;</span> Star<span class="star-count" id="star-count"></span></a>
         <a href="https://pkg.go.dev/github.com/mvrahden/go-test" onclick="gtag('event','click',{event_category:'outbound',event_label:'pkg.go.dev'})">pkg.go.dev</a>
@@ -636,7 +637,7 @@
   <span class="t-test">Delete</span>
     <span class="t-pass">&#10003;</span> soft-deletes the user <span class="t-time">(5ms)</span>
     <span class="t-skip">~</span><span class="t-skip"> hard-deletes after 30 days &#8212; SKIPPED</span>
-<span class="t-summary">2 suites, 5 behaviors: <span class="t-pass">4 passed</span>, 0 failed, <span class="t-skip">1 skipped</span></span></pre>
+<span class="t-summary">1 suite, 5 behaviors: <span class="t-pass">4 passed</span>, 0 failed, <span class="t-skip">1 skipped</span></span></pre>
         </div>
         <p class="caption">Under the hood it's <code>go test</code>. On the surface, your suites read as specifications.</p>
       </div>
@@ -809,6 +810,7 @@
       <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
       <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
       <a href="reference.html">Reference</a>
+      <a href="blog/">Blog</a>
       <a href="https://github.com/mvrahden/go-test/blob/main/LICENSE">MIT License</a>
     </div>
     <p class="footer-copy">Built for Go developers who want tests that explain themselves.</p>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -212,6 +212,7 @@
       margin-right: 0.4rem;
     }
     .toc a { font-size: 0.9rem; }
+    .toc-desc { font-size: 0.8rem; color: var(--text-dimmed); }
 
     /* ===== Sections ===== */
     .ref-section {
@@ -394,6 +395,7 @@
       </a>
       <div class="nav-links">
         <a href="./" class="nav-home">Home</a>
+        <a href="blog/">Blog</a>
         <a href="https://github.com/mvrahden/go-test" class="star-btn"><span class="star-icon">&#9734;</span> Star<span class="star-count" id="star-count"></span></a>
         <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
         <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code</a>
@@ -410,16 +412,16 @@
     <div class="toc">
       <div class="toc-title">Contents</div>
       <ol>
-        <li><a href="#conceptual-model">Conceptual Model</a></li>
-        <li><a href="#naming-conventions">Naming Conventions</a></li>
-        <li><a href="#lifecycle">Suite Lifecycle</a></li>
-        <li><a href="#test-dsl">Test DSL</a></li>
-        <li><a href="#fixtures">Fixtures</a></li>
-        <li><a href="#assertions">Assertions</a></li>
-        <li><a href="#configuration">Configuration</a></li>
-        <li><a href="#coverage">Coverage</a></li>
-        <li><a href="#cli">CLI Reference</a></li>
-        <li><a href="#ci-integration">CI Integration</a></li>
+        <li><a href="#conceptual-model">Conceptual Model</a> <span class="toc-desc">— how Go constructs map to spec concepts</span></li>
+        <li><a href="#naming-conventions">Naming Conventions</a> <span class="toc-desc">— suffixes, prefixes, and lifecycle methods</span></li>
+        <li><a href="#lifecycle">Suite Lifecycle</a> <span class="toc-desc">— execution order, hooks, and parallel modes</span></li>
+        <li><a href="#test-dsl">Test DSL</a> <span class="toc-desc">— When/It, data-driven tests, snapshots, polling</span></li>
+        <li><a href="#fixtures">Fixtures</a> <span class="toc-desc">— package fixtures, DAG ordering, shared fixtures</span></li>
+        <li><a href="#assertions">Assertions</a> <span class="toc-desc">— type-safe generics for equality, errors, collections</span></li>
+        <li><a href="#configuration">Configuration</a> <span class="toc-desc">— project file, suite config, fixture config</span></li>
+        <li><a href="#coverage">Coverage</a> <span class="toc-desc">— statement-weighted calculation and thresholds</span></li>
+        <li><a href="#cli">CLI Reference</a> <span class="toc-desc">— commands, flags, go test passthrough</span></li>
+        <li><a href="#ci-integration">CI Integration</a> <span class="toc-desc">— summary output, GitHub Action, PR annotations</span></li>
       </ol>
     </div>
 
@@ -979,7 +981,7 @@ percentage = covered / total</div>
           <tr><td><code>--update-snapshots</code></td><td>Regenerate all snapshot files.</td></tr>
           <tr><td><code>--no-cache</code></td><td>Disable overlay cache, force fresh generation.</td></tr>
           <tr><td><code>--min=&lt;pct&gt;</code></td><td>Fail if coverage falls below threshold.</td></tr>
-          <tr><td><code>--format=md</code></td><td>Markdown output for <code>spec</code> command.</td></tr>
+          <tr><td><code>--format=&lt;fmt&gt;</code></td><td>Output format for <code>spec</code> command: <code>md</code> (Markdown) or <code>json</code> (structured JSON).</td></tr>
           <tr><td><code>--output=&lt;path&gt;</code></td><td>Write formatted output to file.</td></tr>
           <tr><td><code>--no-color</code></td><td>Strip ANSI codes from output.</td></tr>
           <tr><td><code>--debug</code></td><td>Preserve overlays after the run for inspection.</td></tr>
@@ -1089,6 +1091,7 @@ FAIL  pkg/bar TestProcessOrder / concurrent writes (1.2s)
       <a href="https://github.com/mvrahden/go-test">GitHub</a>
       <a href="https://pkg.go.dev/github.com/mvrahden/go-test">pkg.go.dev</a>
       <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest">VS Code Extension</a>
+      <a href="blog/">Blog</a>
       <a href="https://github.com/mvrahden/go-test/blob/main/LICENSE">MIT License</a>
     </div>
     <p class="footer-copy">Built for Go developers who want tests that explain themselves.</p>


### PR DESCRIPTION
Five articles covering gotest's design philosophy, test organization patterns, fixtures, BDD-style output, and the code generation internals. Includes the blog index page and updates to the homepage and reference page.