### PR TITLE
Replace the retired Go Report Card badge

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,6 +1,9 @@
 name: quality
 
 on:
+  push:
+    branches: [main]
+    paths-ignore: [vscode-gotest/**]
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore: [vscode-gotest/**]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![CI](https://github.com/mvrahden/go-test/actions/workflows/test.yml/badge.svg)](https://github.com/mvrahden/go-test/actions/workflows/test.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/mvrahden/go-test.svg)](https://pkg.go.dev/github.com/mvrahden/go-test)
-[![Go Report Card](https://goreportcard.com/badge/github.com/mvrahden/go-test)](https://goreportcard.com/report/github.com/mvrahden/go-test)
+[![Quality](https://img.shields.io/github/actions/workflow/status/mvrahden/go-test/quality.yml?branch=main&label=quality)](https://github.com/mvrahden/go-test/actions/workflows/quality.yml)
 [![Go 1.24+](https://img.shields.io/badge/Go-1.24%2B-00ADD8?logo=go)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 


### PR DESCRIPTION
The Go Report Card service has shut down, so its README badge was broken. This swaps it for a badge backed by our own quality workflow, which shows the same "is the code healthy?" signal from a source we control.