### PR TITLE
Publish the Go testing research article

### DIFF
--- a/site/assets/css/main.css
+++ b/site/assets/css/main.css
@@ -53,7 +53,7 @@ body {
   flex-direction: column;
 }
 
-main { flex: 1; }
+main { flex: 1; width: 100%; min-width: 0; }
 
 a { color: var(--cyan-dark); text-decoration: none; }
 @media (prefers-color-scheme: dark) { a { color: var(--cyan); } }
@@ -1263,4 +1263,26 @@ footer a:hover { color: var(--cyan); }
   .nav-links { gap: 0.75rem; font-size: 0.8rem; }
   .terminal-body { font-size: 0.75rem; padding: 1rem; }
   .install-cmd { font-size: 0.8rem; }
+}
+
+
+/* ===== Mobile refinements ===== */
+/* geometric no-ops on desktop: fire only when space runs out */
+.article-body img { max-width: 100%; height: auto; }
+.article-body { overflow-wrap: break-word; }
+.article-meta, .post-entry-meta { flex-wrap: wrap; row-gap: 0.35rem; }
+
+@media (max-width: 640px) {
+  /* wide tables scroll inside their own box instead of breaking the page */
+  .article-body table, .comparison-table, .ref-table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  /* outbound nav links live in footer and CTAs; drop them from the bar */
+  .nav-links .nav-out, .nav-links .nav-home-link { display: none; }
+}
+
+@media (max-width: 480px) {
+  .nav-inner, .article, .post-list, .page-header, .blog-header { padding-left: 1rem; padding-right: 1rem; }
 }

--- a/site/assets/css/main.css
+++ b/site/assets/css/main.css
@@ -63,7 +63,7 @@ a:hover { text-decoration: underline; }
 
 
 /* ===== Nav ===== */
-nav {
+body > nav {
   position: sticky;
   top: 0;
   z-index: 10;
@@ -1140,24 +1140,53 @@ footer a:hover { color: var(--cyan); }
 
 /* ===== Article TOC ===== */
 .article-toc {
-  background: var(--bg-alt);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 1rem 1.5rem;
   margin: 0 0 2rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-alt);
+  border-left: 3px solid var(--cyan-dark);
+  border-radius: 0 8px 8px 0;
   font-size: 0.9rem;
 }
-.article-toc strong {
-  display: block;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-secondary);
-  margin-bottom: 0.5rem;
+@media (prefers-color-scheme: dark) {
+  .article-toc { border-left-color: var(--cyan); }
 }
-.article-toc ul { list-style: none; margin: 0; padding: 0; }
-.article-toc ul ul { padding-left: 1rem; }
-.article-toc li { margin: 0.25rem 0; }
+.article-toc summary {
+  cursor: pointer;
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: var(--text);
+}
+.article-toc summary::-webkit-details-marker { display: none; }
+.article-toc summary::after {
+  content: "\25B8";
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  transition: transform 0.15s;
+}
+.article-toc[open] summary::after { transform: rotate(90deg); }
+.article-toc > ul, .article-toc > nav > ul { columns: 2; column-gap: 2rem; }
+.article-toc ul { list-style: none; margin: 0.6rem 0 0; padding: 0; }
+.article-toc ul ul { padding-left: 1rem; margin-top: 0; columns: 1; }
+.article-toc li {
+  margin: 0.35rem 0;
+  padding-left: 0.9rem;
+  position: relative;
+  line-height: 1.4;
+  break-inside: avoid;
+}
+.article-toc li::before {
+  content: "\2022";
+  position: absolute;
+  left: 0;
+  color: var(--text-dimmed);
+}
+.article-toc ul ul li::before { content: "\25E6"; }
+@media (max-width: 640px) {
+  .article-toc > ul, .article-toc > nav > ul { columns: 1; }
+}
 
 /* ===== Related posts ===== */
 .related-posts {

--- a/site/content/blog/advanced-fixture-patterns.md
+++ b/site/content/blog/advanced-fixture-patterns.md
@@ -5,7 +5,6 @@ description: "Go test fixture patterns at scale: composition, container-backed f
 tags: ["Deep Dive"]
 keywords: ["go test fixtures", "testcontainers go", "go fixture composition", "go test per-test isolation"]
 cta_text: "Compose your first fixture DAG."
-toc: true
 ---
 
 A single fixture gets you started: start a thing, stop a thing, point your tests at it. Real projects need more. Fixtures that compose into dependency graphs, containers that survive flaky startup, per-test isolation that keeps parallel tests from stepping on each other, and configuration that adapts to each environment. These are the patterns that emerge when fixtures grow beyond a single struct with two hooks.

--- a/site/content/blog/code-generation-not-reflection.md
+++ b/site/content/blog/code-generation-not-reflection.md
@@ -4,7 +4,6 @@ date: 2026-07-09
 description: "Most Go test frameworks use reflection to find suites at runtime. gotest uses AST-based code generation with overlay filesystem injection instead."
 tags: ["Internals"]
 keywords: ["go code generation testing", "reflection vs code generation go", "go ast test discovery", "go test overlay flag", "go generate tests"]
-toc: true
 cta_text: "Run gotest generate on your own suite and read the bridge it writes."
 aliases: ["/blog/code-generation-not-reflection.html"]
 ---

--- a/site/content/blog/go-test-lifecycle.md
+++ b/site/content/blog/go-test-lifecycle.md
@@ -4,7 +4,6 @@ date: 2026-07-14
 description: "Go test setup and teardown, in order: suite hooks, fixture hooks, cleanup guarantees, and retries — the full gotest lifecycle from BeforeAll to AfterAll."
 tags: ["Patterns"]
 keywords: ["go test setup teardown", "go test lifecycle", "beforeeach aftereach go", "go test cleanup order"]
-toc: true
 cta_text: "See these lifecycle guarantees in your own suite."
 faq:
   - q: "Does AfterEach run after t.Fatal?"

--- a/site/content/blog/go-testing-at-scale.md
+++ b/site/content/blog/go-testing-at-scale.md
@@ -5,7 +5,6 @@ description: "Most slow Go test suites aren't slow because of slow tests. Sequen
 tags: ["Performance"]
 keywords: ["why are my go tests slow", "speed up go tests", "go test parallelism", "go test t.parallel", "go test slow"]
 cta_text: "Run your slowest suites as parallel processes."
-toc: true
 faq:
   - q: "Why are my Go tests slow even though each test is fast?"
     a: "Usually it is structure, not the tests. Every test in a package runs in one process, sequentially by default, so the longest single-package run sets your ceiling no matter how many CPU cores you have."

--- a/site/content/blog/how-go-actually-tests.md
+++ b/site/content/blog/how-go-actually-tests.md
@@ -4,7 +4,6 @@ date: 2026-07-24
 description: "We parsed 720,118 test functions across the 1,000 most-starred Go repos. What the data says about parallelism, sleeps, golden files, and containers."
 tags: ["Research"]
 keywords: ["go testing statistics", "state of go testing", "go test parallel adoption", "testify vs ginkgo usage", "go testing survey"]
-toc: true
 cta_text: "See what structured suites change about these numbers."
 faq:
   - q: "How many Go tests run in parallel?"

--- a/site/content/blog/how-go-actually-tests.md
+++ b/site/content/blog/how-go-actually-tests.md
@@ -1,0 +1,143 @@
+---
+title: "How Go Actually Tests: Data From 1,000 Repositories"
+date: 2026-07-24
+description: "We parsed 720,118 test functions across the 1,000 most-starred Go repos. What the data says about parallelism, sleeps, golden files, and containers."
+tags: ["Research"]
+keywords: ["go testing statistics", "state of go testing", "go test parallel adoption", "testify vs ginkgo usage", "go testing survey"]
+toc: true
+cta_text: "See what structured suites change about these numbers."
+faq:
+  - q: "How many Go tests run in parallel?"
+    a: "Across the 1,000 most-starred Go repositories, 11.2% of test functions call t.Parallel() themselves. 46% of repos use it somewhere — adoption is broad, but shallow."
+  - q: "What testing framework do most Go projects use?"
+    a: "56% of the top Go repos import testify's assert or require packages. Only 10% use testify/suite and 8% use ginkgo. The stdlib's httptest appears in 60% — more than any third-party framework."
+  - q: "How much do Go tests sleep?"
+    a: "We counted 27,453 time.Sleep calls in test code across 917 repos with tests — at least 251 hours of fixed waiting per full run of the corpus, counting only compile-time-constant durations."
+---
+
+The tests of the 1,000 most-starred Go repositories spend at least **251 hours asleep**. Not blocked on I/O, not waiting for a condition. Sleeping, in `time.Sleep` calls with constant durations, written into test code on purpose. That is ten and a half days of deliberate waiting per full run of the corpus, and it is a floor: we could only count durations that are compile-time constants.
+
+We measured this because we couldn't find anyone who had. There is no shortage of opinions about how Go tests should be written. There is very little data about how they are written. So we parsed them.
+
+## What we measured
+
+We took the 1,000 most-starred Go repositories on GitHub (excluding archived repos and forks, with [hard-fork lineages deduplicated](#methodology-and-limitations)), pinned each to a commit, and parsed every non-generated `_test.go` file with `go/parser`. No compilation, no execution. 76 repos have no test files at all, which leaves **917 repos and 720,118 test functions**, plus 69,619 ginkgo specs counted separately.
+
+The scanner, the corpus with commit SHAs, and the full per-repo dataset are [on GitHub](https://github.com/mvrahden/go-test/tree/research/test-census), so every number below is reproducible.
+
+A note on how to read this post: we build a test framework, and this census exists because we wanted to know whether the problems gotest targets are real at ecosystem scale. The numbers are reported straight. The interpretation is ours, and we say so where it matters.
+
+## Most Go tests never run in parallel
+
+`t.Parallel()` is the stdlib's one-line speedup, and 46% of repos call it somewhere. But look at tests instead of repos and the picture inverts: **11.2% of test functions are parallel**. Even in the top 100 repos by stars, where 67% have adopted it somewhere, only 9.1% of tests actually use it.
+
+![Grouped bar chart: share of repos using t.Parallel() anywhere (46% full corpus, 67% top 100, 41% long tail) versus share of tests that actually run in parallel (11.2%, 9.1%, 9.1%).](../../census/parallel.svg)
+
+The gap between adoption and use has a simple explanation: `t.Parallel()` is only safe for tests that share nothing, and most tests share a database, a global, or a fixture. The flag is trivial. Making tests independent is the actual work, and most teams stop before it. [Why Your Go Tests Are Slow]({{< ref "/blog/go-testing-at-scale" >}}) makes the structural argument; this is its baseline. It is also why gotest runs each suite as its own process and makes per-test state explicit — a returning `BeforeEach` gives every test its own copy, so parallelism stops being a data-race gamble.
+
+## The sleep problem is universal
+
+68% of repos have `time.Sleep` in their test code — 27,453 calls in total. Where the duration was a constant we could resolve, the corpus sleeps 251 hours per full test run, roughly 24 minutes of fixed waiting per affected repo. Sleeps with computed durations, retry loops, and helper indirection are not counted, so the real figure is higher.
+
+A sleep is a guess about how long the async thing takes. Guess short and the test flakes. Guess long and the suite crawls. Polling assertions like gotest's `Eventually` and `Consistently` replace the guess with a deadline and a check interval — that argument, and the migration path, is in [Testing Async Code in Go Without time.Sleep]({{< ref "/blog/testing-async-go" >}}).
+
+## What the ecosystem imports
+
+![Horizontal bar chart of framework adoption as share of 917 repos: httptest 60%, testify assert/require 56%, go-cmp 21%, testify/mock 14%, testify/suite 10%, gomock 9%, gomega 8%, ginkgo 8%, testing/quick 5%, testcontainers-go 3%.](../../census/frameworks.svg)
+
+Three things stand out.
+
+**`httptest` beats every third-party package.** The stdlib's HTTP test server appears in 60% of repos. Where the standard library actually solves a problem, Go developers use it and skip the dependency. That is worth remembering when reading the rest of this post: the gaps we measure below are places where the stdlib offers no equivalent to reach for.
+
+**testify spread as an assertion library, not a suite framework.** 56% of repos import `assert`/`require`; only 10% use `testify/suite`. It would be easy to read that as "Go doesn't want test structure." The rest of the data argues otherwise — 42% of repos wire up `TestMain`, 36.7% of test names encode scenarios in underscores, and helper conventions are everywhere. The demand for structure is visible in every workaround column of our dataset. What 10% prices is the cost of the available implementation: testify/suite brings reflection, a runtime dependency, and sequential method execution. Teams looked at that trade and hand-rolled structure instead. (If you are in the 10%, [the migration guide]({{< ref "/blog/testify-migration-guide" >}}) covers moving a suite codebase to generated, parallel-safe suites.)
+
+**BDD frameworks are a committed minority.** ginkgo appears in 8% of repos, but those repos contain 69,619 specs. BDD in Go is polarized, not fringe. Our position on why — and what behavioral structure looks like without a DSL — is in [BDD in Go]({{< ref "/blog/what-bdd-means-in-go" >}}).
+
+Snapshot libraries register at 2%. That number is interesting only next to the following one.
+
+## Golden files: everyone does it, nobody standardizes it
+
+43% of repos reference `testdata/` from their test code — expected-output files compared against actual output. Only 7% have an update workflow (an `-update` flag that regenerates the files), and only 6% use the `.golden` naming convention. The corpus is full of `testdata/*.json`, `*.txtar`, and `*.txt` compared by hand-rolled helpers.
+
+Golden testing is a 43% practice with a 7% workflow. Every team reinvents the read-compare-update loop, and most stop before the "update" part. [Snapshot Testing in Go]({{< ref "/blog/snapshot-testing-in-go" >}}) covers what a built-in version looks like — `MatchSnapshot` with parallel-safe writes and a read-only mode for CI.
+
+## What Go tests against: Postgres
+
+7% of repos start real containers in their tests, via testcontainers-go, dockertest, or compose files wired into test orchestration. What do they run?
+
+![Horizontal bar chart of container images used in tests, by repo count: postgres 82, redis 46, mysql 45, prometheus 36, grafana 28, nginx 25, minio 25, jaeger 24, mongo 21, clickhouse 20.](../../census/containers.svg)
+
+Postgres appears in 82 repos, nearly twice its closest rival. If you are building test infrastructure for Go, this ranking is a priority list.
+
+The structural finding matters more than the ranking: **26 repos have the multi-package `TestMain` container pattern** — several packages, each with a `TestMain` that starts its own container, directly or through a helper package. coder/coder has 61 such packages; telegraf has 477 test packages that reach container code. `go test` runs each package as a separate OS process, so these packages cannot share a container through Go code. Each one pays startup independently, or the team gives up and orchestrates containers outside the test run. gotest's `SharedFixture` exists for exactly this boundary: one setup process starts the container, and its state is serialized and rehydrated into each package's process. The full mechanics are in [Sharing Test Fixtures Across Go Packages]({{< ref "/blog/shared-fixtures" >}}).
+
+## The workaround gradient
+
+We measured four markers across the corpus and compared the top 100 repos by stars with the bottom 400:
+
+![Grouped bar chart comparing top 100 repos vs the long tail: TestMain 61% vs 38%, native fuzz tests 31% vs 15%, t.Cleanup 74% vs 45%, t.Helper 81% vs 56%.](../../census/maturity.svg)
+
+Our first reading of this chart was "popular repos invest more in testing." We think that reading is wrong, because three of these four markers are not investments. They are compensations.
+
+`t.Helper()` is the clearest case. It exists so that a failing assertion inside a helper reports the caller's line instead of the helper's. To get that, you must annotate every helper — and every helper your helper calls — by hand, and forgetting one silently breaks failure attribution. 64% of repos carry these annotations; 81% of the top 100 do. That is not a maturity signal. It is a measure of how far a manual patch for broken failure attribution has spread. It also does not need to exist: gotest's assertions resolve the outermost caller in the test file automatically, so a helper is just a function.
+
+`t.Cleanup` (53% of repos) is the same story for teardown: per-test cleanup wired call-site by call-site, because the stdlib has no per-test lifecycle. A suite's `BeforeEach`/`AfterEach` says the same thing once, structurally, with defined ordering — see [Go Test Lifecycle]({{< ref "/blog/go-test-lifecycle" >}}) for what those guarantees buy. And `TestMain` (42%, 61% at the top) is the bluntest of the three: one hook per package, no per-test granularity, no dependencies between resources — the workaround this article already met in the containers section.
+
+So the gradient reads differently than we expected: **the most sophisticated Go projects spend the most effort compensating for what the testing stdlib doesn't provide.** The pain scales with the project. Fuzzing is the honest counterexample in the chart — a real stdlib feature, not a workaround — and the top repos adopt it at twice the rate, which is what genuine feature adoption looks like.
+
+## What CI actually runs
+
+87% of repos have GitHub Actions workflows. 51% invoke `go test` (or gotestsum) directly in a workflow step, and another 32% run tests behind a `make`, `task`, or script target — where the flags live outside the workflow and we cannot read them. Combined, at least 70% test in Actions.
+
+For the 51% whose test invocations we can read, the flags on those lines say:
+
+- **42% use `-race`.** The race detector is the strongest correctness tool the stdlib ships, and it is one flag away — its cost is CI minutes, not effort. A majority of readable CI test runs don't pay it.
+- **39% collect coverage** (a coverage flag on the test line, or a codecov/coveralls upload).
+- **11% pin `-count=1`** to defeat test caching, and **3% use `-shuffle`** — order-dependence bugs go largely unhunted.
+- **4% ship retry machinery** (gotestsum `--rerun-fails` or a retry action). Flaky tests are being medicated at the CI layer instead of fixed — the same story as `time.Sleep`, one level up.
+
+These numbers are attributed line-by-line to direct test invocations, so they are honest for the repos we can read — but the 32% testing through indirection are absent from them, and other CI systems entirely so. A fuller pipeline — failure summaries, coverage gates, annotations — is the subject of [Go Tests in GitHub Actions]({{< ref "/blog/gotest-in-ci" >}}).
+
+## Quick hits
+
+| Claim you've heard | What the data says |
+|---|---|
+| "Go tests are table-driven" | 21.8% of test functions are |
+| "Everyone nests subtests" | 21.9% of test functions contain a subtest; 38% of repos nest ≥2 deep somewhere |
+| "Scenario names use underscores" | 36.7% of test names do |
+| "The top repos are well-tested" | 76 of the top 1,000 (7.7%) have **zero** test files |
+| "Popular means maintained" | 19% of the top 1,000 hadn't pushed in 6 months |
+
+The table-driven and subtest numbers deserve a note: 21.8% of tests are table-driven and 21.9% contain a subtest, and the near-equality is coincidence, not identity. 15.7% of test functions are both; 6.1% are tables without subtests (the classic loop over cases with `t.Errorf`); 6.2% are subtests without tables. 71.9% are neither.
+
+That underscore number deserves one more sentence. A third of the ecosystem writes names like `TestCreateUser_WhenEmailInvalid_ReturnsError` because a function name is the only place the stdlib gives you to state a scenario. That is structure demand, expressed in snake case. [Readable Go Tests with BDD-Style Subtests]({{< ref "/blog/readable-tests-with-bdd" >}}) is about giving it a real home.
+
+## Methodology and limitations
+
+Full details ship with [the dataset](https://github.com/mvrahden/go-test/tree/research/test-census); the short version:
+
+- **Corpus**: top 1,000 GitHub repositories by stars with `language:Go`, `archived:false`, `fork:false`, fetched 2026-07-24, each pinned to a commit SHA. Hard forks that share code lineage (terraform/opentofu, vault/openbao, gogs/gitea, and four others) were deduplicated by a documented rule — keep the actively maintained member, tie-break by stars — so no codebase is counted twice.
+- **Parsing**: `go/parser` over every `_test.go` file, skipping `vendor/`, `testdata/` code, and files carrying Go's standard `Code generated … DO NOT EDIT` header. No type checking. Heuristics (table-driven detection, golden-workflow detection, container reachability across package imports) are documented in the scanner source and err toward undercounting.
+- **Known biases**: stars select for infrastructure and libraries over applications; repo-level percentages weight kubernetes and a 5k-star library equally; the sleep total counts only compile-time-constant durations (resolved across each package's files). Every "at least" in this post is meant literally.
+- **CI metrics** read GitHub Actions workflow files only, with flags attributed line-by-line to direct test invocations (continuations and GOFLAGS included). Indirect test steps (make/task/scripts) are counted but their flags are invisible; other CI systems are not read.
+- **Ginkgo repos** are counted as a separate stratum (`It`/`Specify` specs), since their tests aren't `func TestX` and would otherwise distort per-test rates.
+
+The scanner is built on the same AST discovery that powers [gotest's code generation]({{< ref "/blog/code-generation-not-reflection" >}}).
+
+## What we take from it
+
+The census was a bet that the problems gotest targets are common, not local to our projects. Finding by finding:
+
+| The data says | The gotest answer |
+|---|---|
+| 68% of repos sleep in tests; 225+ hours of fixed waiting | `Eventually` / `Consistently` polling assertions |
+| 11.2% of tests run in parallel; independence is the blocker | process-isolated suites, per-test state via returning `BeforeEach` |
+| 64% hand-annotate helpers with `t.Helper()` | assertions resolve the test-file caller automatically |
+| 42% wire `TestMain`; 53% scatter `t.Cleanup` | suite and fixture lifecycle with ordering guarantees |
+| 26 repos run containers per package because processes can't share | `SharedFixture` state transfer across package processes |
+| golden testing: 43% practice, 7% workflow | `MatchSnapshot` with update mode and CI read-only |
+| 36.7% of test names encode scenarios in underscores | `When` / `It` structure that renders as a [spec]({{< ref "/blog/tests-as-documentation" >}}) |
+
+Whether those answers fit your codebase is a judgment the linked posts try to earn, not this one. The shortest way to check is [Your First Go Test Suite in 10 Minutes]({{< ref "/blog/zero-to-suite" >}}).
+
+We plan to rerun this census as the ecosystem moves. If you want a metric added, or think one of ours is measured wrong, the [scanner is right there](https://github.com/mvrahden/go-test/tree/research/test-census).

--- a/site/content/blog/organizing-go-tests.md
+++ b/site/content/blog/organizing-go-tests.md
@@ -4,7 +4,6 @@ date: 2026-07-06
 description: "Why flat Go test functions, table-driven tests, and subtests each solve part of the organization problem — and what happens when you need all three at once."
 tags: ["Patterns"]
 keywords: ["go test organization", "table-driven tests", "go subtests", "testify suite alternative", "go test suite"]
-toc: true
 cta_text: "See how a flat test file becomes a gotest suite in minutes."
 aliases: ["/blog/organizing-go-tests.html"]
 ---

--- a/site/content/blog/readable-tests-with-bdd.md
+++ b/site/content/blog/readable-tests-with-bdd.md
@@ -4,7 +4,6 @@ date: 2026-07-08
 description: "Test names like TestCreateUser_WhenEmailInvalid_ReturnsError are hard to scan. BDD-style labeled subtests turn Go tests into living documentation."
 tags: ["Testing"]
 keywords: ["go bdd", "bdd go testing", "readable go tests", "go subtests", "ginkgo alternative"]
-toc: true
 cta_text: "Turn your next test suite into a readable spec with gotest spec."
 aliases: ["/blog/readable-tests-with-bdd.html"]
 ---

--- a/site/content/blog/shared-fixtures.md
+++ b/site/content/blog/shared-fixtures.md
@@ -5,7 +5,6 @@ description: "go test runs each package in a separate OS process. How do you sha
 tags: ["Deep Dive"]
 keywords: ["share database across go test packages", "go testmain fixture", "go shared test fixtures", "go test process boundary"]
 cta_text: "Try shared fixtures in your next project."
-toc: true
 ---
 
 `go test` compiles each package into a separate test binary and runs it as a separate OS process. That design buys you isolation, and it makes one thing structurally difficult: sharing a fixture *across* packages. A Postgres container that `pkg/user`, `pkg/order`, and `pkg/billing` all need. A Redis instance that three packages query. A schema migration that should run once for the entire test run, not once per package. Sharing any of these means crossing process boundaries.

--- a/site/content/blog/test-fixtures-in-go.md
+++ b/site/content/blog/test-fixtures-in-go.md
@@ -4,7 +4,6 @@ date: 2026-07-07
 description: "Every growing Go project needs shared test infrastructure. Fixture patterns from global vars to DAG-based lifecycle management, and when to use each."
 tags: ["Patterns"]
 keywords: ["go test fixtures", "testmain go", "sync.once test setup", "shared test database go", "go test setup teardown"]
-toc: true
 cta_text: "Share one Postgres container across every test package with gotest fixtures."
 aliases: ["/blog/test-fixtures-in-go.html"]
 ---

--- a/site/content/blog/testify-migration-guide.md
+++ b/site/content/blog/testify-migration-guide.md
@@ -6,7 +6,6 @@ tags: ["Migration"]
 keywords: ["migrate from testify", "testify suite alternative", "testify to gotest", "gotest migrate", "go test suite migration"]
 cta_text: "Run gotest migrate on your first testify suite today."
 cta_command: "gotest migrate ./..."
-toc: true
 howto:
   name: "Migrate a testify/suite codebase to gotest"
   steps:

--- a/site/content/blog/why-gotest.md
+++ b/site/content/blog/why-gotest.md
@@ -4,7 +4,6 @@ date: 2026-07-05
 description: "Go's testing package is deliberately minimal. Where growing projects hit its gaps, and the five principles behind gotest's suite layer."
 tags: ["Philosophy"]
 keywords: ["go test suite", "go testing package", "testify suite alternative", "go test setup and teardown", "go test framework"]
-toc: true
 cta_text: "See it in action — build your first gotest suite in 10 minutes."
 aliases: ["/blog/why-gotest.html"]
 ---

--- a/site/layouts/blog/single.html
+++ b/site/layouts/blog/single.html
@@ -14,12 +14,10 @@
     </header>
 
     <div class="article-body">
-      {{ if .Params.toc }}
-      <nav class="article-toc">
-        <strong>Contents</strong>
+      <details class="article-toc">
+        <summary>Contents</summary>
         {{ .TableOfContents }}
-      </nav>
-      {{ end }}
+      </details>
 
       {{ .Content }}
 

--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -5,12 +5,12 @@
         gotest
       </a>
       <div class="nav-links">
-        {{ if not .IsHome }}<a href="{{ "/" | relURL }}">Home</a>{{ end }}
+        {{ if not .IsHome }}<a href="{{ "/" | relURL }}" class="nav-home-link">Home</a>{{ end }}
         <a href="{{ "blog/" | relURL }}">Blog</a>
         <a href="{{ "reference/" | relURL }}" class="nav-ref">Reference</a>
         <a href="https://github.com/mvrahden/go-test" class="star-btn"><span class="star-icon">&#9734;</span> Star<span class="star-count" id="star-count"></span></a>
-        <a href="https://pkg.go.dev/github.com/mvrahden/go-test" onclick="gtag('event','click',{event_category:'outbound',event_label:'pkg.go.dev'})">pkg.go.dev</a>
-        <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest" onclick="gtag('event','click',{event_category:'outbound',event_label:'vscode_marketplace'})">VS Code</a>
+        <a href="https://pkg.go.dev/github.com/mvrahden/go-test" class="nav-out" onclick="gtag('event','click',{event_category:'outbound',event_label:'pkg.go.dev'})">pkg.go.dev</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest" class="nav-out" onclick="gtag('event','click',{event_category:'outbound',event_label:'vscode_marketplace'})">VS Code</a>
       </div>
     </div>
   </nav>

--- a/site/static/census/containers.svg
+++ b/site/static/census/containers.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 312" width="680" height="312" role="img">
+<style>
+svg{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif}
+:root{--s1:#007d9c;--s2:#eb6834;--ink:#24292f;--ink2:#656d76;--grid:#d0d7de}
+@media (prefers-color-scheme:dark){:root{--s1:#0a9cc4;--s2:#d95926;--ink:#e6edf3;--ink2:#8b949e;--grid:#30363d}}
+.lbl{fill:var(--ink);font-size:13px}
+.val{fill:var(--ink2);font-size:12px}
+.tick{fill:var(--ink2);font-size:11px}
+.grid{stroke:var(--grid);stroke-width:1}
+</style>
+<line class="grid" x1="268" y1="8" x2="268" y2="288"/>
+<text class="tick" x="268" y="304" text-anchor="middle">25</text>
+<line class="grid" x1="385" y1="8" x2="385" y2="288"/>
+<text class="tick" x="385" y="304" text-anchor="middle">50</text>
+<line class="grid" x1="502" y1="8" x2="502" y2="288"/>
+<text class="tick" x="502" y="304" text-anchor="middle">75</text>
+<line class="grid" x1="620" y1="8" x2="620" y2="288"/>
+<text class="tick" x="620" y="304" text-anchor="middle">100</text>
+<text class="lbl" x="142" y="20" text-anchor="end">postgres</text>
+<path d="M150,8 h381.4 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-381.4 z" fill="var(--s1)"/>
+<text class="val" x="541" y="20">82</text>
+<text class="lbl" x="142" y="48" text-anchor="end">redis</text>
+<path d="M150,36 h212.2 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-212.2 z" fill="var(--s1)"/>
+<text class="val" x="372" y="48">46</text>
+<text class="lbl" x="142" y="76" text-anchor="end">mysql</text>
+<path d="M150,64 h207.5 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-207.5 z" fill="var(--s1)"/>
+<text class="val" x="368" y="76">45</text>
+<text class="lbl" x="142" y="104" text-anchor="end">prometheus</text>
+<path d="M150,92 h165.2 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-165.2 z" fill="var(--s1)"/>
+<text class="val" x="325" y="104">36</text>
+<text class="lbl" x="142" y="132" text-anchor="end">grafana</text>
+<path d="M150,120 h127.6 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-127.6 z" fill="var(--s1)"/>
+<text class="val" x="288" y="132">28</text>
+<text class="lbl" x="142" y="160" text-anchor="end">nginx</text>
+<path d="M150,148 h113.5 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-113.5 z" fill="var(--s1)"/>
+<text class="val" x="274" y="160">25</text>
+<text class="lbl" x="142" y="188" text-anchor="end">minio</text>
+<path d="M150,176 h113.5 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-113.5 z" fill="var(--s1)"/>
+<text class="val" x="274" y="188">25</text>
+<text class="lbl" x="142" y="216" text-anchor="end">jaeger</text>
+<path d="M150,204 h108.8 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-108.8 z" fill="var(--s1)"/>
+<text class="val" x="269" y="216">24</text>
+<text class="lbl" x="142" y="244" text-anchor="end">mongo</text>
+<path d="M150,232 h94.7 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-94.7 z" fill="var(--s1)"/>
+<text class="val" x="255" y="244">21</text>
+<text class="lbl" x="142" y="272" text-anchor="end">clickhouse</text>
+<path d="M150,260 h90.0 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-90.0 z" fill="var(--s1)"/>
+<text class="val" x="250" y="272">20</text>
+</svg>

--- a/site/static/census/frameworks.svg
+++ b/site/static/census/frameworks.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 312" width="680" height="312" role="img">
+<style>
+svg{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif}
+:root{--s1:#007d9c;--s2:#eb6834;--ink:#24292f;--ink2:#656d76;--grid:#d0d7de}
+@media (prefers-color-scheme:dark){:root{--s1:#0a9cc4;--s2:#d95926;--ink:#e6edf3;--ink2:#8b949e;--grid:#30363d}}
+.lbl{fill:var(--ink);font-size:13px}
+.val{fill:var(--ink2);font-size:12px}
+.tick{fill:var(--ink2);font-size:11px}
+.grid{stroke:var(--grid);stroke-width:1}
+</style>
+<line class="grid" x1="268" y1="8" x2="268" y2="288"/>
+<text class="tick" x="268" y="304" text-anchor="middle">15%</text>
+<line class="grid" x1="385" y1="8" x2="385" y2="288"/>
+<text class="tick" x="385" y="304" text-anchor="middle">30%</text>
+<line class="grid" x1="502" y1="8" x2="502" y2="288"/>
+<text class="tick" x="502" y="304" text-anchor="middle">45%</text>
+<line class="grid" x1="620" y1="8" x2="620" y2="288"/>
+<text class="tick" x="620" y="304" text-anchor="middle">60%</text>
+<text class="lbl" x="142" y="20" text-anchor="end">httptest (stdlib)</text>
+<path d="M150,8 h466.0 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-466.0 z" fill="var(--s1)"/>
+<text class="val" x="626" y="20">60%</text>
+<text class="lbl" x="142" y="48" text-anchor="end">testify assert/require</text>
+<path d="M150,36 h434.6666666666667 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-434.6666666666667 z" fill="var(--s1)"/>
+<text class="val" x="595" y="48">56%</text>
+<text class="lbl" x="142" y="76" text-anchor="end">go-cmp</text>
+<path d="M150,64 h160.5 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-160.5 z" fill="var(--s1)"/>
+<text class="val" x="320" y="76">21%</text>
+<text class="lbl" x="142" y="104" text-anchor="end">testify/mock</text>
+<path d="M150,92 h105.66666666666667 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-105.66666666666667 z" fill="var(--s1)"/>
+<text class="val" x="266" y="104">14%</text>
+<text class="lbl" x="142" y="132" text-anchor="end">testify/suite</text>
+<path d="M150,120 h74.33333333333333 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-74.33333333333333 z" fill="var(--s1)"/>
+<text class="val" x="234" y="132">10%</text>
+<text class="lbl" x="142" y="160" text-anchor="end">gomock</text>
+<path d="M150,148 h66.5 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-66.5 z" fill="var(--s1)"/>
+<text class="val" x="226" y="160">9%</text>
+<text class="lbl" x="142" y="188" text-anchor="end">gomega</text>
+<path d="M150,176 h58.666666666666664 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-58.666666666666664 z" fill="var(--s1)"/>
+<text class="val" x="219" y="188">8%</text>
+<text class="lbl" x="142" y="216" text-anchor="end">ginkgo</text>
+<path d="M150,204 h58.666666666666664 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-58.666666666666664 z" fill="var(--s1)"/>
+<text class="val" x="219" y="216">8%</text>
+<text class="lbl" x="142" y="244" text-anchor="end">testing/quick (stdlib)</text>
+<path d="M150,232 h35.166666666666664 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-35.166666666666664 z" fill="var(--s1)"/>
+<text class="val" x="195" y="244">5%</text>
+<text class="lbl" x="142" y="272" text-anchor="end">testcontainers-go</text>
+<path d="M150,260 h19.5 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-19.5 z" fill="var(--s1)"/>
+<text class="val" x="180" y="272">3%</text>
+</svg>

--- a/site/static/census/maturity.svg
+++ b/site/static/census/maturity.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 266" width="680" height="266" role="img">
+<style>
+svg{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif}
+:root{--s1:#007d9c;--s2:#eb6834;--ink:#24292f;--ink2:#656d76;--grid:#d0d7de}
+@media (prefers-color-scheme:dark){:root{--s1:#0a9cc4;--s2:#d95926;--ink:#e6edf3;--ink2:#8b949e;--grid:#30363d}}
+.lbl{fill:var(--ink);font-size:13px}
+.val{fill:var(--ink2);font-size:12px}
+.tick{fill:var(--ink2);font-size:11px}
+.grid{stroke:var(--grid);stroke-width:1}
+</style>
+<rect x="170" y="6" width="12" height="12" rx="3" fill="var(--s1)"/>
+<text class="lbl" x="188" y="16">Top 100 by stars</text>
+<rect x="340" y="6" width="12" height="12" rx="3" fill="var(--s2)"/>
+<text class="lbl" x="358" y="16">Long tail (bottom 400)</text>
+<line class="grid" x1="282" y1="34" x2="282" y2="242"/>
+<text class="tick" x="282" y="258" text-anchor="middle">25%</text>
+<line class="grid" x1="395" y1="34" x2="395" y2="242"/>
+<text class="tick" x="395" y="258" text-anchor="middle">50%</text>
+<line class="grid" x1="508" y1="34" x2="508" y2="242"/>
+<text class="tick" x="508" y="258" text-anchor="middle">75%</text>
+<line class="grid" x1="620" y1="34" x2="620" y2="242"/>
+<text class="tick" x="620" y="258" text-anchor="middle">100%</text>
+<text class="lbl" x="162" y="56" text-anchor="end">TestMain</text>
+<path d="M170,34 h270.5 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-270.5 z" fill="var(--s1)"/>
+<text class="val" x="450" y="46">61%</text>
+<path d="M170,52 h167.0 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-167.0 z" fill="var(--s2)"/>
+<text class="val" x="347" y="64">38%</text>
+<text class="lbl" x="162" y="108" text-anchor="end">Native fuzz tests</text>
+<path d="M170,86 h135.5 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-135.5 z" fill="var(--s1)"/>
+<text class="val" x="316" y="98">31%</text>
+<path d="M170,104 h63.5 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-63.5 z" fill="var(--s2)"/>
+<text class="val" x="244" y="116">15%</text>
+<text class="lbl" x="162" y="160" text-anchor="end">t.Cleanup()</text>
+<path d="M170,138 h329.0 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-329.0 z" fill="var(--s1)"/>
+<text class="val" x="509" y="150">74%</text>
+<path d="M170,156 h198.5 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-198.5 z" fill="var(--s2)"/>
+<text class="val" x="378" y="168">45%</text>
+<text class="lbl" x="162" y="212" text-anchor="end">t.Helper()</text>
+<path d="M170,190 h360.5 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-360.5 z" fill="var(--s1)"/>
+<text class="val" x="540" y="202">81%</text>
+<path d="M170,208 h248.0 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-248.0 z" fill="var(--s2)"/>
+<text class="val" x="428" y="220">56%</text>
+</svg>

--- a/site/static/census/parallel.svg
+++ b/site/static/census/parallel.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 214" width="680" height="214" role="img">
+<style>
+svg{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif}
+:root{--s1:#007d9c;--s2:#eb6834;--ink:#24292f;--ink2:#656d76;--grid:#d0d7de}
+@media (prefers-color-scheme:dark){:root{--s1:#0a9cc4;--s2:#d95926;--ink:#e6edf3;--ink2:#8b949e;--grid:#30363d}}
+.lbl{fill:var(--ink);font-size:13px}
+.val{fill:var(--ink2);font-size:12px}
+.tick{fill:var(--ink2);font-size:11px}
+.grid{stroke:var(--grid);stroke-width:1}
+</style>
+<rect x="170" y="6" width="12" height="12" rx="3" fill="var(--s1)"/>
+<text class="lbl" x="188" y="16">Repos using t.Parallel() anywhere</text>
+<rect x="459" y="6" width="12" height="12" rx="3" fill="var(--s2)"/>
+<text class="lbl" x="477" y="16">Tests that run in parallel</text>
+<line class="grid" x1="282" y1="34" x2="282" y2="190"/>
+<text class="tick" x="282" y="206" text-anchor="middle">20%</text>
+<line class="grid" x1="395" y1="34" x2="395" y2="190"/>
+<text class="tick" x="395" y="206" text-anchor="middle">40%</text>
+<line class="grid" x1="508" y1="34" x2="508" y2="190"/>
+<text class="tick" x="508" y="206" text-anchor="middle">60%</text>
+<line class="grid" x1="620" y1="34" x2="620" y2="190"/>
+<text class="tick" x="620" y="206" text-anchor="middle">80%</text>
+<text class="lbl" x="162" y="56" text-anchor="end">Full corpus</text>
+<path d="M170,34 h254.75 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-254.75 z" fill="var(--s1)"/>
+<text class="val" x="435" y="46">46%</text>
+<path d="M170,52 h59.0 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-59.0 z" fill="var(--s2)"/>
+<text class="val" x="239" y="64">11.2%</text>
+<text class="lbl" x="162" y="108" text-anchor="end">Top 100 by stars</text>
+<path d="M170,86 h372.875 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-372.875 z" fill="var(--s1)"/>
+<text class="val" x="553" y="98">67%</text>
+<path d="M170,104 h47.1875 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-47.1875 z" fill="var(--s2)"/>
+<text class="val" x="227" y="116">9.1%</text>
+<text class="lbl" x="162" y="160" text-anchor="end">Long tail (400)</text>
+<path d="M170,138 h226.625 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-226.625 z" fill="var(--s1)"/>
+<text class="val" x="407" y="150">41%</text>
+<path d="M170,156 h47.1875 a4,4 0 0 1 4,4 v8 a4,4 0 0 1 -4,4 h-47.1875 z" fill="var(--s2)"/>
+<text class="val" x="227" y="168">9.1%</text>
+</svg>


### PR DESCRIPTION
Adds a new article to the blog: we analyzed how the 1,000 most popular Go projects actually write and run their tests, and turned the findings into a data-backed story with charts.

- Every number comes from a public dataset and can be reproduced.
- The article links back to our existing posts wherever a finding relates to them.
- Includes charts that work in light and dark mode — the blog's first.