### PR TITLE
Resilient Go SDK discovery in VSCode extension

### DIFF
--- a/vscode-gotest/src/batchRunner.ts
+++ b/vscode-gotest/src/batchRunner.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import type { GoTestController } from "./testController.js";
 import type { CoverageStore } from "./coverageStore.js";
 import { type TestEvent } from "./outputParser.js";
-import { buildCliCommand, formatCliCommand } from "./cli.js";
+import { buildCliCommand, clearBinaryCache, formatCliCommand } from "./cli.js";
 import {
   applyEvent,
   skipUnresolved,
@@ -249,6 +249,9 @@ export async function executeBatch(config: BatchConfig): Promise<BatchResult> {
     return { stdout: result.stdout };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+      clearBinaryCache();
+    }
     outputChannel.error(`[${label}] ${message}`);
     for (const info of pkgInfos) {
       for (const item of info.items) {

--- a/vscode-gotest/src/discovery.ts
+++ b/vscode-gotest/src/discovery.ts
@@ -8,7 +8,7 @@ import type {
   DiscoverPackage,
   DiscoverWarning,
 } from "./types.js";
-import { buildCliCommand, formatCliCommand } from "./cli.js";
+import { buildCliCommand, clearBinaryCache, formatCliCommand } from "./cli.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -277,6 +277,11 @@ export class DiscoveryService {
         return;
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
+        const isENOENT =
+          err instanceof Error && "code" in err && err.code === "ENOENT";
+        if (isENOENT) {
+          clearBinaryCache();
+        }
         if (attempt < DiscoveryService.MAX_RETRIES) {
           this.outputChannel.debug(
             `[discovery] attempt ${attempt}/${DiscoveryService.MAX_RETRIES} failed, retrying: ${message}`,

--- a/vscode-gotest/src/goBinary.ts
+++ b/vscode-gotest/src/goBinary.ts
@@ -57,15 +57,17 @@ async function resolveProjectGoBinary(
   }
 
   // go1.26.2 on PATH (installed via `go install golang.org/dl/go1.26.2`)
+  // These can be wrapper stubs that fail when the SDK isn't downloaded,
+  // so validate before accepting.
   const versionedName = `go${goVersion}`;
   const shellVersioned = await whichFromShell(versionedName);
-  if (shellVersioned) {
+  if (shellVersioned && (await validateBinary(shellVersioned))) {
     log?.debug(`[go] resolved go ${goVersion} via shell: ${shellVersioned}`);
     return shellVersioned;
   }
 
   const whichVersioned = await which(versionedName);
-  if (whichVersioned) {
+  if (whichVersioned && (await validateBinary(whichVersioned))) {
     log?.debug(`[go] resolved go ${goVersion} via PATH: ${whichVersioned}`);
     return whichVersioned;
   }
@@ -122,6 +124,15 @@ async function readGoVersionFromMod(
     return match?.[1];
   } catch {
     return undefined;
+  }
+}
+
+async function validateBinary(bin: string): Promise<boolean> {
+  try {
+    await execFileAsync(bin, ["version"], { timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -3,7 +3,12 @@ import { spawn, type ChildProcess } from "node:child_process";
 import type { GoTestController } from "./testController.js";
 import type { DiscoveryCache } from "./discovery.js";
 import { parseTestEvents, type TestEvent } from "./outputParser.js";
-import { buildCliCommand, formatCliCommand, type CliCommand } from "./cli.js";
+import {
+  buildCliCommand,
+  clearBinaryCache,
+  formatCliCommand,
+  type CliCommand,
+} from "./cli.js";
 import {
   resolveTestItem,
   applyResults,
@@ -28,17 +33,22 @@ class WatchProcess implements vscode.Disposable {
   private cycleBuffer = "";
   private disposed = false;
   private consecutiveCrashes = 0;
+  private needsResolve = false;
+
+  private cmd: CliCommand;
 
   constructor(
     private readonly pkgScope: string,
     private readonly cwd: string,
-    private readonly cmd: CliCommand,
+    cmd: CliCommand,
+    private readonly buildCmd: () => Promise<CliCommand>,
     private readonly outputChannel: vscode.LogOutputChannel,
     private readonly onCycleStart: () => void,
     private readonly onEvents: (jsonLines: string) => void,
     private readonly onError: (msg: string) => void,
     private readonly onExit: () => void,
   ) {
+    this.cmd = cmd;
     this.start();
   }
 
@@ -71,6 +81,10 @@ class WatchProcess implements vscode.Disposable {
 
     this.child.on("error", (err: Error) => {
       this.outputChannel.error(`[watch] process error: ${err.message}`);
+      if ("code" in err && err.code === "ENOENT") {
+        clearBinaryCache();
+        this.needsResolve = true;
+      }
       if (!this.disposed) {
         this.maybeRestart();
       }
@@ -159,10 +173,18 @@ class WatchProcess implements vscode.Disposable {
       `[watch] restarting in ${delay / 1000}s (crash ${this.consecutiveCrashes}/${WatchProcess.MAX_CONSECUTIVE_CRASHES}, scope: ${this.pkgScope})`,
     );
 
-    setTimeout(() => {
-      if (!this.disposed) {
-        this.start();
+    setTimeout(async () => {
+      if (this.disposed) return;
+      if (this.needsResolve) {
+        this.needsResolve = false;
+        try {
+          this.cmd = await this.buildCmd();
+        } catch {
+          this.onExit();
+          return;
+        }
       }
+      this.start();
     }, delay);
   }
 
@@ -230,7 +252,9 @@ export class WatchManager implements vscode.Disposable {
       this.stop(pkgScope);
     }
 
-    const cmd = await buildCliCommand(["watch", "--", "-json", pkgScope], cwd);
+    const buildCmd = () =>
+      buildCliCommand(["watch", "--", "-json", pkgScope], cwd);
+    const cmd = await buildCmd();
 
     let cycleJsonAccumulator = "";
 
@@ -238,6 +262,7 @@ export class WatchManager implements vscode.Disposable {
       pkgScope,
       cwd,
       cmd,
+      buildCmd,
       this.outputChannel,
       // onCycleStart
       () => {


### PR DESCRIPTION
When a Go SDK is missing or removed mid-session, the extension kept using the cached path to the deleted binary, failing until the window was reloaded. Now the binary cache is cleared on ENOENT so subsequent operations self-heal.