### PR TITLE
Make the linter docs match the linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ lint:
 | `parallel` | int | `--parallel` | Total concurrent test method budget |
 | `compile-parallel` | int | `--compile-parallel` | Concurrent compilation processes (default: NumCPU, auto-halved for -race/-msan/-asan) |
 | `debounce` | duration | `--debounce` | Watch mode re-run delay |
-| `lint.skip` | list | — | Lint rules to disable project-wide |
+| `lint.skip` | list | — | Non-integrity lint rules to disable project-wide |
 
 ## Test Selection
 
@@ -718,8 +718,14 @@ Catch common mistakes in test suites with static analysis:
 gotest lint ./...
 ```
 
-Detects: lifecycle hook typos, value receivers on suite methods, missing `AfterAll` when `BeforeAll` exists, committed `F_` prefixes, and orphaned generated files.
-Also available as a standalone binary (`gotest-lint`) compatible with `golangci-lint` via `go/analysis`.
+Sixteen rules in three tiers:
+
+- **Integrity** — test outcomes can lie or resources can leak: committed `F_` prefixes, value receivers on suite methods, lifecycle hook typos, `BeforeAll` without `AfterAll`, `X_` prefixes on lifecycle hooks, wrong test signatures, suite-lifecycle bypasses via `t.T()` (`Cleanup`/`Parallel`/`Run`), outer `t` inside `Eventually`/`Consistently` callbacks, `Nil`/`Empty` assertions on types their runtime guards reject, and generated files checked into version control.
+- **Expressiveness** — the test is correct but says it worse: simplifiable assertions (`True(t, a == b)` → `Equal`, `Len(t, x, 0)` → `Empty`, …), redundant assertions, `if cond { Fail(...) }` guards that an assertion expresses directly, and unnecessary `t.T()` escapes. `-fix` applies the safe rewrites.
+- **Migration** — legitimate coexistence, nudged: stdlib test functions and testify imports.
+
+Suppress per line with `//nolint:<rule>` (same line or the comment block directly above); expressiveness and migration rules can also be disabled project-wide via `.gotest.yml` (`lint.skip`). See the [design spec](docs/design/spec.md#linter) for the full rule table.
+Also available as a standalone `go/analysis` binary (`gotest-lint`). There is no golangci-lint plugin — run it as its own CI step alongside your existing linter.
 
 ## GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -720,9 +720,9 @@ gotest lint ./...
 
 Sixteen rules in three tiers:
 
-- **Integrity** — test outcomes can lie or resources can leak: committed `F_` prefixes, value receivers on suite methods, lifecycle hook typos, `BeforeAll` without `AfterAll`, `X_` prefixes on lifecycle hooks, wrong test signatures, suite-lifecycle bypasses via `t.T()` (`Cleanup`/`Parallel`/`Run`), outer `t` inside `Eventually`/`Consistently` callbacks, `Nil`/`Empty` assertions on types their runtime guards reject, and generated files checked into version control.
-- **Expressiveness** — the test is correct but says it worse: simplifiable assertions (`True(t, a == b)` → `Equal`, `Len(t, x, 0)` → `Empty`, …), redundant assertions, `if cond { Fail(...) }` guards that an assertion expresses directly, and unnecessary `t.T()` escapes. `-fix` applies the safe rewrites.
-- **Migration** — legitimate coexistence, nudged: stdlib test functions and testify imports.
+- **Integrity** — violations can make test outcomes unreliable or leak resources: committed `F_` prefixes, value receivers on suite methods, lifecycle hook typos, `BeforeAll` without `AfterAll`, `X_` prefixes on lifecycle hooks, wrong test signatures, suite-lifecycle bypasses via `t.T()` (`Cleanup`/`Parallel`/`Run`), outer `t` inside `Eventually`/`Consistently` callbacks, `Nil`/`Empty` assertions on types their runtime guards reject, and generated files checked into version control.
+- **Expressiveness** — the test is correct but its syntax can be improved: simplifiable assertions (`True(t, a == b)` → `Equal`, `Len(t, x, 0)` → `Empty`, …), redundant assertions, `if cond { Fail(...) }` guards that an assertion expresses directly, and unnecessary `t.T()` escapes. `-fix` applies the safe rewrites.
+- **Migration** — adoption aids for codebases moving to gotest: stdlib test functions and testify imports; coexistence is legitimate.
 
 Suppress per line with `//nolint:<rule>` (same line or the comment block directly above); expressiveness and migration rules can also be disabled project-wide via `.gotest.yml` (`lint.skip`). See the [design spec](docs/design/spec.md#linter) for the full rule table.
 Also available as a standalone `go/analysis` binary (`gotest-lint`). There is no golangci-lint plugin — run it as its own CI step alongside your existing linter.

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -365,6 +365,12 @@ Suppress individual diagnostics with //nolint comments:
   //nolint:stdlib-test             Same line or the comment block directly above
   package foo //nolint:stdlib-test  Suppress for entire file
 
+Exit codes:
+  0   No findings
+  1   Uncompilable target packages (nothing was proven about them)
+  2   Usage or configuration error (e.g. an integrity rule in lint.skip)
+  3   Findings reported
+
 Examples:
   gotest lint ./...                          Lint all packages
   gotest lint -skip-testify ./...            Skip testify rule

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -362,7 +362,7 @@ Flags:
   -fix                    Apply suggested fixes
 
 Suppress individual diagnostics with //nolint comments:
-  //nolint:stdlib-test             Suppress on same line or line above
+  //nolint:stdlib-test             Same line or the comment block directly above
   package foo //nolint:stdlib-test  Suppress for entire file
 
 Examples:
@@ -476,7 +476,8 @@ Fields:
   lint:
     skip: [<rule>, ...]     Lint rules to disable globally
 
-Skippable lint rules: stdlib-test, testify
+Skippable lint rules (non-integrity only): assertion-redundant,
+assertion-simplify, fail-guard, stdlib-test, t-escape, testify
 
 Example .gotest.yml:
 

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -1268,7 +1268,7 @@ Method-parallel suites additionally emit the `ƒfailed` coordination described u
 
 ## Linter
 
-Available as a subcommand and as a standalone binary, built on `go/analysis` and compatible with `golangci-lint`:
+Available as a subcommand and as a standalone binary, built on `go/analysis`. `pkg/lint` exports the analyzer for external `go/analysis` drivers; there is no golangci-lint plugin — the linter runs as its own step alongside a project's existing linter:
 
 ```bash
 gotest lint ./...                                          # subcommand
@@ -1314,7 +1314,7 @@ One construct yields one finding: integrity rules own the constructs they flag, 
 
 Suppression and configuration:
 
-- `//nolint:<rule>` on a line; on the `package` line it applies file-wide
+- `//nolint:<rule>` on the diagnostic's line, or in a standalone comment block ending on the line directly above it (a comment trailing other code does not reach the next line); on the `package` line it applies file-wide
 - `.gotest.yml` → `lint.skip: [<rule>, ...]` disables non-integrity rules project-wide
 - `.gotest.yml` `lint.skip` naming an integrity rule is a hard error — integrity rules can only be suppressed per line; unknown rule IDs are also a hard error
 - Flags: `-fix` applies suggested fixes; `-skip-<rule>` for every non-integrity rule; `-disable-nolint`

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -1318,6 +1318,7 @@ Suppression and configuration:
 - `.gotest.yml` → `lint.skip: [<rule>, ...]` disables non-integrity rules project-wide
 - `.gotest.yml` `lint.skip` naming an integrity rule is a hard error — integrity rules can only be suppressed per line; unknown rule IDs are also a hard error
 - Flags: `-fix` applies suggested fixes; `-skip-<rule>` for every non-integrity rule; `-disable-nolint`
+- Exit codes: `0` no findings; `1` uncompilable target packages (the preflight fails loudly — nothing was proven about them); `2` usage or configuration error; `3` findings reported
 
 ---
 

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -259,25 +259,31 @@ func isSuppressed(pass *analysis.Pass, pos token.Pos, rule Rule) bool {
 			if cLine == pkgLine || cLine == line {
 				return true
 			}
+			if pass.Fset.Position(cg.End()).Line == line-1 && startsItsLine(pass, file, cg) {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-func docSuppressed(doc *ast.CommentGroup, rule Rule) bool {
-	if doc == nil {
-		return false
-	}
-	for _, c := range doc.List {
-		rules, ok := parseNolint(c.Text)
-		if !ok {
-			continue
+// startsItsLine reports whether no code precedes the comment group on its
+// opening line — a comment trailing the previous statement must not suppress
+// the line below it.
+func startsItsLine(pass *analysis.Pass, file *ast.File, cg *ast.CommentGroup) bool {
+	cgLine := pass.Fset.Position(cg.Pos()).Line
+	standalone := true
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n == nil || !standalone {
+			return false
 		}
-		if ruleMatched(rules, rule) {
-			return true
+		if n.End() <= cg.Pos() && pass.Fset.Position(n.End()).Line == cgLine {
+			standalone = false
+			return false
 		}
-	}
-	return false
+		return n.Pos() < cg.Pos()
+	})
+	return standalone
 }
 
 func parseNolint(text string) (rules map[Rule]bool, ok bool) {
@@ -429,7 +435,7 @@ func checkMethods(pass *analysis.Pass, insp *inspector.Inspector, suites map[str
 					"focused method %s.%s should not be committed", recvName, methodName)
 			}
 			if !hasValidTestSignature(fd) {
-				report(pass, TestSignature, fd.Pos(), "test method %s.%s has wrong signature — must accept *gotest.T", recvName, methodName)
+				report(pass, TestSignature, fd.Pos(), "test method %s.%s has wrong signature — must accept *gotest.T (or *testing.T)", recvName, methodName)
 			}
 			return
 		}
@@ -1011,9 +1017,6 @@ func checkStdlibTests(pass *analysis.Pass, insp *inspector.Inspector) {
 			return
 		}
 		if !isTestingT(fd.Type.Params.List[0].Type) {
-			return
-		}
-		if !cfg.disableNolint && docSuppressed(fd.Doc, StdlibTest) {
 			return
 		}
 		report(pass, StdlibTest, fd.Pos(), "stdlib test %s — consider using a gotest suite", name)

--- a/internal/lint/testdata/src/sample/sample_test.go
+++ b/internal/lint/testdata/src/sample/sample_test.go
@@ -8,7 +8,7 @@ import (
 
 type UserServiceTestSuite struct{}
 
-func (s *UserServiceTestSuite) TestCreate()                                  {} // want `test method UserServiceTestSuite.TestCreate has wrong signature`
+func (s *UserServiceTestSuite) TestCreate()                                  {} // want `test method UserServiceTestSuite.TestCreate has wrong signature — must accept \*gotest\.T \(or \*testing\.T\)`
 func (s *UserServiceTestSuite) TestCorrectSig(t *gotest.T)                   {}
 func (s *UserServiceTestSuite) TestContextualSig(t *gotest.T, ctx *struct{}) {}
 func (s *UserServiceTestSuite) TestStdlibSig(t *testing.T)                   {}

--- a/internal/lint/testdata/src/withnolint/withnolint_test.go
+++ b/internal/lint/testdata/src/withnolint/withnolint_test.go
@@ -47,3 +47,36 @@ func TestFailGuardNolint(t *testing.T) { //nolint:stdlib-test
 		gotest.Fail(t, "boom")
 	}
 }
+
+// AboveTestSuite exercises nolint suppression via the comment block
+// directly above the diagnostic line, for all rules.
+type AboveTestSuite struct{}
+
+// suppressed: standalone nolint on the line directly above
+//
+//nolint:receiver
+func (s AboveTestSuite) TestReceiverAbove(t *testing.T) {}
+
+// suppressed: nolint:receiver is not the last line of the attached block
+//
+//nolint:receiver
+//nolint:testify
+func (s AboveTestSuite) TestReceiverDocBlock(t *testing.T) {}
+
+// NOT suppressed: wrong rule above
+//
+//nolint:testify
+func (s AboveTestSuite) TestWrongRuleAbove(t *testing.T) {} // want `suite method AboveTestSuite.TestWrongRuleAbove should use a pointer receiver`
+
+var _ = 0 //nolint:receiver
+// NOT suppressed: the nolint above trails other code, it does not start the line
+func (s AboveTestSuite) TestTrailingAbove(t *testing.T) {} // want `suite method AboveTestSuite.TestTrailingAbove should use a pointer receiver`
+
+// suppressed: standalone nolint above a statement-level finding
+func TestFailGuardNolintAbove(t *testing.T) { //nolint:stdlib-test
+	var err error
+	//nolint:fail-guard
+	if err != nil {
+		gotest.Fail(t, "boom")
+	}
+}

--- a/pkg/lint/analyzer.go
+++ b/pkg/lint/analyzer.go
@@ -2,6 +2,6 @@ package lint
 
 import "github.com/mvrahden/go-test/internal/lint"
 
-// Analyzer is the gotestlint analyzer for integration with
-// external analysis drivers such as golangci-lint.
+// Analyzer is the gotestlint analyzer, exported for external go/analysis
+// drivers (multichecker-style integration; there is no golangci-lint plugin).
 var Analyzer = lint.Analyzer

--- a/site/content/reference.html
+++ b/site/content/reference.html
@@ -473,7 +473,7 @@ CacheFixture.AfterAll <span class="d">─┘</span></div>
           <tr><td><code>min-coverage</code></td><td>int</td><td>0 (off)</td><td><code>--min</code></td><td>Minimum coverage percentage, 0–100.</td></tr>
           <tr><td><code>parallel</code></td><td>int</td><td>0 (auto)</td><td><code>--parallel</code></td><td>Total concurrent test method budget. 0 means 2×GOMAXPROCS.</td></tr>
           <tr><td><code>debounce</code></td><td>duration</td><td>200ms</td><td><code>--debounce</code></td><td>Watch mode re-run delay.</td></tr>
-          <tr><td><code>lint.skip</code></td><td>[string]</td><td><em>none</em></td><td>—</td><td>Lint rules to disable: <code>stdlib-test</code>, <code>testify</code>.</td></tr>
+          <tr><td><code>lint.skip</code></td><td>[string]</td><td><em>none</em></td><td>—</td><td>Non-integrity lint rules to disable: <code>assertion-simplify</code>, <code>assertion-redundant</code>, <code>fail-guard</code>, <code>t-escape</code>, <code>stdlib-test</code>, <code>testify</code>.</td></tr>
         </tbody>
       </table>
       <div class="code-block">

--- a/site/content/reference.html
+++ b/site/content/reference.html
@@ -24,6 +24,7 @@ aliases: ["/reference.html"]
         <li><a href="#configuration">Configuration</a> <span class="toc-desc">— project file, suite config, fixture config</span></li>
         <li><a href="#coverage">Coverage</a> <span class="toc-desc">— statement-weighted calculation and thresholds</span></li>
         <li><a href="#cli">CLI Reference</a> <span class="toc-desc">— commands, flags, go test passthrough</span></li>
+        <li><a href="#linter">Linter</a> <span class="toc-desc">— rule tiers, suppression, exit codes</span></li>
         <li><a href="#ci-integration">CI Integration</a> <span class="toc-desc">— summary output, GitHub Action, PR annotations</span></li>
       </ol>
     </div>
@@ -566,7 +567,7 @@ percentage = covered / total</div>
           <tr><td><code>gotest watch ./...</code></td><td>Re-run on file changes. Only affected packages re-run.</td></tr>
           <tr><td><code>gotest spec ./...</code></td><td>Run tests and render the behavioral specification.</td></tr>
           <tr><td><code>gotest summary ./...</code></td><td>Failure-focused summary for CI. Shows only failing tests with assertion output.</td></tr>
-          <tr><td><code>gotest lint ./...</code></td><td>Static analysis for test suites.</td></tr>
+          <tr><td><code>gotest lint ./...</code></td><td>Static analysis for test suites — see <a href="#linter">Linter</a>.</td></tr>
           <tr><td><code>gotest scaffold ./pkg/user.Svc</code></td><td>Generate a suite skeleton from any Go type.</td></tr>
           <tr><td><code>gotest migrate ./...</code></td><td>Convert testify/suite tests automatically.</td></tr>
           <tr><td><code>gotest generate ./...</code></td><td>Generate suite files without running tests.</td></tr>
@@ -598,6 +599,70 @@ percentage = covered / total</div>
 
       <div class="callout">
         Standard <code>go test</code> flags work unchanged: <code>-v</code>, <code>-race</code>, <code>-cover</code>, <code>-count</code>, <code>-run</code>, <code>-json</code>, <code>-short</code>, <code>-timeout</code>.
+      </div>
+    </section>
+
+    <!-- 9. Linter -->
+    <section class="ref-section" id="linter">
+      <h2>Linter</h2>
+      <p class="lead">Sixteen rules in three tiers. A rule's tier determines how it may be suppressed.</p>
+
+      <h3>Integrity rules</h3>
+      <p>Violations can make test outcomes unreliable or leak resources. These rules can only be suppressed per line — never project-wide.</p>
+      <table class="ref-table">
+        <thead><tr><th>Rule</th><th>Detects</th></tr></thead>
+        <tbody>
+          <tr><td><code>focus</code></td><td>Committed <code>F_</code> prefixes on suites or methods.</td></tr>
+          <tr><td><code>receiver</code></td><td>Suite methods with value receivers instead of pointer receivers.</td></tr>
+          <tr><td><code>lifecycle-typo</code></td><td>Method names one typo away from a lifecycle hook (<code>BeforAll</code>, <code>AfterEeach</code>).</td></tr>
+          <tr><td><code>lifecycle-pair</code></td><td><code>BeforeAll</code> without <code>AfterAll</code> — resources may leak.</td></tr>
+          <tr><td><code>x-lifecycle</code></td><td><code>X_</code> prefix on a lifecycle hook — a no-op.</td></tr>
+          <tr><td><code>test-signature</code></td><td>Test methods not accepting <code>*gotest.T</code> (or <code>*testing.T</code>).</td></tr>
+          <tr><td><code>suite-lifecycle</code></td><td><code>Cleanup</code>/<code>Parallel</code>/<code>Run</code> via <code>t.T()</code> — they bypass the suite lifecycle.</td></tr>
+          <tr><td><code>poll-scope</code></td><td>Assertions inside <code>Eventually</code>/<code>Consistently</code> callbacks using the outer <code>t</code> instead of <code>poll</code>.</td></tr>
+          <tr><td><code>assertion-type-guard</code></td><td><code>Nil</code>/<code>Empty</code> on types their runtime guards would reject.</td></tr>
+          <tr><td><code>generated-file</code></td><td>Generated overlay files present in source control.</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Expressiveness rules</h3>
+      <p>The test is correct but its syntax can be improved. These rules can be suppressed per line or project-wide via <code>lint.skip</code>; <code>-fix</code> applies the safe rewrites.</p>
+      <table class="ref-table">
+        <thead><tr><th>Rule</th><th>Detects</th></tr></thead>
+        <tbody>
+          <tr><td><code>assertion-simplify</code></td><td>Simplifiable assertions: <code>True(t, a == b)</code> → <code>Equal</code>, <code>Len(t, x, 0)</code> → <code>Empty</code>, …</td></tr>
+          <tr><td><code>assertion-redundant</code></td><td>An assertion made redundant by the next one on the same argument.</td></tr>
+          <tr><td><code>fail-guard</code></td><td><code>if cond { Fail/Fatal(...) }</code> guards — the assertion expresses the check directly.</td></tr>
+          <tr><td><code>t-escape</code></td><td>Unnecessary <code>t.T()</code> convenience escapes (<code>Errorf</code>, <code>Helper</code>, <code>Log</code>, <code>Fatal</code>, …).</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Migration rules</h3>
+      <p>Adoption aids for codebases moving to gotest — coexistence is legitimate. These rules can be suppressed per line or project-wide via <code>lint.skip</code>.</p>
+      <table class="ref-table">
+        <thead><tr><th>Rule</th><th>Detects</th></tr></thead>
+        <tbody>
+          <tr><td><code>stdlib-test</code></td><td><code>func TestX(*testing.T)</code> — consider a suite method; coexisting stdlib tests are legitimate.</td></tr>
+          <tr><td><code>testify</code></td><td>Any <code>github.com/stretchr/testify/*</code> import — migration incomplete.</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Suppression</h3>
+      <p>Silence a single diagnostic with <code>//nolint:&lt;rule&gt;</code> on its line or in the comment block directly above it; on the <code>package</code> line it applies file-wide. Non-integrity rules can also be disabled per run (<code>-skip-&lt;rule&gt;</code>) or project-wide (<code>.gotest.yml</code> → <code>lint.skip</code>).</p>
+
+      <h3>Exit codes</h3>
+      <table class="ref-table">
+        <thead><tr><th>Code</th><th>Meaning</th></tr></thead>
+        <tbody>
+          <tr><td><code>0</code></td><td>No findings.</td></tr>
+          <tr><td><code>1</code></td><td>One or more target packages do not compile — they could not be analyzed, so the run fails instead of passing silently.</td></tr>
+          <tr><td><code>2</code></td><td>Usage or configuration error (e.g. an integrity rule in <code>lint.skip</code>).</td></tr>
+          <tr><td><code>3</code></td><td>Findings reported.</td></tr>
+        </tbody>
+      </table>
+
+      <div class="callout">
+        The linter is a standard <code>go/analysis</code> analyzer (also available as the standalone <code>gotest-lint</code> binary). There is no golangci-lint plugin — run it as its own CI step alongside your existing linter.
       </div>
     </section>
 


### PR DESCRIPTION
A full pass over the linter's documentation against what the tool actually does. The README now describes all sixteen rules and how they're grouped, the help texts and website list the correct rule and exit-code information, and the conflicting statements about golangci-lint integration now agree everywhere. One behavior fix came out of the audit: placing a `//nolint` comment on the line above a finding now silences it for every rule, as the help text always claimed, previously that only worked for one rule.