### PR TITLE
Smarter test linting: assertions everywhere, with rules organized by how much they matter

### DIFF
--- a/cmd/gotest/gotest_suite_test.go
+++ b/cmd/gotest/gotest_suite_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/tools/go/packages"
+
 	. "github.com/mvrahden/go-test/cmd/gotest"
 	"github.com/mvrahden/go-test/internal/config"
 	"github.com/mvrahden/go-test/internal/gotestgen"
@@ -559,20 +561,14 @@ func (s *CmdGotestTestSuite) TestResolveGlobalTimeout(t *gotest.T) {
 func (s *CmdGotestTestSuite) TestRunDiscover_SimpleSuite(t *gotest.T) {
 	t.It("discovers suites in examples/cart", func(it *gotest.T) {
 		absExamples, err := filepath.Abs(filepath.Join("..", "..", "examples"))
-		if err != nil {
-			gotest.Fail(it, "%v", err)
-		}
+		gotest.NoError(it, err, "%v", err)
 		if _, err := os.Stat(filepath.Join(absExamples, "go.mod")); err != nil {
 			it.Skipf("examples directory not found: %v", err)
 		}
 
 		loadResults, _, err := gotestgen.LoadPackages([]string{filepath.Join(absExamples, "cart")}, nil)
-		if err != nil {
-			gotest.Fail(it, "LoadPackages: %v", err)
-		}
-		if len(loadResults) == 0 {
-			gotest.Fail(it, "expected at least one load result")
-		}
+		gotest.NoError(it, err, "LoadPackages: %v", err)
+		gotest.NotEmpty(it, loadResults, "expected at least one load result")
 
 		out := ExportDiscoverOutput{}
 		c := gotestgen.NewCollector()
@@ -582,39 +578,34 @@ func (s *CmdGotestTestSuite) TestRunDiscover_SimpleSuite(t *gotest.T) {
 				Dir:        lr.PkgDir,
 			}
 
-			if lr.Ptest != nil {
-				result := c.CollectSuiteSpecs(lr.Ptest)
-				if len(result.Errs) > 0 {
-					gotest.Fail(it, "collector error: %v", result.Errs[0].Err)
+			collect := func(pkg *packages.Package) {
+				result := c.CollectSuiteSpecs(pkg)
+				var collectorErrs []string
+				for _, cerr := range result.Errs {
+					collectorErrs = append(collectorErrs, cerr.Err.Error())
 				}
+				gotest.Empty(it, collectorErrs, "collector errors")
 				for _, suite := range result.Suites {
 					pkgEntry.Suites = append(pkgEntry.Suites, ExportBuildDiscoverSuite(suite))
 				}
 			}
+			if lr.Ptest != nil {
+				collect(lr.Ptest)
+			}
 			if lr.Pxtest != nil {
-				result := c.CollectSuiteSpecs(lr.Pxtest)
-				if len(result.Errs) > 0 {
-					gotest.Fail(it, "collector error: %v", result.Errs[0].Err)
-				}
-				for _, suite := range result.Suites {
-					pkgEntry.Suites = append(pkgEntry.Suites, ExportBuildDiscoverSuite(suite))
-				}
+				collect(lr.Pxtest)
 			}
 
 			out.Packages = append(out.Packages, pkgEntry)
 		}
 
-		if len(out.Packages) != 1 {
-			gotest.Fail(it, "expected 1 package, got %d", len(out.Packages))
-		}
+		gotest.Len(it, out.Packages, 1)
 
 		pkg := out.Packages[0]
 		gotest.Equal(it, "github.com/mvrahden/go-test/examples/cart", pkg.ImportPath)
 		gotest.True(it, filepath.IsAbs(pkg.Dir), "dir should be absolute, got %q", pkg.Dir)
 
-		if len(pkg.Suites) != 4 {
-			gotest.Fail(it, "expected 4 suites, got %d", len(pkg.Suites))
-		}
+		gotest.Len(it, pkg.Suites, 4)
 
 		suiteByNameAndFile := map[string]ExportDiscoverSuite{}
 		for i := range pkg.Suites {
@@ -635,9 +626,7 @@ func (s *CmdGotestTestSuite) TestRunDiscover_SimpleSuite(t *gotest.T) {
 		gotest.Equal(it, expectedLifecycle, st.Lifecycle)
 		gotest.Empty(it, st.Fixtures)
 
-		if len(st.Methods) != 9 {
-			gotest.Fail(it, "expected 9 methods, got %d", len(st.Methods))
-		}
+		gotest.Len(it, st.Methods, 9)
 		gotest.Equal(it, "TestAddSingleItem", st.Methods[0].Name)
 		gotest.Equal(it, 15, st.Methods[0].Line)
 		gotest.Equal(it, 1, st.Methods[0].Col)
@@ -650,9 +639,7 @@ func (s *CmdGotestTestSuite) TestRunDiscover_SimpleSuite(t *gotest.T) {
 		// Verify pxtest ShoppingCartTestSuite
 		sx := suiteByNameAndFile["ShoppingCartTestSuite:suite_ext_test.go"]
 		gotest.Equal(it, "ShoppingCartTestSuite", sx.Name)
-		if len(sx.Methods) != 2 {
-			gotest.Fail(it, "expected 2 pxtest methods, got %d", len(sx.Methods))
-		}
+		gotest.Len(it, sx.Methods, 2)
 		gotest.Equal(it, "TestAddItem", sx.Methods[0].Name)
 		gotest.Equal(it, "TestRemoveItem", sx.Methods[1].Name)
 
@@ -662,13 +649,9 @@ func (s *CmdGotestTestSuite) TestRunDiscover_SimpleSuite(t *gotest.T) {
 
 		// Verify JSON serialization roundtrip
 		data, err := json.Marshal(out)
-		if err != nil {
-			gotest.Fail(it, "json.Marshal: %v", err)
-		}
+		gotest.NoError(it, err, "json.Marshal: %v", err)
 		var roundtrip ExportDiscoverOutput
-		if err := json.Unmarshal(data, &roundtrip); err != nil {
-			gotest.Fail(it, "json.Unmarshal: %v", err)
-		}
+		gotest.NoError(it, json.Unmarshal(data, &roundtrip))
 		gotest.Len(it, roundtrip.Packages, 1)
 	})
 }
@@ -713,46 +696,31 @@ func (s *CmdGotestTestSuite) TestGenerateOverlay(t *gotest.T) {
 	t.When("suites are present", func(w *gotest.T) {
 		w.It("produces valid overlay JSON", func(it *gotest.T) {
 			absExamples, err := filepath.Abs(filepath.Join("..", "..", "examples"))
-			if err != nil {
-				gotest.Fail(it, "%v", err)
-			}
+			gotest.NoError(it, err, "%v", err)
 			if _, err := os.Stat(filepath.Join(absExamples, "go.mod")); err != nil {
 				it.Skipf("examples directory not found: %v", err)
 			}
 
 			loaded, _, err := gotestgen.LoadPackages([]string{filepath.Join(absExamples, "cart")}, nil)
-			if err != nil {
-				gotest.Fail(it, "LoadPackages: %v", err)
-			}
+			gotest.NoError(it, err, "LoadPackages: %v", err)
 			results, _, err := gotestgen.GenerateFromLoaded(loaded)
-			if err != nil {
-				gotest.Fail(it, "GenerateFromLoaded: %v", err)
-			}
-			if len(results) == 0 {
-				gotest.Fail(it, "expected at least one generate result")
-			}
+			gotest.NoError(it, err, "GenerateFromLoaded: %v", err)
+			gotest.NotEmpty(it, results, "expected at least one generate result")
 
 			tmpDir, err := gotestrunner.WriteOverlay(results)
-			if err != nil {
-				gotest.Fail(it, "WriteOverlay: %v", err)
-			}
+			gotest.NoError(it, err, "WriteOverlay: %v", err)
 			defer os.RemoveAll(tmpDir)
 
 			overlayFile := filepath.Join(tmpDir, "overlay.json")
-			if _, err := os.Stat(overlayFile); err != nil {
-				gotest.Fail(it, "overlay.json not found: %v", err)
-			}
+			_, err = os.Stat(overlayFile)
+			gotest.NoError(it, err)
 
 			data, err := os.ReadFile(overlayFile)
-			if err != nil {
-				gotest.Fail(it, "reading overlay.json: %v", err)
-			}
+			gotest.NoError(it, err, "reading overlay.json: %v", err)
 			var overlayContent struct {
 				Replace map[string]string `json:"Replace"`
 			}
-			if err := json.Unmarshal(data, &overlayContent); err != nil {
-				gotest.Fail(it, "overlay.json is not valid JSON: %v", err)
-			}
+			gotest.NoError(it, json.Unmarshal(data, &overlayContent), "overlay.json is not valid JSON")
 			gotest.NotEmpty(it, overlayContent.Replace, "overlay.json Replace map is empty")
 		})
 	})
@@ -760,26 +728,16 @@ func (s *CmdGotestTestSuite) TestGenerateOverlay(t *gotest.T) {
 	t.When("no suites", func(w *gotest.T) {
 		w.It("returns empty results for package without suites", func(it *gotest.T) {
 			tmpDir, err := os.MkdirTemp("", "overlay-test-nosuite-*")
-			if err != nil {
-				gotest.Fail(it, "%v", err)
-			}
+			gotest.NoError(it, err, "%v", err)
 			defer os.RemoveAll(tmpDir)
 
-			if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module nosuite\n\ngo 1.24\n"), 0600); err != nil {
-				gotest.Fail(it, "%v", err)
-			}
-			if err := os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0600); err != nil {
-				gotest.Fail(it, "%v", err)
-			}
+			gotest.NoError(it, os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module nosuite\n\ngo 1.24\n"), 0600))
+			gotest.NoError(it, os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0600))
 
 			loaded, _, err := gotestgen.LoadPackages([]string{tmpDir}, nil)
-			if err != nil {
-				gotest.Fail(it, "LoadPackages: %v", err)
-			}
+			gotest.NoError(it, err, "LoadPackages: %v", err)
 			results, _, err := gotestgen.GenerateFromLoaded(loaded)
-			if err != nil {
-				gotest.Fail(it, "GenerateFromLoaded: %v", err)
-			}
+			gotest.NoError(it, err, "GenerateFromLoaded: %v", err)
 
 			var allResults gotestgen.GenerateResults
 			allResults = append(allResults, results...)
@@ -869,26 +827,18 @@ func (s *CmdGotestTestSuite) TestSpecFlagParsing(t *gotest.T) {
 func (s *CmdGotestTestSuite) TestRunSpec_InputStdin(t *gotest.T) {
 	t.It("renders spec output from stdin-like JSON", func(it *gotest.T) {
 		absExamples, err := filepath.Abs(filepath.Join("..", "..", "examples"))
-		if err != nil {
-			gotest.Fail(it, "%v", err)
-		}
+		gotest.NoError(it, err, "%v", err)
 		if _, err := os.Stat(filepath.Join(absExamples, "go.mod")); err != nil {
 			it.Skipf("examples directory not found: %v", err)
 		}
 
 		loaded, _, err := gotestgen.LoadPackages([]string{filepath.Join(absExamples, "cart")}, nil)
-		if err != nil {
-			gotest.Fail(it, "LoadPackages: %v", err)
-		}
+		gotest.NoError(it, err, "LoadPackages: %v", err)
 		results, _, err := gotestgen.GenerateFromLoaded(loaded)
-		if err != nil {
-			gotest.Fail(it, "GenerateFromLoaded: %v", err)
-		}
+		gotest.NoError(it, err, "GenerateFromLoaded: %v", err)
 
 		tmpDir, err := gotestrunner.WriteOverlay(results)
-		if err != nil {
-			gotest.Fail(it, "WriteOverlay: %v", err)
-		}
+		gotest.NoError(it, err, "WriteOverlay: %v", err)
 		defer os.RemoveAll(tmpDir)
 
 		cmd := exec.CommandContext(context.Background(), "go", //nolint:gosec // G204: go tool with controlled arguments
@@ -899,19 +849,13 @@ func (s *CmdGotestTestSuite) TestRunSpec_InputStdin(t *gotest.T) {
 		cmd.Stdout = &jsonOut
 		cmd.Stderr = os.Stderr
 		mp := gotestrunner.NewManagedProcess(cmd, gotestrunner.ProcessConfig{Grace: gotestrunner.GraceKill})
-		if err := mp.Start(); err != nil {
-			gotest.Fail(it, "go test start: %v", err)
-		}
+		gotest.NoError(it, mp.Start(), "go test start")
 		_ = mp.WaitWithGrace(context.Background())
-		if cmd.ProcessState == nil {
-			gotest.Fail(it, "go test: process state is nil")
-		}
+		gotest.NotZero(it, cmd.ProcessState, "go test: process state is nil")
 		jsonData := jsonOut.Bytes()
 
 		events, err := gotestspec.ParseEvents(bytes.NewReader(jsonData))
-		if err != nil {
-			gotest.Fail(it, "ParseEvents: %v", err)
-		}
+		gotest.NoError(it, err, "ParseEvents: %v", err)
 
 		tree := gotestspec.BuildTree(events)
 

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -344,14 +344,20 @@ Rules:
   poll-scope            Outer t used inside Eventually/Consistently callbacks
   test-signature        Test methods not accepting *gotest.T or *testing.T
   x-lifecycle           X_ prefix on a lifecycle hook (a no-op)
+  suite-lifecycle       Cleanup/Parallel/Run via t.T() — bypass the suite lifecycle
   assertion-simplify    Simplifiable assertions (True(t, a == b) → Equal, …)
   assertion-type-guard  Nil/Empty on types their runtime guards reject
   assertion-redundant   Assertions made redundant by the following assertion
-  t-escape              Unnecessary or harmful t.T() escapes (incl. Helper/Fatal/Log)
+  fail-guard            if cond { Fail/Fatal(...) } guards — use assertions directly
+  t-escape              Unnecessary t.T() convenience escapes (incl. Helper/Fatal/Log)
+
+Integrity rules can only be suppressed per line with //nolint. All other
+rules also accept a project-wide skip flag (mirrored by .gotest.yml lint.skip):
 
 Flags:
-  -skip-stdlib-test       Disable the stdlib-test rule
-  -skip-testify           Disable the testify rule
+  -skip-<rule>            Disable a non-integrity rule, e.g. -skip-fail-guard
+                          (assertion-simplify, assertion-redundant, fail-guard,
+                          t-escape, stdlib-test, testify)
   -disable-nolint         Ignore //nolint comments
   -fix                    Apply suggested fixes
 

--- a/cmd/gotest/lint.go
+++ b/cmd/gotest/lint.go
@@ -44,6 +44,9 @@ func lintSkipFlags(args []string, cfg config.ProjectConfig) ([]string, error) { 
 	var flags []string
 	for _, rule := range cfg.Lint.Skip {
 		if !lint.SkippableRules[lint.Rule(rule)] {
+			if lint.Known(lint.Rule(rule)) {
+				return nil, fmt.Errorf("integrity lint rule in %s: %q can only be suppressed per line with //nolint", config.FileName, rule)
+			}
 			return nil, fmt.Errorf("unknown lint rule in %s: %q", config.FileName, rule)
 		}
 		flag := "-skip-" + rule

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -1275,7 +1275,7 @@ gotest lint ./...                                          # subcommand
 go run github.com/mvrahden/go-test/cmd/gotest-lint ./...   # standalone
 ```
 
-Rules (IDs are canonical — used by `//nolint:<rule>`; `.gotest.yml` `lint.skip` accepts only the adoption-phase rules `stdlib-test` and `testify`):
+Rules (IDs are canonical — used by `//nolint:<rule>`; `.gotest.yml` `lint.skip` accepts any non-integrity rule):
 
 Rules are grouped into three tiers by what breaks when a finding is ignored; the tier derives the suppression policy.
 
@@ -1310,7 +1310,7 @@ Rules are grouped into three tiers by what breaks when a finding is ignored; the
 | `stdlib-test` | `func TestX(*testing.T)` — migration aid suggesting a suite method (fires in any package; coexisting stdlib tests are legitimate, see The Two Runners) |
 | `testify` | Any `github.com/stretchr/testify/*` import — migration incomplete |
 
-One construct yields one finding: integrity rules own the constructs they flag, and expressiveness rules stand down on them (a guard whose body escapes the poll scope gets the `poll-scope` finding, not a `fail-guard` rewrite). The assertion surface itself is derived from the gotest package's type information, so the linter cannot drift from the API and lookalike names from other packages never match.
+One construct yields one finding: integrity rules own the constructs they flag, and expressiveness rules stand down on them (a guard whose body escapes the poll scope gets the `poll-scope` finding, not a `fail-guard` rewrite). The assertion surface itself is derived from the gotest package's type information, so the linter cannot drift from the API and lookalike names from other packages never match expressiveness rules. `poll-scope` is the deliberate exception: as an integrity rule it also matches assertion-shaped names from foreign libraries (an escaping testify assertion breaks the poll loop exactly as a gotest one would), and it recognizes polling contexts by the callback's typed `*gotest.R` parameter rather than the callee, so wrapped or re-exported polling helpers stay covered.
 
 Suppression and configuration:
 

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -1292,6 +1292,7 @@ Rules (IDs are canonical — used by `//nolint:<rule>`; `.gotest.yml` `lint.skip
 | `assertion-simplify` | Simplifiable assertions: `True(t, a == b)` → `Equal`, `Len(t, x, 0)` → `Empty`, … |
 | `assertion-type-guard` | `Nil`/`Empty` on types their runtime guards would reject |
 | `assertion-redundant` | An assertion made redundant by the next one on the same argument |
+| `fail-guard` | `if cond { gotest.Fail(…) }` guards (also halting `Fatal`/`Fatalf`/`FailNow` bodies) — the assertion expresses the check directly; `\|\|` conditions and `else if` chains decompose into sequential assertions, non-halting `Errorf` bodies and init-scoped guards report without a fix; fires only in files that import gotest |
 | `t-escape` | Unnecessary `t.T()` escapes: `Errorf`/`FailNow`/`Skipf`/`Setenv`/`TempDir` (available on `gotest.T`), `Skip`/`SkipNow` (use `Skipf`), `Cleanup`/`Parallel`/`Run` (bypass the suite lifecycle), `Helper` (degrades call-site reporting), `Log`/`Fatal`/`Fatalf` (use assertions and their message args) |
 
 Suppression and configuration:

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -1277,30 +1277,47 @@ go run github.com/mvrahden/go-test/cmd/gotest-lint ./...   # standalone
 
 Rules (IDs are canonical — used by `//nolint:<rule>`; `.gotest.yml` `lint.skip` accepts only the adoption-phase rules `stdlib-test` and `testify`):
 
+Rules are grouped into three tiers by what breaks when a finding is ignored; the tier derives the suppression policy.
+
+**Integrity** — test outcomes can lie or resources can leak. Suppressible per line only, never project-wide.
+
 | Rule ID | Detects |
 |---------|---------|
 | `focus` | Committed `F_` prefixes on suites or methods |
 | `receiver` | Suite methods with value receivers instead of pointer receivers |
 | `lifecycle-typo` | Method names within Levenshtein distance ≤ 2 of a lifecycle hook (`BeforAll`, `AfterEeach`) |
 | `lifecycle-pair` | `BeforeAll` without `AfterAll` — resources may leak |
-| `generated-file` | `gotest_p(x)suite_test.go` files present in source control |
-| `stdlib-test` | `func TestX(*testing.T)` — migration aid suggesting a suite method (fires in any package; skippable — coexisting stdlib tests are legitimate, see The Two Runners) |
-| `testify` | Any `github.com/stretchr/testify/*` import — migration incomplete |
-| `poll-scope` | Assertions inside `Eventually`/`Consistently` callbacks using the outer `t` instead of `poll` |
-| `test-signature` | Test methods not accepting `*gotest.T` (or `*testing.T`) |
 | `x-lifecycle` | `X_` prefix on a lifecycle hook — a no-op |
-| `assertion-simplify` | Simplifiable assertions: `True(t, a == b)` → `Equal`, `Len(t, x, 0)` → `Empty`, … |
+| `test-signature` | Test methods not accepting `*gotest.T` (or `*testing.T`) |
+| `suite-lifecycle` | `Cleanup`/`Parallel`/`Run` via `t.T()` — they bypass the suite lifecycle (split out of `t-escape`; committed `//nolint:t-escape` comments still suppress it) |
+| `poll-scope` | Assertions inside `Eventually`/`Consistently` callbacks using the outer `t` instead of `poll` |
 | `assertion-type-guard` | `Nil`/`Empty` on types their runtime guards would reject |
+| `generated-file` | `gotest_p(x)suite_test.go` files present in source control |
+
+**Expressiveness** — the test is correct but says it worse. Suppressible per line or project-wide via `lint.skip`.
+
+| Rule ID | Detects |
+|---------|---------|
+| `assertion-simplify` | Simplifiable assertions: `True(t, a == b)` → `Equal`, `Len(t, x, 0)` → `Empty`, … |
 | `assertion-redundant` | An assertion made redundant by the next one on the same argument |
 | `fail-guard` | `if cond { gotest.Fail(…) }` guards (also halting `Fatal`/`Fatalf`/`FailNow` bodies) — the assertion expresses the check directly; `\|\|` conditions and `else if` chains decompose into sequential assertions, non-halting `Errorf` bodies and init-scoped guards report without a fix; fires only in files that import gotest |
-| `t-escape` | Unnecessary `t.T()` escapes: `Errorf`/`FailNow`/`Skipf`/`Setenv`/`TempDir` (available on `gotest.T`), `Skip`/`SkipNow` (use `Skipf`), `Cleanup`/`Parallel`/`Run` (bypass the suite lifecycle), `Helper` (degrades call-site reporting), `Log`/`Fatal`/`Fatalf` (use assertions and their message args) |
+| `t-escape` | Unnecessary `t.T()` convenience escapes: `Errorf`/`FailNow`/`Skipf`/`Setenv`/`TempDir` (available on `gotest.T`), `Skip`/`SkipNow` (use `Skipf`), `Helper` (degrades call-site reporting), `Log`/`Fatal`/`Fatalf` (use assertions and their message args) |
+
+**Migration** — legitimate coexistence, nudged. Suppressible per line or project-wide via `lint.skip`.
+
+| Rule ID | Detects |
+|---------|---------|
+| `stdlib-test` | `func TestX(*testing.T)` — migration aid suggesting a suite method (fires in any package; coexisting stdlib tests are legitimate, see The Two Runners) |
+| `testify` | Any `github.com/stretchr/testify/*` import — migration incomplete |
+
+One construct yields one finding: integrity rules own the constructs they flag, and expressiveness rules stand down on them (a guard whose body escapes the poll scope gets the `poll-scope` finding, not a `fail-guard` rewrite). The assertion surface itself is derived from the gotest package's type information, so the linter cannot drift from the API and lookalike names from other packages never match.
 
 Suppression and configuration:
 
 - `//nolint:<rule>` on a line; on the `package` line it applies file-wide
-- `.gotest.yml` → `lint.skip: [<rule>, ...]` disables rules project-wide
-- `.gotest.yml` `lint.skip` with any other rule ID is a hard error — correctness rules can only be suppressed per line
-- Flags: `-fix` applies suggested fixes; `-skip-stdlib-test`, `-skip-testify`, `-disable-nolint`
+- `.gotest.yml` → `lint.skip: [<rule>, ...]` disables non-integrity rules project-wide
+- `.gotest.yml` `lint.skip` naming an integrity rule is a hard error — integrity rules can only be suppressed per line; unknown rule IDs are also a hard error
+- Flags: `-fix` applies suggested fixes; `-skip-<rule>` for every non-integrity rule; `-disable-nolint`
 
 ---
 

--- a/internal/gotestgen/renderer_suite_test.go
+++ b/internal/gotestgen/renderer_suite_test.go
@@ -461,7 +461,7 @@ func (s *RendererTestSuite) TestResolvedFixtures(t *gotest.T) {
 			gotest.Equal(it, "PGSharedFixture", sf.QualifiedType)
 			gotest.Equal(it, "PGSharedFixture", sf.FieldName)
 			gotest.Equal(it, "PGSharedFixture", sf.Identifier)
-			gotest.Equal(it, "", sf.PkgPath, "same-package shared fixture should have empty PkgPath")
+			gotest.Empty(it, sf.PkgPath, "same-package shared fixture should have empty PkgPath")
 			gotest.Equal(it, pkg.PkgPath+".PGSharedFixture", sf.StateKey)
 		})
 	})

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -805,7 +805,7 @@ func (s *GotestrunnerTestSuite) TestOutputCollector(t *gotest.T) {
 			c.Register("example.com/c", 1)
 
 			c.RecordResult("example.com/c", 0, pass(30*time.Millisecond))
-			gotest.Equal(it, "", stdout.String(), "c should be buffered because a and b are not done")
+			gotest.Empty(it, stdout.String(), "c should be buffered because a and b are not done")
 
 			c.RecordResult("example.com/a", 0, pass(10*time.Millisecond))
 			gotest.Equal(it, "ok  \texample.com/a\t0.010s\n", stdout.String(), "a should flush as the head")
@@ -919,7 +919,7 @@ func (s *GotestrunnerTestSuite) TestOutputCollector(t *gotest.T) {
 			c.RecordResult("example.com/a", 0, gotestrunner.SuiteResult{ExitCode: 1})
 			stdout.Reset()
 			c.Finalize([]string{"example.com/empty"})
-			gotest.Equal(it, "", stdout.String())
+			gotest.Empty(it, stdout.String())
 		})
 	})
 

--- a/internal/gotestspec/interiorfailure_test.go
+++ b/internal/gotestspec/interiorfailure_test.go
@@ -84,19 +84,16 @@ func TestRenderTerminal_BareFailIsMarked(t *testing.T) {
 		"the failing node must carry a visible mark in the tree")
 }
 
+// statCounts aggregates the CollectStats expectations so a failure reports
+// every mismatched counter at once.
+type statCounts struct{ Failed, Passed, Total int }
+
 func TestCollectStats_CountsInteriorNodeFailure(t *testing.T) {
 	stats := CollectStats(interiorFailurePackages())
 
-	if stats.Failed != 1 {
-		t.Errorf("Failed = %d, want 1", stats.Failed)
-	}
-	if stats.Passed != 2 {
-		t.Errorf("Passed = %d, want 2", stats.Passed)
-	}
-	if stats.Total() != stats.Behaviors+stats.Tests {
-		t.Errorf("Passed+Failed+Skipped = %d, want it to equal Behaviors+Tests = %d",
-			stats.Total(), stats.Behaviors+stats.Tests)
-	}
+	gotest.Equal(t,
+		statCounts{Failed: 1, Passed: 2, Total: stats.Behaviors + stats.Tests},
+		statCounts{Failed: stats.Failed, Passed: stats.Passed, Total: stats.Total()})
 }
 
 func TestRenderSummary_ReportsInteriorNodeFailure(t *testing.T) {
@@ -104,15 +101,9 @@ func TestRenderSummary_ReportsInteriorNodeFailure(t *testing.T) {
 	RenderSummary(&buf, interiorFailurePackages(), WithNoColor())
 	out := buf.String()
 
-	if !strings.Contains(out, "could not release the database") {
-		t.Errorf("expected the node's own diagnostic in the summary, got:\n%s", out)
-	}
-	if !strings.Contains(out, "Boot") {
-		t.Errorf("expected the failing node to be named, got:\n%s", out)
-	}
-	if strings.Contains(out, "tests passed (") {
-		t.Errorf("expected a failure summary, not an all-passed line:\n%s", out)
-	}
+	gotest.Contains(t, out, "could not release the database")
+	gotest.Contains(t, out, "Boot")
+	gotest.NotContains(t, out, "tests passed (")
 }
 
 func TestRenderTerminal_ReportsInteriorNodeFailure(t *testing.T) {
@@ -120,9 +111,7 @@ func TestRenderTerminal_ReportsInteriorNodeFailure(t *testing.T) {
 	RenderTerminal(&buf, interiorFailurePackages(), WithNoColor())
 	out := stripANSI(buf.String())
 
-	if !strings.Contains(out, "could not release the database") {
-		t.Errorf("expected the node's own diagnostic in the tree, got:\n%s", out)
-	}
+	gotest.Contains(t, out, "could not release the database")
 }
 
 // A failed child marks its whole ancestry FAIL. Those ancestors carry only the
@@ -153,15 +142,11 @@ func TestCollectStats_IgnoresFailureInheritedFromAChild(t *testing.T) {
 	}}
 
 	stats := CollectStats(packages)
-	if stats.Failed != 1 {
-		t.Errorf("Failed = %d, want 1 (the leaf only)", stats.Failed)
-	}
+	gotest.Equal(t, 1, stats.Failed, "the leaf only")
 
 	var buf bytes.Buffer
 	RenderSummary(&buf, packages, WithNoColor())
-	if got := strings.Count(buf.String(), "FAIL  example.com/pkg"); got != 1 {
-		t.Errorf("reported %d failures, want 1:\n%s", got, buf.String())
-	}
+	gotest.Equal(t, 1, strings.Count(buf.String(), "FAIL  example.com/pkg"))
 }
 
 // An interior node that merely logged is not a verdict. BeforeEach output lands
@@ -195,13 +180,10 @@ func TestCollectStats_IgnoresInteriorLogWhenADescendantFailed(t *testing.T) {
 	}}
 
 	stats := CollectStats(packages)
-	if stats.Failed != 1 {
-		t.Errorf("Failed = %d, want 1 (the leaf only)", stats.Failed)
-	}
-	if stats.Total() != stats.Behaviors+stats.Tests {
-		t.Errorf("Passed+Failed+Skipped = %d, want it to equal Behaviors+Tests = %d",
-			stats.Total(), stats.Behaviors+stats.Tests)
-	}
+	gotest.Equal(t,
+		statCounts{Failed: 1, Passed: 0, Total: stats.Behaviors + stats.Tests},
+		statCounts{Failed: stats.Failed, Passed: stats.Passed, Total: stats.Total()},
+		"the leaf only")
 
 	// Rendering deliberately uses the weaker hasOwnDiagnostic, not
 	// failedOnItsOwn: it cannot tell this stray t.Log apart from a genuine
@@ -212,9 +194,7 @@ func TestCollectStats_IgnoresInteriorLogWhenADescendantFailed(t *testing.T) {
 	// regress is the count above: Failed stays 1 either way.
 	var buf bytes.Buffer
 	RenderSummary(&buf, packages, WithNoColor())
-	if got := strings.Count(buf.String(), "boot_test.go:9: True failed"); got != 1 {
-		t.Errorf("expected the leaf's own diagnostic exactly once, got %d:\n%s", got, buf.String())
-	}
+	gotest.Equal(t, 1, strings.Count(buf.String(), "boot_test.go:9: True failed"))
 }
 
 // An interior node can carry a genuine diagnostic of its own (AfterAll failed)
@@ -253,19 +233,13 @@ func TestCollectStats_CountsLeafButStillRendersInteriorDiagnostic(t *testing.T) 
 	}}
 
 	stats := CollectStats(packages)
-	if stats.Failed != 1 {
-		t.Errorf("Failed = %d, want 1 (the leaf only)", stats.Failed)
-	}
+	gotest.Equal(t, 1, stats.Failed, "the leaf only")
 
 	var termBuf bytes.Buffer
 	RenderTerminal(&termBuf, packages, WithNoColor())
-	if termOut := stripANSI(termBuf.String()); !strings.Contains(termOut, "could not release the database") {
-		t.Errorf("expected the interior node's own diagnostic in the tree, got:\n%s", termOut)
-	}
+	gotest.Contains(t, stripANSI(termBuf.String()), "could not release the database")
 
 	var summaryBuf bytes.Buffer
 	RenderSummary(&summaryBuf, packages, WithNoColor())
-	if summaryOut := summaryBuf.String(); !strings.Contains(summaryOut, "could not release the database") {
-		t.Errorf("expected the interior node's own diagnostic in the summary, got:\n%s", summaryOut)
-	}
+	gotest.Contains(t, summaryBuf.String(), "could not release the database")
 }

--- a/internal/lint/export_test.go
+++ b/internal/lint/export_test.go
@@ -3,3 +3,5 @@ package lint
 var ExportParseNolint = parseNolint
 
 func ExportSetDisableNolint(v bool) { cfg.disableNolint = v }
+
+func ExportSetSkip(r Rule, v bool) { *cfg.skip[r] = v }

--- a/internal/lint/failguard.go
+++ b/internal/lint/failguard.go
@@ -205,7 +205,7 @@ func extractHaltingUnit(pass *analysis.Pass, body *ast.BlockStmt) *failGuardUnit
 		return nil
 	}
 
-	if isGotestCallNamed(pass, call, "Fail") && len(call.Args) >= 1 {
+	if assertionFuncName(pass, call.Fun) == "Fail" && len(call.Args) >= 1 {
 		return &failGuardUnit{
 			tArg:    call.Args[0],
 			msgArgs: call.Args[1:],
@@ -356,22 +356,6 @@ func splitOr(expr ast.Expr) []ast.Expr {
 		return append(splitOr(bin.X), splitOr(bin.Y)...)
 	}
 	return []ast.Expr{expr}
-}
-
-// isGotestCallNamed reports whether call invokes the named function from the
-// gotest package, whether qualified (gotest.Fail) or dot-imported (Fail).
-func isGotestCallNamed(pass *analysis.Pass, call *ast.CallExpr, name string) bool {
-	switch fn := call.Fun.(type) {
-	case *ast.SelectorExpr:
-		return fn.Sel.Name == name && isGotestPkgRef(pass, fn.X)
-	case *ast.Ident:
-		if fn.Name != name {
-			return false
-		}
-		obj := pass.TypesInfo.Uses[fn]
-		return obj != nil && obj.Pkg() != nil && obj.Pkg().Path() == gotestImportPath
-	}
-	return false
 }
 
 // msgArgsSafe reports whether every message arg is trivially total to

--- a/internal/lint/failguard.go
+++ b/internal/lint/failguard.go
@@ -18,7 +18,7 @@ import (
 // preserves control flow: ||-chained conditions and else-if chains decompose
 // into sequential assertions, where halting on the first failure reproduces
 // the original short-circuit evaluation.
-func checkFailGuard(pass *analysis.Pass, insp *inspector.Inspector) {
+func checkFailGuard(pass *analysis.Pass, insp *inspector.Inspector, cl *claims) {
 	// else-branch if-statements belong to their parent's chain and must never
 	// be reported standalone: replacing one would leave `else <expr>` behind.
 	// Preorder visits parents first, so marking suffices.
@@ -48,6 +48,11 @@ func checkFailGuard(pass *analysis.Pass, insp *inspector.Inspector) {
 
 		units, hasInit := collectFailChain(pass, ifStmt)
 		if len(units) == 0 {
+			return
+		}
+		// An integrity rule already owns a call inside this guard — its
+		// finding tells the sharper story.
+		if cl.anyWithin(ifStmt.Pos(), ifStmt.End()) {
 			return
 		}
 
@@ -220,15 +225,6 @@ func extractHaltingUnit(pass *analysis.Pass, body *ast.BlockStmt) *failGuardUnit
 		return nil
 	}
 	name := sel.Sel.Name
-	// Guards on escaped t.T() receivers whose method the t-escape rule
-	// covers are that rule's finding; reporting here too would produce
-	// overlapping, non-convergent fixes. Methods t-escape does not know
-	// (Error) stay with fail-guard.
-	if isTMethodCall(sel.X) {
-		if _, covered := escapeConfigs[name]; covered {
-			return nil
-		}
-	}
 	recvType := pass.TypesInfo.TypeOf(sel.X)
 	onTestingT := namedPtrType(recvType, "testing", "T")
 	onGotestT := namedPtrType(recvType, gotestImportPath, "T")

--- a/internal/lint/failguard.go
+++ b/internal/lint/failguard.go
@@ -1,0 +1,400 @@
+package lint
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// checkFailGuard flags if-statements whose sole purpose is to call
+// gotest.Fail when a condition holds — an assertion expresses the same check
+// directly, with a richer failure report. Fail halts the test exactly like a
+// failing assertion (both funnel through Errorf+FailNow), so the rewrite
+// preserves control flow: ||-chained conditions and else-if chains decompose
+// into sequential assertions, where halting on the first failure reproduces
+// the original short-circuit evaluation.
+func checkFailGuard(pass *analysis.Pass, insp *inspector.Inspector) {
+	// else-branch if-statements belong to their parent's chain and must never
+	// be reported standalone: replacing one would leave `else <expr>` behind.
+	// Preorder visits parents first, so marking suffices.
+	elseChild := map[*ast.IfStmt]bool{}
+
+	sourceCache := map[string][]byte{}
+	readSource := func(name string) []byte {
+		if content, ok := sourceCache[name]; ok {
+			return content
+		}
+		content, err := pass.ReadFile(name)
+		if err != nil {
+			content = nil
+		}
+		sourceCache[name] = content
+		return content
+	}
+
+	insp.Preorder([]ast.Node{(*ast.IfStmt)(nil)}, func(n ast.Node) {
+		ifStmt := n.(*ast.IfStmt)
+		if inner, ok := ifStmt.Else.(*ast.IfStmt); ok {
+			elseChild[inner] = true
+		}
+		if elseChild[ifStmt] {
+			return
+		}
+
+		units, hasInit := collectFailChain(pass, ifStmt)
+		if len(units) == 0 {
+			return
+		}
+
+		var plans []failGuardPlan
+		fixable := !hasInit
+		weakLabel := ""
+		for _, u := range units {
+			if u.forceReport {
+				fixable = false
+			}
+			if !u.halting && !u.returns && weakLabel == "" {
+				weakLabel = u.label
+			}
+			for _, cond := range splitOr(u.cond) {
+				m, ok := mapBoolExpr(pass, cond, true)
+				if !ok {
+					m = conditionMapping{"False", []ast.Expr{cond}, "failure guard"}
+				}
+				plans = append(plans, failGuardPlan{
+					m:       m,
+					tArg:    u.tArg,
+					msgArgs: u.msgArgs,
+					qual:    u.qual,
+				})
+			}
+		}
+
+		var targets []string
+		for _, p := range plans {
+			targets = append(targets, p.m.target)
+		}
+		targetList := strings.Join(targets, " + ")
+
+		desc := plans[0].m.desc
+		switch {
+		case len(units) > 1:
+			desc = "else-if failure guard"
+		case len(plans) > 1:
+			desc = "or-chained failure guard"
+		}
+
+		// The if body evaluated message args only on failure; an assertion
+		// evaluates them on every run. Calls could have side effects, and
+		// index/selector/deref expressions can panic exactly when the guard
+		// would not have fired (errs[0] guarded by len > 0) — so only
+		// trivially total args keep the autofix.
+		for _, p := range plans {
+			if !msgArgsSafe(p.msgArgs) {
+				fixable = false
+			}
+		}
+		from := "if+" + units[0].label
+		// A non-halting body makes the rewrite a semantic strengthening, not
+		// an equivalence — say so, and never offer a fix.
+		if weakLabel != "" {
+			report(pass, FailGuard, ifStmt.Pos(), "use %s instead of %s for %s — assertions halt where %s continues", targetList, from, desc, weakLabel)
+			return
+		}
+		trailing, interior := spanComments(pass, ifStmt)
+		if !fixable || interior {
+			report(pass, FailGuard, ifStmt.Pos(), "use %s instead of %s for %s", targetList, from, desc)
+			return
+		}
+
+		indent := "\n" + sourceIndent(pass.Fset, readSource, ifStmt.Pos())
+		var lines []string
+		for _, p := range plans {
+			lines = append(lines, renderAssertion(pass.Fset, p.qual, p.m.target, append([]ast.Expr{p.tArg}, p.m.args...), p.msgArgs))
+		}
+		lines[0] += trailing
+		reportWithFix(pass, FailGuard, ifStmt.Pos(),
+			[]analysis.SuggestedFix{{
+				Message: fmt.Sprintf("use %s", targetList),
+				TextEdits: []analysis.TextEdit{{
+					Pos:     ifStmt.Pos(),
+					End:     ifStmt.End(),
+					NewText: []byte(strings.Join(lines, indent)),
+				}},
+			}},
+			"use %s instead of %s for %s", targetList, from, desc)
+	})
+}
+
+// failGuardUnit is one branch of an if / else-if chain whose body halts the
+// test: the guard condition, the halting call's t expression, the message
+// args to carry over, the qualifier to render the assertion with, a label
+// naming the halting call for diagnostics, and whether a fix can be offered.
+type failGuardUnit struct {
+	cond        ast.Expr
+	tArg        ast.Expr
+	msgArgs     []ast.Expr
+	qual        string
+	label       string
+	halting     bool
+	returns     bool
+	forceReport bool
+}
+
+type failGuardPlan struct {
+	m       conditionMapping
+	tArg    ast.Expr
+	msgArgs []ast.Expr
+	qual    string
+}
+
+// collectFailChain walks an if / else-if chain and returns one unit per
+// branch. It returns nil unless every branch consists of exactly one
+// test-halting call (plus at most an unreachable bare return) and no branch
+// carries an init statement.
+func collectFailChain(pass *analysis.Pass, ifStmt *ast.IfStmt) (units []failGuardUnit, hasInit bool) {
+	for cur := ifStmt; ; {
+		if cur.Init != nil {
+			// The init variable is scoped to the if — hoisting it for an
+			// assertion can break compilation, so such chains report only.
+			hasInit = true
+		}
+		unit := extractHaltingUnit(pass, cur.Body)
+		if unit == nil {
+			return nil, false
+		}
+		unit.cond = cur.Cond
+		units = append(units, *unit)
+		switch e := cur.Else.(type) {
+		case nil:
+			return units, hasInit
+		case *ast.IfStmt:
+			cur = e
+		default:
+			return nil, false
+		}
+	}
+}
+
+// extractHaltingUnit recognizes a block that only halts the test: a
+// gotest.Fail call, or a Fatal/Fatalf/FailNow call on a testing.T (FailNow
+// also on gotest.T), optionally followed by a bare return that the halt
+// makes unreachable.
+func extractHaltingUnit(pass *analysis.Pass, body *ast.BlockStmt) *failGuardUnit {
+	if body == nil || len(body.List) == 0 || len(body.List) > 2 {
+		return nil
+	}
+	hasReturn := len(body.List) == 2
+	if hasReturn {
+		ret, ok := body.List[1].(*ast.ReturnStmt)
+		if !ok || ret.Results != nil {
+			return nil
+		}
+	}
+	es, ok := body.List[0].(*ast.ExprStmt)
+	if !ok {
+		return nil
+	}
+	call, ok := es.X.(*ast.CallExpr)
+	if !ok {
+		return nil
+	}
+
+	if isGotestCallNamed(pass, call, "Fail") && len(call.Args) >= 1 {
+		return &failGuardUnit{
+			tArg:    call.Args[0],
+			msgArgs: call.Args[1:],
+			qual:    assertionQualifier(call.Fun),
+			label:   "Fail",
+			halting: true,
+		}
+	}
+
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return nil
+	}
+	name := sel.Sel.Name
+	// Guards on escaped t.T() receivers whose method the t-escape rule
+	// covers are that rule's finding; reporting here too would produce
+	// overlapping, non-convergent fixes. Methods t-escape does not know
+	// (Error) stay with fail-guard.
+	if isTMethodCall(sel.X) {
+		if _, covered := escapeConfigs[name]; covered {
+			return nil
+		}
+	}
+	recvType := pass.TypesInfo.TypeOf(sel.X)
+	onTestingT := namedPtrType(recvType, "testing", "T")
+	onGotestT := namedPtrType(recvType, gotestImportPath, "T")
+	halting := (name == "FailNow" && (onTestingT || onGotestT)) ||
+		((name == "Fatal" || name == "Fatalf") && onTestingT)
+	weak := (name == "Errorf" && (onTestingT || onGotestT)) ||
+		(name == "Error" && onTestingT)
+	if !halting && !weak {
+		return nil
+	}
+
+	// Only files that import gotest have adopted the framework — halting
+	// guards elsewhere are idiomatic stdlib Go and out of scope.
+	qual, imported := gotestQualifier(pass, call.Pos())
+	if !imported {
+		return nil
+	}
+	unit := &failGuardUnit{tArg: sel.X, label: name, halting: halting, returns: hasReturn, qual: qual}
+	if name != "FailNow" {
+		unit.msgArgs = call.Args
+	}
+	// A weak call followed by return already stops the enclosing function —
+	// converting it would strengthen a helper-local exit into a whole-test
+	// halt, so such branches report without a fix and without the
+	// "continues" note.
+	if !halting && hasReturn {
+		unit.forceReport = true
+	}
+	// t.Fatal is Println-style while msgAndArgs is Printf-style: a single
+	// arg survives the translation verbatim, but more would be reinterpreted
+	// as format string plus operands — report without a fix.
+	if name == "Fatal" && len(call.Args) > 1 {
+		unit.forceReport = true
+	}
+	return unit
+}
+
+// spanComments partitions the comments inside the if-statement's span:
+// trailing comments on the if line ride along on a rewrite, while a comment
+// on any later line makes the rewrite lossy and blocks the fix.
+func spanComments(pass *analysis.Pass, ifStmt *ast.IfStmt) (trailing string, interior bool) {
+	file := fileContaining(pass, ifStmt.Pos())
+	if file == nil {
+		return "", false
+	}
+	ifLine := pass.Fset.Position(ifStmt.Pos()).Line
+	var parts []string
+	for _, cg := range file.Comments {
+		for _, c := range cg.List {
+			if c.Pos() <= ifStmt.Pos() || c.End() >= ifStmt.End() {
+				continue
+			}
+			if pass.Fset.Position(c.Pos()).Line == ifLine {
+				parts = append(parts, c.Text)
+			} else {
+				interior = true
+			}
+		}
+	}
+	if len(parts) > 0 {
+		trailing = " " + strings.Join(parts, " ")
+	}
+	return trailing, interior
+}
+
+// sourceIndent returns the actual leading whitespace of the line holding
+// pos, falling back to tabs when the source is unreadable or pos does not
+// start its line.
+func sourceIndent(fset *token.FileSet, read func(string) []byte, pos token.Pos) string {
+	position := fset.Position(pos)
+	if content := read(position.Filename); content != nil {
+		lineStart := position.Offset - (position.Column - 1)
+		if lineStart >= 0 && position.Offset <= len(content) {
+			prefix := string(content[lineStart:position.Offset])
+			if strings.TrimLeft(prefix, " 	") == "" {
+				return prefix
+			}
+		}
+	}
+	return strings.Repeat("	", position.Column-1)
+}
+
+func namedPtrType(t types.Type, pkgPath, name string) bool {
+	ptr, ok := t.(*types.Pointer)
+	if !ok {
+		return false
+	}
+	named, ok := ptr.Elem().(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj.Name() == name && obj.Pkg() != nil && obj.Pkg().Path() == pkgPath
+}
+
+// gotestQualifier resolves how the file containing pos refers to the gotest
+// package. ok is false when the file does not import it — there is nothing
+// to qualify a rewritten assertion with.
+func gotestQualifier(pass *analysis.Pass, pos token.Pos) (qual string, ok bool) {
+	file := fileContaining(pass, pos)
+	if file == nil {
+		return "", false
+	}
+	for _, imp := range file.Imports {
+		if strings.Trim(imp.Path.Value, `"`) != gotestImportPath {
+			continue
+		}
+		if imp.Name != nil {
+			if imp.Name.Name == "." {
+				return "", true
+			}
+			return imp.Name.Name + ".", true
+		}
+		return "gotest.", true
+	}
+	return "", false
+}
+
+// splitOr flattens a top-level chain of || operands.
+func splitOr(expr ast.Expr) []ast.Expr {
+	if paren, ok := expr.(*ast.ParenExpr); ok {
+		return splitOr(paren.X)
+	}
+	if bin, ok := expr.(*ast.BinaryExpr); ok && bin.Op == token.LOR {
+		return append(splitOr(bin.X), splitOr(bin.Y)...)
+	}
+	return []ast.Expr{expr}
+}
+
+// isGotestCallNamed reports whether call invokes the named function from the
+// gotest package, whether qualified (gotest.Fail) or dot-imported (Fail).
+func isGotestCallNamed(pass *analysis.Pass, call *ast.CallExpr, name string) bool {
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		return fn.Sel.Name == name && isGotestPkgRef(pass, fn.X)
+	case *ast.Ident:
+		if fn.Name != name {
+			return false
+		}
+		obj := pass.TypesInfo.Uses[fn]
+		return obj != nil && obj.Pkg() != nil && obj.Pkg().Path() == gotestImportPath
+	}
+	return false
+}
+
+// msgArgsSafe reports whether every message arg is trivially total to
+// evaluate: a basic literal, a plain identifier, or parens around those.
+// Anything else — calls, index/selector/deref/type-assertion expressions —
+// may have side effects or panic under the assertion's eager evaluation.
+func msgArgsSafe(exprs []ast.Expr) bool {
+	for _, e := range exprs {
+		if !isTotalExpr(e) {
+			return false
+		}
+	}
+	return true
+}
+
+func isTotalExpr(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.BasicLit:
+		return true
+	case *ast.Ident:
+		return true
+	case *ast.ParenExpr:
+		return isTotalExpr(x.X)
+	}
+	return false
+}

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -462,20 +462,6 @@ var escapeConfigs = map[string]escapeConfig{
 	"Fatalf":   {TEscape, "use assertions instead — T.Fatalf bypasses the assertion tracer", false, false, true},
 }
 
-var gotestAssertionFuncs = map[string]bool{
-	"True": true, "False": true,
-	"Equal": true, "NotEqual": true,
-	"Greater": true, "GreaterOrEqual": true,
-	"Less": true, "LessOrEqual": true,
-	"Zero": true, "NotZero": true,
-	"Empty": true, "NotEmpty": true,
-	"Len": true, "Contains": true, "NotContains": true,
-	"NoError": true, "Error": true,
-	"ErrorIs": true, "ErrorContains": true,
-	"Regexp": true, "MatchSnapshot": true,
-	"Eventually": true, "Consistently": true,
-}
-
 type deferredReport struct {
 	rule    Rule
 	pos     token.Pos
@@ -594,7 +580,7 @@ func reportDirectEscape(pass *analysis.Pass, call *ast.CallExpr, isSuiteMethod b
 		}
 	}
 
-	if gotestAssertionFuncs[sel.Sel.Name] && isGotestPkgRef(pass, sel.X) && len(call.Args) > 0 {
+	if assertionFuncName(pass, call.Fun) != "" && len(call.Args) > 0 {
 		arg := call.Args[0]
 		if inner, ok := arg.(*ast.CallExpr); ok && isTMethodCall(inner) {
 			reported[inner.Pos()] = true
@@ -632,20 +618,38 @@ func collectInterproceduralEscape(call *ast.CallExpr, tVars, gotestTVars map[str
 
 var gotestImportPath = about.Repo + "/pkg/gotest"
 
-func isGotestPkgRef(pass *analysis.Pass, expr ast.Expr) bool {
-	id, ok := expr.(*ast.Ident)
-	if !ok {
-		return false
+// assertionFuncName resolves fun to an exported gotest function whose first
+// parameter is the package's testingT interface — the assertion shape — and
+// returns its name. Deriving the surface from type information means the
+// linter can never drift from the API, and lookalike names from other
+// packages never match.
+func assertionFuncName(pass *analysis.Pass, fun ast.Expr) string {
+	var id *ast.Ident
+	switch fn := fun.(type) {
+	case *ast.SelectorExpr:
+		id = fn.Sel
+	case *ast.Ident:
+		id = fn
+	case *ast.IndexExpr:
+		return assertionFuncName(pass, fn.X)
+	case *ast.IndexListExpr:
+		return assertionFuncName(pass, fn.X)
+	default:
+		return ""
 	}
-	obj := pass.TypesInfo.Uses[id]
-	if obj == nil {
-		return false
+	fn, ok := pass.TypesInfo.Uses[id].(*types.Func)
+	if !ok || fn.Pkg() == nil || fn.Pkg().Path() != gotestImportPath {
+		return ""
 	}
-	pkgName, ok := obj.(*types.PkgName)
-	if !ok {
-		return false
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok || sig.Params().Len() == 0 {
+		return ""
 	}
-	return pkgName.Imported().Path() == gotestImportPath
+	named, ok := sig.Params().At(0).Type().(*types.Named)
+	if !ok || named.Obj().Name() != "testingT" {
+		return ""
+	}
+	return fn.Name()
 }
 
 func isGotestTType(pass *analysis.Pass, field *ast.Field) bool {
@@ -1062,22 +1066,6 @@ func isLifecycleHook(name string) bool {
 
 // --- poll-scope check ---
 
-var pollScopeAssertionFuncs = map[string]bool{
-	"Consistently": true, "Contains": true, "ElementsMatch": true,
-	"Empty": true, "Equal": true, "Error": true,
-	"ErrorAs": true, "ErrorContains": true, "ErrorIs": true,
-	"Eventually": true, "Fail": true, "False": true,
-	"Greater": true, "GreaterOrEqual": true, "InDelta": true,
-	"JSONEq": true, "Len": true, "Less": true,
-	"LessOrEqual": true, "MatchSnapshot": true, "Nil": true,
-	"NoError":     true,
-	"NotContains": true, "NotEmpty": true, "NotEqual": true,
-	"NotNil":  true,
-	"NotZero": true, "Panics": true, "Regexp": true,
-	"Subset": true, "TimeIsNow": true, "TimeWithin": true,
-	"True": true, "Zero": true,
-}
-
 var pollScopeMethodNames = map[string]bool{
 	"Errorf":  true,
 	"Fatal":   true,
@@ -1089,8 +1077,8 @@ func checkPollScope(pass *analysis.Pass, insp *inspector.Inspector) {
 	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
 		call := n.(*ast.CallExpr)
 
-		fnName := pollingFuncName(call)
-		if fnName == "" {
+		fnName := assertionFuncName(pass, call.Fun)
+		if fnName != "Eventually" && fnName != "Consistently" {
 			return
 		}
 
@@ -1106,7 +1094,7 @@ func checkPollScope(pass *analysis.Pass, insp *inspector.Inspector) {
 			}
 
 			// Case 1: gotest assertion with wrong first arg — gotest.Equal(t, ...) or Equal(t, ...)
-			if name := resolveAssertionName(innerCall.Fun); name != "" && len(innerCall.Args) > 0 {
+			if name := assertionFuncName(pass, innerCall.Fun); name != "" && len(innerCall.Args) > 0 {
 				if ident, ok := innerCall.Args[0].(*ast.Ident); ok && ident.Name != pollParam {
 					report(pass, PollScope, ident.Pos(),
 						"use %s instead of %s in poll callback passed to %s",
@@ -1132,20 +1120,6 @@ func checkPollScope(pass *analysis.Pass, insp *inspector.Inspector) {
 			return true
 		})
 	})
-}
-
-func pollingFuncName(call *ast.CallExpr) string {
-	switch fn := call.Fun.(type) {
-	case *ast.SelectorExpr:
-		if fn.Sel.Name == "Eventually" || fn.Sel.Name == "Consistently" {
-			return fn.Sel.Name
-		}
-	case *ast.Ident:
-		if fn.Name == "Eventually" || fn.Name == "Consistently" {
-			return fn.Name
-		}
-	}
-	return ""
 }
 
 func extractPollCallback(call *ast.CallExpr) (string, *ast.FuncLit) {
@@ -1182,24 +1156,6 @@ func isStarR(expr ast.Expr) bool {
 		return x.Sel.Name == "R"
 	}
 	return false
-}
-
-func resolveAssertionName(expr ast.Expr) string {
-	switch fn := expr.(type) {
-	case *ast.SelectorExpr:
-		if pollScopeAssertionFuncs[fn.Sel.Name] {
-			return fn.Sel.Name
-		}
-	case *ast.Ident:
-		if pollScopeAssertionFuncs[fn.Name] {
-			return fn.Name
-		}
-	case *ast.IndexExpr:
-		return resolveAssertionName(fn.X)
-	case *ast.IndexListExpr:
-		return resolveAssertionName(fn.X)
-	}
-	return ""
 }
 
 func levenshtein(a, b string) int {

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -148,13 +148,41 @@ func run(pass *analysis.Pass) (any, error) {
 	checkOrphanedFiles(pass)
 	checkStdlibTests(pass, insp)
 	checkTestifyImports(pass)
-	checkPollScope(pass, insp)
-	checkAssertionSimplify(pass, insp)
-	checkFailGuard(pass, insp)
-	checkRedundantAssertion(pass, insp)
-	checkTEscape(pass, insp, suites)
+
+	// Integrity rules run first and claim the constructs they own;
+	// expressiveness rules stand down on claimed spans so one construct
+	// yields one finding, from the rule with the stronger story.
+	cl := &claims{}
+	checkPollScope(pass, insp, cl)
+	checkTEscape(pass, insp, suites, cl)
+	checkAssertionSimplify(pass, insp, cl)
+	checkFailGuard(pass, insp, cl)
+	checkRedundantAssertion(pass, insp, cl)
 
 	return nil, nil
+}
+
+// claims records positions owned by earlier findings, whether or not a
+// diagnostic was shown — per-line suppression exempts the construct, not
+// just the message. A skipped expressiveness rule releases its constructs
+// to the remaining active rules; integrity rules cannot be skipped and
+// always claim.
+type claims struct{ positions []token.Pos }
+
+func (c *claims) add(rule Rule, pos token.Pos) {
+	if ruleMeta[rule].Tier != TierIntegrity && skipped(rule) {
+		return
+	}
+	c.positions = append(c.positions, pos)
+}
+
+func (c *claims) anyWithin(start, end token.Pos) bool {
+	for _, p := range c.positions {
+		if p >= start && p < end {
+			return true
+		}
+	}
+	return false
 }
 
 func report(pass *analysis.Pass, rule Rule, pos token.Pos, format string, args ...any) {
@@ -468,10 +496,26 @@ type deferredReport struct {
 	message string
 }
 
-func checkTEscape(pass *analysis.Pass, insp *inspector.Inspector, suites map[string]*suiteInfo) {
+func checkTEscape(pass *analysis.Pass, insp *inspector.Inspector, suites map[string]*suiteInfo, cl *claims) {
 	mr := buildMethodReach(pass, insp, 5)
 	reported := map[token.Pos]bool{}
 	var deferred []deferredReport
+
+	scanBody := func(body *ast.BlockStmt, isSuiteMethod bool, gotestTVars map[string]bool) {
+		tVars := map[string]bool{}
+		ast.Inspect(body, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.AssignStmt:
+				trackTVarAssign(node, tVars, gotestTVars)
+			case *ast.CallExpr:
+				reportDirectEscape(pass, cl, node, isSuiteMethod, tVars, reported)
+				if isSuiteMethod {
+					collectInterproceduralEscape(node, tVars, gotestTVars, mr, &deferred)
+				}
+			}
+			return true
+		})
+	}
 
 	insp.Preorder([]ast.Node{(*ast.FuncDecl)(nil)}, func(n ast.Node) {
 		fd := n.(*ast.FuncDecl)
@@ -484,7 +528,6 @@ func checkTEscape(pass *analysis.Pass, insp *inspector.Inspector, suites map[str
 			_, isSuiteMethod = suites[receiverTypeName(fd.Recv)]
 		}
 
-		tVars := map[string]bool{}
 		gotestTVars := map[string]bool{}
 		if isSuiteMethod && fd.Type.Params != nil {
 			for _, field := range fd.Type.Params.List {
@@ -496,23 +539,36 @@ func checkTEscape(pass *analysis.Pass, insp *inspector.Inspector, suites map[str
 			}
 		}
 
-		ast.Inspect(fd.Body, func(n ast.Node) bool {
-			switch node := n.(type) {
-			case *ast.AssignStmt:
-				trackTVarAssign(node, tVars, gotestTVars)
-			case *ast.CallExpr:
-				reportDirectEscape(pass, node, isSuiteMethod, tVars, reported)
-				if isSuiteMethod {
-					collectInterproceduralEscape(node, tVars, gotestTVars, mr, &deferred)
+		scanBody(fd.Body, isSuiteMethod, gotestTVars)
+	})
+
+	// Package-level var function literals are not FuncDecls but their bodies
+	// escape t.T() the same way — without scanning them the claims table
+	// would have blind spots the expressiveness rules rely on.
+	for _, file := range pass.Files {
+		for _, decl := range file.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for _, value := range vs.Values {
+					if lit, ok := value.(*ast.FuncLit); ok && lit.Body != nil {
+						scanBody(lit.Body, false, map[string]bool{})
+					}
 				}
 			}
-			return true
-		})
-	})
+		}
+	}
 
 	for _, d := range deferred {
 		if !reported[d.pos] {
 			reported[d.pos] = true
+			cl.add(d.rule, d.pos)
 			report(pass, d.rule, d.pos, "%s", d.message)
 		}
 	}
@@ -542,7 +598,7 @@ func trackTVarAssign(assign *ast.AssignStmt, tVars, gotestTVars map[string]bool)
 	}
 }
 
-func reportDirectEscape(pass *analysis.Pass, call *ast.CallExpr, isSuiteMethod bool, tVars map[string]bool, reported map[token.Pos]bool) {
+func reportDirectEscape(pass *analysis.Pass, cl *claims, call *ast.CallExpr, isSuiteMethod bool, tVars map[string]bool, reported map[token.Pos]bool) {
 	sel, _ := call.Fun.(*ast.SelectorExpr)
 	if sel == nil {
 		return
@@ -559,6 +615,7 @@ func reportDirectEscape(pass *analysis.Pass, call *ast.CallExpr, isSuiteMethod b
 			}
 			if isDirect || isAlias {
 				reported[call.Pos()] = true
+				cl.add(esc.rule, call.Pos())
 				if esc.canAutofix && isDirect {
 					inner := sel.X.(*ast.CallExpr)
 					innerSel := inner.Fun.(*ast.SelectorExpr)
@@ -1073,7 +1130,7 @@ var pollScopeMethodNames = map[string]bool{
 	"FailNow": true,
 }
 
-func checkPollScope(pass *analysis.Pass, insp *inspector.Inspector) {
+func checkPollScope(pass *analysis.Pass, insp *inspector.Inspector, cl *claims) {
 	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
 		call := n.(*ast.CallExpr)
 
@@ -1096,6 +1153,7 @@ func checkPollScope(pass *analysis.Pass, insp *inspector.Inspector) {
 			// Case 1: gotest assertion with wrong first arg — gotest.Equal(t, ...) or Equal(t, ...)
 			if name := assertionFuncName(pass, innerCall.Fun); name != "" && len(innerCall.Args) > 0 {
 				if ident, ok := innerCall.Args[0].(*ast.Ident); ok && ident.Name != pollParam {
+					cl.add(PollScope, innerCall.Pos())
 					report(pass, PollScope, ident.Pos(),
 						"use %s instead of %s in poll callback passed to %s",
 						pollParam, ident.Name, fnName)
@@ -1113,6 +1171,7 @@ func checkPollScope(pass *analysis.Pass, insp *inspector.Inspector) {
 				return true
 			}
 			if pollScopeMethodNames[sel.Sel.Name] && ident.Name != pollParam {
+				cl.add(PollScope, innerCall.Pos())
 				report(pass, PollScope, ident.Pos(),
 					"%s.%s in poll callback bypasses assertion recording — use %s",
 					ident.Name, sel.Sel.Name, pollParam)

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -37,6 +37,7 @@ const (
 	AssertionTypeGuard Rule = "assertion-type-guard"
 	AssertionRedundant Rule = "assertion-redundant"
 	TEscape            Rule = "t-escape"
+	SuiteLifecycle     Rule = "suite-lifecycle"
 )
 
 // Tier classifies what breaks when a rule's finding is ignored, and derives
@@ -80,6 +81,7 @@ var ruleMeta = map[Rule]struct {
 	AssertionTypeGuard: {TierIntegrity, ScopeGotestFiles},
 	AssertionRedundant: {TierExpressiveness, ScopeGotestFiles},
 	TEscape:            {TierExpressiveness, ScopeSuites},
+	SuiteLifecycle:     {TierIntegrity, ScopeSuites},
 	FailGuard:          {TierExpressiveness, ScopeGotestFiles},
 }
 
@@ -194,6 +196,21 @@ func fileContaining(pass *analysis.Pass, pos token.Pos) *ast.File {
 	return nil
 }
 
+// nolintAliases maps a rule to the historical umbrella ID whose nolint
+// comments also suppress it: suite-lifecycle was split out of t-escape, and
+// committed //nolint:t-escape comments must keep working.
+var nolintAliases = map[Rule]Rule{
+	SuiteLifecycle: TEscape,
+}
+
+func ruleMatched(rules map[Rule]bool, rule Rule) bool {
+	if rules == nil || rules[rule] {
+		return true
+	}
+	umbrella, ok := nolintAliases[rule]
+	return ok && rules[umbrella]
+}
+
 func isSuppressed(pass *analysis.Pass, pos token.Pos, rule Rule) bool {
 	file := fileContaining(pass, pos)
 	if file == nil {
@@ -207,7 +224,7 @@ func isSuppressed(pass *analysis.Pass, pos token.Pos, rule Rule) bool {
 			if !ok {
 				continue
 			}
-			if rules != nil && !rules[rule] {
+			if !ruleMatched(rules, rule) {
 				continue
 			}
 			cLine := pass.Fset.Position(c.Pos()).Line
@@ -228,7 +245,7 @@ func docSuppressed(doc *ast.CommentGroup, rule Rule) bool {
 		if !ok {
 			continue
 		}
-		if rules == nil || rules[rule] {
+		if ruleMatched(rules, rule) {
 			return true
 		}
 	}
@@ -436,9 +453,9 @@ var escapeConfigs = map[string]escapeConfig{
 	"TempDir":  {TEscape, "TempDir is available on gotest.T — unnecessary T escape", false, true, false},
 	"Skip":     {TEscape, "must use Skipf instead — unnecessary T escape", false, false, false},
 	"SkipNow":  {TEscape, "must use Skipf instead — unnecessary T escape", false, false, false},
-	"Cleanup":  {TEscape, "use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle", true, false, false},
-	"Parallel": {TEscape, "use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination", true, false, false},
-	"Run":      {TEscape, "use It or When instead — T.Run bypasses gotest wrapping", true, false, false},
+	"Cleanup":  {SuiteLifecycle, "use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle", true, false, false},
+	"Parallel": {SuiteLifecycle, "use SuiteConfig.Parallel instead — T.Parallel bypasses suite lifecycle coordination", true, false, false},
+	"Run":      {SuiteLifecycle, "use It or When instead — T.Run bypasses gotest wrapping", true, false, false},
 	"Helper":   {TEscape, "never call Helper — gotest resolves call sites automatically; Helper degrades failure locations", false, false, true},
 	"Log":      {TEscape, "use assertion message args instead — T.Log bypasses the failure report", false, false, true},
 	"Fatal":    {TEscape, "use assertions instead — T.Fatal bypasses the assertion tracer", false, false, true},

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -33,6 +33,7 @@ const (
 	TestSignature      Rule = "test-signature"
 	XLifecycle         Rule = "x-lifecycle"
 	AssertionSimplify  Rule = "assertion-simplify"
+	FailGuard          Rule = "fail-guard"
 	AssertionTypeGuard Rule = "assertion-type-guard"
 	AssertionRedundant Rule = "assertion-redundant"
 	TEscape            Rule = "t-escape"
@@ -80,6 +81,7 @@ func run(pass *analysis.Pass) (any, error) {
 	checkTestifyImports(pass)
 	checkPollScope(pass, insp)
 	checkAssertionSimplify(pass, insp)
+	checkFailGuard(pass, insp)
 	checkRedundantAssertion(pass, insp)
 	checkTEscape(pass, insp, suites)
 
@@ -109,32 +111,37 @@ func reportWithFix(pass *analysis.Pass, rule Rule, pos token.Pos, fixes []analys
 	})
 }
 
-func isSuppressed(pass *analysis.Pass, pos token.Pos, rule Rule) bool {
-	position := pass.Fset.Position(pos)
+// fileContaining returns the syntax file whose span contains pos, or nil.
+func fileContaining(pass *analysis.Pass, pos token.Pos) *ast.File {
 	for _, file := range pass.Files {
-		if pass.Fset.Position(file.Pos()).Filename != position.Filename {
-			continue
+		if pos >= file.FileStart && pos <= file.FileEnd {
+			return file
 		}
-		pkgLine := pass.Fset.Position(file.Package).Line
-		for _, cg := range file.Comments {
-			for _, c := range cg.List {
-				rules, ok := parseNolint(c.Text)
-				if !ok {
-					continue
-				}
-				if rules != nil && !rules[rule] {
-					continue
-				}
-				cLine := pass.Fset.Position(c.Pos()).Line
-				if cLine == pkgLine {
-					return true
-				}
-				if cLine == position.Line {
-					return true
-				}
+	}
+	return nil
+}
+
+func isSuppressed(pass *analysis.Pass, pos token.Pos, rule Rule) bool {
+	file := fileContaining(pass, pos)
+	if file == nil {
+		return false
+	}
+	line := pass.Fset.Position(pos).Line
+	pkgLine := pass.Fset.Position(file.Package).Line
+	for _, cg := range file.Comments {
+		for _, c := range cg.List {
+			rules, ok := parseNolint(c.Text)
+			if !ok {
+				continue
+			}
+			if rules != nil && !rules[rule] {
+				continue
+			}
+			cLine := pass.Fset.Position(c.Pos()).Line
+			if cLine == pkgLine || cLine == line {
+				return true
 			}
 		}
-		return false
 	}
 	return false
 }
@@ -552,20 +559,7 @@ func isGotestPkgRef(pass *analysis.Pass, expr ast.Expr) bool {
 }
 
 func isGotestTType(pass *analysis.Pass, field *ast.Field) bool {
-	typ := pass.TypesInfo.TypeOf(field.Type)
-	if typ == nil {
-		return false
-	}
-	ptr, ok := typ.(*types.Pointer)
-	if !ok {
-		return false
-	}
-	named, ok := ptr.Elem().(*types.Named)
-	if !ok {
-		return false
-	}
-	obj := named.Obj()
-	return obj.Name() == "T" && obj.Pkg() != nil && obj.Pkg().Path() == gotestImportPath
+	return namedPtrType(pass.TypesInfo.TypeOf(field.Type), gotestImportPath, "T")
 }
 
 // --- interprocedural method reachability ---

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -1123,6 +1123,24 @@ func isLifecycleHook(name string) bool {
 
 // --- poll-scope check ---
 
+// foreignAssertionNames is deliberately syntactic and package-agnostic:
+// poll-scope is an integrity rule, and an assertion from a foreign library
+// (testify et al.) escaping the poll loop is exactly as broken as a gotest
+// one. This vocabulary cannot be derived from gotest's type information.
+var foreignAssertionNames = map[string]bool{
+	"Consistently": true, "Contains": true, "ElementsMatch": true,
+	"Empty": true, "Equal": true, "Error": true,
+	"ErrorAs": true, "ErrorContains": true, "ErrorIs": true,
+	"Eventually": true, "Fail": true, "FailNow": true,
+	"False": true, "Greater": true, "GreaterOrEqual": true,
+	"InDelta": true, "JSONEq": true, "Len": true,
+	"Less": true, "LessOrEqual": true, "Nil": true,
+	"NoError": true, "NotContains": true, "NotEmpty": true,
+	"NotEqual": true, "NotNil": true, "NotZero": true,
+	"Panics": true, "Regexp": true, "Subset": true,
+	"True": true, "Zero": true,
+}
+
 var pollScopeMethodNames = map[string]bool{
 	"Errorf":  true,
 	"Fatal":   true,
@@ -1134,24 +1152,39 @@ func checkPollScope(pass *analysis.Pass, insp *inspector.Inspector, cl *claims) 
 	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
 		call := n.(*ast.CallExpr)
 
-		fnName := assertionFuncName(pass, call.Fun)
-		if fnName != "Eventually" && fnName != "Consistently" {
+		// A polling context needs both signals: an Eventually/Consistently
+		// callee shape (case-insensitive so wrappers and re-exports stay
+		// covered, package-agnostic by design) and a callback with a typed
+		// *gotest.R parameter (so foreign lookalike R types and other
+		// func(*R)-taking harnesses like Record stay excluded).
+		fnName := calleeName(call.Fun)
+		if !strings.EqualFold(fnName, "Eventually") && !strings.EqualFold(fnName, "Consistently") {
 			return
 		}
-
-		pollParam, funcLit := extractPollCallback(call)
+		pollParam, funcLit := extractPollCallback(pass, call)
 		if funcLit == nil {
 			return
 		}
 
 		ast.Inspect(funcLit.Body, func(n ast.Node) bool {
+			// A nested poll callback owns its subtree; it is visited by its
+			// own enclosing call.
+			if lit, ok := n.(*ast.FuncLit); ok && lit != funcLit && hasTypedRParam(pass, lit) {
+				return false
+			}
 			innerCall, ok := n.(*ast.CallExpr)
 			if !ok {
 				return true
 			}
 
-			// Case 1: gotest assertion with wrong first arg — gotest.Equal(t, ...) or Equal(t, ...)
-			if name := assertionFuncName(pass, innerCall.Fun); name != "" && len(innerCall.Args) > 0 {
+			// Case 1: assertion with wrong first arg — gotest.Equal(t, ...) or a
+			// foreign library's Equal(t, ...): integrity coverage is deliberately
+			// package-agnostic for assertion-shaped names.
+			name := assertionFuncName(pass, innerCall.Fun)
+			if name == "" && foreignAssertionNames[calleeName(innerCall.Fun)] {
+				name = calleeName(innerCall.Fun)
+			}
+			if name != "" && len(innerCall.Args) > 0 {
 				if ident, ok := innerCall.Args[0].(*ast.Ident); ok && ident.Name != pollParam {
 					cl.add(PollScope, innerCall.Pos())
 					report(pass, PollScope, ident.Pos(),
@@ -1170,7 +1203,9 @@ func checkPollScope(pass *analysis.Pass, insp *inspector.Inspector, cl *claims) 
 			if !ok {
 				return true
 			}
-			if pollScopeMethodNames[sel.Sel.Name] && ident.Name != pollParam {
+			onTestT := namedPtrType(pass.TypesInfo.TypeOf(ident), "testing", "T") ||
+				namedPtrType(pass.TypesInfo.TypeOf(ident), gotestImportPath, "T")
+			if pollScopeMethodNames[sel.Sel.Name] && onTestT && ident.Name != pollParam {
 				cl.add(PollScope, innerCall.Pos())
 				report(pass, PollScope, ident.Pos(),
 					"%s.%s in poll callback bypasses assertion recording — use %s",
@@ -1181,7 +1216,14 @@ func checkPollScope(pass *analysis.Pass, insp *inspector.Inspector, cl *claims) 
 	})
 }
 
-func extractPollCallback(call *ast.CallExpr) (string, *ast.FuncLit) {
+func hasTypedRParam(pass *analysis.Pass, lit *ast.FuncLit) bool {
+	if lit.Type.Params == nil || len(lit.Type.Params.List) != 1 {
+		return false
+	}
+	return namedPtrType(pass.TypesInfo.TypeOf(lit.Type.Params.List[0].Type), gotestImportPath, "R")
+}
+
+func extractPollCallback(pass *analysis.Pass, call *ast.CallExpr) (string, *ast.FuncLit) {
 	if len(call.Args) == 0 {
 		return "", nil
 	}
@@ -1193,28 +1235,30 @@ func extractPollCallback(call *ast.CallExpr) (string, *ast.FuncLit) {
 	if funcLit.Type.Params == nil || len(funcLit.Type.Params.List) != 1 {
 		return "", nil
 	}
-	param := funcLit.Type.Params.List[0]
-	if !isStarR(param.Type) {
+	if !hasTypedRParam(pass, funcLit) {
 		return "", nil
 	}
+	param := funcLit.Type.Params.List[0]
 	if len(param.Names) == 0 {
 		return "", nil
 	}
 	return param.Names[0].Name, funcLit
 }
 
-func isStarR(expr ast.Expr) bool {
-	star, ok := expr.(*ast.StarExpr)
-	if !ok {
-		return false
-	}
-	switch x := star.X.(type) {
-	case *ast.Ident:
-		return x.Name == "R"
+// calleeName returns the last identifier of a call target, for matching and
+// messages that should be independent of qualification.
+func calleeName(fun ast.Expr) string {
+	switch fn := fun.(type) {
 	case *ast.SelectorExpr:
-		return x.Sel.Name == "R"
+		return fn.Sel.Name
+	case *ast.Ident:
+		return fn.Name
+	case *ast.IndexExpr:
+		return calleeName(fn.X)
+	case *ast.IndexListExpr:
+		return calleeName(fn.X)
 	}
-	return false
+	return ""
 }
 
 func levenshtein(a, b string) int {

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -39,16 +39,71 @@ const (
 	TEscape            Rule = "t-escape"
 )
 
-// SkippableRules is the set of rules that support opt-out via skip flags.
-var SkippableRules = map[Rule]bool{
-	StdlibTest: true,
-	Testify:    true,
+// Tier classifies what breaks when a rule's finding is ignored, and derives
+// the suppression policy: integrity rules (test outcomes can lie, resources
+// can leak) are suppressible per line only; expressiveness rules (the test is
+// correct but says it worse) and migration rules (legitimate coexistence) may
+// additionally be skipped project-wide.
+type Tier int
+
+const (
+	TierIntegrity Tier = iota
+	TierExpressiveness
+	TierMigration
+)
+
+// Scope documents where a rule may fire.
+type Scope int
+
+const (
+	ScopeEverywhere Scope = iota
+	ScopeGotestFiles
+	ScopeSuites
+	ScopePollCallbacks
+)
+
+var ruleMeta = map[Rule]struct {
+	Tier  Tier
+	Scope Scope
+}{
+	Focus:              {TierIntegrity, ScopeSuites},
+	Receiver:           {TierIntegrity, ScopeSuites},
+	LifecycleTypo:      {TierIntegrity, ScopeSuites},
+	LifecyclePair:      {TierIntegrity, ScopeSuites},
+	GeneratedFile:      {TierIntegrity, ScopeEverywhere},
+	StdlibTest:         {TierMigration, ScopeEverywhere},
+	Testify:            {TierMigration, ScopeEverywhere},
+	PollScope:          {TierIntegrity, ScopePollCallbacks},
+	TestSignature:      {TierIntegrity, ScopeSuites},
+	XLifecycle:         {TierIntegrity, ScopeSuites},
+	AssertionSimplify:  {TierExpressiveness, ScopeGotestFiles},
+	AssertionTypeGuard: {TierIntegrity, ScopeGotestFiles},
+	AssertionRedundant: {TierExpressiveness, ScopeGotestFiles},
+	TEscape:            {TierExpressiveness, ScopeSuites},
+	FailGuard:          {TierExpressiveness, ScopeGotestFiles},
 }
 
+// Known reports whether the rule ID exists.
+func Known(r Rule) bool {
+	_, ok := ruleMeta[r]
+	return ok
+}
+
+// SkippableRules is derived from the tier table: every non-integrity rule
+// supports opt-out via a skip flag (and .gotest.yml lint.skip).
+var SkippableRules = func() map[Rule]bool {
+	m := make(map[Rule]bool, len(ruleMeta))
+	for r, meta := range ruleMeta {
+		if meta.Tier != TierIntegrity {
+			m[r] = true
+		}
+	}
+	return m
+}()
+
 var cfg struct {
-	skipStdlibTest bool
-	skipTestify    bool
-	disableNolint  bool
+	skip          map[Rule]*bool
+	disableNolint bool
 }
 
 var Analyzer = &analysis.Analyzer{
@@ -59,9 +114,21 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func init() {
-	Analyzer.Flags.BoolVar(&cfg.skipStdlibTest, "skip-stdlib-test", false, "disable stdlib test function detection")
-	Analyzer.Flags.BoolVar(&cfg.skipTestify, "skip-testify", false, "disable testify import detection")
+	cfg.skip = make(map[Rule]*bool, len(SkippableRules))
+	rules := make([]string, 0, len(SkippableRules))
+	for r := range SkippableRules {
+		rules = append(rules, string(r))
+	}
+	slices.Sort(rules)
+	for _, r := range rules {
+		cfg.skip[Rule(r)] = Analyzer.Flags.Bool("skip-"+r, false, "disable the "+r+" rule")
+	}
 	Analyzer.Flags.BoolVar(&cfg.disableNolint, "disable-nolint", false, "report all diagnostics and let the analysis driver handle suppression")
+}
+
+func skipped(rule Rule) bool {
+	b, ok := cfg.skip[rule]
+	return ok && *b
 }
 
 var lifecycleHooks = []string{"BeforeAll", "AfterAll", "BeforeEach", "AfterEach"}
@@ -89,6 +156,9 @@ func run(pass *analysis.Pass) (any, error) {
 }
 
 func report(pass *analysis.Pass, rule Rule, pos token.Pos, format string, args ...any) {
+	if skipped(rule) {
+		return
+	}
 	if !cfg.disableNolint && isSuppressed(pass, pos, rule) {
 		return
 	}
@@ -100,6 +170,9 @@ func report(pass *analysis.Pass, rule Rule, pos token.Pos, format string, args .
 }
 
 func reportWithFix(pass *analysis.Pass, rule Rule, pos token.Pos, fixes []analysis.SuggestedFix, format string, args ...any) {
+	if skipped(rule) {
+		return
+	}
 	if !cfg.disableNolint && isSuppressed(pass, pos, rule) {
 		return
 	}
@@ -837,7 +910,7 @@ func checkOrphanedFiles(pass *analysis.Pass) {
 }
 
 func checkStdlibTests(pass *analysis.Pass, insp *inspector.Inspector) {
-	if cfg.skipStdlibTest {
+	if skipped(StdlibTest) {
 		return
 	}
 
@@ -870,7 +943,7 @@ func checkStdlibTests(pass *analysis.Pass, insp *inspector.Inspector) {
 }
 
 func checkTestifyImports(pass *analysis.Pass) {
-	if cfg.skipTestify {
+	if skipped(Testify) {
 		return
 	}
 

--- a/internal/lint/lint_suite_test.go
+++ b/internal/lint/lint_suite_test.go
@@ -93,6 +93,23 @@ func (s *LintTestSuite) TestDisableNolintFlag(t *gotest.T) {
 	})
 }
 
+func (s *LintTestSuite) TestTierPolicy(t *gotest.T) {
+	t.When("tier-derived skip surface", func(w *gotest.T) {
+		w.It("registers a skip flag for every non-integrity rule and none for integrity rules", func(it *gotest.T) {
+			for _, rule := range []lint.Rule{lint.StdlibTest, lint.Testify, lint.AssertionSimplify, lint.AssertionRedundant, lint.FailGuard, lint.TEscape} {
+				gotest.NotZero(it, lint.Analyzer.Flags.Lookup("skip-"+string(rule)), "missing skip flag for %s", rule)
+				gotest.True(it, lint.SkippableRules[rule], "rule %s should be skippable", rule)
+			}
+			for _, rule := range []lint.Rule{lint.Focus, lint.PollScope, lint.TestSignature} {
+				gotest.Zero(it, lint.Analyzer.Flags.Lookup("skip-"+string(rule)), "unexpected skip flag for %s", rule)
+				gotest.False(it, lint.SkippableRules[rule], "integrity rule %s must not be skippable", rule)
+			}
+			gotest.True(it, lint.Known(lint.Focus))
+			gotest.False(it, lint.Known(lint.Rule("nope")))
+		})
+	})
+}
+
 func (s *LintTestSuite) TestParseNolint(t *gotest.T) {
 	tests := []struct {
 		desc      string
@@ -135,6 +152,23 @@ func (s *LintTestSuite) TestParseNolint(t *gotest.T) {
 
 // DisableNolintTestSuite runs separately and non-parallel because it
 // temporarily mutates the shared analyzer flag.
+// SkippedStyleTestSuite runs separately and non-parallel because it
+// temporarily mutates the shared analyzer flags.
+type SkippedStyleTestSuite struct{}
+
+func (s *SkippedStyleTestSuite) TestSkipSilencesExpressivenessRule(t *gotest.T) {
+	testdata := analysistest.TestData()
+
+	lint.ExportSetSkip(lint.FailGuard, true)
+	defer lint.ExportSetSkip(lint.FailGuard, false)
+
+	t.When("skip-fail-guard is set", func(w *gotest.T) {
+		w.It("reports nothing for fail-guard findings", func(it *gotest.T) {
+			analysistest.Run(it.T(), testdata, lint.Analyzer, "withskippedstyle")
+		})
+	})
+}
+
 type DisableNolintTestSuite struct{}
 
 func (s *DisableNolintTestSuite) TestNolintDirectivesIgnored(t *gotest.T) {

--- a/internal/lint/lint_suite_test.go
+++ b/internal/lint/lint_suite_test.go
@@ -100,7 +100,7 @@ func (s *LintTestSuite) TestTierPolicy(t *gotest.T) {
 				gotest.NotZero(it, lint.Analyzer.Flags.Lookup("skip-"+string(rule)), "missing skip flag for %s", rule)
 				gotest.True(it, lint.SkippableRules[rule], "rule %s should be skippable", rule)
 			}
-			for _, rule := range []lint.Rule{lint.Focus, lint.PollScope, lint.TestSignature} {
+			for _, rule := range []lint.Rule{lint.Focus, lint.PollScope, lint.TestSignature, lint.SuiteLifecycle} {
 				gotest.Zero(it, lint.Analyzer.Flags.Lookup("skip-"+string(rule)), "unexpected skip flag for %s", rule)
 				gotest.False(it, lint.SkippableRules[rule], "integrity rule %s must not be skippable", rule)
 			}

--- a/internal/lint/lint_suite_test.go
+++ b/internal/lint/lint_suite_test.go
@@ -46,6 +46,12 @@ func (s *LintTestSuite) TestAnalyzer(t *gotest.T) {
 		})
 	})
 
+	t.When("fail guard", func(w *gotest.T) {
+		w.It("detects if+Fail guards that assertions express directly", func(it *gotest.T) {
+			analysistest.RunWithSuggestedFixes(it.T(), testdata, lint.Analyzer, "withfailguard", "withfailguard_noimport")
+		})
+	})
+
 	t.When("assertion redundant", func(w *gotest.T) {
 		w.It("detects redundant guard assertions before stronger ones", func(it *gotest.T) {
 			analysistest.RunWithSuggestedFixes(it.T(), testdata, lint.Analyzer, "withredundant")

--- a/internal/lint/lint_suite_test.go
+++ b/internal/lint/lint_suite_test.go
@@ -175,6 +175,23 @@ func (s *SkippedStyleTestSuite) TestSkipSilencesExpressivenessRule(t *gotest.T) 
 	})
 }
 
+// SkippedEscapeTestSuite runs separately and non-parallel because it
+// temporarily mutates the shared analyzer flags.
+type SkippedEscapeTestSuite struct{}
+
+func (s *SkippedEscapeTestSuite) TestSkippedRuleReleasesClaims(t *gotest.T) {
+	testdata := analysistest.TestData()
+
+	lint.ExportSetSkip(lint.TEscape, true)
+	defer lint.ExportSetSkip(lint.TEscape, false)
+
+	t.When("skip-t-escape is set", func(w *gotest.T) {
+		w.It("lets fail-guard take over escaped halting guards", func(it *gotest.T) {
+			analysistest.Run(it.T(), testdata, lint.Analyzer, "withskippedtescape")
+		})
+	})
+}
+
 type DisableNolintTestSuite struct{}
 
 func (s *DisableNolintTestSuite) TestNolintDirectivesIgnored(t *gotest.T) {

--- a/internal/lint/lint_suite_test.go
+++ b/internal/lint/lint_suite_test.go
@@ -156,17 +156,15 @@ func (s *LintTestSuite) TestParseNolint(t *gotest.T) {
 	}
 }
 
-// DisableNolintTestSuite runs separately and non-parallel because it
-// temporarily mutates the shared analyzer flag.
 // SkippedStyleTestSuite runs separately and non-parallel because it
 // temporarily mutates the shared analyzer flags.
 type SkippedStyleTestSuite struct{}
 
+func (s *SkippedStyleTestSuite) BeforeEach(_ *gotest.T) { lint.ExportSetSkip(lint.FailGuard, true) }
+func (s *SkippedStyleTestSuite) AfterEach(_ *gotest.T)  { lint.ExportSetSkip(lint.FailGuard, false) }
+
 func (s *SkippedStyleTestSuite) TestSkipSilencesExpressivenessRule(t *gotest.T) {
 	testdata := analysistest.TestData()
-
-	lint.ExportSetSkip(lint.FailGuard, true)
-	defer lint.ExportSetSkip(lint.FailGuard, false)
 
 	t.When("skip-fail-guard is set", func(w *gotest.T) {
 		w.It("reports nothing for fail-guard findings", func(it *gotest.T) {
@@ -179,11 +177,11 @@ func (s *SkippedStyleTestSuite) TestSkipSilencesExpressivenessRule(t *gotest.T) 
 // temporarily mutates the shared analyzer flags.
 type SkippedEscapeTestSuite struct{}
 
+func (s *SkippedEscapeTestSuite) BeforeEach(_ *gotest.T) { lint.ExportSetSkip(lint.TEscape, true) }
+func (s *SkippedEscapeTestSuite) AfterEach(_ *gotest.T)  { lint.ExportSetSkip(lint.TEscape, false) }
+
 func (s *SkippedEscapeTestSuite) TestSkippedRuleReleasesClaims(t *gotest.T) {
 	testdata := analysistest.TestData()
-
-	lint.ExportSetSkip(lint.TEscape, true)
-	defer lint.ExportSetSkip(lint.TEscape, false)
 
 	t.When("skip-t-escape is set", func(w *gotest.T) {
 		w.It("lets fail-guard take over escaped halting guards", func(it *gotest.T) {
@@ -192,13 +190,15 @@ func (s *SkippedEscapeTestSuite) TestSkippedRuleReleasesClaims(t *gotest.T) {
 	})
 }
 
+// DisableNolintTestSuite runs separately and non-parallel because it
+// temporarily mutates the shared analyzer flags.
 type DisableNolintTestSuite struct{}
+
+func (s *DisableNolintTestSuite) BeforeEach(_ *gotest.T) { lint.ExportSetDisableNolint(true) }
+func (s *DisableNolintTestSuite) AfterEach(_ *gotest.T)  { lint.ExportSetDisableNolint(false) }
 
 func (s *DisableNolintTestSuite) TestNolintDirectivesIgnored(t *gotest.T) {
 	testdata := analysistest.TestData()
-
-	lint.ExportSetDisableNolint(true)
-	defer lint.ExportSetDisableNolint(false)
 
 	t.When("disable-nolint is set", func(w *gotest.T) {
 		w.It("reports all diagnostics regardless of nolint directives", func(it *gotest.T) {

--- a/internal/lint/lint_suite_test.go
+++ b/internal/lint/lint_suite_test.go
@@ -34,6 +34,12 @@ func (s *LintTestSuite) TestAnalyzer(t *gotest.T) {
 		})
 	})
 
+	t.When("foreign lookalikes", func(w *gotest.T) {
+		w.It("ignores assertion and polling names from other packages", func(it *gotest.T) {
+			analysistest.Run(it.T(), testdata, lint.Analyzer, "withforeign")
+		})
+	})
+
 	t.When("poll scope", func(w *gotest.T) {
 		w.It("detects poll scope violations", func(it *gotest.T) {
 			analysistest.Run(it.T(), testdata, lint.Analyzer, "withpollscope")

--- a/internal/lint/redundant.go
+++ b/internal/lint/redundant.go
@@ -12,8 +12,8 @@ func checkRedundantAssertion(pass *analysis.Pass, insp *inspector.Inspector) {
 	insp.Preorder([]ast.Node{(*ast.BlockStmt)(nil)}, func(n ast.Node) {
 		block := n.(*ast.BlockStmt)
 		for i := 0; i < len(block.List)-1; i++ {
-			first := extractAssertionCall(block.List[i])
-			second := extractAssertionCall(block.List[i+1])
+			first := extractAssertionCall(pass, block.List[i])
+			second := extractAssertionCall(pass, block.List[i+1])
 			if first == nil || second == nil {
 				continue
 			}
@@ -45,7 +45,7 @@ type parsedAssertion struct {
 	guardedArg ast.Expr
 }
 
-func extractAssertionCall(stmt ast.Stmt) *parsedAssertion {
+func extractAssertionCall(pass *analysis.Pass, stmt ast.Stmt) *parsedAssertion {
 	es, ok := stmt.(*ast.ExprStmt)
 	if !ok {
 		return nil
@@ -54,7 +54,7 @@ func extractAssertionCall(stmt ast.Stmt) *parsedAssertion {
 	if !ok {
 		return nil
 	}
-	name := resolveAssertionName(call.Fun)
+	name := assertionFuncName(pass, call.Fun)
 	if name == "" || len(call.Args) < 2 {
 		return nil
 	}

--- a/internal/lint/redundant.go
+++ b/internal/lint/redundant.go
@@ -8,13 +8,16 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-func checkRedundantAssertion(pass *analysis.Pass, insp *inspector.Inspector) {
+func checkRedundantAssertion(pass *analysis.Pass, insp *inspector.Inspector, cl *claims) {
 	insp.Preorder([]ast.Node{(*ast.BlockStmt)(nil)}, func(n ast.Node) {
 		block := n.(*ast.BlockStmt)
 		for i := 0; i < len(block.List)-1; i++ {
 			first := extractAssertionCall(pass, block.List[i])
 			second := extractAssertionCall(pass, block.List[i+1])
 			if first == nil || second == nil {
+				continue
+			}
+			if cl.anyWithin(first.call.Pos(), first.call.End()) || cl.anyWithin(second.call.Pos(), second.call.End()) {
 				continue
 			}
 			if !sameExprText(pass, first.guardedArg, second.guardedArg) {

--- a/internal/lint/simplify.go
+++ b/internal/lint/simplify.go
@@ -86,12 +86,16 @@ func simplifyBoolAssertion(pass *analysis.Pass, call *ast.CallExpr, negated bool
 // (the False(t, expr) reading).
 func mapBoolExpr(pass *analysis.Pass, expr ast.Expr, negated bool) (conditionMapping, bool) {
 	switch e := expr.(type) {
+	case *ast.ParenExpr:
+		return mapBoolExpr(pass, e.X, negated)
+
 	case *ast.UnaryExpr:
 		if e.Op != token.NOT {
 			return conditionMapping{}, false
 		}
-		if s, sub, ok := isStringsContains(e.X); ok {
-			return conditionMapping{pick(negated, "Contains", "NotContains"), []ast.Expr{s, sub}, "negated strings.Contains call"}, true
+		// !X asserted is X asserted with flipped polarity.
+		if m, ok := mapBoolExpr(pass, e.X, !negated); ok {
+			return m, true
 		}
 		return conditionMapping{pick(negated, "True", "False"), []ast.Expr{e.X}, "negation"}, true
 
@@ -115,7 +119,11 @@ func mapBoolBinary(pass *analysis.Pass, bin *ast.BinaryExpr, negated bool) (cond
 		if m, ok := mapLenEqNeq(left, right, negated, false); ok {
 			return m, true
 		}
-		return conditionMapping{pick(negated, "NotEqual", "Equal"), []ast.Expr{left, right}, "== comparison"}, true
+		if m, ok := mapEmptyStrEqNeq(pass, left, right, negated, false); ok {
+			return m, true
+		}
+		l, r := constFirst(pass, left, right)
+		return conditionMapping{pick(negated, "NotEqual", "Equal"), []ast.Expr{l, r}, "== comparison"}, true
 
 	case token.NEQ:
 		if m, ok, handled := mapNilComparison(pass, left, right, negated, true); handled {
@@ -124,7 +132,11 @@ func mapBoolBinary(pass *analysis.Pass, bin *ast.BinaryExpr, negated bool) (cond
 		if m, ok := mapLenEqNeq(left, right, negated, true); ok {
 			return m, true
 		}
-		return conditionMapping{pick(negated, "Equal", "NotEqual"), []ast.Expr{left, right}, "!= comparison"}, true
+		if m, ok := mapEmptyStrEqNeq(pass, left, right, negated, true); ok {
+			return m, true
+		}
+		l, r := constFirst(pass, left, right)
+		return conditionMapping{pick(negated, "Equal", "NotEqual"), []ast.Expr{l, r}, "!= comparison"}, true
 
 	case token.GTR:
 		if inner, ok := isLenCall(left); ok && isIntLit(right, 0) {
@@ -189,12 +201,50 @@ func mapLenEqNeq(left, right ast.Expr, negated, isNeq bool) (conditionMapping, b
 		return conditionMapping{pick(!positive, "NotEmpty", "Empty"), []ast.Expr{inner}, "len == 0 check"}, true
 	}
 
-	// len(x) == n where n is not 0 — suggest Len in non-negated EQL context only
-	if !isNeq && !negated {
+	// len(x) == n where n is not 0 — Len fits whenever the asserted reading
+	// is the equality: EQL non-negated, or NEQ negated.
+	if isNeq == negated {
 		return conditionMapping{"Len", []ast.Expr{inner, other}, "len comparison"}, true
 	}
 
 	return conditionMapping{}, false
+}
+
+// mapEmptyStrEqNeq handles comparisons of string operands against the empty
+// string literal, which Empty/NotEmpty express directly.
+func mapEmptyStrEqNeq(pass *analysis.Pass, left, right ast.Expr, negated, isNeq bool) (conditionMapping, bool) {
+	var other ast.Expr
+	switch {
+	case isEmptyStringLit(left):
+		other = right
+	case isEmptyStringLit(right):
+		other = left
+	default:
+		return conditionMapping{}, false
+	}
+	if !isStringType(pass, other) {
+		return conditionMapping{}, false
+	}
+	positive := !isNeq
+	if negated {
+		positive = !positive
+	}
+	return conditionMapping{pick(!positive, "NotEmpty", "Empty"), []ast.Expr{other}, "empty string check"}, true
+}
+
+// constFirst orders Equal/NotEqual operands: a lone constant operand —
+// literal, negative literal, or named constant — is the expected value and
+// belongs in the expected slot.
+func constFirst(pass *analysis.Pass, left, right ast.Expr) (ast.Expr, ast.Expr) {
+	if isConstExpr(pass, right) && !isConstExpr(pass, left) {
+		return right, left
+	}
+	return left, right
+}
+
+func isConstExpr(pass *analysis.Pass, expr ast.Expr) bool {
+	tv, ok := pass.TypesInfo.Types[expr]
+	return ok && tv.Value != nil
 }
 
 func extractLenSide(left, right ast.Expr) (inner, lenExpr, other ast.Expr, ok bool) {
@@ -249,6 +299,18 @@ func simplifyEquality(pass *analysis.Pass, call *ast.CallExpr, negated bool) {
 		positive := v != negated // true+Equal or false+NotEqual → True; otherwise False
 		emitSimplify(pass, call, source, pick(!positive, "False", "True"), []ast.Expr{tArg, expr}, msgArgs, "bool literal comparison")
 		return
+	}
+
+	// Empty-string literals: Equal(t, "", x) / Equal(t, x, "")
+	if isEmptyStringLit(expected) || isEmptyStringLit(actual) {
+		other := expected
+		if isEmptyStringLit(expected) {
+			other = actual
+		}
+		if isStringType(pass, other) {
+			emitSimplify(pass, call, source, pick(negated, "NotEmpty", "Empty"), []ast.Expr{tArg, other}, msgArgs, "empty string comparison")
+			return
+		}
 	}
 
 	// Nil literals: Equal(t, nil, x) / Equal(t, x, nil)
@@ -436,15 +498,7 @@ func guardErrorContains(pass *analysis.Pass, call *ast.CallExpr) {
 
 func emitSimplify(pass *analysis.Pass, call *ast.CallExpr, from, to string, newArgs, msgArgs []ast.Expr, desc string) {
 	qual := assertionQualifier(call.Fun)
-
-	var parts []string
-	for _, arg := range newArgs {
-		parts = append(parts, renderExpr(pass.Fset, arg))
-	}
-	for _, arg := range msgArgs {
-		parts = append(parts, renderExpr(pass.Fset, arg))
-	}
-	newText := qual + to + "(" + strings.Join(parts, ", ") + ")"
+	newText := renderAssertion(pass.Fset, qual, to, newArgs, msgArgs)
 
 	reportWithFix(pass, AssertionSimplify, call.Pos(),
 		[]analysis.SuggestedFix{{
@@ -456,6 +510,17 @@ func emitSimplify(pass *analysis.Pass, call *ast.CallExpr, from, to string, newA
 			}},
 		}},
 		"use %s instead of %s for %s", to, from, desc)
+}
+
+func renderAssertion(fset *token.FileSet, qual, target string, args, msgArgs []ast.Expr) string {
+	var parts []string
+	for _, arg := range args {
+		parts = append(parts, renderExpr(fset, arg))
+	}
+	for _, arg := range msgArgs {
+		parts = append(parts, renderExpr(fset, arg))
+	}
+	return qual + target + "(" + strings.Join(parts, ", ") + ")"
 }
 
 // --- expression helpers ---
@@ -555,24 +620,10 @@ func isRegexpMatchString(pass *analysis.Pass, expr ast.Expr) (re, s ast.Expr, ok
 	if !ok || sel.Sel.Name != "MatchString" {
 		return nil, nil, false
 	}
-	t := pass.TypesInfo.TypeOf(sel.X)
-	if t == nil || !isRegexpType(t) {
+	if !namedPtrType(pass.TypesInfo.TypeOf(sel.X), "regexp", "Regexp") {
 		return nil, nil, false
 	}
 	return sel.X, call.Args[0], true
-}
-
-func isRegexpType(t types.Type) bool {
-	ptr, ok := t.(*types.Pointer)
-	if !ok {
-		return false
-	}
-	named, ok := ptr.Elem().(*types.Named)
-	if !ok {
-		return false
-	}
-	obj := named.Obj()
-	return obj.Name() == "Regexp" && obj.Pkg() != nil && obj.Pkg().Path() == "regexp"
 }
 
 func isReflectDeepEqual(expr ast.Expr) (a, b ast.Expr, ok bool) {
@@ -649,6 +700,15 @@ func isConcreteComparableNilableType(pass *analysis.Pass, expr ast.Expr) bool {
 		return true
 	}
 	return false
+}
+
+func isStringType(pass *analysis.Pass, expr ast.Expr) bool {
+	t := pass.TypesInfo.TypeOf(expr)
+	if t == nil {
+		return false
+	}
+	b, ok := t.Underlying().(*types.Basic)
+	return ok && b.Info()&types.IsString != 0
 }
 
 func isPointerType(pass *analysis.Pass, expr ast.Expr) bool {

--- a/internal/lint/simplify.go
+++ b/internal/lint/simplify.go
@@ -60,94 +60,99 @@ func checkAssertionSimplify(pass *analysis.Pass, insp *inspector.Inspector) {
 
 // --- True / False ---
 
+// conditionMapping is the outcome of mapping a boolean expression onto a
+// stronger assertion: the target assertion name, its arguments after the
+// t argument, and a short description of the recognized pattern.
+type conditionMapping struct {
+	target string
+	args   []ast.Expr
+	desc   string
+}
+
 func simplifyBoolAssertion(pass *analysis.Pass, call *ast.CallExpr, negated bool) {
 	if len(call.Args) < 2 {
 		return
 	}
-	tArg := call.Args[0]
-	expr := call.Args[1]
-	msgArgs := call.Args[2:]
-	source := "True"
-	if negated {
-		source = "False"
+	m, ok := mapBoolExpr(pass, call.Args[1], negated)
+	if !ok {
+		return
 	}
+	source := pick(negated, "False", "True")
+	emitSimplify(pass, call, source, m.target, append([]ast.Expr{call.Args[0]}, m.args...), call.Args[2:], m.desc)
+}
 
+// mapBoolExpr maps a boolean expression to the assertion that expresses it
+// directly. With negated set, the mapping targets the expression's negation
+// (the False(t, expr) reading).
+func mapBoolExpr(pass *analysis.Pass, expr ast.Expr, negated bool) (conditionMapping, bool) {
 	switch e := expr.(type) {
 	case *ast.UnaryExpr:
 		if e.Op != token.NOT {
-			return
+			return conditionMapping{}, false
 		}
 		if s, sub, ok := isStringsContains(e.X); ok {
-			target := "NotContains"
-			if negated {
-				target = "Contains"
-			}
-			emitSimplify(pass, call, source, target, []ast.Expr{tArg, s, sub}, msgArgs, "negated strings.Contains call")
-			return
+			return conditionMapping{pick(negated, "Contains", "NotContains"), []ast.Expr{s, sub}, "negated strings.Contains call"}, true
 		}
-		target := "False"
-		if negated {
-			target = "True"
-		}
-		emitSimplify(pass, call, source, target, []ast.Expr{tArg, e.X}, msgArgs, "negation")
+		return conditionMapping{pick(negated, "True", "False"), []ast.Expr{e.X}, "negation"}, true
 
 	case *ast.BinaryExpr:
-		simplifyBoolBinary(pass, call, e, tArg, msgArgs, negated, source)
+		return mapBoolBinary(pass, e, negated)
 
 	case *ast.CallExpr:
-		simplifyBoolCall(pass, call, e, tArg, msgArgs, negated, source)
+		return mapBoolCall(pass, e, negated)
 	}
+	return conditionMapping{}, false
 }
 
-func simplifyBoolBinary(pass *analysis.Pass, call *ast.CallExpr, bin *ast.BinaryExpr, tArg ast.Expr, msgArgs []ast.Expr, negated bool, source string) {
+func mapBoolBinary(pass *analysis.Pass, bin *ast.BinaryExpr, negated bool) (conditionMapping, bool) {
 	left, right := bin.X, bin.Y
 
 	switch bin.Op {
 	case token.EQL:
-		if simplifyNilComparison(pass, call, left, right, tArg, msgArgs, negated, source, false) {
-			return
+		if m, ok, handled := mapNilComparison(pass, left, right, negated, false); handled {
+			return m, ok
 		}
-		if simplifyLenEqNeq(pass, call, left, right, tArg, msgArgs, negated, source, false) {
-			return
+		if m, ok := mapLenEqNeq(left, right, negated, false); ok {
+			return m, true
 		}
-		target := pick(negated, "NotEqual", "Equal")
-		emitSimplify(pass, call, source, target, []ast.Expr{tArg, left, right}, msgArgs, "== comparison")
+		return conditionMapping{pick(negated, "NotEqual", "Equal"), []ast.Expr{left, right}, "== comparison"}, true
 
 	case token.NEQ:
-		if simplifyNilComparison(pass, call, left, right, tArg, msgArgs, negated, source, true) {
-			return
+		if m, ok, handled := mapNilComparison(pass, left, right, negated, true); handled {
+			return m, ok
 		}
-		if simplifyLenEqNeq(pass, call, left, right, tArg, msgArgs, negated, source, true) {
-			return
+		if m, ok := mapLenEqNeq(left, right, negated, true); ok {
+			return m, true
 		}
-		target := pick(negated, "Equal", "NotEqual")
-		emitSimplify(pass, call, source, target, []ast.Expr{tArg, left, right}, msgArgs, "!= comparison")
+		return conditionMapping{pick(negated, "Equal", "NotEqual"), []ast.Expr{left, right}, "!= comparison"}, true
 
 	case token.GTR:
 		if inner, ok := isLenCall(left); ok && isIntLit(right, 0) {
-			emitSimplify(pass, call, source, pick(negated, "Empty", "NotEmpty"), []ast.Expr{tArg, inner}, msgArgs, "len > 0 check")
-			return
+			return conditionMapping{pick(negated, "Empty", "NotEmpty"), []ast.Expr{inner}, "len > 0 check"}, true
 		}
-		emitSimplify(pass, call, source, pick(negated, "LessOrEqual", "Greater"), []ast.Expr{tArg, left, right}, msgArgs, "> comparison")
+		return conditionMapping{pick(negated, "LessOrEqual", "Greater"), []ast.Expr{left, right}, "> comparison"}, true
 
 	case token.GEQ:
 		if inner, ok := isLenCall(left); ok && isIntLit(right, 1) {
-			emitSimplify(pass, call, source, pick(negated, "Empty", "NotEmpty"), []ast.Expr{tArg, inner}, msgArgs, "len >= 1 check")
-			return
+			return conditionMapping{pick(negated, "Empty", "NotEmpty"), []ast.Expr{inner}, "len >= 1 check"}, true
 		}
-		emitSimplify(pass, call, source, pick(negated, "Less", "GreaterOrEqual"), []ast.Expr{tArg, left, right}, msgArgs, ">= comparison")
+		return conditionMapping{pick(negated, "Less", "GreaterOrEqual"), []ast.Expr{left, right}, ">= comparison"}, true
 
 	case token.LSS:
-		emitSimplify(pass, call, source, pick(negated, "GreaterOrEqual", "Less"), []ast.Expr{tArg, left, right}, msgArgs, "< comparison")
+		return conditionMapping{pick(negated, "GreaterOrEqual", "Less"), []ast.Expr{left, right}, "< comparison"}, true
 
 	case token.LEQ:
-		emitSimplify(pass, call, source, pick(negated, "Greater", "LessOrEqual"), []ast.Expr{tArg, left, right}, msgArgs, "<= comparison")
+		return conditionMapping{pick(negated, "Greater", "LessOrEqual"), []ast.Expr{left, right}, "<= comparison"}, true
 	}
+	return conditionMapping{}, false
 }
 
-func simplifyNilComparison(pass *analysis.Pass, call *ast.CallExpr, left, right, tArg ast.Expr, msgArgs []ast.Expr, negated bool, source string, isNeq bool) bool {
+// mapNilComparison handles comparisons against nil. handled reports that the
+// expression is a nil comparison and no other mapping should be attempted,
+// even when no assertion fits the operand's type category.
+func mapNilComparison(pass *analysis.Pass, left, right ast.Expr, negated, isNeq bool) (m conditionMapping, ok, handled bool) {
 	if !isNilIdent(left) && !isNilIdent(right) {
-		return false
+		return conditionMapping{}, false, false
 	}
 	other := left
 	if isNilIdent(left) {
@@ -160,33 +165,20 @@ func simplifyNilComparison(pass *analysis.Pass, call *ast.CallExpr, left, right,
 	}
 	switch {
 	case isErrorType(pass, other):
-		target := "NoError"
-		if !positive {
-			target = "Error"
-		}
-		emitSimplify(pass, call, source, target, []ast.Expr{tArg, other}, msgArgs, "error nil check")
+		return conditionMapping{pick(!positive, "Error", "NoError"), []ast.Expr{other}, "error nil check"}, true, true
 	case isComparableType(pass, other):
-		target := "Zero"
-		if !positive {
-			target = "NotZero"
-		}
-		emitSimplify(pass, call, source, target, []ast.Expr{tArg, other}, msgArgs, "nil check")
+		return conditionMapping{pick(!positive, "NotZero", "Zero"), []ast.Expr{other}, "nil check"}, true, true
 	case isNonComparableNilableType(pass, other):
-		target := "Nil"
-		if !positive {
-			target = "NotNil"
-		}
-		emitSimplify(pass, call, source, target, []ast.Expr{tArg, other}, msgArgs, "nil check")
+		return conditionMapping{pick(!positive, "NotNil", "Nil"), []ast.Expr{other}, "nil check"}, true, true
 	}
-	return true
+	return conditionMapping{}, false, true
 }
 
-func simplifyLenEqNeq(pass *analysis.Pass, call *ast.CallExpr, left, right, tArg ast.Expr, msgArgs []ast.Expr, negated bool, source string, isNeq bool) bool {
-	inner, lenExpr, other, ok := extractLenSide(left, right)
+func mapLenEqNeq(left, right ast.Expr, negated, isNeq bool) (conditionMapping, bool) {
+	inner, _, other, ok := extractLenSide(left, right)
 	if !ok {
-		return false
+		return conditionMapping{}, false
 	}
-	_ = lenExpr
 
 	// len(x) == 0 or 0 == len(x)
 	if isIntLit(other, 0) {
@@ -194,17 +186,15 @@ func simplifyLenEqNeq(pass *analysis.Pass, call *ast.CallExpr, left, right, tArg
 		if negated {
 			positive = !positive
 		}
-		emitSimplify(pass, call, source, pick(!positive, "NotEmpty", "Empty"), []ast.Expr{tArg, inner}, msgArgs, "len == 0 check")
-		return true
+		return conditionMapping{pick(!positive, "NotEmpty", "Empty"), []ast.Expr{inner}, "len == 0 check"}, true
 	}
 
 	// len(x) == n where n is not 0 — suggest Len in non-negated EQL context only
 	if !isNeq && !negated {
-		emitSimplify(pass, call, source, "Len", []ast.Expr{tArg, inner, other}, msgArgs, "len comparison")
-		return true
+		return conditionMapping{"Len", []ast.Expr{inner, other}, "len comparison"}, true
 	}
 
-	return false
+	return conditionMapping{}, false
 }
 
 func extractLenSide(left, right ast.Expr) (inner, lenExpr, other ast.Expr, ok bool) {
@@ -217,30 +207,29 @@ func extractLenSide(left, right ast.Expr) (inner, lenExpr, other ast.Expr, ok bo
 	return nil, nil, nil, false
 }
 
-func simplifyBoolCall(pass *analysis.Pass, call *ast.CallExpr, inner *ast.CallExpr, tArg ast.Expr, msgArgs []ast.Expr, negated bool, source string) {
+func mapBoolCall(pass *analysis.Pass, inner *ast.CallExpr, negated bool) (conditionMapping, bool) {
 	if s, sub, ok := isStringsContains(inner); ok {
-		emitSimplify(pass, call, source, pick(negated, "NotContains", "Contains"), []ast.Expr{tArg, s, sub}, msgArgs, "strings.Contains call")
-		return
+		return conditionMapping{pick(negated, "NotContains", "Contains"), []ast.Expr{s, sub}, "strings.Contains call"}, true
 	}
 
 	if err, target, ok := isErrorsIs(inner); ok {
 		if isNilIdent(target) {
-			emitSimplify(pass, call, source, pick(negated, "Error", "NoError"), []ast.Expr{tArg, err}, msgArgs, "errors.Is nil check")
-		} else if !negated {
-			emitSimplify(pass, call, source, "ErrorIs", []ast.Expr{tArg, err, target}, msgArgs, "errors.Is call")
+			return conditionMapping{pick(negated, "Error", "NoError"), []ast.Expr{err}, "errors.Is nil check"}, true
 		}
-		return
+		if !negated {
+			return conditionMapping{"ErrorIs", []ast.Expr{err, target}, "errors.Is call"}, true
+		}
+		return conditionMapping{}, false
 	}
 
 	if re, s, ok := isRegexpMatchString(pass, inner); ok && !negated {
-		emitSimplify(pass, call, source, "Regexp", []ast.Expr{tArg, re, s}, msgArgs, "MatchString call")
-		return
+		return conditionMapping{"Regexp", []ast.Expr{re, s}, "MatchString call"}, true
 	}
 
 	if a, b, ok := isReflectDeepEqual(inner); ok {
-		emitSimplify(pass, call, source, pick(negated, "NotEqual", "Equal"), []ast.Expr{tArg, a, b}, msgArgs, "reflect.DeepEqual call")
-		return
+		return conditionMapping{pick(negated, "NotEqual", "Equal"), []ast.Expr{a, b}, "reflect.DeepEqual call"}, true
 	}
+	return conditionMapping{}, false
 }
 
 // --- Equal / NotEqual ---

--- a/internal/lint/simplify.go
+++ b/internal/lint/simplify.go
@@ -13,11 +13,14 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-func checkAssertionSimplify(pass *analysis.Pass, insp *inspector.Inspector) {
+func checkAssertionSimplify(pass *analysis.Pass, insp *inspector.Inspector, cl *claims) {
 	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
 		call := n.(*ast.CallExpr)
 		name := assertionFuncName(pass, call.Fun)
 		if name == "" {
+			return
+		}
+		if cl.anyWithin(call.Pos(), call.End()) {
 			return
 		}
 

--- a/internal/lint/simplify.go
+++ b/internal/lint/simplify.go
@@ -16,7 +16,7 @@ import (
 func checkAssertionSimplify(pass *analysis.Pass, insp *inspector.Inspector) {
 	insp.Preorder([]ast.Node{(*ast.CallExpr)(nil)}, func(n ast.Node) {
 		call := n.(*ast.CallExpr)
-		name := resolveAssertionName(call.Fun)
+		name := assertionFuncName(pass, call.Fun)
 		if name == "" {
 			return
 		}

--- a/internal/lint/testdata/src/github.com/mvrahden/go-test/pkg/gotest/gotest.go
+++ b/internal/lint/testdata/src/github.com/mvrahden/go-test/pkg/gotest/gotest.go
@@ -32,6 +32,7 @@ type testingT interface {
 func Eventually(t testingT, waitFor, tick time.Duration, fn func(poll *R))   {}
 func Consistently(t testingT, waitFor, tick time.Duration, fn func(poll *R)) {}
 
+func Fail(t testingT, msgAndArgs ...any)                                      {}
 func True(t testingT, value bool, msgAndArgs ...any)                          {}
 func False(t testingT, value bool, msgAndArgs ...any)                         {}
 func Equal(t testingT, expected, actual any, msgAndArgs ...any)               {}

--- a/internal/lint/testdata/src/withcleanup/withcleanup_test.go
+++ b/internal/lint/testdata/src/withcleanup/withcleanup_test.go
@@ -103,3 +103,13 @@ type cleanupHelper struct{}
 func (h *cleanupHelper) doCleanup(t *testing.T) {
 	t.Cleanup(func() {}) // want `use AfterEach or AfterAll for cleanup — T.Cleanup bypasses suite lifecycle`
 }
+
+// The new suite-lifecycle ID suppresses directly, and the historical
+// t-escape ID keeps working as an umbrella alias.
+func (s *ResourceTestSuite) TestNolintNewID(t *gotest.T) {
+	t.T().Cleanup(func() {}) //nolint:suite-lifecycle
+}
+
+func (s *ResourceTestSuite) TestNolintAlias(t *gotest.T) {
+	t.T().Cleanup(func() {}) //nolint:t-escape
+}

--- a/internal/lint/testdata/src/withfailguard/withfailguard_test.go
+++ b/internal/lint/testdata/src/withfailguard/withfailguard_test.go
@@ -285,3 +285,12 @@ func TestChainWithWeakReturn(t *testing.T) {
 		return
 	}
 }
+
+// A guard whose body t-escape owns stands fail-guard down even inside a
+// package-level var function literal.
+var packageGuard = func(t *gotest.T) {
+	err := errors.New("boom")
+	if err != nil {
+		t.T().FailNow() // want `FailNow is available on gotest.T — unnecessary T escape`
+	}
+}

--- a/internal/lint/testdata/src/withfailguard/withfailguard_test.go
+++ b/internal/lint/testdata/src/withfailguard/withfailguard_test.go
@@ -1,0 +1,287 @@
+package withfailguard //nolint:stdlib-test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// === error nil guards ===
+
+func TestErrorGuards(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Fail for error nil check`
+		gotest.Fail(t, "unexpected error: %v", err)
+	}
+	if err == nil { // want `use Error instead of if\+Fail for error nil check`
+		gotest.Fail(t, "expected an error")
+	}
+}
+
+// === len guards ===
+
+func TestLenGuards(t *testing.T) {
+	items := []string{"a"}
+	if len(items) == 0 { // want `use NotEmpty instead of if\+Fail for len == 0 check`
+		gotest.Fail(t, "expected at least one item")
+	}
+	if len(items) > 0 { // want `use Empty instead of if\+Fail for len > 0 check`
+		gotest.Fail(t, "expected no items")
+	}
+	if len(items) != 3 { // want `use Len instead of if\+Fail for len comparison`
+		gotest.Fail(t, "expected three items")
+	}
+}
+
+// === comparison guards ===
+
+func TestComparisonGuards(t *testing.T) {
+	a, b := 1, 2
+	if a != b { // want `use Equal instead of if\+Fail for != comparison`
+		gotest.Fail(t, "a and b differ")
+	}
+	if a >= b { // want `use Less instead of if\+Fail for >= comparison`
+		gotest.Fail(t, "a should be below b")
+	}
+}
+
+// === nil guards on non-error types ===
+
+func TestNilGuards(t *testing.T) {
+	var p *int
+	if p == nil { // want `use NotZero instead of if\+Fail for nil check`
+		gotest.Fail(t, "expected a pointer")
+	}
+	var m map[string]int
+	if m != nil { // want `use Nil instead of if\+Fail for nil check`
+		gotest.Fail(t, "expected no map")
+	}
+}
+
+// === bool guards, including the False fallback ===
+
+func TestBoolGuards(t *testing.T) {
+	ok := false
+	if !ok { // want `use True instead of if\+Fail for negation`
+		gotest.Fail(t, "should be ok")
+	}
+	if ok { // want `use False instead of if\+Fail for failure guard`
+		gotest.Fail(t, "should not be ok")
+	}
+}
+
+// === predicate guards ===
+
+var errSentinel = errors.New("sentinel")
+
+func TestPredicateGuards(t *testing.T) {
+	s := "hello"
+	if strings.Contains(s, "bye") { // want `use NotContains instead of if\+Fail for strings.Contains call`
+		gotest.Fail(t, "unexpected substring")
+	}
+	err := errors.New("boom")
+	if !errors.Is(err, errSentinel) { // want `use ErrorIs instead of if\+Fail for errors.Is call`
+		gotest.Fail(t, "wrong error")
+	}
+	if s == "" { // want `use NotEmpty instead of if\+Fail for empty string check`
+		gotest.Fail(t, "expected content")
+	}
+}
+
+// === message args containing calls: report, but no autofix — the if body
+// evaluates them only on failure, an assertion would evaluate them always ===
+
+func TestMessageArgGate(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Fail for error nil check`
+		gotest.Fail(t, "unexpected error: %v", describe(err))
+	}
+}
+
+func describe(err error) string { return err.Error() }
+
+// === shapes that must not be flagged ===
+
+type failer struct{}
+
+func (failer) Fail(t *testing.T, msg string, args ...any) {}
+
+func TestNotFlagged(t *testing.T) {
+	err := errors.New("boom")
+	// body has more than the fail call
+	if err != nil {
+		t.Log("saw error")
+		gotest.Fail(t, "unexpected error")
+	}
+	// else branch present
+	if err != nil {
+		gotest.Fail(t, "unexpected error")
+	} else {
+		t.Log("no error")
+	}
+	// init statement scopes the value to the if
+	if err := errors.New("x"); err != nil { // want `use NoError instead of if\+Fail for error nil check`
+		gotest.Fail(t, "unexpected error")
+	}
+	// same-name method on another type
+	var f failer
+	if err != nil {
+		f.Fail(t, "unexpected error")
+	}
+}
+
+// === || guards decompose into sequential assertions — halting on the first
+// failure reproduces the short-circuit exactly ===
+
+func TestOrGuards(t *testing.T) {
+	err := errors.New("boom")
+	items := []string{"a"}
+	if err != nil || len(items) == 0 { // want `use NoError \+ NotEmpty instead of if\+Fail for or-chained failure guard`
+		gotest.Fail(t, "load failed: %v", err)
+	}
+}
+
+// === else-if Fail chains decompose with per-branch messages ===
+
+func TestElseIfChains(t *testing.T) {
+	err := errors.New("boom")
+	items := []string{"a"}
+	if err != nil { // want `use NoError \+ NotEmpty instead of if\+Fail for else-if failure guard`
+		gotest.Fail(t, "unexpected error: %v", err)
+	} else if len(items) == 0 {
+		gotest.Fail(t, "expected items")
+	}
+}
+
+// === && does not decompose (the negation is a disjunction) — only the
+// False fallback is sound ===
+
+func TestAndGuards(t *testing.T) {
+	err := errors.New("boom")
+	fatal := true
+	if err != nil && fatal { // want `use False instead of if\+Fail for failure guard`
+		gotest.Fail(t, "fatal error")
+	}
+}
+
+// === Fail followed by a bare return — unreachable after the halt ===
+
+func TestFailReturn(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Fail for error nil check`
+		gotest.Fail(t, "unexpected: %v", err)
+		return
+	}
+}
+
+// === halting testing.T bodies rewrite the same way ===
+
+func TestFatalGuards(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Fatal for error nil check`
+		t.Fatal(err)
+	}
+	items := []string{}
+	if len(items) == 0 { // want `use NotEmpty instead of if\+Fatalf for len == 0 check`
+		t.Fatalf("no items: %v", err)
+	}
+	ok := true
+	if !ok { // want `use True instead of if\+FailNow for negation`
+		t.FailNow()
+	}
+}
+
+// === non-halting bodies: Errorf continues where an assertion halts —
+// report only, never autofix ===
+
+func TestErrorfGuards(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Errorf for error nil check — assertions halt where Errorf continues`
+		t.Errorf("unexpected: %v", err)
+	}
+}
+
+// === message args that can panic under eager evaluation (index, selector,
+// deref) block the autofix — errs[0] is valid exactly when the guard fires ===
+
+func TestMessagePanicGate(t *testing.T) {
+	var errs []error
+	if len(errs) > 0 { // want `use Empty instead of if\+Fail for len > 0 check`
+		gotest.Fail(t, "first error: %v", errs[0])
+	}
+}
+
+// === Errorf+return still deserves the pointer, but without the false claim
+// that Errorf continues, and never a fix ===
+
+func TestErrorfReturnGuard(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Errorf for error nil check`
+		t.Errorf("unexpected error")
+		return
+	}
+}
+
+// === print-style Fatal args beyond one cannot ride printf-style msgAndArgs ===
+
+func TestFatalPrintArgs(t *testing.T) {
+	a, b := 1, 2
+	if a != b { // want `use Equal instead of if\+Fatal for != comparison`
+		t.Fatal("expected", a, "got", b)
+	}
+}
+
+// === a lone literal operand belongs in Equal's expected slot ===
+
+func TestLiteralFirst(t *testing.T) {
+	got := 7
+	if got != 3 { // want `use Equal instead of if\+Fail for != comparison`
+		gotest.Fail(t, "wrong count")
+	}
+	if got != -1 { // want `use Equal instead of if\+Fail for != comparison`
+		gotest.Fail(t, "negative")
+	}
+}
+
+// === comments inside the guard body would be destroyed by the rewrite ===
+
+func TestCommentedGuard(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Fail for error nil check`
+		// teardown failures here indicate a leaked fixture
+		gotest.Fail(t, "unexpected error")
+	}
+}
+
+// === guards on escaped t.T() receivers belong to the t-escape rule ===
+
+type EscapeGuardTestSuite struct{}
+
+func (s *EscapeGuardTestSuite) TestEscape(it *gotest.T) {
+	err := errors.New("boom")
+	if err != nil {
+		it.T().Fatalf("unexpected: %v", err) // want `use assertions instead — T.Fatalf bypasses the assertion tracer`
+	}
+}
+
+func (s *EscapeGuardTestSuite) TestEscapeError(it *gotest.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Error for error nil check — assertions halt where Error continues`
+		it.T().Error("boom")
+	}
+}
+
+// === a weak+return branch makes the chain report-only, never invisible ===
+
+func TestChainWithWeakReturn(t *testing.T) {
+	a, b := 1, 2
+	err := errors.New("boom")
+	if a != b { // want `use Equal \+ NoError instead of if\+Fatal for else-if failure guard`
+		t.Fatal("mismatch")
+	} else if err != nil {
+		t.Errorf("boom: %v", err)
+		return
+	}
+}

--- a/internal/lint/testdata/src/withfailguard/withfailguard_test.go.golden
+++ b/internal/lint/testdata/src/withfailguard/withfailguard_test.go.golden
@@ -1,0 +1,239 @@
+package withfailguard //nolint:stdlib-test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// === error nil guards ===
+
+func TestErrorGuards(t *testing.T) {
+	err := errors.New("boom")
+	gotest.NoError(t, err, "unexpected error: %v", err) // want `use NoError instead of if\+Fail for error nil check`
+	gotest.Error(t, err, "expected an error")           // want `use Error instead of if\+Fail for error nil check`
+}
+
+// === len guards ===
+
+func TestLenGuards(t *testing.T) {
+	items := []string{"a"}
+	gotest.NotEmpty(t, items, "expected at least one item") // want `use NotEmpty instead of if\+Fail for len == 0 check`
+	gotest.Empty(t, items, "expected no items")             // want `use Empty instead of if\+Fail for len > 0 check`
+	gotest.Len(t, items, 3, "expected three items")         // want `use Len instead of if\+Fail for len comparison`
+}
+
+// === comparison guards ===
+
+func TestComparisonGuards(t *testing.T) {
+	a, b := 1, 2
+	gotest.Equal(t, a, b, "a and b differ")     // want `use Equal instead of if\+Fail for != comparison`
+	gotest.Less(t, a, b, "a should be below b") // want `use Less instead of if\+Fail for >= comparison`
+}
+
+// === nil guards on non-error types ===
+
+func TestNilGuards(t *testing.T) {
+	var p *int
+	gotest.NotZero(t, p, "expected a pointer") // want `use NotZero instead of if\+Fail for nil check`
+	var m map[string]int
+	gotest.Nil(t, m, "expected no map") // want `use Nil instead of if\+Fail for nil check`
+}
+
+// === bool guards, including the False fallback ===
+
+func TestBoolGuards(t *testing.T) {
+	ok := false
+	gotest.True(t, ok, "should be ok")      // want `use True instead of if\+Fail for negation`
+	gotest.False(t, ok, "should not be ok") // want `use False instead of if\+Fail for failure guard`
+}
+
+// === predicate guards ===
+
+var errSentinel = errors.New("sentinel")
+
+func TestPredicateGuards(t *testing.T) {
+	s := "hello"
+	gotest.NotContains(t, s, "bye", "unexpected substring") // want `use NotContains instead of if\+Fail for strings.Contains call`
+	err := errors.New("boom")
+	gotest.ErrorIs(t, err, errSentinel, "wrong error") // want `use ErrorIs instead of if\+Fail for errors.Is call`
+	gotest.NotEmpty(t, s, "expected content")          // want `use NotEmpty instead of if\+Fail for empty string check`
+}
+
+// === message args containing calls: report, but no autofix — the if body
+// evaluates them only on failure, an assertion would evaluate them always ===
+
+func TestMessageArgGate(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Fail for error nil check`
+		gotest.Fail(t, "unexpected error: %v", describe(err))
+	}
+}
+
+func describe(err error) string { return err.Error() }
+
+// === shapes that must not be flagged ===
+
+type failer struct{}
+
+func (failer) Fail(t *testing.T, msg string, args ...any) {}
+
+func TestNotFlagged(t *testing.T) {
+	err := errors.New("boom")
+	// body has more than the fail call
+	if err != nil {
+		t.Log("saw error")
+		gotest.Fail(t, "unexpected error")
+	}
+	// else branch present
+	if err != nil {
+		gotest.Fail(t, "unexpected error")
+	} else {
+		t.Log("no error")
+	}
+	// init statement scopes the value to the if
+	if err := errors.New("x"); err != nil { // want `use NoError instead of if\+Fail for error nil check`
+		gotest.Fail(t, "unexpected error")
+	}
+	// same-name method on another type
+	var f failer
+	if err != nil {
+		f.Fail(t, "unexpected error")
+	}
+}
+
+// === || guards decompose into sequential assertions — halting on the first
+// failure reproduces the short-circuit exactly ===
+
+func TestOrGuards(t *testing.T) {
+	err := errors.New("boom")
+	items := []string{"a"}
+	gotest.NoError(t, err, "load failed: %v", err) // want `use NoError \+ NotEmpty instead of if\+Fail for or-chained failure guard`
+	gotest.NotEmpty(t, items, "load failed: %v", err)
+}
+
+// === else-if Fail chains decompose with per-branch messages ===
+
+func TestElseIfChains(t *testing.T) {
+	err := errors.New("boom")
+	items := []string{"a"}
+	gotest.NoError(t, err, "unexpected error: %v", err) // want `use NoError \+ NotEmpty instead of if\+Fail for else-if failure guard`
+	gotest.NotEmpty(t, items, "expected items")
+}
+
+// === && does not decompose (the negation is a disjunction) — only the
+// False fallback is sound ===
+
+func TestAndGuards(t *testing.T) {
+	err := errors.New("boom")
+	fatal := true
+	gotest.False(t, err != nil && fatal, "fatal error") // want `use False instead of if\+Fail for failure guard`
+}
+
+// === Fail followed by a bare return — unreachable after the halt ===
+
+func TestFailReturn(t *testing.T) {
+	err := errors.New("boom")
+	gotest.NoError(t, err, "unexpected: %v", err) // want `use NoError instead of if\+Fail for error nil check`
+}
+
+// === halting testing.T bodies rewrite the same way ===
+
+func TestFatalGuards(t *testing.T) {
+	err := errors.New("boom")
+	gotest.NoError(t, err, err) // want `use NoError instead of if\+Fatal for error nil check`
+	items := []string{}
+	gotest.NotEmpty(t, items, "no items: %v", err) // want `use NotEmpty instead of if\+Fatalf for len == 0 check`
+	ok := true
+	gotest.True(t, ok) // want `use True instead of if\+FailNow for negation`
+}
+
+// === non-halting bodies: Errorf continues where an assertion halts —
+// report only, never autofix ===
+
+func TestErrorfGuards(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Errorf for error nil check — assertions halt where Errorf continues`
+		t.Errorf("unexpected: %v", err)
+	}
+}
+
+// === message args that can panic under eager evaluation (index, selector,
+// deref) block the autofix — errs[0] is valid exactly when the guard fires ===
+
+func TestMessagePanicGate(t *testing.T) {
+	var errs []error
+	if len(errs) > 0 { // want `use Empty instead of if\+Fail for len > 0 check`
+		gotest.Fail(t, "first error: %v", errs[0])
+	}
+}
+
+// === Errorf+return still deserves the pointer, but without the false claim
+// that Errorf continues, and never a fix ===
+
+func TestErrorfReturnGuard(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Errorf for error nil check`
+		t.Errorf("unexpected error")
+		return
+	}
+}
+
+// === print-style Fatal args beyond one cannot ride printf-style msgAndArgs ===
+
+func TestFatalPrintArgs(t *testing.T) {
+	a, b := 1, 2
+	if a != b { // want `use Equal instead of if\+Fatal for != comparison`
+		t.Fatal("expected", a, "got", b)
+	}
+}
+
+// === a lone literal operand belongs in Equal's expected slot ===
+
+func TestLiteralFirst(t *testing.T) {
+	got := 7
+	gotest.Equal(t, 3, got, "wrong count") // want `use Equal instead of if\+Fail for != comparison`
+	gotest.Equal(t, -1, got, "negative")   // want `use Equal instead of if\+Fail for != comparison`
+}
+
+// === comments inside the guard body would be destroyed by the rewrite ===
+
+func TestCommentedGuard(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Fail for error nil check`
+		// teardown failures here indicate a leaked fixture
+		gotest.Fail(t, "unexpected error")
+	}
+}
+
+// === guards on escaped t.T() receivers belong to the t-escape rule ===
+
+type EscapeGuardTestSuite struct{}
+
+func (s *EscapeGuardTestSuite) TestEscape(it *gotest.T) {
+	err := errors.New("boom")
+	if err != nil {
+		it.T().Fatalf("unexpected: %v", err) // want `use assertions instead — T.Fatalf bypasses the assertion tracer`
+	}
+}
+
+func (s *EscapeGuardTestSuite) TestEscapeError(it *gotest.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Error for error nil check — assertions halt where Error continues`
+		it.T().Error("boom")
+	}
+}
+
+// === a weak+return branch makes the chain report-only, never invisible ===
+
+func TestChainWithWeakReturn(t *testing.T) {
+	a, b := 1, 2
+	err := errors.New("boom")
+	if a != b { // want `use Equal \+ NoError instead of if\+Fatal for else-if failure guard`
+		t.Fatal("mismatch")
+	} else if err != nil {
+		t.Errorf("boom: %v", err)
+		return
+	}
+}

--- a/internal/lint/testdata/src/withfailguard/withfailguard_test.go.golden
+++ b/internal/lint/testdata/src/withfailguard/withfailguard_test.go.golden
@@ -237,3 +237,12 @@ func TestChainWithWeakReturn(t *testing.T) {
 		return
 	}
 }
+
+// A guard whose body t-escape owns stands fail-guard down even inside a
+// package-level var function literal.
+var packageGuard = func(t *gotest.T) {
+	err := errors.New("boom")
+	if err != nil {
+		t.FailNow() // want `FailNow is available on gotest.T — unnecessary T escape`
+	}
+}

--- a/internal/lint/testdata/src/withfailguard_noimport/withfailguard_noimport_test.go
+++ b/internal/lint/testdata/src/withfailguard_noimport/withfailguard_noimport_test.go
@@ -1,0 +1,15 @@
+package withfailguard_noimport //nolint:stdlib-test
+
+import (
+	"errors"
+	"testing"
+)
+
+// Without a gotest import the file has not adopted the framework — halting
+// guards here are idiomatic stdlib Go and none of fail-guard's business.
+func TestNoImport(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/lint/testdata/src/withfailguard_noimport/withfailguard_noimport_test.go.golden
+++ b/internal/lint/testdata/src/withfailguard_noimport/withfailguard_noimport_test.go.golden
@@ -1,0 +1,15 @@
+package withfailguard_noimport //nolint:stdlib-test
+
+import (
+	"errors"
+	"testing"
+)
+
+// Without a gotest import the file has not adopted the framework — halting
+// guards here are idiomatic stdlib Go and none of fail-guard's business.
+func TestNoImport(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/lint/testdata/src/withforeign/withforeign_test.go
+++ b/internal/lint/testdata/src/withforeign/withforeign_test.go
@@ -1,0 +1,24 @@
+package withforeign //nolint:stdlib-test
+
+import (
+	"testing"
+	"time"
+)
+
+type R struct{}
+
+func (r *R) Errorf(string, ...any) {}
+
+func True(t *testing.T, v bool, msgAndArgs ...any)                           {}
+func Equal(t *testing.T, a, b any, msgAndArgs ...any)                        {}
+func Eventually(t *testing.T, waitFor, tick time.Duration, fn func(poll *R)) {}
+
+// Lookalike names from a foreign package — no gotest rule may fire on them.
+func TestForeignNames(t *testing.T) {
+	a, b := 1, 2
+	True(t, a == b)
+	Equal(t, a, b)
+	Eventually(t, time.Second, time.Millisecond, func(poll *R) {
+		True(t, a == b)
+	})
+}

--- a/internal/lint/testdata/src/withnolint/withnolint_test.go
+++ b/internal/lint/testdata/src/withnolint/withnolint_test.go
@@ -3,6 +3,7 @@ package withnolint
 import (
 	"testing"
 
+	"github.com/mvrahden/go-test/pkg/gotest"
 	_ "github.com/stretchr/testify/assert"  //nolint:testify
 	_ "github.com/stretchr/testify/require" // want `testify import github.com/stretchr/testify/require — consider migrating to gotest`
 )
@@ -38,3 +39,11 @@ func TestUnsuppressed(t *testing.T) {} // want `stdlib test TestUnsuppressed —
 
 // suppressed: nolint with reason
 func TestWithReason(t *testing.T) {} //nolint:stdlib-test // legacy test
+
+// suppressed: fail-guard inline
+func TestFailGuardNolint(t *testing.T) { //nolint:stdlib-test
+	var err error
+	if err != nil { //nolint:fail-guard
+		gotest.Fail(t, "boom")
+	}
+}

--- a/internal/lint/testdata/src/withpollscope/withpollscope_test.go
+++ b/internal/lint/testdata/src/withpollscope/withpollscope_test.go
@@ -84,3 +84,58 @@ func TestRedundantInsideCallback(t *testing.T) {
 }
 
 var errSentinelPS = errors.New("sentinel")
+
+// Foreign assertion libraries still escape the poll scope — integrity
+// coverage is deliberately package-agnostic for assertion-shaped names.
+func NoError(t *testing.T, err error, msgAndArgs ...any) {}
+
+func TestForeignAssertionInsideCallback(t *testing.T) {
+	var err error
+	gotest.Eventually(t, time.Second, time.Millisecond, func(poll *gotest.R) {
+		NoError(t, err) // want `use poll instead of t in poll callback passed to Eventually`
+	})
+}
+
+// Receiver methods are matched by type, not name — loggers stay silent.
+type retryLogger struct{}
+
+func (l *retryLogger) Errorf(string, ...any) {}
+
+func TestLoggerInsideCallback(t *testing.T) {
+	log := &retryLogger{}
+	gotest.Eventually(t, time.Second, time.Millisecond, func(poll *gotest.R) {
+		log.Errorf("retrying")
+	})
+}
+
+// Wrapped or re-exported polling functions are recognized by the typed
+// *gotest.R callback parameter, not by the callee's name or package.
+var eventually = gotest.Eventually
+
+func TestWrappedEventually(t *testing.T) {
+	eventually(t, time.Second, time.Millisecond, func(poll *gotest.R) {
+		t.Errorf("boom") // want `t\.Errorf in poll callback bypasses assertion recording — use poll`
+	})
+}
+
+// Other functions taking func(*gotest.R) callbacks (Record-style harnesses)
+// are not polling contexts — only Eventually/Consistently shapes are.
+func record(fn func(r *gotest.R)) {}
+
+func TestRecordStyleCallback(t *testing.T) {
+	record(func(r *gotest.R) {
+		gotest.Eventually(r, time.Second, time.Millisecond, func(poll *gotest.R) {
+			gotest.True(poll, true)
+		})
+	})
+}
+
+// A nested poll callback owns its subtree — the outer scope must not
+// claim the inner poll's assertions.
+func TestNestedEventually(t *testing.T) {
+	gotest.Eventually(t, time.Second, time.Millisecond, func(outer *gotest.R) {
+		gotest.Consistently(outer, time.Millisecond, time.Millisecond, func(inner *gotest.R) {
+			gotest.True(inner, true)
+		})
+	})
+}

--- a/internal/lint/testdata/src/withpollscope/withpollscope_test.go
+++ b/internal/lint/testdata/src/withpollscope/withpollscope_test.go
@@ -1,6 +1,7 @@
 package withpollscope //nolint:stdlib-test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -54,3 +55,32 @@ func TestCustomPollParamName(t *testing.T) {
 func TestOutsidePollCallback(t *testing.T) {
 	gotest.Equal(t, 1, 2) // ok — not inside a poll callback
 }
+
+// A guard inside a poll callback is poll-scope's finding alone — the
+// expressiveness rule must stand down on the owned construct.
+func TestGuardInsideCallback(t *testing.T) {
+	var err error
+	gotest.Eventually(t, time.Second, time.Millisecond, func(poll *gotest.R) {
+		if err != nil {
+			t.Errorf("boom: %v", err) // want `t\.Errorf in poll callback bypasses assertion recording — use poll`
+		}
+	})
+}
+
+// Constructs owned by poll-scope get no expressiveness findings on top.
+func TestSimplifiableInsideCallback(t *testing.T) {
+	a, b := 1, 2
+	gotest.Eventually(t, time.Second, time.Millisecond, func(poll *gotest.R) {
+		gotest.True(t, a == b) // want `use poll instead of t in poll callback passed to Eventually`
+	})
+}
+
+func TestRedundantInsideCallback(t *testing.T) {
+	var err error
+	gotest.Eventually(t, time.Second, time.Millisecond, func(poll *gotest.R) {
+		gotest.Error(t, err)                  // want `use poll instead of t in poll callback passed to Eventually`
+		gotest.ErrorIs(t, err, errSentinelPS) // want `use poll instead of t in poll callback passed to Eventually`
+	})
+}
+
+var errSentinelPS = errors.New("sentinel")

--- a/internal/lint/testdata/src/withsimplify/withsimplify_test.go
+++ b/internal/lint/testdata/src/withsimplify/withsimplify_test.go
@@ -99,7 +99,7 @@ func TestTrueNegation(t *testing.T) {
 	gotest.True(t, !b) // want `use False instead of True for negation`
 
 	s := "hello"
-	gotest.True(t, !strings.Contains(s, "z")) // want `use NotContains instead of True for negated strings.Contains call`
+	gotest.True(t, !strings.Contains(s, "z")) // want `use NotContains instead of True for strings.Contains call`
 }
 
 // === False with binary comparisons ===
@@ -183,7 +183,7 @@ func TestFalseNegation(t *testing.T) {
 	gotest.False(t, !b) // want `use True instead of False for negation`
 
 	s := "hello"
-	gotest.False(t, !strings.Contains(s, "h")) // want `use Contains instead of False for negated strings.Contains call`
+	gotest.False(t, !strings.Contains(s, "h")) // want `use Contains instead of False for strings.Contains call`
 }
 
 // === Equal with special values ===
@@ -431,4 +431,46 @@ func TestErrorContainsTypeGuard(t *testing.T) {
 func TestWithMsgArgs(t *testing.T) {
 	a, b := 1, 2
 	gotest.True(t, a == b, "values should match") // want `use Equal instead of True for == comparison`
+}
+
+// === Negation recurses with flipped polarity ===
+
+func TestNegationRecursion(t *testing.T) {
+	var err error
+	gotest.True(t, !(err != nil)) // want `use NoError instead of True for error nil check`
+	items := []int{1}
+	gotest.False(t, !(len(items) == 0)) // want `use Empty instead of False for len == 0 check`
+}
+
+// === len != n in negated context ===
+
+func TestLenNeq(t *testing.T) {
+	items := []int{1, 2}
+	gotest.False(t, len(items) != 2) // want `use Len instead of False for len comparison`
+}
+
+// === Empty-string comparisons ===
+
+func TestEmptyString(t *testing.T) {
+	s := "x"
+	gotest.True(t, s == "")   // want `use Empty instead of True for empty string check`
+	gotest.True(t, s != "")   // want `use NotEmpty instead of True for empty string check`
+	gotest.False(t, s == "")  // want `use NotEmpty instead of False for empty string check`
+	gotest.Equal(t, s, "")    // want `use Empty instead of Equal for empty string comparison`
+	gotest.NotEqual(t, "", s) // want `use NotEmpty instead of NotEqual for empty string comparison`
+}
+
+// === literal operands move to the expected slot ===
+
+func TestLiteralFirstSimplify(t *testing.T) {
+	x := 7
+	gotest.True(t, x == 5) // want `use Equal instead of True for == comparison`
+}
+
+// === named constants also belong in the expected slot ===
+
+func TestConstFirstSimplify(t *testing.T) {
+	const limit = 9
+	x := 7
+	gotest.True(t, x == limit) // want `use Equal instead of True for == comparison`
 }

--- a/internal/lint/testdata/src/withsimplify/withsimplify_test.go.golden
+++ b/internal/lint/testdata/src/withsimplify/withsimplify_test.go.golden
@@ -97,7 +97,7 @@ func TestTrueNegation(t *testing.T) {
 	gotest.False(t, b) // want `use False instead of True for negation`
 
 	s := "hello"
-	gotest.NotContains(t, s, "z") // want `use NotContains instead of True for negated strings.Contains call`
+	gotest.NotContains(t, s, "z") // want `use NotContains instead of True for strings.Contains call`
 }
 
 // === False with binary comparisons ===
@@ -181,7 +181,7 @@ func TestFalseNegation(t *testing.T) {
 	gotest.True(t, b) // want `use True instead of False for negation`
 
 	s := "hello"
-	gotest.Contains(t, s, "h") // want `use Contains instead of False for negated strings.Contains call`
+	gotest.Contains(t, s, "h") // want `use Contains instead of False for strings.Contains call`
 }
 
 // === Equal with special values ===
@@ -429,4 +429,46 @@ func TestErrorContainsTypeGuard(t *testing.T) {
 func TestWithMsgArgs(t *testing.T) {
 	a, b := 1, 2
 	gotest.Equal(t, a, b, "values should match") // want `use Equal instead of True for == comparison`
+}
+
+// === Negation recurses with flipped polarity ===
+
+func TestNegationRecursion(t *testing.T) {
+	var err error
+	gotest.NoError(t, err) // want `use NoError instead of True for error nil check`
+	items := []int{1}
+	gotest.Empty(t, items) // want `use Empty instead of False for len == 0 check`
+}
+
+// === len != n in negated context ===
+
+func TestLenNeq(t *testing.T) {
+	items := []int{1, 2}
+	gotest.Len(t, items, 2) // want `use Len instead of False for len comparison`
+}
+
+// === Empty-string comparisons ===
+
+func TestEmptyString(t *testing.T) {
+	s := "x"
+	gotest.Empty(t, s)    // want `use Empty instead of True for empty string check`
+	gotest.NotEmpty(t, s) // want `use NotEmpty instead of True for empty string check`
+	gotest.NotEmpty(t, s) // want `use NotEmpty instead of False for empty string check`
+	gotest.Empty(t, s)    // want `use Empty instead of Equal for empty string comparison`
+	gotest.NotEmpty(t, s) // want `use NotEmpty instead of NotEqual for empty string comparison`
+}
+
+// === literal operands move to the expected slot ===
+
+func TestLiteralFirstSimplify(t *testing.T) {
+	x := 7
+	gotest.Equal(t, 5, x) // want `use Equal instead of True for == comparison`
+}
+
+// === named constants also belong in the expected slot ===
+
+func TestConstFirstSimplify(t *testing.T) {
+	const limit = 9
+	x := 7
+	gotest.Equal(t, limit, x) // want `use Equal instead of True for == comparison`
 }

--- a/internal/lint/testdata/src/withskippedstyle/withskippedstyle_test.go
+++ b/internal/lint/testdata/src/withskippedstyle/withskippedstyle_test.go
@@ -1,0 +1,16 @@
+package withskippedstyle //nolint:stdlib-test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// With skip-fail-guard set, this expressiveness finding must stay silent.
+func TestSkipped(t *testing.T) {
+	err := errors.New("boom")
+	if err != nil {
+		gotest.Fail(t, "unexpected error")
+	}
+}

--- a/internal/lint/testdata/src/withskippedtescape/withskippedtescape_test.go
+++ b/internal/lint/testdata/src/withskippedtescape/withskippedtescape_test.go
@@ -1,0 +1,18 @@
+package withskippedtescape //nolint:stdlib-test
+
+import (
+	"errors"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type SkippedEscapeTestSuite struct{}
+
+// With t-escape skipped project-wide its claims must not stand fail-guard
+// down — the active rule takes the construct.
+func (s *SkippedEscapeTestSuite) TestGuard(it *gotest.T) {
+	err := errors.New("boom")
+	if err != nil { // want `use NoError instead of if\+Fatal for error nil check`
+		it.T().Fatal(err)
+	}
+}

--- a/internal/lint/testdata/src/withtescape/withtescape_test.go
+++ b/internal/lint/testdata/src/withtescape/withtescape_test.go
@@ -135,3 +135,8 @@ type escapeHelper struct{}
 func (h *escapeHelper) doErrorf(t *testing.T) {
 	t.Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
 }
+
+// Package-level var function literals are part of the traversal too.
+var packageLevelCheck = func(t *gotest.T) {
+	t.T().Errorf("boom") // want `Errorf is available on gotest.T — unnecessary T escape`
+}

--- a/internal/lint/testdata/src/withtescape/withtescape_test.go.golden
+++ b/internal/lint/testdata/src/withtescape/withtescape_test.go.golden
@@ -135,3 +135,8 @@ type escapeHelper struct{}
 func (h *escapeHelper) doErrorf(t *testing.T) {
 	t.Errorf("msg") // want `Errorf is available on gotest.T — unnecessary T escape`
 }
+
+// Package-level var function literals are part of the traversal too.
+var packageLevelCheck = func(t *gotest.T) {
+	t.Errorf("boom") // want `Errorf is available on gotest.T — unnecessary T escape`
+}

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -25,9 +25,7 @@ func TestDeriveNewName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			got := DeriveNewName(tt.input)
-			if got != tt.expected {
-				t.Errorf("DeriveNewName(%q) = %q, want %q", tt.input, got, tt.expected)
-			}
+			gotest.Equal(t, tt.expected, got)
 		})
 	}
 }
@@ -36,70 +34,43 @@ func TestAnalyzeFile(t *testing.T) {
 	fset := token.NewFileSet()
 	inputPath := filepath.Join("testdata", "basic", "input_test.go")
 	f, err := parser.ParseFile(fset, inputPath, nil, parser.ParseComments)
-	if err != nil {
-		t.Fatalf("failed to parse input: %v", err)
-	}
+	gotest.NoError(t, err, "failed to parse input: %v", err)
 
 	plan := AnalyzeFile(f)
 
-	if len(plan.Suites) != 1 {
-		t.Fatalf("expected 1 suite, got %d", len(plan.Suites))
-	}
+	gotest.Len(t, plan.Suites, 1)
 
 	s := plan.Suites[0]
-	if s.OldName != "UserSuite" {
-		t.Errorf("OldName = %q, want %q", s.OldName, "UserSuite")
-	}
-	if s.NewName != "UserTestSuite" {
-		t.Errorf("NewName = %q, want %q", s.NewName, "UserTestSuite")
-	}
-	if s.SetupSuite != "SetupSuite" {
-		t.Errorf("SetupSuite = %q, want %q", s.SetupSuite, "SetupSuite")
-	}
-	if s.TearDownSuite != "TearDownSuite" {
-		t.Errorf("TearDownSuite = %q, want %q", s.TearDownSuite, "TearDownSuite")
-	}
-	if s.SetupTest != "SetupTest" {
-		t.Errorf("SetupTest = %q, want %q", s.SetupTest, "SetupTest")
-	}
-	if s.TearDownTest != "TearDownTest" {
-		t.Errorf("TearDownTest = %q, want %q", s.TearDownTest, "TearDownTest")
-	}
-	if len(s.TestMethods) != 2 {
-		t.Errorf("expected 2 test methods, got %d: %v", len(s.TestMethods), s.TestMethods)
-	}
-	if s.RunnerFunc != "TestUserSuite" {
-		t.Errorf("RunnerFunc = %q, want %q", s.RunnerFunc, "TestUserSuite")
-	}
+	gotest.Equal(t, "UserSuite", s.OldName)
+	gotest.Equal(t, "UserTestSuite", s.NewName)
+	gotest.Equal(t, "SetupSuite", s.SetupSuite)
+	gotest.Equal(t, "TearDownSuite", s.TearDownSuite)
+	gotest.Equal(t, "SetupTest", s.SetupTest)
+	gotest.Equal(t, "TearDownTest", s.TearDownTest)
+	gotest.Len(t, s.TestMethods, 2)
+	gotest.Equal(t, "TestUserSuite", s.RunnerFunc)
 }
 
 func TestTransformFile(t *testing.T) {
 	fset := token.NewFileSet()
 	inputPath := filepath.Join("testdata", "basic", "input_test.go")
 	f, err := parser.ParseFile(fset, inputPath, nil, parser.ParseComments)
-	if err != nil {
-		t.Fatalf("failed to parse input: %v", err)
-	}
+	gotest.NoError(t, err, "failed to parse input: %v", err)
 
 	plan := AnalyzeFile(f)
-	if len(plan.Suites) == 0 {
-		t.Fatal("no suites detected")
-	}
+	gotest.NotEmpty(t, plan.Suites, "no suites detected")
 
 	TransformFile(fset, f, plan)
 
 	// Format the result
 	var buf strings.Builder
-	if err := format.Node(&buf, fset, f); err != nil {
-		t.Fatalf("failed to format transformed AST: %v", err)
-	}
+	err = format.Node(&buf, fset, f)
+	gotest.NoError(t, err, "failed to format transformed AST")
 	got := buf.String()
 
 	// Re-format for consistent whitespace
 	gotBytes, err := format.Source([]byte(got))
-	if err != nil {
-		t.Fatalf("failed to gofmt result: %v\n\nraw output:\n%s", err, got)
-	}
+	gotest.NoError(t, err, "failed to gofmt result: %v\n\nraw output:\n%s", err, got)
 
 	gotest.MatchSnapshot(t, string(gotBytes))
 }

--- a/internal/scaffold/scaffold_test.go
+++ b/internal/scaffold/scaffold_test.go
@@ -3,7 +3,6 @@ package scaffold //nolint:stdlib-test
 import (
 	"go/parser"
 	"go/token"
-	"strings"
 	"testing"
 
 	"github.com/mvrahden/go-test/pkg/gotest"
@@ -56,20 +55,12 @@ func TestParseTarget(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pkg, typeName, err := ParseTarget(tc.input)
 			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
+				gotest.Error(t, err, "expected error, got nil")
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if pkg != tc.wantPkg {
-				t.Errorf("pkg: want %q, got %q", tc.wantPkg, pkg)
-			}
-			if typeName != tc.wantType {
-				t.Errorf("typeName: want %q, got %q", tc.wantType, typeName)
-			}
+			gotest.NoError(t, err, "unexpected error: %v", err)
+			gotest.Equal(t, tc.wantPkg, pkg)
+			gotest.Equal(t, tc.wantType, typeName)
 		})
 	}
 }
@@ -77,82 +68,46 @@ func TestParseTarget(t *testing.T) {
 func TestIntrospectType_Struct(t *testing.T) {
 	// Use the testdata sampletype package
 	info, err := IntrospectType("./testdata/sampletype", "UserService")
-	if err != nil {
-		t.Fatalf("IntrospectType failed: %v", err)
-	}
+	gotest.NoError(t, err, "IntrospectType failed: %v", err)
 
-	if info.Name != "UserService" {
-		t.Errorf("Name: want %q, got %q", "UserService", info.Name)
-	}
-	if info.PkgName != "sampletype" {
-		t.Errorf("PkgName: want %q, got %q", "sampletype", info.PkgName)
-	}
-	if info.IsInterface {
-		t.Error("expected IsInterface=false for struct")
-	}
-	if info.PkgDir == "" {
-		t.Error("PkgDir should not be empty")
-	}
+	gotest.Equal(t, "UserService", info.Name)
+	gotest.Equal(t, "sampletype", info.PkgName)
+	gotest.False(t, info.IsInterface)
+	gotest.NotEmpty(t, info.PkgDir)
 
 	// Should have exactly 3 exported methods: Create, Delete, GetByID (sorted)
-	if len(info.Methods) != 3 {
-		t.Fatalf("expected 3 methods, got %d: %+v", len(info.Methods), info.Methods)
-	}
+	gotest.Len(t, info.Methods, 3)
 
 	wantNames := []string{"Create", "Delete", "GetByID"}
 	for i, want := range wantNames {
-		if info.Methods[i].Name != want {
-			t.Errorf("method[%d]: want %q, got %q", i, want, info.Methods[i].Name)
-		}
+		gotest.Equal(t, want, info.Methods[i].Name)
 	}
 
 	// Create returns error
-	if !info.Methods[0].ReturnsError {
-		t.Error("Create should return error")
-	}
+	gotest.True(t, info.Methods[0].ReturnsError, "Create should return error")
 	// Delete returns error
-	if !info.Methods[1].ReturnsError {
-		t.Error("Delete should return error")
-	}
+	gotest.True(t, info.Methods[1].ReturnsError, "Delete should return error")
 	// GetByID returns error
-	if !info.Methods[2].ReturnsError {
-		t.Error("GetByID should return error")
-	}
+	gotest.True(t, info.Methods[2].ReturnsError, "GetByID should return error")
 }
 
 func TestIntrospectType_Interface(t *testing.T) {
 	info, err := IntrospectType("./testdata/sampletype", "Validator")
-	if err != nil {
-		t.Fatalf("IntrospectType failed: %v", err)
-	}
+	gotest.NoError(t, err, "IntrospectType failed: %v", err)
 
-	if info.Name != "Validator" {
-		t.Errorf("Name: want %q, got %q", "Validator", info.Name)
-	}
-	if !info.IsInterface {
-		t.Error("expected IsInterface=true for interface")
-	}
+	gotest.Equal(t, "Validator", info.Name)
+	gotest.True(t, info.IsInterface)
 
-	if len(info.Methods) != 2 {
-		t.Fatalf("expected 2 methods, got %d: %+v", len(info.Methods), info.Methods)
-	}
+	gotest.Len(t, info.Methods, 2)
 
 	// Sorted: IsValid, Validate
-	if info.Methods[0].Name != "IsValid" {
-		t.Errorf("method[0]: want %q, got %q", "IsValid", info.Methods[0].Name)
-	}
-	if info.Methods[1].Name != "Validate" {
-		t.Errorf("method[1]: want %q, got %q", "Validate", info.Methods[1].Name)
-	}
+	gotest.Equal(t, "IsValid", info.Methods[0].Name)
+	gotest.Equal(t, "Validate", info.Methods[1].Name)
 
 	// IsValid does NOT return error
-	if info.Methods[0].ReturnsError {
-		t.Error("IsValid should not return error")
-	}
+	gotest.False(t, info.Methods[0].ReturnsError, "IsValid should not return error")
 	// Validate returns error
-	if !info.Methods[1].ReturnsError {
-		t.Error("Validate should return error")
-	}
+	gotest.True(t, info.Methods[1].ReturnsError, "Validate should return error")
 }
 
 func TestGenerateScaffold_Struct(t *testing.T) {
@@ -167,54 +122,32 @@ func TestGenerateScaffold_Struct(t *testing.T) {
 	}
 
 	out, err := GenerateScaffold(info)
-	if err != nil {
-		t.Fatalf("GenerateScaffold failed: %v", err)
-	}
+	gotest.NoError(t, err, "GenerateScaffold failed: %v", err)
 
 	src := string(out)
 
 	// Check package declaration
-	if !strings.Contains(src, "package user") {
-		t.Error("missing package declaration")
-	}
+	gotest.Contains(t, src, "package user")
 
 	// Check import
-	if !strings.Contains(src, `"github.com/mvrahden/go-test/pkg/gotest"`) {
-		t.Error("missing gotest import")
-	}
+	gotest.Contains(t, src, `"github.com/mvrahden/go-test/pkg/gotest"`)
 
 	// Check suite struct
-	if !strings.Contains(src, "type UserServiceTestSuite struct") {
-		t.Error("missing test suite struct")
-	}
-	if !strings.Contains(src, "sut *UserService") {
-		t.Error("missing sut field")
-	}
+	gotest.Contains(t, src, "type UserServiceTestSuite struct")
+	gotest.Contains(t, src, "sut *UserService")
 
 	// Check BeforeEach
-	if !strings.Contains(src, "func (s *UserServiceTestSuite) BeforeEach(t *gotest.T)") {
-		t.Error("missing BeforeEach method")
-	}
+	gotest.Contains(t, src, "func (s *UserServiceTestSuite) BeforeEach(t *gotest.T)")
 
 	// Check test methods for error-returning methods
-	if !strings.Contains(src, "func (s *UserServiceTestSuite) TestCreate(t *gotest.T)") {
-		t.Error("missing TestCreate method")
-	}
-	if !strings.Contains(src, `t.It("succeeds"`) {
-		t.Error("missing 'succeeds' It block for error-returning method")
-	}
-	if !strings.Contains(src, `t.It("returns error"`) {
-		t.Error("missing 'returns error' It block for error-returning method")
-	}
+	gotest.Contains(t, src, "func (s *UserServiceTestSuite) TestCreate(t *gotest.T)")
+	gotest.Contains(t, src, `t.It("succeeds"`)
+	gotest.Contains(t, src, `t.It("returns error"`)
 
 	// Check test method for non-error method
-	if !strings.Contains(src, "func (s *UserServiceTestSuite) TestList(t *gotest.T)") {
-		t.Error("missing TestList method")
-	}
+	gotest.Contains(t, src, "func (s *UserServiceTestSuite) TestList(t *gotest.T)")
 	// TestList should have "works" It block
-	if !strings.Contains(src, `t.It("works"`) {
-		t.Error("missing 'works' It block for non-error method")
-	}
+	gotest.Contains(t, src, `t.It("works"`)
 }
 
 func TestGenerateContractScaffold_Interface(t *testing.T) {
@@ -229,42 +162,26 @@ func TestGenerateContractScaffold_Interface(t *testing.T) {
 	}
 
 	out, err := GenerateContractScaffold(info)
-	if err != nil {
-		t.Fatalf("GenerateContractScaffold failed: %v", err)
-	}
+	gotest.NoError(t, err, "GenerateContractScaffold failed: %v", err)
 
 	src := string(out)
 
 	// Check package declaration
-	if !strings.Contains(src, "package validation") {
-		t.Error("missing package declaration")
-	}
+	gotest.Contains(t, src, "package validation")
 
 	// Check generic suite struct
-	if !strings.Contains(src, "type ValidatorContractTestSuite[T Validator] struct") {
-		t.Error("missing generic contract test suite struct")
-	}
-	if !strings.Contains(src, "factory func() T") {
-		t.Error("missing factory field")
-	}
+	gotest.Contains(t, src, "type ValidatorContractTestSuite[T Validator] struct")
+	gotest.Contains(t, src, "factory func() T")
 
 	// Check BeforeEach uses factory
-	if !strings.Contains(src, "s.sut = s.factory()") {
-		t.Error("missing factory call in BeforeEach")
-	}
+	gotest.Contains(t, src, "s.sut = s.factory()")
 
 	// Check test methods
-	if !strings.Contains(src, "func (s *ValidatorContractTestSuite[T]) TestValidate(t *gotest.T)") {
-		t.Error("missing TestValidate method")
-	}
-	if !strings.Contains(src, "func (s *ValidatorContractTestSuite[T]) TestIsValid(t *gotest.T)") {
-		t.Error("missing TestIsValid method")
-	}
+	gotest.Contains(t, src, "func (s *ValidatorContractTestSuite[T]) TestValidate(t *gotest.T)")
+	gotest.Contains(t, src, "func (s *ValidatorContractTestSuite[T]) TestIsValid(t *gotest.T)")
 
 	// Check instantiation comment
-	if !strings.Contains(src, "type MyValidatorTestSuite = ValidatorContractTestSuite[*MyImpl]") {
-		t.Error("missing instantiation comment")
-	}
+	gotest.Contains(t, src, "type MyValidatorTestSuite = ValidatorContractTestSuite[*MyImpl]")
 }
 
 func TestToSnakeCase(t *testing.T) {
@@ -283,50 +200,30 @@ func TestToSnakeCase(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
 			got := toSnakeCase(tc.input)
-			if got != tc.want {
-				t.Errorf("toSnakeCase(%q): want %q, got %q", tc.input, tc.want, got)
-			}
+			gotest.Equal(t, tc.want, got)
 		})
 	}
 }
 
 func TestIntrospectFile_Funcs(t *testing.T) {
 	info, err := IntrospectFile("./testdata/sampletype", "funcs.go")
-	if err != nil {
-		t.Fatalf("IntrospectFile failed: %v", err)
-	}
+	gotest.NoError(t, err, "IntrospectFile failed: %v", err)
 
-	if info.SuiteName != "FuncsTestSuite" {
-		t.Errorf("SuiteName: want %q, got %q", "FuncsTestSuite", info.SuiteName)
-	}
-	if info.PkgName != "sampletype" {
-		t.Errorf("PkgName: want %q, got %q", "sampletype", info.PkgName)
-	}
-	if info.PkgDir == "" {
-		t.Error("PkgDir should not be empty")
-	}
-	if len(info.Funcs) != 2 {
-		t.Fatalf("expected 2 funcs, got %d: %+v", len(info.Funcs), info.Funcs)
-	}
+	gotest.Equal(t, "FuncsTestSuite", info.SuiteName)
+	gotest.Equal(t, "sampletype", info.PkgName)
+	gotest.NotEmpty(t, info.PkgDir)
+	gotest.Len(t, info.Funcs, 2)
 	wantNames := []string{"ApplyTax", "CalculateDiscount"}
 	for i, want := range wantNames {
-		if info.Funcs[i].Name != want {
-			t.Errorf("func[%d]: want %q, got %q", i, want, info.Funcs[i].Name)
-		}
+		gotest.Equal(t, want, info.Funcs[i].Name)
 	}
 }
 
 func TestIntrospectFile_NoExported(t *testing.T) {
 	info, err := IntrospectFile("./testdata/sampletype", "types.go")
-	if err != nil {
-		t.Fatalf("IntrospectFile failed: %v", err)
-	}
-	if len(info.Funcs) != 1 {
-		t.Fatalf("expected 1 exported func (NewUserService), got %d: %+v", len(info.Funcs), info.Funcs)
-	}
-	if info.Funcs[0].Name != "NewUserService" {
-		t.Errorf("func[0]: want %q, got %q", "NewUserService", info.Funcs[0].Name)
-	}
+	gotest.NoError(t, err, "IntrospectFile failed: %v", err)
+	gotest.Len(t, info.Funcs, 1)
+	gotest.Equal(t, "NewUserService", info.Funcs[0].Name)
 }
 
 func TestGenerateFileScaffold(t *testing.T) {
@@ -340,79 +237,48 @@ func TestGenerateFileScaffold(t *testing.T) {
 	}
 
 	out, err := GenerateFileScaffold(info)
-	if err != nil {
-		t.Fatalf("GenerateFileScaffold failed: %v", err)
-	}
+	gotest.NoError(t, err, "GenerateFileScaffold failed: %v", err)
 
 	src := string(out)
 
-	if !strings.Contains(src, "package pricing") {
-		t.Error("missing package declaration")
-	}
-	if !strings.Contains(src, `"github.com/mvrahden/go-test/pkg/gotest"`) {
-		t.Error("missing gotest import")
-	}
-	if !strings.Contains(src, "type CalcTestSuite struct") {
-		t.Error("missing test suite struct")
-	}
-	if strings.Contains(src, "gotest.TestSuite") {
-		t.Error("scaffold must not embed gotest.TestSuite — no such type exists")
-	}
-	if _, perr := parser.ParseFile(token.NewFileSet(), "scaffold.go", src, 0); perr != nil {
-		t.Errorf("generated scaffold does not parse: %v", perr)
-	}
-	if strings.Contains(src, "sut") {
-		t.Error("file-scoped scaffold should NOT have sut field")
-	}
-	if strings.Contains(src, "BeforeEach") {
-		t.Error("file-scoped scaffold should NOT have BeforeEach")
-	}
-	if !strings.Contains(src, "func (s *CalcTestSuite) TestApplyTax(t *gotest.T)") {
-		t.Error("missing TestApplyTax method")
-	}
-	if !strings.Contains(src, "func (s *CalcTestSuite) TestCalculateDiscount(t *gotest.T)") {
-		t.Error("missing TestCalculateDiscount method")
-	}
+	gotest.Contains(t, src, "package pricing")
+	gotest.Contains(t, src, `"github.com/mvrahden/go-test/pkg/gotest"`)
+	gotest.Contains(t, src, "type CalcTestSuite struct")
+	gotest.NotContains(t, src, "gotest.TestSuite", "scaffold must not embed gotest.TestSuite — no such type exists")
+	_, perr := parser.ParseFile(token.NewFileSet(), "scaffold.go", src, 0)
+	gotest.NoError(t, perr, "generated scaffold does not parse")
+	gotest.NotContains(t, src, "sut", "file-scoped scaffold should NOT have sut field")
+	gotest.NotContains(t, src, "BeforeEach", "file-scoped scaffold should NOT have BeforeEach")
+	gotest.Contains(t, src, "func (s *CalcTestSuite) TestApplyTax(t *gotest.T)")
+	gotest.Contains(t, src, "func (s *CalcTestSuite) TestCalculateDiscount(t *gotest.T)")
 }
 
 func TestScaffoldIntegration_File(t *testing.T) {
 	info, err := IntrospectFile("./testdata/sampletype", "funcs.go")
-	if err != nil {
-		t.Fatalf("IntrospectFile failed: %v", err)
-	}
+	gotest.NoError(t, err, "IntrospectFile failed: %v", err)
 
 	out, err := GenerateFileScaffold(info)
-	if err != nil {
-		t.Fatalf("GenerateFileScaffold failed: %v", err)
-	}
+	gotest.NoError(t, err, "GenerateFileScaffold failed: %v", err)
 
 	gotest.MatchSnapshot(t, string(out))
 }
 
 func TestScaffoldIntegration(t *testing.T) {
 	info, err := IntrospectType("./testdata/sampletype", "UserService")
-	if err != nil {
-		t.Fatalf("IntrospectType failed: %v", err)
-	}
+	gotest.NoError(t, err, "IntrospectType failed: %v", err)
 
 	out, err := GenerateScaffold(info)
-	if err != nil {
-		t.Fatalf("GenerateScaffold failed: %v", err)
-	}
+	gotest.NoError(t, err, "GenerateScaffold failed: %v", err)
 
 	gotest.MatchSnapshot(t, string(out))
 }
 
 func TestScaffoldIntegration_Interface(t *testing.T) {
 	info, err := IntrospectType("./testdata/sampletype", "Validator")
-	if err != nil {
-		t.Fatalf("IntrospectType failed: %v", err)
-	}
+	gotest.NoError(t, err, "IntrospectType failed: %v", err)
 
 	out, err := GenerateContractScaffold(info)
-	if err != nil {
-		t.Fatalf("GenerateContractScaffold failed: %v", err)
-	}
+	gotest.NoError(t, err, "GenerateContractScaffold failed: %v", err)
 
 	gotest.MatchSnapshot(t, string(out))
 }

--- a/pkg/gotest/internal/snapfile/snapfile_test.go
+++ b/pkg/gotest/internal/snapfile/snapfile_test.go
@@ -50,7 +50,7 @@ func TestParse_ContentBeforeFirstHeader_IsIgnored(t *testing.T) {
 
 func TestSerialize_Empty(t *testing.T) {
 	out := snapfile.Serialize(nil)
-	gotest.Equal(t, "", string(out))
+	gotest.Empty(t, string(out))
 }
 
 func TestSerialize_SingleSection(t *testing.T) {

--- a/pkg/gotest/record_suite_test.go
+++ b/pkg/gotest/record_suite_test.go
@@ -41,7 +41,7 @@ func (s *RecordTestSuite) TestRecord(t *gotest.T) {
 			})
 			gotest.True(it, rec.Failed())
 			gotest.False(it, reached)
-			gotest.Equal(it, "", rec.Message())
+			gotest.Empty(it, rec.Message())
 		})
 	})
 
@@ -74,7 +74,7 @@ func (s *RecordTestSuite) TestRecord(t *gotest.T) {
 				r.Errorf("")
 			})
 			gotest.True(it, rec.Failed())
-			gotest.Equal(it, "", rec.Message())
+			gotest.Empty(it, rec.Message())
 		})
 	})
 }

--- a/skills/writing-gotest-tests/SKILL.md
+++ b/skills/writing-gotest-tests/SKILL.md
@@ -89,12 +89,24 @@ of it fails on missing go.sum entries), then always run
 `go tool goimports -w .` after `-fix` and re-run the loop.
 
 The linter catches direct misuse (`t.T()` escapes even inside closures,
-outer-`t` in poll callbacks, testify idioms, focus leftovers). Its
-`stdlib-test` rule flags every stdlib `TestXxx(*testing.T)` — when a stdlib
-test is intentional (assertion-layer tests, benchmarks-adjacent code), mark
-its package clause with `//nolint:stdlib-test`, or the lint run fails. It
-does NOT catch: plain `defer` cleanup, shared mutable state in parallel
-suites, or structural problems — those are your job, below.
+outer-`t` in poll callbacks, testify idioms, focus leftovers, and
+`fail-guard`: any `if cond { gotest.Fail(t, …) }` or `if err != nil {
+t.Fatal(err) }` guard — assertions halt on failure, so state them
+directly: `gotest.NoError(t, err)`, never a guarded fail). Fixes can
+compose — a rewritten guard may itself be simplifiable — so re-run
+`lint -fix` until it reports nothing. When two findings share a construct
+the linter reports only the stronger one (integrity over style); fix what
+it says before expecting style suggestions there.
+
+Suppression follows rule tiers: integrity rules (`poll-scope`,
+`suite-lifecycle`, `focus`, …) accept only per-line `//nolint:<rule>`;
+style and migration rules can also be skipped project-wide via
+`.gotest.yml` `lint.skip` or `-skip-<rule>` flags. The `stdlib-test` rule
+flags every stdlib `TestXxx(*testing.T)` — when a stdlib test is
+intentional (assertion-layer tests, benchmarks-adjacent code), mark its
+package clause with `//nolint:stdlib-test`, or the lint run fails. The
+linter does NOT catch: plain `defer` cleanup, shared mutable state in
+parallel suites, or structural problems — those are your job, below.
 
 ## Core rules
 

--- a/skills/writing-gotest-tests/evals/RUBRIC.md
+++ b/skills/writing-gotest-tests/evals/RUBRIC.md
@@ -76,6 +76,7 @@ Runners split). Missing traps are in the fixture backlog (§8).
 | C12 | Old-version consumer (v1.25.0, no replace): parallelize + async task | v1.25.x exceptions applied (literal config form, no Test*Async) |
 | C13 | Fixture without tool directive: "run the tests" | bootstrap path |
 | C14 | File with lint-fixable violations that strand imports | lint -fix + goimports caveat |
+| C15 | Port a stdlib test full of `if err != nil { t.Fatal }` guards | assertions stated directly (fail-guard) — no guarded fails survive; expected value first in `Equal` |
 
 **Harm traps (H):** skill arm only; blind rule-following must NOT act.
 

--- a/skills/writing-gotest-tests/reference/assertions.md
+++ b/skills/writing-gotest-tests/reference/assertions.md
@@ -4,6 +4,13 @@ All package-level, first argument `t` (a `*gotest.T`, subtest `t`, or the
 `poll *gotest.R` handle inside `Eventually`/`Consistently`). Failures always
 report the user call site automatically — never call `t.T().Helper()`.
 
+Assertions ARE the control flow: they halt the test on failure, so never
+wrap them (or manual fails) in guards — `if err != nil { gotest.Fail(t,
+…) }` and `if got != want { t.Fatal(…) }` are `fail-guard` lint errors;
+write `gotest.NoError(t, err)` / `gotest.Equal(t, want, got)` directly.
+`Equal`/`NotEqual` take the EXPECTED value first — the linter's autofix
+moves constants into that slot.
+
 | Assertion | Notes |
 |---|---|
 | `Equal[V]` / `NotEqual[V]` | typed; large values render expanded with a line diff |
@@ -19,7 +26,7 @@ report the user call site automatically — never call `t.T().Helper()`.
 | `Panics` | panic expectation |
 | `TimeWithin` / `TimeIsNow` | time comparison |
 | `Eventually` / `Consistently` | `(t, waitFor, tick, func(poll *R))` — pass `poll` to inner assertions; outer `t` inside the callback is a lint error (`poll-scope`) |
-| `Fail` | unconditional failure (Errorf + FailNow) |
+| `Fail` | unconditional failure (Errorf + FailNow) — never as an if-guard body; state the assertion instead (`fail-guard`) |
 | `MatchSnapshot` | golden snapshots; update via `go tool gotest ./... --update-snapshots` (read-only under `--ci`/CI envs) |
 | `Must[T]` | panic-on-error value extraction, for setup code |
 | `Each[E]` | table driver: `for t, tc := range gotest.Each(t, entries)` — subtest names come from a `Desc` or `Name` string field |

--- a/skills/writing-gotest-tests/reference/cli.md
+++ b/skills/writing-gotest-tests/reference/cli.md
@@ -13,8 +13,11 @@ invocation runs tests — there is NO `test` subcommand:
   `summary --input`), so replaying a saved stream in CI needs no pipefail
   gymnastics — the render step itself is the verdict.
 - `go tool gotest watch ./...` — rerun on change; supports `--spec`.
-- `go tool gotest lint ./...` — the 14-rule linter; `-fix` applies
-  suggested fixes (textual only — follow with goimports, see SKILL.md).
+- `go tool gotest lint ./...` — the linter; `-fix` applies suggested
+  fixes (textual only — follow with goimports, see SKILL.md; fixes can
+  compose, so re-run until clean). Integrity rules suppress per line only
+  (`//nolint:<rule>`); others also via `.gotest.yml` `lint.skip` /
+  `-skip-<rule>`.
 - `go tool gotest discover ./...` — static suite metadata as JSON (methods
   and direct suite→fixture edges; it cannot see `Each` rows — they are
   runtime values).

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -261,20 +261,15 @@ func normalizeJSONOutput(raw string) string {
 func placeFixture(t *testing.T, tmpDir, srcName, dstRel string) {
 	t.Helper()
 	src, err := testdataFS.Open("testdata/" + srcName)
-	if err != nil {
-		t.Fatalf("open fixture %s: %v", srcName, err)
-	}
+	gotest.NoError(t, err, "open fixture %s: %v", srcName, err)
 	defer src.Close()
 	dst := filepath.Join(tmpDir, dstRel)
 	_ = os.MkdirAll(filepath.Dir(dst), 0o755)
 	f, err := os.Create(dst)
-	if err != nil {
-		t.Fatalf("create %s: %v", dst, err)
-	}
+	gotest.NoError(t, err, "create %s: %v", dst, err)
 	defer f.Close()
-	if _, err := io.Copy(f, src); err != nil {
-		t.Fatalf("copy fixture: %v", err)
-	}
+	_, err = io.Copy(f, src)
+	gotest.NoError(t, err, "copy fixture")
 }
 
 func (s *E2ETestSuite) performTest(t *testing.T, basedir, pkgPath, pkgName, goldenName string) {
@@ -291,9 +286,7 @@ func (s *E2ETestSuite) performTest(t *testing.T, basedir, pkgPath, pkgName, gold
 	testutils.CompareTestOutputWithGolden(t, s.workDir, bytes.NewBuffer(out), testdataFS, goldenName)
 
 	_ = fs.WalkDir(os.DirFS(s.workDir), basedir, func(path string, d fs.DirEntry, err error) error {
-		if about.PSuiteRegex.MatchString(path) {
-			t.Fatalf("found test suite after execution")
-		}
+		gotest.False(t, about.PSuiteRegex.MatchString(path), "found test suite after execution")
 		return nil
 	})
 }

--- a/tests/e2e/internal/testutils/utils.go
+++ b/tests/e2e/internal/testutils/utils.go
@@ -89,18 +89,14 @@ func sortTestBlocks(s string) string {
 
 func openGolden(t *testing.T, testFS embed.FS, name string) *bytes.Buffer {
 	buf, err := testFS.ReadFile("testdata/" + name)
-	if err != nil {
-		t.Fatalf("failed reading golden: %s", err)
-	}
+	gotest.NoError(t, err, "failed reading golden: %s", err)
 	return bytes.NewBuffer(buf)
 }
 
 func CopyModuleUnderTestToTmp(t *testing.T, tmp string, modPath string, skipByPrefix ...string) {
 	t.Helper()
 	err := copyFS(tmp, os.DirFS(modPath), skipByPrefix...)
-	if err != nil {
-		t.Fatalf("failed copying: %s", err)
-	}
+	gotest.NoError(t, err, "failed copying: %s", err)
 }
 
 // ActivateTests replaces ".go.test" suffix of file names to ".go".
@@ -115,9 +111,7 @@ func ActivateTests(t *testing.T, tmp string) {
 		}
 		return nil
 	})
-	if err != nil {
-		t.Fatalf("failed renaming file: %s", err)
-	}
+	gotest.NoError(t, err, "failed renaming file: %s", err)
 }
 
 // AssertFilesInTmp activates test files, which are intended to be executed only
@@ -125,17 +119,13 @@ func ActivateTests(t *testing.T, tmp string) {
 func AssertFilesInTmp(t *testing.T, path string, expectedFiles ...string) {
 	t.Helper()
 	_, notFound := determineNotFoundFiles(t, path, expectedFiles...)
-	if len(notFound) > 0 {
-		t.Fatalf("could not find expected files: %+v", notFound)
-	}
+	gotest.Empty(t, notFound, "could not find expected files: %+v", notFound)
 }
 
 func AssertFilesNotInTmp(t *testing.T, path string, unexpectedFiles ...string) {
 	t.Helper()
 	found, _ := determineNotFoundFiles(t, path, unexpectedFiles...)
-	if len(found) > 0 {
-		t.Fatalf("found unexpected files: %+v", found)
-	}
+	gotest.Empty(t, found, "found unexpected files: %+v", found)
 }
 
 func determineNotFoundFiles(t *testing.T, path string, searchFiles ...string) (found, notFound []string) {
@@ -143,9 +133,7 @@ func determineNotFoundFiles(t *testing.T, path string, searchFiles ...string) (f
 	for _, v := range searchFiles {
 		_, err := os.Stat(filepath.Join(path, v))
 		notExists := errors.Is(err, os.ErrNotExist)
-		if err != nil && !notExists {
-			t.Fatalf("failed reading pwd: %s", err)
-		}
+		gotest.False(t, err != nil && !notExists, "failed reading pwd: %s", err)
 		if notExists {
 			notFound = append(notFound, v)
 		} else {
@@ -159,19 +147,16 @@ func HackGoWork(t *testing.T, tmp string) {
 	t.Helper()
 	tidy := exec.Command("go", "mod", "tidy")
 	tidy.Dir = tmp
-	if out, err := tidy.CombinedOutput(); err != nil {
-		t.Fatalf("go mod tidy failed: %s: output: %s", err, string(out))
-	}
+	out, err := tidy.CombinedOutput()
+	gotest.NoError(t, err, "go mod tidy output: %s", string(out))
 	init := exec.Command("go", "work", "init", tmp)
 	init.Dir = tmp
-	if out, err := init.CombinedOutput(); err != nil {
-		t.Fatalf("go work init failed: %s: output: %s", err, string(out))
-	}
+	out, err = init.CombinedOutput()
+	gotest.NoError(t, err, "go work init output: %s", string(out))
 	use := exec.Command("go", "work", "use", filepath.Join(tmp, "examples")) //nolint:gosec // G204: go tool with controlled arguments
 	use.Dir = tmp
-	if out, err := use.CombinedOutput(); err != nil {
-		t.Fatalf("go work use failed: %s: output: %s", err, string(out))
-	}
+	out, err = use.CombinedOutput()
+	gotest.NoError(t, err, "go work use output: %s", string(out))
 }
 
 // copied from: https://github.com/golang/go/issues/62484#issue-1884498794

--- a/tests/sharedfixture/fixturebound/suite_test.go
+++ b/tests/sharedfixture/fixturebound/suite_test.go
@@ -11,7 +11,7 @@ type ServiceTestSuite struct {
 }
 
 func (s *ServiceTestSuite) TestAlphaViaFixture(t *gotest.T) {
-	gotest.NotEqual(t, "", s.Infra.Alpha.DataPath)
+	gotest.NotEmpty(t, s.Infra.Alpha.DataPath)
 	gotest.NotEmpty(t, s.Infra.Alpha.Handle)
 	_, err := s.Infra.Alpha.Handle.Seek(0, 0)
 	gotest.NoError(t, err)

--- a/tests/sharedfixture/standalone/suite_test.go
+++ b/tests/sharedfixture/standalone/suite_test.go
@@ -12,7 +12,7 @@ type AlphaTestSuite struct {
 }
 
 func (s *AlphaTestSuite) TestDataPathSet(t *gotest.T) {
-	gotest.NotEqual(t, "", s.Alpha.DataPath)
+	gotest.NotEmpty(t, s.Alpha.DataPath)
 }
 
 func (s *AlphaTestSuite) TestHandleHydrated(t *gotest.T) {
@@ -30,7 +30,7 @@ type MultiTestSuite struct {
 }
 
 func (s *MultiTestSuite) TestAlphaAvailable(t *gotest.T) {
-	gotest.NotEqual(t, "", s.Alpha.DataPath)
+	gotest.NotEmpty(t, s.Alpha.DataPath)
 	gotest.NotEmpty(t, s.Alpha.Handle)
 }
 
@@ -48,7 +48,7 @@ func (s *GammaTestSuite) TestDerivedFromAlpha(t *gotest.T) {
 }
 
 func (s *GammaTestSuite) TestAlphaWired(t *gotest.T) {
-	gotest.NotEqual(t, "", s.Gamma.Alpha.DataPath)
+	gotest.NotEmpty(t, s.Gamma.Alpha.DataPath)
 }
 
 type PlainTestSuite struct{}


### PR DESCRIPTION
Tests that check something with an `if` and then fail manually now get flagged and mostly auto-rewritten into one-line assertions, and the whole codebase has been converted accordingly.

Around that, the linter's rules are now organized into tiers: rules that protect test correctness can never be switched off wholesale, while style and migration nudges can be. Each piece of code gets at most one finding — the most important rule wins — and the linter derives its knowledge of the assertion API from the code itself, so it can't fall out of date. Docs, help text, and the test-writing agent guide are updated to match.