### PR TITLE
Reliable test runs on busy machines

### DIFF
--- a/.github/actions/extension-check/action.yml
+++ b/.github/actions/extension-check/action.yml
@@ -15,7 +15,7 @@ runs:
     - run: npm run format:check
       shell: bash
       working-directory: vscode-gotest
-    - run: npx tsc --noEmit
+    - run: npm run typecheck
       shell: bash
       working-directory: vscode-gotest
     - run: npm test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,7 +298,7 @@ func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
 }
 ```
 
-Fields: `Timeout` (per-test deadline), `SetupTimeout`, `FailFast` (stop on first failure), `Parallel`.
+Fields: `Timeout` (per-test deadline), `SetupTimeout`, `FailFast` (stop on first failure), `Parallel`, `Exclusive` (dispatched strictly alone, after every non-exclusive suite — for suites whose verdicts measure wall-clock behavior or contend for resources).
 Presets: `DefaultSuiteConfig()` (30s/30s), `IntegrationSuiteConfig()` (2m/5m).
 
 The returned config is used as-is. A zero or omitted duration means **no deadline**,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,6 +460,7 @@ func (f *PostgresSharedFixture) SharedFixtureConfig() gotest.FixtureConfig {
 
 Suites reference shared fixtures via pointer fields (same as package fixtures).
 Shared fixtures must not live in `internal/` packages.
+Shared fixtures are window-scheduled: each is resident exactly while a scheduled suite needs it — never started when no dispatched suite requires it, and released or started at the bulk→exclusive-tail barrier as the phases' needs differ.
 
 ### Generic test suites (contract testing)
 

--- a/README.md
+++ b/README.md
@@ -780,7 +780,7 @@ All `go test` flags work unchanged: `-race`, `-cover`, `-count`, `-run`, `-json`
 | `*SharedFixture` suffix | Cross-package shared fixture |
 | `FixtureConfig()` method | Fixture timeout/retry config |
 | `SharedFixtureConfig()` method | Shared fixture timeout/retry config |
-| `SuiteConfig()` method | Suite timeout/parallelism/failfast config |
+| `SuiteConfig()` method | Suite timeout/parallelism/exclusive/failfast config |
 | `Hydrate` / `Dehydrate` | SharedFixture test-process resource reconstruction |
 
 ## VS Code Extension

--- a/cmd/gotest/args.go
+++ b/cmd/gotest/args.go
@@ -168,11 +168,21 @@ func extractStringFlag(args []string, name, defaultVal string) string {
 
 func ExtractPackagePatterns(goTestArgs []string) []string {
 	var patterns []string
-	for _, arg := range goTestArgs {
+	for i := 0; i < len(goTestArgs); i++ {
+		arg := goTestArgs[i]
 		if arg == "-args" {
 			break
 		}
 		if strings.HasPrefix(arg, "-") {
+			// Pair space-separated values with their flag, exactly as
+			// SplitArgs does when it builds goTestArgs: the value of
+			// "-bench ^BenchmarkSuite$/^BenchmarkMethod$" carries a "/" that
+			// LooksLikePackagePattern would otherwise claim as a package.
+			if name, _, hasEquals := strings.Cut(arg, "="); !hasEquals {
+				if isValue, known := gotestrunner.IsGoTestFlag(name); known && isValue && i+1 < len(goTestArgs) {
+					i++
+				}
+			}
 			continue
 		}
 		if gotestrunner.LooksLikePackagePattern(arg) {

--- a/cmd/gotest/gotest_suite_test.go
+++ b/cmd/gotest/gotest_suite_test.go
@@ -345,6 +345,8 @@ func (s *CmdGotestTestSuite) TestPackagePatterns(t *gotest.T) {
 			{Desc: "stops at -args", args: []string{"-v", "./...", "-args", "-custom", "./not/a/pkg"}, expected: []string{"./..."}},
 			{Desc: "no args defaults to dot", args: nil, expected: []string{"."}},
 			{Desc: "bare relative path", args: []string{"-v", "./cmd/gotest"}, expected: []string{"./cmd/gotest"}},
+			{Desc: "space-separated flag value with a slash is not a package", args: []string{"./pkg/a", "-bench", "^BenchmarkFooTestSuite$/^BenchmarkParse$"}, expected: []string{"./pkg/a"}},
+			{Desc: "space-separated -run value with a slash is not a package", args: []string{"-run", "TestFoo/sub", "./pkg/a"}, expected: []string{"./pkg/a"}},
 		}) {
 			result := ExtractPackagePatterns(tc.args)
 			gotest.Equal(sub, tc.expected, result)

--- a/cmd/gotest/gotest_suite_test.go
+++ b/cmd/gotest/gotest_suite_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mvrahden/go-test/internal/gotestgen"
 	"github.com/mvrahden/go-test/internal/gotestrunner"
 	"github.com/mvrahden/go-test/internal/gotestspec"
+	"github.com/mvrahden/go-test/internal/lint"
 	"github.com/mvrahden/go-test/pkg/gotest"
 )
 
@@ -177,12 +178,18 @@ func (s *CmdGotestTestSuite) TestDefaultArgs(t *gotest.T) {
 // specTableEntries extracts `name` from rows shaped `| `name` | ... |` within the
 // doc section starting at heading until the next heading of the same level.
 func specTableEntries(doc, heading string) map[string]bool {
+	return specTableEntriesUntil(doc, heading, "\n### ")
+}
+
+// specTableEntriesUntil is specTableEntries with an explicit section
+// terminator, for sections delimited by a different heading level.
+func specTableEntriesUntil(doc, heading, next string) map[string]bool {
 	start := strings.Index(doc, heading)
 	if start < 0 {
 		return nil
 	}
 	section := doc[start:]
-	if end := strings.Index(section[len(heading):], "\n### "); end >= 0 {
+	if end := strings.Index(section[len(heading):], next); end >= 0 {
 		section = section[:len(heading)+end]
 	}
 	entries := map[string]bool{}
@@ -224,6 +231,20 @@ func (s *CmdGotestTestSuite) TestCLISurfaceMatchesSpec(t *gotest.T) {
 			for flag := range documented {
 				_, known := ExportGotestFlags[flag]
 				gotest.True(it, known, "spec.md documents unknown flag %q", flag)
+			}
+		})
+	})
+
+	t.When("comparing the Linter rule tables", func(w *gotest.T) {
+		documented := specTableEntriesUntil(doc, "## Linter", "\n## ")
+		w.It("documents every registered lint rule", func(it *gotest.T) {
+			for _, rule := range lint.RuleIDs() {
+				gotest.True(it, documented[string(rule)], "lint rule %q missing from spec.md", rule)
+			}
+		})
+		w.It("documents no phantom lint rules", func(it *gotest.T) {
+			for id := range documented {
+				gotest.True(it, lint.Known(lint.Rule(id)), "spec.md documents unknown lint rule %q", id)
 			}
 		})
 	})

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -480,7 +480,7 @@ Fields:
   setup-timeout: <duration> Total budget for all shared fixture setup (default: 2m, 0 to disable)
   timeout: <duration>       Global pipeline deadline (default: 15m, 0 to disable)
   min-coverage: <int>       Minimum coverage percentage, 0-100
-  parallel: <int>           Total concurrent test method budget (default: 2×GOMAXPROCS)
+  parallel: <int>           Total concurrent test method budget (default: 2×GOMAXPROCS, auto-halved for -race/-msan/-asan)
   compile-parallel: <int>   Concurrent compilation processes (default: NumCPU, auto-halved for -race/-msan/-asan)
   debounce: <duration>      Watch mode re-run delay (e.g., "500ms", default: 200ms)
   lint:

--- a/docs/design/fixtures.md
+++ b/docs/design/fixtures.md
@@ -8,7 +8,8 @@ Any struct whose name ends in `Fixture` is a package fixture; any struct ending 
 
 ## Package Fixture (`*Fixture` suffix)
 
-A package fixture runs `BeforeAll` once per package, then injects state into child test suites via named pointer fields.
+A package fixture runs `BeforeAll` once per suite process, then injects state into child test suites via named pointer fields.
+Each suite is dispatched in its own test process, so suites binding the same package fixture each get a fresh instance — package fixtures share code, not runtime state, across suites.
 
 ```go
 // fixture_test.go
@@ -354,6 +355,13 @@ gotest ./tests/e2e ./tests/integration -v
 6. Send SIGTERM to the setup subprocess (calls `AfterAll` in reverse order)
 
 ## Execution Model
+
+### Never speculative
+
+Shared fixtures are never speculative: a shared fixture is resident exactly while a scheduled suite needs it.
+Before anything starts, the runner computes the set of suites the run will dispatch — after `-run` filtering and config-level skips — and starts only the shared fixtures some scheduled suite requires, closed over the dependency DAG.
+A fixture nothing scheduled needs is never started, and can therefore never fail the run.
+When fixtures are skipped this way, the runner emits one debug line to stderr: `gotest: N shared fixture(s) not started (no scheduled suite requires them)`.
 
 ### Lazy, reference-counted lifecycle
 

--- a/docs/design/fixtures.md
+++ b/docs/design/fixtures.md
@@ -363,6 +363,21 @@ Before anything starts, the runner computes the set of suites the run will dispa
 A fixture nothing scheduled needs is never started, and can therefore never fail the run.
 When fixtures are skipped this way, the runner emits one debug line to stderr: `gotest: N shared fixture(s) not started (no scheduled suite requires them)`.
 
+### Window scheduling
+
+A run dispatches in two phases: the parallel bulk, then the serial tail of `Exclusive` suites.
+Each phase has an alive set — `Alive(phase)` is the DAG-closure of the union of the shared fixture keys the phase's suites require — and a shared fixture is resident exactly for the phases that need it:
+
+- Fixtures in neither alive set never start.
+- `Alive(bulk)` starts up-front, concurrent with package compilation.
+- At the bulk→tail barrier — every parallel suite drained, no exclusive suite dispatched yet — the runner tears down `Alive(bulk) ∖ Alive(tail)` in reverse dependency order, then starts `Alive(tail) ∖ Alive(bulk)` in dependency order, under the same per-fixture retry and budget policy as the up-front phase.
+- Run-end teardown releases whatever is still resident. Fixtures released at the barrier are skipped there: every fixture's teardown has exactly one owner.
+
+The barrier speaks two verbs to the setup subprocess over its stdin — start and teardown, each naming a set of state keys — acknowledged on stdout after any late state lines.
+`Alive(tail)` is computed from the tail suites that actually became runnable, so a fixture whose only exclusive suite failed to compile is released at the barrier, not started for nothing.
+On cancellation the barrier is skipped entirely and run-end teardown owns everything.
+Window scheduling is always on; there is no configuration.
+
 ### Lazy, reference-counted lifecycle
 
 Fixture setup does not run at package init.
@@ -381,6 +396,7 @@ The default `gotest` run streams: each shared fixture's state is emitted as its 
 - Shared-fixture setup failure aborts the run: exit code 2 in batch modes (`watch`/`spec`/`summary`/`prepare`); in the default streaming run the affected suites are reported as failures (exit 1).
   In-test-process package-fixture setup failure is a `t.Fatalf` (exit 1).
 - Fixture teardown failure flips an otherwise passing run to a failure (`fixture teardown failed`).
+- Barrier-time failures — an early teardown or a tail-phase start — fail the run through the same aggregation as run-end teardown failures; the terminal teardown still runs and owns the remainder.
 
 ### Config markers
 

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -621,8 +621,11 @@ type SuiteConfig struct {
     SetupTimeout time.Duration // BeforeAll/AfterAll deadline
     FailFast     bool          // stop suite on first failure
     Parallel     bool          // method-level parallelism (requires returning BeforeEach)
+    Exclusive    bool          // dispatched strictly alone, after every non-exclusive suite
 }
 ```
+
+`Exclusive` is resolved statically like `Parallel` and consumed by the runner, not the harness: exclusive suites are held back until every non-exclusive suite has finished, then dispatched one at a time in deterministic (package, suite) order — in batch and streaming pipelines alike. It exists for suites whose verdicts measure wall-clock behavior or fight over resources (timing budgets, containers, ports, per-invocation child builds): a budget verdict taken on a saturated machine is not a verdict you can act on. Shared fixture processes stay up for exclusive suites — they are infrastructure, not competing suites. Under `-race`/`-msan`/`-asan`, dispatch and compile concurrency defaults are additionally halved (an explicit `--parallel`/`--compile-parallel` always wins): instrumentation at least doubles the CPU cost per instruction stream, and the uninstrumented defaults would oversubscribe the machine.
 
 (Test-case retries are deliberately not offered — retrying flaky tests hides real defects; fixture `Retries` exist because infrastructure setup is legitimately flaky.)
 

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -142,7 +142,7 @@ gotest [subcommand] [packages...] [go-test-flags...] [--gotest-flags...]
 | `--setup-timeout=<dur>` | Total budget for shared fixture setup (default: 2m; 0 disables) |
 | `--timeout=<dur>` | Global pipeline deadline (default: 15m; 0 disables) |
 | `--debounce=<dur>` | Debounce interval for watch mode (default 200ms) |
-| `--parallel=<n>` | Total concurrent test method budget (default: 2×GOMAXPROCS) |
+| `--parallel=<n>` | Total concurrent test method budget (default: 2×GOMAXPROCS, auto-halved for -race/-msan/-asan) |
 | `--compile-parallel=<n>` | Concurrent compilation processes (default: NumCPU, auto-halved for -race/-msan/-asan) |
 | `--input=<path>` | Replay a saved `go test -json` stream in `spec`/`summary` (`-` reads stdin) |
 | `--github` | Emit GitHub annotations and step summary (auto-enabled in GitHub Actions) |

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -1296,6 +1296,7 @@ Rules are grouped into three tiers by what breaks when a finding is ignored; the
 | `poll-scope` | Assertions inside `Eventually`/`Consistently` callbacks using the outer `t` instead of `poll` |
 | `assertion-type-guard` | `Nil`/`Empty` on types their runtime guards would reject |
 | `generated-file` | `gotest_p(x)suite_test.go` files present in source control |
+| `shared-fixture-undeclared` | Suite-method reads of a `*SharedFixture` value the suite never declared as a pointer field (directly or through the fixture DAG) — window scheduling starts only declared fixtures, so the value may be absent; locally-constructed fixtures (fixture self-tests) are exempt |
 
 **Expressiveness** — the test is correct but says it worse. Suppressible per line or project-wide via `lint.skip`.
 

--- a/internal/gotestast/spec.go
+++ b/internal/gotestast/spec.go
@@ -205,6 +205,10 @@ func (ts *TestSuiteSpec) HasGuard() bool { return ts.th.Guard != nil }
 // FOR RENDERING
 func (ts *TestSuiteSpec) IsMethodParallel() bool { return ts.th.ConfigParallel }
 
+// IsExclusive returns true when SuiteConfig has Exclusive: true — the runner
+// then dispatches this suite strictly alone, after the parallel bulk.
+func (ts *TestSuiteSpec) IsExclusive() bool { return ts.th.ConfigExclusive }
+
 // HasReturningBeforeEach returns true when BeforeEach is defined and returns a context value.
 //
 // FOR RENDERING
@@ -287,6 +291,9 @@ type TestSuiteHarness struct {
 	Config         *types.Func // SuiteConfig() method, may be nil
 	Guard          *types.Func // SuiteGuard() method, may be nil
 	ConfigParallel bool
+	// ConfigExclusive mirrors SuiteConfig.Exclusive, resolved statically so
+	// the runner can schedule the suite outside the parallel bulk.
+	ConfigExclusive bool
 }
 
 type TestSuiteMethod struct {
@@ -340,12 +347,20 @@ func (m *TestSuiteMethod) Identifier() string {
 }
 
 // suiteConfigBodyErr describes the statically-parseable forms: the generator
-// needs Parallel at generation time, so SuiteConfig bodies cannot be arbitrary Go.
+// needs Parallel and Exclusive at generation time, so SuiteConfig bodies
+// cannot be arbitrary Go.
 const suiteConfigBodyErr = "SuiteConfig method body must return a gotest.SuiteConfig literal or preset call, optionally composed as `cfg := <literal|preset>` followed by plain `cfg.<Field> = <value>` assignments"
 
-func parseSuiteConfigAST(pkg *packages.Package, funcDecl *ast.FuncDecl) (parallel bool, err error) {
+// staticSuiteConfig carries the SuiteConfig fields the generator and runner
+// resolve statically. Everything else in SuiteConfig is runtime-only.
+type staticSuiteConfig struct {
+	Parallel  bool
+	Exclusive bool
+}
+
+func parseSuiteConfigAST(pkg *packages.Package, funcDecl *ast.FuncDecl) (cfg staticSuiteConfig, err error) {
 	if funcDecl.Body == nil || len(funcDecl.Body.List) == 0 {
-		return false, errors.New(suiteConfigBodyErr)
+		return cfg, errors.New(suiteConfigBodyErr)
 	}
 	stmts := funcDecl.Body.List
 
@@ -353,78 +368,82 @@ func parseSuiteConfigAST(pkg *packages.Package, funcDecl *ast.FuncDecl) (paralle
 	if len(stmts) == 1 {
 		retStmt, ok := stmts[0].(*ast.ReturnStmt)
 		if !ok || len(retStmt.Results) != 1 {
-			return false, errors.New(suiteConfigBodyErr)
+			return cfg, errors.New(suiteConfigBodyErr)
 		}
 		switch result := retStmt.Results[0].(type) {
 		case *ast.CompositeLit:
-			return suiteConfigParallelFromLiteral(result)
+			return suiteConfigFromLiteral(result)
 		case *ast.CallExpr:
 			if !isKnownSuitePreset(result, pkg) {
-				return false, fmt.Errorf("SuiteConfig: only the gotest presets (DefaultSuiteConfig, IntegrationSuiteConfig) may be called — Parallel is resolved statically and a custom helper would silently drop it")
+				return cfg, fmt.Errorf("SuiteConfig: only the gotest presets (DefaultSuiteConfig, IntegrationSuiteConfig) may be called — Parallel and Exclusive are resolved statically and a custom helper would silently drop them")
 			}
-			return false, nil
+			return cfg, nil
 		default:
-			return false, errors.New(suiteConfigBodyErr)
+			return cfg, errors.New(suiteConfigBodyErr)
 		}
 	}
 
 	// Compose form: cfg := <literal|preset>; cfg.Field = value ...; return cfg.
 	first, ok := stmts[0].(*ast.AssignStmt)
 	if !ok || first.Tok != token.DEFINE || len(first.Lhs) != 1 || len(first.Rhs) != 1 {
-		return false, errors.New(suiteConfigBodyErr)
+		return cfg, errors.New(suiteConfigBodyErr)
 	}
 	cfgIdent, ok := first.Lhs[0].(*ast.Ident)
 	if !ok {
-		return false, errors.New(suiteConfigBodyErr)
+		return cfg, errors.New(suiteConfigBodyErr)
 	}
 	switch rhs := first.Rhs[0].(type) {
 	case *ast.CompositeLit:
-		parallel, err = suiteConfigParallelFromLiteral(rhs)
+		cfg, err = suiteConfigFromLiteral(rhs)
 		if err != nil {
-			return false, err
+			return staticSuiteConfig{}, err
 		}
 	case *ast.CallExpr:
 		if !isKnownSuitePreset(rhs, pkg) {
-			return false, fmt.Errorf("SuiteConfig: only the gotest presets (DefaultSuiteConfig, IntegrationSuiteConfig) may be called — Parallel is resolved statically and a custom helper would silently drop it")
+			return cfg, fmt.Errorf("SuiteConfig: only the gotest presets (DefaultSuiteConfig, IntegrationSuiteConfig) may be called — Parallel and Exclusive are resolved statically and a custom helper would silently drop them")
 		}
 	default:
-		return false, errors.New(suiteConfigBodyErr)
+		return cfg, errors.New(suiteConfigBodyErr)
 	}
 
 	last, ok := stmts[len(stmts)-1].(*ast.ReturnStmt)
 	if !ok || len(last.Results) != 1 {
-		return false, errors.New(suiteConfigBodyErr)
+		return staticSuiteConfig{}, errors.New(suiteConfigBodyErr)
 	}
 	if retIdent, ok := last.Results[0].(*ast.Ident); !ok || retIdent.Name != cfgIdent.Name {
-		return false, errors.New(suiteConfigBodyErr)
+		return staticSuiteConfig{}, errors.New(suiteConfigBodyErr)
 	}
 
 	for _, stmt := range stmts[1 : len(stmts)-1] {
 		assign, ok := stmt.(*ast.AssignStmt)
 		if !ok || assign.Tok != token.ASSIGN || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
-			return false, errors.New(suiteConfigBodyErr)
+			return staticSuiteConfig{}, errors.New(suiteConfigBodyErr)
 		}
 		sel, ok := assign.Lhs[0].(*ast.SelectorExpr)
 		if !ok {
-			return false, errors.New(suiteConfigBodyErr)
+			return staticSuiteConfig{}, errors.New(suiteConfigBodyErr)
 		}
 		if base, ok := sel.X.(*ast.Ident); !ok || base.Name != cfgIdent.Name {
-			return false, errors.New(suiteConfigBodyErr)
+			return staticSuiteConfig{}, errors.New(suiteConfigBodyErr)
 		}
-		if sel.Sel.Name == "Parallel" {
+		if sel.Sel.Name == "Parallel" || sel.Sel.Name == "Exclusive" {
 			val, ok := assign.Rhs[0].(*ast.Ident)
 			if !ok || (val.Name != "true" && val.Name != "false") {
-				return false, fmt.Errorf("SuiteConfig: Parallel must be assigned a boolean literal — the generator resolves it statically")
+				return staticSuiteConfig{}, fmt.Errorf("SuiteConfig: %s must be assigned a boolean literal — the generator resolves it statically", sel.Sel.Name)
 			}
-			parallel = val.Name == "true"
+			if sel.Sel.Name == "Parallel" {
+				cfg.Parallel = val.Name == "true"
+			} else {
+				cfg.Exclusive = val.Name == "true"
+			}
 		}
 	}
-	return parallel, nil
+	return cfg, nil
 }
 
 // isKnownSuitePreset accepts only the gotest-shipped presets as config bases:
-// they are known to leave Parallel false, so static Parallel detection stays
-// sound. The call must resolve to pkg/gotest — a same-named function or method
+// they are known to leave Parallel and Exclusive false, so static detection
+// of both stays sound. The call must resolve to pkg/gotest — a same-named function or method
 // from anywhere else could return Parallel: true and be silently mis-read.
 func isKnownSuitePreset(call *ast.CallExpr, pkg *packages.Package) bool {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
@@ -441,27 +460,32 @@ func isKnownSuitePreset(call *ast.CallExpr, pkg *packages.Package) bool {
 	return obj.Pkg().Path() == about.Repo+"/pkg/gotest"
 }
 
-func suiteConfigParallelFromLiteral(lit *ast.CompositeLit) (bool, error) {
+func suiteConfigFromLiteral(lit *ast.CompositeLit) (staticSuiteConfig, error) {
+	var cfg staticSuiteConfig
 	for _, elt := range lit.Elts {
 		kv, ok := elt.(*ast.KeyValueExpr)
 		if !ok {
 			// A positional literal sets fields the scan below cannot see, so a
-			// Parallel value would silently read as false.
-			return false, fmt.Errorf("SuiteConfig literal must use keyed fields (Field: value) — Parallel is resolved statically from the Parallel: key")
+			// Parallel or Exclusive value would silently read as false.
+			return staticSuiteConfig{}, fmt.Errorf("SuiteConfig literal must use keyed fields (Field: value) — Parallel and Exclusive are resolved statically from their keys")
 		}
 		key, ok := kv.Key.(*ast.Ident)
 		if !ok {
 			continue
 		}
-		if key.Name == "Parallel" {
+		if key.Name == "Parallel" || key.Name == "Exclusive" {
 			ident, ok := kv.Value.(*ast.Ident)
 			if !ok || (ident.Name != "true" && ident.Name != "false") {
-				return false, fmt.Errorf("SuiteConfig: Parallel must be assigned a boolean literal — the generator resolves it statically")
+				return staticSuiteConfig{}, fmt.Errorf("SuiteConfig: %s must be assigned a boolean literal — the generator resolves it statically", key.Name)
 			}
-			return ident.Name == "true", nil
+			if key.Name == "Parallel" {
+				cfg.Parallel = ident.Name == "true"
+			} else {
+				cfg.Exclusive = ident.Name == "true"
+			}
 		}
 	}
-	return false, nil
+	return cfg, nil
 }
 
 func DetermineTestSuite(n ast.Node, pkg *packages.Package) (*TestSuiteSpec, token.Pos, error) {
@@ -569,11 +593,12 @@ func DetermineTestSuiteHarness(n ast.Node, pkg *packages.Package, s *TestSuiteSp
 			return m.Pos(), fmt.Errorf("unsupported return type for %q: expected gotest.SuiteConfig, got %s", methodID, resType)
 		}
 		s.th.Config = m
-		parallel, err := parseSuiteConfigAST(pkg, decl)
+		staticCfg, err := parseSuiteConfigAST(pkg, decl)
 		if err != nil {
 			return m.Pos(), fmt.Errorf("%s.SuiteConfig: %w", s.ts.Name.Name, err)
 		}
-		s.th.ConfigParallel = parallel
+		s.th.ConfigParallel = staticCfg.Parallel
+		s.th.ConfigExclusive = staticCfg.Exclusive
 		return -1, nil
 	}
 

--- a/internal/gotestgen/collector_suite_test.go
+++ b/internal/gotestgen/collector_suite_test.go
@@ -380,6 +380,27 @@ func (s *CollectorTestSuite) TestSuiteConfig(t *gotest.T) {
 		})
 	})
 
+	t.When("Exclusive appears in the literal", func(w *gotest.T) {
+		w.It("is resolved statically like Parallel", func(it *gotest.T) {
+			pkg := gotestgen.ExportMustTestPkg(it.T(), "TestCollector_SuiteConfig_ExclusiveParsed")
+			c := gotestgen.NewCollector()
+			result := c.CollectSuiteSpecs(pkg)
+			gotest.Empty(it, result.Errs, "expected no errors, got: %v", result.Errs)
+			gotest.True(it, result.Suites[0].IsExclusive(), "Exclusive: true in the literal must be detected")
+			gotest.False(it, result.Suites[0].IsMethodParallel())
+		})
+	})
+
+	t.When("Exclusive is assigned in the compose form over a preset", func(w *gotest.T) {
+		w.It("is resolved statically", func(it *gotest.T) {
+			pkg := gotestgen.ExportMustTestPkg(it.T(), "TestCollector_SuiteConfig_ExclusiveCompose")
+			c := gotestgen.NewCollector()
+			result := c.CollectSuiteSpecs(pkg)
+			gotest.Empty(it, result.Errs, "expected no errors, got: %v", result.Errs)
+			gotest.True(it, result.Suites[0].IsExclusive(), "cfg.Exclusive = true over a preset must be detected")
+		})
+	})
+
 	t.When("Parallel is overridden back to false", func(w *gotest.T) {
 		w.It("reports not parallel", func(it *gotest.T) {
 			pkg := gotestgen.ExportMustTestPkg(it.T(), "TestCollector_SuiteConfig_ParallelFalseOverride")

--- a/internal/gotestgen/generator.go
+++ b/internal/gotestgen/generator.go
@@ -21,6 +21,7 @@ type GenerateResult struct {
 	PXTest                         []byte              // generated external test source
 	SuiteNames                     []string            // suite struct identifiers (e.g. "FooTestSuite")
 	SkippedSuiteNames              []string            // identifiers of suites excluded by focus/X_ rules
+	ExclusiveSuiteNames            []string            // identifiers of suites with SuiteConfig{Exclusive: true} — dispatched alone, after the parallel bulk
 	FixtureDepSuites               []string            // test function names that depend on shared fixtures (e.g. "TestFooSuite")
 	SuiteRequiredSharedFixtureKeys map[string][]string // test func name → required state keys
 	StdlibTestCount                int                 // stdlib func TestX(*testing.T) declarations — reported, never run by gotest
@@ -290,11 +291,17 @@ func generateFromLoaded(loadResults []*LoadResult) (GenerateResults, []SharedFix
 
 		seen := map[string]bool{}
 		var suiteNames []string
+		var exclusiveNames []string
+		exclusiveSeen := map[string]bool{}
 		for _, s := range ptestSpec.EffectiveTestSuites {
 			id := s.Identifier()
 			if !seen[id] {
 				seen[id] = true
 				suiteNames = append(suiteNames, id)
+			}
+			if s.IsExclusive() && !exclusiveSeen[id] {
+				exclusiveSeen[id] = true
+				exclusiveNames = append(exclusiveNames, id)
 			}
 		}
 		for _, s := range pxtestSpec.EffectiveTestSuites {
@@ -302,6 +309,10 @@ func generateFromLoaded(loadResults []*LoadResult) (GenerateResults, []SharedFix
 			if !seen[id] {
 				seen[id] = true
 				suiteNames = append(suiteNames, id)
+			}
+			if s.IsExclusive() && !exclusiveSeen[id] {
+				exclusiveSeen[id] = true
+				exclusiveNames = append(exclusiveNames, id)
 			}
 		}
 
@@ -336,6 +347,7 @@ func generateFromLoaded(loadResults []*LoadResult) (GenerateResults, []SharedFix
 			PXTest:                         pxtestBuf,
 			SuiteNames:                     suiteNames,
 			SkippedSuiteNames:              skippedNames,
+			ExclusiveSuiteNames:            exclusiveNames,
 			FixtureDepSuites:               append(ptestFixtureDeps, pxtestFixtureDeps...),
 			SuiteRequiredSharedFixtureKeys: mergedReqKeys,
 			StdlibTestCount:                countStdlibTests(lr.Ptest, lr.Pxtest),

--- a/internal/gotestgen/panic_resilience_suite_test.go
+++ b/internal/gotestgen/panic_resilience_suite_test.go
@@ -17,7 +17,8 @@ import (
 type PanicResilienceTestSuite struct{}
 
 func (s *PanicResilienceTestSuite) SuiteConfig() gotest.SuiteConfig {
-	return gotest.SuiteConfig{Parallel: true, Timeout: 3 * time.Minute}
+	// Exclusive: see ParallelLifecycleTestSuite — same wall-clock budget harness.
+	return gotest.SuiteConfig{Parallel: true, Exclusive: true, Timeout: 3 * time.Minute}
 }
 
 func (s *PanicResilienceTestSuite) TestPanicInPollFunction(t *gotest.T) {

--- a/internal/gotestgen/parallel_lifecycle_suite_test.go
+++ b/internal/gotestgen/parallel_lifecycle_suite_test.go
@@ -33,7 +33,9 @@ const childWallClock = 90 * time.Second
 type ParallelLifecycleTestSuite struct{}
 
 func (s *ParallelLifecycleTestSuite) SuiteConfig() gotest.SuiteConfig {
-	return gotest.SuiteConfig{Parallel: true, Timeout: 3 * time.Minute}
+	// Exclusive: these methods hold child suites to wall-clock budgets, and a
+	// budget verdict taken on a saturated machine is not a verdict to act on.
+	return gotest.SuiteConfig{Parallel: true, Exclusive: true, Timeout: 3 * time.Minute}
 }
 
 type childRun struct {

--- a/internal/gotestgen/parallel_lifecycle_suite_test.go
+++ b/internal/gotestgen/parallel_lifecycle_suite_test.go
@@ -16,7 +16,10 @@ import (
 // childTimeout is the -test.timeout of the compiled suite binary. If suite
 // cleanup ever waits on work that is itself blocked behind that cleanup, the
 // child dies here with "test timed out" instead of hanging this package.
-const childTimeout = 15 * time.Second
+// 60s: generous headroom over the harness's own promptness assertions —
+// under a loaded gate a runnable-but-unscheduled child is starvation, not a
+// hang, and must not be executed by this backstop alarm.
+const childTimeout = 60 * time.Second
 
 // childWallClock bounds the whole subprocess, so even a child that ignores its
 // own timeout cannot stall the parent run.

--- a/internal/gotestgen/sharedfixture.go
+++ b/internal/gotestgen/sharedfixture.go
@@ -26,6 +26,10 @@ type SharedFixtureInfo struct {
 	LocalFields      []string          // exported fields assigned in Hydrate
 	Dependencies     []string          // state keys of shared fixtures this one depends on
 	DependencyFields map[string]string // dep state key → field name in this struct
+	// Deferred is runner scheduling, not discovery output: a deferred fixture
+	// is compiled into the setup program but not started up-front — it starts
+	// when a StartKeys command names it (the bulk→tail barrier).
+	Deferred bool
 }
 
 type sharedSetupData struct {
@@ -61,6 +65,7 @@ type sharedSetupFixture struct {
 	DependsOnVars     []string           // var names of fixtures this depends on (e.g. ["sf0"])
 	DependsOnIndices  []int              // indices of dependency fixtures in the Fixtures slice
 	ParentAssignments []parentAssignment // parent var → field name assignments
+	Deferred          bool               // excluded from the up-front phase; starts on StartKeys
 }
 
 // GenerateSharedSetup generates a standalone Go main package source that
@@ -131,6 +136,7 @@ func GenerateSharedSetup(fixtures []SharedFixtureInfo) ([]byte, error) {
 			DependsOnVars:     dependsOnVars,
 			DependsOnIndices:  dependsOnIndices,
 			ParentAssignments: parentAssigns,
+			Deferred:          sf.Deferred,
 		})
 	}
 

--- a/internal/gotestgen/sharedfixture_suite_test.go
+++ b/internal/gotestgen/sharedfixture_suite_test.go
@@ -426,12 +426,14 @@ func (s *SharedFixtureTestSuite) TestGeneratedCodeStructure(t *gotest.T) {
 				}
 			}
 			gotest.Equal(it, []string{
+				"bufio",
 				"context",
 				"encoding/json",
 				"errors",
 				"fmt",
 				"os",
 				"os/signal",
+				"strings",
 				"sync",
 				"syscall",
 				"time",

--- a/internal/gotestgen/static/sharedfixture.go.tpl
+++ b/internal/gotestgen/static/sharedfixture.go.tpl
@@ -2,12 +2,14 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -24,8 +26,24 @@ func ƒquote(s string) string {
 	return string(b)
 }
 
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
 {{- /*
-  Configs start as the defaults and are derived inside each fixture's goroutine,
+  Configs start as the defaults and are derived inside each fixture's setup,
   not here: a config marker that panics at the top of main would kill the
   process before the handshake, attributed to nothing. A fixture whose
   derivation fails reports the error, its dependents and its teardown skip it,
@@ -44,15 +62,24 @@ func main() {
 	ƒcfg_{{ $f.VarName }} := gotest.DefaultFixtureConfig()
 {{ end }}
 	ƒerrs := make([]error, {{ len .Fixtures }})
+	ƒstarted := make([]bool, {{ len .Fixtures }})
+	ƒtorn := make([]bool, {{ len .Fixtures }})
 {{ range $f := .Fixtures }}
 	ƒdone_{{ $f.VarName }} := make(chan struct{})
 {{- end }}
 
-	var ƒwg sync.WaitGroup
+{{- /*
+  One setup body per fixture, shared verbatim by the up-front phase and the
+  StartKeys verb: same config derivation, same dependency gating, same retry
+  and budget policy through RunFixtureSetup. A fixture starts at most once —
+  its window opens exactly one time per run.
+*/}}
 {{ range $i, $f := .Fixtures }}
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_{{ $f.VarName }} := func() {
+		if ƒstarted[{{ $i }}] {
+			return
+		}
+		ƒstarted[{{ $i }}] = true
 		defer close(ƒdone_{{ $f.VarName }})
 {{- if $f.HasConfig }}
 {{- /*
@@ -117,7 +144,52 @@ func main() {
 {{- else }}
 		fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":{}}\n", ƒquote("{{ $f.StateKey }}"))
 {{- end }}
+	}
+{{ end }}
+
+{{- /*
+  One teardown body per fixture, shared by the TeardownKeys verb and the
+  epilogue: whichever fires first wins, the other finds ƒtorn set and skips —
+  the terminal teardown owns exactly the remainder. A fixture that never
+  started, or whose setup failed, has nothing to release; one whose setup
+  merely overran its budget still initialized, so it is torn down like a
+  success. Panics are contained and a declared Timeout is a verdict — the
+  same policy the in-process DAG runs under.
+*/}}
+{{ range $f := .Fixtures }}
+	ƒteardown_{{ $f.VarName }} := func() bool {
+		if ƒtorn[{{ $f.Index }}] || !ƒstarted[{{ $f.Index }}] {
+			ƒtorn[{{ $f.Index }}] = true
+			return false
+		}
+		ƒtorn[{{ $f.Index }}] = true
+		if ƒerrs[{{ $f.Index }}] == nil || errors.Is(ƒerrs[{{ $f.Index }}], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "{{ $f.Identifier }}",
+				Timeout:  ƒcfg_{{ $f.VarName }}.Timeout,
+				Budget:   {{ if $f.HasConfig }}ƒcfg_{{ $f.VarName }}.Timeout{{ else }}0{{ end }},
+				AfterAll: {{ $f.VarName }}.AfterAll,
+			})
+		}
+		return false
+	}
+{{ end }}
+
+{{- /*
+  Up-front phase: every non-deferred fixture, concurrently, gated by the
+  dependency channels. Deferred fixtures wait for their StartKeys window —
+  their dependencies are non-deferred or ordered earlier in the same command,
+  so their channel waits can never deadlock.
+*/}}
+	var ƒwg sync.WaitGroup
+{{ range $f := .Fixtures }}
+{{- if not $f.Deferred }}
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_{{ $f.VarName }}()
 	}()
+{{- end }}
 {{ end }}
 	ƒwg.Wait()
 
@@ -130,10 +202,12 @@ func main() {
 	}
 
 {{- /*
-  Teardown here is strictly sequential, so the budget the supervisor gets is
-  the SUM of the members' budgets: a max would force-kill a set of teardowns
-  that each obeyed its own declared Timeout. Reported on both _done forms —
-  a failed setup still has succeeded siblings to release under this budget.
+  Teardown is strictly sequential, so the budget the supervisor gets is the
+  SUM of the members' budgets: a max would force-kill a set of teardowns that
+  each obeyed its own declared Timeout. Deferred fixtures are counted at their
+  default config — their derivation runs at StartKeys time. Reported on both
+  _done forms — a failed setup still has succeeded siblings to release under
+  this budget.
 */}}
 	var ƒbudget time.Duration
 {{ range $f := .Fixtures }}
@@ -147,40 +221,86 @@ func main() {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
 
-{{- /*
-  The runner owns shutdown TIMING — only it knows when every suite has stopped
-  using the fixtures — so even a failed setup reports and then waits for the
-  signal instead of tearing down on its own; this process owns shutdown
-  EXECUTION. A SIGTERM that already arrived (canceling setup above) has ƒctx
-  closed and falls straight through.
-*/}}
-	<-ƒctx.Done()
+	ƒteardownFailed := false
 
 {{- /*
-  One teardown policy, shared with the in-process DAG: panics are contained so
-  every sibling still releases, and a declared Timeout is a verdict, not just
-  a context the teardown may ignore. A fixture whose setup overran its budget
-  still initialized — its resources exist, so it is torn down like a success.
+  Window commands until shutdown. The runner owns shutdown TIMING — only it
+  knows when every suite has stopped using the fixtures — so even a failed
+  setup reports and then serves commands until the signal instead of tearing
+  down on its own; this process owns shutdown EXECUTION. StartKeys runs in
+  DAG order and TeardownKeys in reverse-DAG order because the fixture lists
+  below are generated in topological order. Each command is acknowledged on
+  stdout with a _cmd line carrying the joined per-fixture failures. A SIGTERM
+  that already arrived (canceling setup above) has ƒctx closed and falls
+  straight through.
 */}}
-	ƒteardownFailed := false
-{{ range .TeardownFixtures }}
-	if ƒerrs[{{ .Index }}] == nil || errors.Is(ƒerrs[{{ .Index }}], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "{{ .Identifier }}",
-			Timeout:  ƒcfg_{{ .VarName }}.Timeout,
-			Budget:   {{ if .HasConfig }}ƒcfg_{{ .VarName }}.Timeout{{ else }}0{{ end }},
-			AfterAll: {{ .VarName }}.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
 		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+{{- range $f := .Fixtures }}
+				if ƒhasKey(ƒc.Keys, "{{ $f.StateKey }}") {
+					ƒsetup_{{ $f.VarName }}()
+					if ƒerrs[{{ $f.Index }}] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "{{ $f.Identifier }}: "+ƒerrs[{{ $f.Index }}].Error())
+					}
+				}
+{{- end }}
+			case "teardown":
+{{- range .TeardownFixtures }}
+				if ƒhasKey(ƒc.Keys, "{{ .StateKey }}") {
+					if ƒteardown_{{ .VarName }}() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "{{ .Identifier }}: teardown failed")
+					}
+				}
+{{- end }}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
+		}
+	}
+
+{{- /*
+  Terminal teardown: everything still resident, in reverse-DAG order. Keys an
+  earlier TeardownKeys already released are skipped via ƒtorn — one owner per
+  fixture teardown, always.
+*/}}
+{{ range .TeardownFixtures }}
+	if ƒteardown_{{ .VarName }}() {
+		ƒteardownFailed = true
 	}
 {{- end }}
 
 {{- /*
   Exit 1 for a lifecycle failure of either kind. The runner reads a teardown
   failure from this exact status (gotestrunner.sharedTeardownFailedExit) when
-  setup succeeded; a setup failure was already reported on the _done line. A
-  clean exit is the runner's only proof that teardown ran and passed.
+  setup succeeded; a setup failure was already reported on the _done line, and
+  a StartKeys failure on its _cmd line — deferred errors are the runner's to
+  book, not this status's. A clean exit is the runner's only proof that
+  teardown ran and passed.
 */}}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)

--- a/internal/gotestgen/testdata/__snapshots__/TestSharedFixtureTestSuite_ext.snap
+++ b/internal/gotestgen/testdata/__snapshots__/TestSharedFixtureTestSuite_ext.snap
@@ -3,12 +3,14 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -24,6 +26,22 @@ func ƒquote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 func main() {
 	ƒctx, ƒstop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer ƒstop()
@@ -35,15 +53,17 @@ func main() {
 	ƒcfg_sf1 := gotest.DefaultFixtureConfig()
 
 	ƒerrs := make([]error, 2)
+	ƒstarted := make([]bool, 2)
+	ƒtorn := make([]bool, 2)
 
 	ƒdone_sf0 := make(chan struct{})
 	ƒdone_sf1 := make(chan struct{})
 
-	var ƒwg sync.WaitGroup
-
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf0 := func() {
+		if ƒstarted[0] {
+			return
+		}
+		ƒstarted[0] = true
 		defer close(ƒdone_sf0)
 		ƒerrs[0] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "PostgresFixture",
@@ -70,11 +90,13 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/project/tests/fixtures.PostgresFixture"), string(b))
 		}
-	}()
+	}
 
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf1 := func() {
+		if ƒstarted[1] {
+			return
+		}
+		ƒstarted[1] = true
 		defer close(ƒdone_sf1)
 		ƒerrs[1] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "RedisFixture",
@@ -101,6 +123,54 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/project/tests/redis.RedisFixture"), string(b))
 		}
+	}
+
+	ƒteardown_sf0 := func() bool {
+		if ƒtorn[0] || !ƒstarted[0] {
+			ƒtorn[0] = true
+			return false
+		}
+		ƒtorn[0] = true
+		if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "PostgresFixture",
+				Timeout:  ƒcfg_sf0.Timeout,
+				Budget:   0,
+				AfterAll: sf0.AfterAll,
+			})
+		}
+		return false
+	}
+
+	ƒteardown_sf1 := func() bool {
+		if ƒtorn[1] || !ƒstarted[1] {
+			ƒtorn[1] = true
+			return false
+		}
+		ƒtorn[1] = true
+		if ƒerrs[1] == nil || errors.Is(ƒerrs[1], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "RedisFixture",
+				Timeout:  ƒcfg_sf1.Timeout,
+				Budget:   0,
+				AfterAll: sf1.AfterAll,
+			})
+		}
+		return false
+	}
+
+	var ƒwg sync.WaitGroup
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf0()
+	}()
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf1()
 	}()
 
 	ƒwg.Wait()
@@ -125,28 +195,70 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
-	<-ƒctx.Done()
-	ƒteardownFailed := false
 
-	if ƒerrs[1] == nil || errors.Is(ƒerrs[1], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "RedisFixture",
-			Timeout:  ƒcfg_sf1.Timeout,
-			Budget:   0,
-			AfterAll: sf1.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒteardownFailed := false
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
+		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+				if ƒhasKey(ƒc.Keys, "github.com/example/project/tests/fixtures.PostgresFixture") {
+					ƒsetup_sf0()
+					if ƒerrs[0] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "PostgresFixture: "+ƒerrs[0].Error())
+					}
+				}
+				if ƒhasKey(ƒc.Keys, "github.com/example/project/tests/redis.RedisFixture") {
+					ƒsetup_sf1()
+					if ƒerrs[1] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "RedisFixture: "+ƒerrs[1].Error())
+					}
+				}
+			case "teardown":
+				if ƒhasKey(ƒc.Keys, "github.com/example/project/tests/redis.RedisFixture") {
+					if ƒteardown_sf1() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "RedisFixture: teardown failed")
+					}
+				}
+				if ƒhasKey(ƒc.Keys, "github.com/example/project/tests/fixtures.PostgresFixture") {
+					if ƒteardown_sf0() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "PostgresFixture: teardown failed")
+					}
+				}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
 		}
 	}
-	if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "PostgresFixture",
-			Timeout:  ƒcfg_sf0.Timeout,
-			Budget:   0,
-			AfterAll: sf0.AfterAll,
-		}) {
-			ƒteardownFailed = true
-		}
+
+	if ƒteardown_sf1() {
+		ƒteardownFailed = true
+	}
+	if ƒteardown_sf0() {
+		ƒteardownFailed = true
 	}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)
@@ -158,12 +270,14 @@ func main() {
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -178,6 +292,22 @@ func ƒquote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 func main() {
 	ƒctx, ƒstop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer ƒstop()
@@ -186,14 +316,16 @@ func main() {
 	ƒcfg_sf0 := gotest.DefaultFixtureConfig()
 
 	ƒerrs := make([]error, 1)
+	ƒstarted := make([]bool, 1)
+	ƒtorn := make([]bool, 1)
 
 	ƒdone_sf0 := make(chan struct{})
 
-	var ƒwg sync.WaitGroup
-
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf0 := func() {
+		if ƒstarted[0] {
+			return
+		}
+		ƒstarted[0] = true
 		defer close(ƒdone_sf0)
 		ƒerrs[0] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "PostgresFixture",
@@ -222,6 +354,31 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/fixtures.PostgresFixture"), string(b))
 		}
+	}
+
+	ƒteardown_sf0 := func() bool {
+		if ƒtorn[0] || !ƒstarted[0] {
+			ƒtorn[0] = true
+			return false
+		}
+		ƒtorn[0] = true
+		if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "PostgresFixture",
+				Timeout:  ƒcfg_sf0.Timeout,
+				Budget:   0,
+				AfterAll: sf0.AfterAll,
+			})
+		}
+		return false
+	}
+
+	var ƒwg sync.WaitGroup
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf0()
 	}()
 
 	ƒwg.Wait()
@@ -244,18 +401,55 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
-	<-ƒctx.Done()
-	ƒteardownFailed := false
 
-	if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "PostgresFixture",
-			Timeout:  ƒcfg_sf0.Timeout,
-			Budget:   0,
-			AfterAll: sf0.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒteardownFailed := false
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
 		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PostgresFixture") {
+					ƒsetup_sf0()
+					if ƒerrs[0] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "PostgresFixture: "+ƒerrs[0].Error())
+					}
+				}
+			case "teardown":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PostgresFixture") {
+					if ƒteardown_sf0() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "PostgresFixture: teardown failed")
+					}
+				}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
+		}
+	}
+
+	if ƒteardown_sf0() {
+		ƒteardownFailed = true
 	}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)
@@ -267,12 +461,14 @@ func main() {
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -287,6 +483,22 @@ func ƒquote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 func main() {
 	ƒctx, ƒstop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer ƒstop()
@@ -295,14 +507,16 @@ func main() {
 	ƒcfg_sf0 := gotest.DefaultFixtureConfig()
 
 	ƒerrs := make([]error, 1)
+	ƒstarted := make([]bool, 1)
+	ƒtorn := make([]bool, 1)
 
 	ƒdone_sf0 := make(chan struct{})
 
-	var ƒwg sync.WaitGroup
-
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf0 := func() {
+		if ƒstarted[0] {
+			return
+		}
+		ƒstarted[0] = true
 		defer close(ƒdone_sf0)
 		ƒerrs[0] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "SetupFixture",
@@ -316,6 +530,31 @@ func main() {
 			return
 		}
 		fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":{}}\n", ƒquote("github.com/example/fixtures.SetupFixture"))
+	}
+
+	ƒteardown_sf0 := func() bool {
+		if ƒtorn[0] || !ƒstarted[0] {
+			ƒtorn[0] = true
+			return false
+		}
+		ƒtorn[0] = true
+		if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "SetupFixture",
+				Timeout:  ƒcfg_sf0.Timeout,
+				Budget:   0,
+				AfterAll: sf0.AfterAll,
+			})
+		}
+		return false
+	}
+
+	var ƒwg sync.WaitGroup
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf0()
 	}()
 
 	ƒwg.Wait()
@@ -338,18 +577,55 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
-	<-ƒctx.Done()
-	ƒteardownFailed := false
 
-	if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "SetupFixture",
-			Timeout:  ƒcfg_sf0.Timeout,
-			Budget:   0,
-			AfterAll: sf0.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒteardownFailed := false
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
 		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.SetupFixture") {
+					ƒsetup_sf0()
+					if ƒerrs[0] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "SetupFixture: "+ƒerrs[0].Error())
+					}
+				}
+			case "teardown":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.SetupFixture") {
+					if ƒteardown_sf0() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "SetupFixture: teardown failed")
+					}
+				}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
+		}
+	}
+
+	if ƒteardown_sf0() {
+		ƒteardownFailed = true
 	}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)
@@ -361,12 +637,14 @@ func main() {
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -381,6 +659,22 @@ func ƒquote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 func main() {
 	ƒctx, ƒstop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer ƒstop()
@@ -389,14 +683,16 @@ func main() {
 	ƒcfg_sf0 := gotest.DefaultFixtureConfig()
 
 	ƒerrs := make([]error, 1)
+	ƒstarted := make([]bool, 1)
+	ƒtorn := make([]bool, 1)
 
 	ƒdone_sf0 := make(chan struct{})
 
-	var ƒwg sync.WaitGroup
-
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf0 := func() {
+		if ƒstarted[0] {
+			return
+		}
+		ƒstarted[0] = true
 		defer close(ƒdone_sf0)
 		ƒerrs[0] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "PostgresFixture",
@@ -423,6 +719,31 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/project/tests/fixtures.PostgresFixture"), string(b))
 		}
+	}
+
+	ƒteardown_sf0 := func() bool {
+		if ƒtorn[0] || !ƒstarted[0] {
+			ƒtorn[0] = true
+			return false
+		}
+		ƒtorn[0] = true
+		if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "PostgresFixture",
+				Timeout:  ƒcfg_sf0.Timeout,
+				Budget:   0,
+				AfterAll: sf0.AfterAll,
+			})
+		}
+		return false
+	}
+
+	var ƒwg sync.WaitGroup
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf0()
 	}()
 
 	ƒwg.Wait()
@@ -445,18 +766,55 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
-	<-ƒctx.Done()
-	ƒteardownFailed := false
 
-	if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "PostgresFixture",
-			Timeout:  ƒcfg_sf0.Timeout,
-			Budget:   0,
-			AfterAll: sf0.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒteardownFailed := false
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
 		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+				if ƒhasKey(ƒc.Keys, "github.com/example/project/tests/fixtures.PostgresFixture") {
+					ƒsetup_sf0()
+					if ƒerrs[0] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "PostgresFixture: "+ƒerrs[0].Error())
+					}
+				}
+			case "teardown":
+				if ƒhasKey(ƒc.Keys, "github.com/example/project/tests/fixtures.PostgresFixture") {
+					if ƒteardown_sf0() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "PostgresFixture: teardown failed")
+					}
+				}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
+		}
+	}
+
+	if ƒteardown_sf0() {
+		ƒteardownFailed = true
 	}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)
@@ -468,12 +826,14 @@ func main() {
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -488,6 +848,22 @@ func ƒquote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 func main() {
 	ƒctx, ƒstop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer ƒstop()
@@ -499,15 +875,17 @@ func main() {
 	ƒcfg_sf1 := gotest.DefaultFixtureConfig()
 
 	ƒerrs := make([]error, 2)
+	ƒstarted := make([]bool, 2)
+	ƒtorn := make([]bool, 2)
 
 	ƒdone_sf0 := make(chan struct{})
 	ƒdone_sf1 := make(chan struct{})
 
-	var ƒwg sync.WaitGroup
-
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf0 := func() {
+		if ƒstarted[0] {
+			return
+		}
+		ƒstarted[0] = true
 		defer close(ƒdone_sf0)
 		ƒerrs[0] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "PostgresFixture",
@@ -534,11 +912,13 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/shared.PostgresFixture"), string(b))
 		}
-	}()
+	}
 
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf1 := func() {
+		if ƒstarted[1] {
+			return
+		}
+		ƒstarted[1] = true
 		defer close(ƒdone_sf1)
 		ƒerrs[1] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "RedisFixture",
@@ -565,6 +945,54 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/shared.RedisFixture"), string(b))
 		}
+	}
+
+	ƒteardown_sf0 := func() bool {
+		if ƒtorn[0] || !ƒstarted[0] {
+			ƒtorn[0] = true
+			return false
+		}
+		ƒtorn[0] = true
+		if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "PostgresFixture",
+				Timeout:  ƒcfg_sf0.Timeout,
+				Budget:   0,
+				AfterAll: sf0.AfterAll,
+			})
+		}
+		return false
+	}
+
+	ƒteardown_sf1 := func() bool {
+		if ƒtorn[1] || !ƒstarted[1] {
+			ƒtorn[1] = true
+			return false
+		}
+		ƒtorn[1] = true
+		if ƒerrs[1] == nil || errors.Is(ƒerrs[1], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "RedisFixture",
+				Timeout:  ƒcfg_sf1.Timeout,
+				Budget:   0,
+				AfterAll: sf1.AfterAll,
+			})
+		}
+		return false
+	}
+
+	var ƒwg sync.WaitGroup
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf0()
+	}()
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf1()
 	}()
 
 	ƒwg.Wait()
@@ -589,28 +1017,70 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
-	<-ƒctx.Done()
-	ƒteardownFailed := false
 
-	if ƒerrs[1] == nil || errors.Is(ƒerrs[1], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "RedisFixture",
-			Timeout:  ƒcfg_sf1.Timeout,
-			Budget:   0,
-			AfterAll: sf1.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒteardownFailed := false
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
+		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+				if ƒhasKey(ƒc.Keys, "github.com/example/shared.PostgresFixture") {
+					ƒsetup_sf0()
+					if ƒerrs[0] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "PostgresFixture: "+ƒerrs[0].Error())
+					}
+				}
+				if ƒhasKey(ƒc.Keys, "github.com/example/shared.RedisFixture") {
+					ƒsetup_sf1()
+					if ƒerrs[1] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "RedisFixture: "+ƒerrs[1].Error())
+					}
+				}
+			case "teardown":
+				if ƒhasKey(ƒc.Keys, "github.com/example/shared.RedisFixture") {
+					if ƒteardown_sf1() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "RedisFixture: teardown failed")
+					}
+				}
+				if ƒhasKey(ƒc.Keys, "github.com/example/shared.PostgresFixture") {
+					if ƒteardown_sf0() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "PostgresFixture: teardown failed")
+					}
+				}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
 		}
 	}
-	if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "PostgresFixture",
-			Timeout:  ƒcfg_sf0.Timeout,
-			Budget:   0,
-			AfterAll: sf0.AfterAll,
-		}) {
-			ƒteardownFailed = true
-		}
+
+	if ƒteardown_sf1() {
+		ƒteardownFailed = true
+	}
+	if ƒteardown_sf0() {
+		ƒteardownFailed = true
 	}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)
@@ -622,12 +1092,14 @@ func main() {
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -642,6 +1114,22 @@ func ƒquote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 func main() {
 	ƒctx, ƒstop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer ƒstop()
@@ -650,14 +1138,16 @@ func main() {
 	ƒcfg_sf0 := gotest.DefaultFixtureConfig()
 
 	ƒerrs := make([]error, 1)
+	ƒstarted := make([]bool, 1)
+	ƒtorn := make([]bool, 1)
 
 	ƒdone_sf0 := make(chan struct{})
 
-	var ƒwg sync.WaitGroup
-
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf0 := func() {
+		if ƒstarted[0] {
+			return
+		}
+		ƒstarted[0] = true
 		defer close(ƒdone_sf0)
 		ƒerrs[0] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "PGFixture",
@@ -684,6 +1174,31 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/fixtures.PGFixture"), string(b))
 		}
+	}
+
+	ƒteardown_sf0 := func() bool {
+		if ƒtorn[0] || !ƒstarted[0] {
+			ƒtorn[0] = true
+			return false
+		}
+		ƒtorn[0] = true
+		if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "PGFixture",
+				Timeout:  ƒcfg_sf0.Timeout,
+				Budget:   0,
+				AfterAll: sf0.AfterAll,
+			})
+		}
+		return false
+	}
+
+	var ƒwg sync.WaitGroup
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf0()
 	}()
 
 	ƒwg.Wait()
@@ -706,18 +1221,55 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
-	<-ƒctx.Done()
-	ƒteardownFailed := false
 
-	if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "PGFixture",
-			Timeout:  ƒcfg_sf0.Timeout,
-			Budget:   0,
-			AfterAll: sf0.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒteardownFailed := false
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
 		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					ƒsetup_sf0()
+					if ƒerrs[0] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: "+ƒerrs[0].Error())
+					}
+				}
+			case "teardown":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					if ƒteardown_sf0() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: teardown failed")
+					}
+				}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
+		}
+	}
+
+	if ƒteardown_sf0() {
+		ƒteardownFailed = true
 	}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)
@@ -729,12 +1281,14 @@ func main() {
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -749,6 +1303,22 @@ func ƒquote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 func main() {
 	ƒctx, ƒstop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer ƒstop()
@@ -757,14 +1327,16 @@ func main() {
 	ƒcfg_sf0 := gotest.DefaultFixtureConfig()
 
 	ƒerrs := make([]error, 1)
+	ƒstarted := make([]bool, 1)
+	ƒtorn := make([]bool, 1)
 
 	ƒdone_sf0 := make(chan struct{})
 
-	var ƒwg sync.WaitGroup
-
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf0 := func() {
+		if ƒstarted[0] {
+			return
+		}
+		ƒstarted[0] = true
 		defer close(ƒdone_sf0)
 		ƒerrs[0] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "PGFixture",
@@ -791,6 +1363,31 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/fixtures.PGFixture"), string(b))
 		}
+	}
+
+	ƒteardown_sf0 := func() bool {
+		if ƒtorn[0] || !ƒstarted[0] {
+			ƒtorn[0] = true
+			return false
+		}
+		ƒtorn[0] = true
+		if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "PGFixture",
+				Timeout:  ƒcfg_sf0.Timeout,
+				Budget:   0,
+				AfterAll: sf0.AfterAll,
+			})
+		}
+		return false
+	}
+
+	var ƒwg sync.WaitGroup
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf0()
 	}()
 
 	ƒwg.Wait()
@@ -813,18 +1410,55 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
-	<-ƒctx.Done()
-	ƒteardownFailed := false
 
-	if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "PGFixture",
-			Timeout:  ƒcfg_sf0.Timeout,
-			Budget:   0,
-			AfterAll: sf0.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒteardownFailed := false
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
 		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					ƒsetup_sf0()
+					if ƒerrs[0] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: "+ƒerrs[0].Error())
+					}
+				}
+			case "teardown":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					if ƒteardown_sf0() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: teardown failed")
+					}
+				}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
+		}
+	}
+
+	if ƒteardown_sf0() {
+		ƒteardownFailed = true
 	}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)
@@ -836,12 +1470,14 @@ func main() {
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -856,6 +1492,22 @@ func ƒquote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 func main() {
 	ƒctx, ƒstop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer ƒstop()
@@ -864,14 +1516,16 @@ func main() {
 	ƒcfg_sf0 := gotest.DefaultFixtureConfig()
 
 	ƒerrs := make([]error, 1)
+	ƒstarted := make([]bool, 1)
+	ƒtorn := make([]bool, 1)
 
 	ƒdone_sf0 := make(chan struct{})
 
-	var ƒwg sync.WaitGroup
-
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf0 := func() {
+		if ƒstarted[0] {
+			return
+		}
+		ƒstarted[0] = true
 		defer close(ƒdone_sf0)
 		ƒerrs[0] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "PGFixture",
@@ -898,6 +1552,31 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/fixtures.PGFixture"), string(b))
 		}
+	}
+
+	ƒteardown_sf0 := func() bool {
+		if ƒtorn[0] || !ƒstarted[0] {
+			ƒtorn[0] = true
+			return false
+		}
+		ƒtorn[0] = true
+		if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "PGFixture",
+				Timeout:  ƒcfg_sf0.Timeout,
+				Budget:   0,
+				AfterAll: sf0.AfterAll,
+			})
+		}
+		return false
+	}
+
+	var ƒwg sync.WaitGroup
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf0()
 	}()
 
 	ƒwg.Wait()
@@ -920,18 +1599,55 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
-	<-ƒctx.Done()
-	ƒteardownFailed := false
 
-	if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "PGFixture",
-			Timeout:  ƒcfg_sf0.Timeout,
-			Budget:   0,
-			AfterAll: sf0.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒteardownFailed := false
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
 		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					ƒsetup_sf0()
+					if ƒerrs[0] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: "+ƒerrs[0].Error())
+					}
+				}
+			case "teardown":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					if ƒteardown_sf0() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: teardown failed")
+					}
+				}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
+		}
+	}
+
+	if ƒteardown_sf0() {
+		ƒteardownFailed = true
 	}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)
@@ -943,12 +1659,14 @@ func main() {
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -963,6 +1681,22 @@ func ƒquote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 func main() {
 	ƒctx, ƒstop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer ƒstop()
@@ -971,14 +1705,16 @@ func main() {
 	ƒcfg_sf0 := gotest.DefaultFixtureConfig()
 
 	ƒerrs := make([]error, 1)
+	ƒstarted := make([]bool, 1)
+	ƒtorn := make([]bool, 1)
 
 	ƒdone_sf0 := make(chan struct{})
 
-	var ƒwg sync.WaitGroup
-
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf0 := func() {
+		if ƒstarted[0] {
+			return
+		}
+		ƒstarted[0] = true
 		defer close(ƒdone_sf0)
 		ƒerrs[0] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "PGFixture",
@@ -1005,6 +1741,31 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/fixtures.PGFixture"), string(b))
 		}
+	}
+
+	ƒteardown_sf0 := func() bool {
+		if ƒtorn[0] || !ƒstarted[0] {
+			ƒtorn[0] = true
+			return false
+		}
+		ƒtorn[0] = true
+		if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "PGFixture",
+				Timeout:  ƒcfg_sf0.Timeout,
+				Budget:   0,
+				AfterAll: sf0.AfterAll,
+			})
+		}
+		return false
+	}
+
+	var ƒwg sync.WaitGroup
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf0()
 	}()
 
 	ƒwg.Wait()
@@ -1027,18 +1788,55 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
-	<-ƒctx.Done()
-	ƒteardownFailed := false
 
-	if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "PGFixture",
-			Timeout:  ƒcfg_sf0.Timeout,
-			Budget:   0,
-			AfterAll: sf0.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒteardownFailed := false
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
 		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					ƒsetup_sf0()
+					if ƒerrs[0] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: "+ƒerrs[0].Error())
+					}
+				}
+			case "teardown":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					if ƒteardown_sf0() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: teardown failed")
+					}
+				}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
+		}
+	}
+
+	if ƒteardown_sf0() {
+		ƒteardownFailed = true
 	}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)
@@ -1050,12 +1848,14 @@ func main() {
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -1071,6 +1871,22 @@ func ƒquote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 func main() {
 	ƒctx, ƒstop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer ƒstop()
@@ -1082,15 +1898,17 @@ func main() {
 	ƒcfg_sf1 := gotest.DefaultFixtureConfig()
 
 	ƒerrs := make([]error, 2)
+	ƒstarted := make([]bool, 2)
+	ƒtorn := make([]bool, 2)
 
 	ƒdone_sf0 := make(chan struct{})
 	ƒdone_sf1 := make(chan struct{})
 
-	var ƒwg sync.WaitGroup
-
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf0 := func() {
+		if ƒstarted[0] {
+			return
+		}
+		ƒstarted[0] = true
 		defer close(ƒdone_sf0)
 		ƒerrs[0] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "PGFixture",
@@ -1117,11 +1935,13 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/fixtures.PGFixture"), string(b))
 		}
-	}()
+	}
 
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf1 := func() {
+		if ƒstarted[1] {
+			return
+		}
+		ƒstarted[1] = true
 		defer close(ƒdone_sf1)
 		ƒerrs[1] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "RedisFixture",
@@ -1148,6 +1968,54 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/redis.RedisFixture"), string(b))
 		}
+	}
+
+	ƒteardown_sf0 := func() bool {
+		if ƒtorn[0] || !ƒstarted[0] {
+			ƒtorn[0] = true
+			return false
+		}
+		ƒtorn[0] = true
+		if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "PGFixture",
+				Timeout:  ƒcfg_sf0.Timeout,
+				Budget:   0,
+				AfterAll: sf0.AfterAll,
+			})
+		}
+		return false
+	}
+
+	ƒteardown_sf1 := func() bool {
+		if ƒtorn[1] || !ƒstarted[1] {
+			ƒtorn[1] = true
+			return false
+		}
+		ƒtorn[1] = true
+		if ƒerrs[1] == nil || errors.Is(ƒerrs[1], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "RedisFixture",
+				Timeout:  ƒcfg_sf1.Timeout,
+				Budget:   0,
+				AfterAll: sf1.AfterAll,
+			})
+		}
+		return false
+	}
+
+	var ƒwg sync.WaitGroup
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf0()
+	}()
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf1()
 	}()
 
 	ƒwg.Wait()
@@ -1172,28 +2040,70 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
-	<-ƒctx.Done()
-	ƒteardownFailed := false
 
-	if ƒerrs[1] == nil || errors.Is(ƒerrs[1], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "RedisFixture",
-			Timeout:  ƒcfg_sf1.Timeout,
-			Budget:   0,
-			AfterAll: sf1.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒteardownFailed := false
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
+		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					ƒsetup_sf0()
+					if ƒerrs[0] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: "+ƒerrs[0].Error())
+					}
+				}
+				if ƒhasKey(ƒc.Keys, "github.com/example/redis.RedisFixture") {
+					ƒsetup_sf1()
+					if ƒerrs[1] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "RedisFixture: "+ƒerrs[1].Error())
+					}
+				}
+			case "teardown":
+				if ƒhasKey(ƒc.Keys, "github.com/example/redis.RedisFixture") {
+					if ƒteardown_sf1() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "RedisFixture: teardown failed")
+					}
+				}
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					if ƒteardown_sf0() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: teardown failed")
+					}
+				}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
 		}
 	}
-	if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "PGFixture",
-			Timeout:  ƒcfg_sf0.Timeout,
-			Budget:   0,
-			AfterAll: sf0.AfterAll,
-		}) {
-			ƒteardownFailed = true
-		}
+
+	if ƒteardown_sf1() {
+		ƒteardownFailed = true
+	}
+	if ƒteardown_sf0() {
+		ƒteardownFailed = true
 	}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)
@@ -1205,12 +2115,14 @@ func main() {
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -1225,6 +2137,22 @@ func ƒquote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 func main() {
 	ƒctx, ƒstop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer ƒstop()
@@ -1233,14 +2161,16 @@ func main() {
 	ƒcfg_sf0 := gotest.DefaultFixtureConfig()
 
 	ƒerrs := make([]error, 1)
+	ƒstarted := make([]bool, 1)
+	ƒtorn := make([]bool, 1)
 
 	ƒdone_sf0 := make(chan struct{})
 
-	var ƒwg sync.WaitGroup
-
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf0 := func() {
+		if ƒstarted[0] {
+			return
+		}
+		ƒstarted[0] = true
 		defer close(ƒdone_sf0)
 		ƒerrs[0] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "PGFixture",
@@ -1267,6 +2197,31 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/fixtures.PGFixture"), string(b))
 		}
+	}
+
+	ƒteardown_sf0 := func() bool {
+		if ƒtorn[0] || !ƒstarted[0] {
+			ƒtorn[0] = true
+			return false
+		}
+		ƒtorn[0] = true
+		if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "PGFixture",
+				Timeout:  ƒcfg_sf0.Timeout,
+				Budget:   0,
+				AfterAll: sf0.AfterAll,
+			})
+		}
+		return false
+	}
+
+	var ƒwg sync.WaitGroup
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf0()
 	}()
 
 	ƒwg.Wait()
@@ -1289,18 +2244,55 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
-	<-ƒctx.Done()
-	ƒteardownFailed := false
 
-	if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "PGFixture",
-			Timeout:  ƒcfg_sf0.Timeout,
-			Budget:   0,
-			AfterAll: sf0.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒteardownFailed := false
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
 		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					ƒsetup_sf0()
+					if ƒerrs[0] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: "+ƒerrs[0].Error())
+					}
+				}
+			case "teardown":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					if ƒteardown_sf0() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: teardown failed")
+					}
+				}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
+		}
+	}
+
+	if ƒteardown_sf0() {
+		ƒteardownFailed = true
 	}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)
@@ -1312,12 +2304,14 @@ func main() {
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -1332,6 +2326,22 @@ func ƒquote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 func main() {
 	ƒctx, ƒstop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer ƒstop()
@@ -1340,14 +2350,16 @@ func main() {
 	ƒcfg_sf0 := gotest.DefaultFixtureConfig()
 
 	ƒerrs := make([]error, 1)
+	ƒstarted := make([]bool, 1)
+	ƒtorn := make([]bool, 1)
 
 	ƒdone_sf0 := make(chan struct{})
 
-	var ƒwg sync.WaitGroup
-
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf0 := func() {
+		if ƒstarted[0] {
+			return
+		}
+		ƒstarted[0] = true
 		defer close(ƒdone_sf0)
 		ƒcfg, ƒerr := gotestruntime.DeriveFixtureConfig("PGFixture", sf0.SharedFixtureConfig)
 		if ƒerr != nil {
@@ -1380,6 +2392,31 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/fixtures.PGFixture"), string(b))
 		}
+	}
+
+	ƒteardown_sf0 := func() bool {
+		if ƒtorn[0] || !ƒstarted[0] {
+			ƒtorn[0] = true
+			return false
+		}
+		ƒtorn[0] = true
+		if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "PGFixture",
+				Timeout:  ƒcfg_sf0.Timeout,
+				Budget:   ƒcfg_sf0.Timeout,
+				AfterAll: sf0.AfterAll,
+			})
+		}
+		return false
+	}
+
+	var ƒwg sync.WaitGroup
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf0()
 	}()
 
 	ƒwg.Wait()
@@ -1402,18 +2439,55 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
-	<-ƒctx.Done()
-	ƒteardownFailed := false
 
-	if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "PGFixture",
-			Timeout:  ƒcfg_sf0.Timeout,
-			Budget:   ƒcfg_sf0.Timeout,
-			AfterAll: sf0.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒteardownFailed := false
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
 		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					ƒsetup_sf0()
+					if ƒerrs[0] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: "+ƒerrs[0].Error())
+					}
+				}
+			case "teardown":
+				if ƒhasKey(ƒc.Keys, "github.com/example/fixtures.PGFixture") {
+					if ƒteardown_sf0() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "PGFixture: teardown failed")
+					}
+				}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
+		}
+	}
+
+	if ƒteardown_sf0() {
+		ƒteardownFailed = true
 	}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)
@@ -1425,12 +2499,14 @@ func main() {
 package main
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -1446,6 +2522,22 @@ func ƒquote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// ƒcommand is one runner instruction on stdin: start or tear down a set of
+// fixtures by state key, mid-run, at a window boundary.
+type ƒcommand struct {
+	Verb string   `json:"verb"`
+	Keys []string `json:"keys"`
+}
+
+func ƒhasKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 func main() {
 	ƒctx, ƒstop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer ƒstop()
@@ -1457,15 +2549,17 @@ func main() {
 	ƒcfg_sf1 := gotest.DefaultFixtureConfig()
 
 	ƒerrs := make([]error, 2)
+	ƒstarted := make([]bool, 2)
+	ƒtorn := make([]bool, 2)
 
 	ƒdone_sf0 := make(chan struct{})
 	ƒdone_sf1 := make(chan struct{})
 
-	var ƒwg sync.WaitGroup
-
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf0 := func() {
+		if ƒstarted[0] {
+			return
+		}
+		ƒstarted[0] = true
 		defer close(ƒdone_sf0)
 		ƒerrs[0] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "PostgresFixture",
@@ -1492,11 +2586,13 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/project/tests/fixtures.PostgresFixture"), string(b))
 		}
-	}()
+	}
 
-	ƒwg.Add(1)
-	go func() {
-		defer ƒwg.Done()
+	ƒsetup_sf1 := func() {
+		if ƒstarted[1] {
+			return
+		}
+		ƒstarted[1] = true
 		defer close(ƒdone_sf1)
 		ƒerrs[1] = gotestruntime.RunFixtureSetup(ƒctx, gotestruntime.FixtureSetup{
 			Name:       "GCSFixture",
@@ -1525,6 +2621,54 @@ func main() {
 			}
 			fmt.Fprintf(os.Stdout, "{\"key\":%s,\"state\":%s}\n", ƒquote("github.com/example/project/tests/gcs.GCSFixture"), string(b))
 		}
+	}
+
+	ƒteardown_sf0 := func() bool {
+		if ƒtorn[0] || !ƒstarted[0] {
+			ƒtorn[0] = true
+			return false
+		}
+		ƒtorn[0] = true
+		if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "PostgresFixture",
+				Timeout:  ƒcfg_sf0.Timeout,
+				Budget:   0,
+				AfterAll: sf0.AfterAll,
+			})
+		}
+		return false
+	}
+
+	ƒteardown_sf1 := func() bool {
+		if ƒtorn[1] || !ƒstarted[1] {
+			ƒtorn[1] = true
+			return false
+		}
+		ƒtorn[1] = true
+		if ƒerrs[1] == nil || errors.Is(ƒerrs[1], gotestruntime.ErrSetupOverran) {
+			return gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
+				Name:     "GCSFixture",
+				Timeout:  ƒcfg_sf1.Timeout,
+				Budget:   0,
+				AfterAll: sf1.AfterAll,
+			})
+		}
+		return false
+	}
+
+	var ƒwg sync.WaitGroup
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf0()
+	}()
+
+	ƒwg.Add(1)
+	go func() {
+		defer ƒwg.Done()
+		ƒsetup_sf1()
 	}()
 
 	ƒwg.Wait()
@@ -1549,28 +2693,70 @@ func main() {
 	} else {
 		fmt.Fprintf(os.Stdout, "{\"key\":\"_done\",\"teardownBudget\":%s}\n", ƒbudgetStr)
 	}
-	<-ƒctx.Done()
-	ƒteardownFailed := false
 
-	if ƒerrs[1] == nil || errors.Is(ƒerrs[1], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "GCSFixture",
-			Timeout:  ƒcfg_sf1.Timeout,
-			Budget:   0,
-			AfterAll: sf1.AfterAll,
-		}) {
-			ƒteardownFailed = true
+	ƒteardownFailed := false
+	ƒcmds := make(chan ƒcommand)
+	go func() {
+		ƒsc := bufio.NewScanner(os.Stdin)
+		for ƒsc.Scan() {
+			var ƒc ƒcommand
+			if json.Unmarshal(ƒsc.Bytes(), &ƒc) != nil {
+				continue
+			}
+			select {
+			case ƒcmds <- ƒc:
+			case <-ƒctx.Done():
+				return
+			}
+		}
+	}()
+
+ƒloop:
+	for {
+		select {
+		case <-ƒctx.Done():
+			break ƒloop
+		case ƒc := <-ƒcmds:
+			var ƒcmdErrs []string
+			switch ƒc.Verb {
+			case "start":
+				if ƒhasKey(ƒc.Keys, "github.com/example/project/tests/fixtures.PostgresFixture") {
+					ƒsetup_sf0()
+					if ƒerrs[0] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "PostgresFixture: "+ƒerrs[0].Error())
+					}
+				}
+				if ƒhasKey(ƒc.Keys, "github.com/example/project/tests/gcs.GCSFixture") {
+					ƒsetup_sf1()
+					if ƒerrs[1] != nil {
+						ƒcmdErrs = append(ƒcmdErrs, "GCSFixture: "+ƒerrs[1].Error())
+					}
+				}
+			case "teardown":
+				if ƒhasKey(ƒc.Keys, "github.com/example/project/tests/gcs.GCSFixture") {
+					if ƒteardown_sf1() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "GCSFixture: teardown failed")
+					}
+				}
+				if ƒhasKey(ƒc.Keys, "github.com/example/project/tests/fixtures.PostgresFixture") {
+					if ƒteardown_sf0() {
+						ƒteardownFailed = true
+						ƒcmdErrs = append(ƒcmdErrs, "PostgresFixture: teardown failed")
+					}
+				}
+			default:
+				ƒcmdErrs = append(ƒcmdErrs, "unknown verb: "+ƒc.Verb)
+			}
+			fmt.Fprintf(os.Stdout, "{\"key\":\"_cmd\",\"error\":%s}\n", ƒquote(strings.Join(ƒcmdErrs, "; ")))
 		}
 	}
-	if ƒerrs[0] == nil || errors.Is(ƒerrs[0], gotestruntime.ErrSetupOverran) {
-		if gotestruntime.RunFixtureTeardown(context.Background(), gotestruntime.FixtureTeardown{
-			Name:     "PostgresFixture",
-			Timeout:  ƒcfg_sf0.Timeout,
-			Budget:   0,
-			AfterAll: sf0.AfterAll,
-		}) {
-			ƒteardownFailed = true
-		}
+
+	if ƒteardown_sf1() {
+		ƒteardownFailed = true
+	}
+	if ƒteardown_sf0() {
+		ƒteardownFailed = true
 	}
 	if ƒanyFailed || ƒteardownFailed {
 		os.Exit(1)

--- a/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_ExclusiveCompose/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_ExclusiveCompose/test.go
@@ -1,14 +1,12 @@
 package testpkg
 
-import (
-	"time"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
+import "github.com/mvrahden/go-test/pkg/gotest"
 
 type MyTestSuite struct{}
 
 func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
-	return gotest.SuiteConfig{30 * time.Second, 30 * time.Second, false, true, false}
+	cfg := gotest.DefaultSuiteConfig()
+	cfg.Exclusive = true
+	return cfg
 }
 func (s *MyTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_ExclusiveParsed/test.go
+++ b/internal/gotestgen/testdata/sources/TestCollector_SuiteConfig_ExclusiveParsed/test.go
@@ -1,14 +1,10 @@
 package testpkg
 
-import (
-	"time"
-
-	"github.com/mvrahden/go-test/pkg/gotest"
-)
+import "github.com/mvrahden/go-test/pkg/gotest"
 
 type MyTestSuite struct{}
 
 func (s *MyTestSuite) SuiteConfig() gotest.SuiteConfig {
-	return gotest.SuiteConfig{30 * time.Second, 30 * time.Second, false, true, false}
+	return gotest.SuiteConfig{Exclusive: true}
 }
 func (s *MyTestSuite) TestOne(t *gotest.T) {}

--- a/internal/gotestrunner/compile.go
+++ b/internal/gotestrunner/compile.go
@@ -180,11 +180,17 @@ const slowBuildThreshold = 15 * time.Second
 // visible without ever being failed.
 func logSlowBuild(w io.Writer, what string, threshold time.Duration) (done func()) {
 	start := time.Now()
+	fired := make(chan struct{})
 	timer := time.AfterFunc(threshold, func() {
+		defer close(fired)
 		fmt.Fprintf(w, "gotest: %s has been building for %s and is still running\n", what, threshold)
 	})
 	return func() {
-		timer.Stop()
+		if !timer.Stop() {
+			// The notice is firing on the timer goroutine; wait it out so the
+			// two writes never overlap on a non-concurrent-safe writer.
+			<-fired
+		}
 		if d := time.Since(start); d >= threshold {
 			fmt.Fprintf(w, "gotest: %s finished building after %s\n", what, d.Round(time.Second))
 		}

--- a/internal/gotestrunner/compile.go
+++ b/internal/gotestrunner/compile.go
@@ -93,12 +93,26 @@ func compileConcurrency(compileParallel int, buildFlags []string) int {
 		return compileParallel
 	}
 	n := runtime.NumCPU()
-	for _, f := range buildFlags {
-		if f == "-race" || f == "-msan" || f == "-asan" {
-			return max(1, n/2)
-		}
+	if SanitizerActive(buildFlags) {
+		return max(1, n/2)
 	}
 	return n
+}
+
+// SanitizerActive reports whether buildFlags enable an instrumentation mode
+// (-race/-msan/-asan) that at least doubles the CPU cost per instruction
+// stream. Compile and dispatch concurrency halve their defaults under it:
+// the ordinary defaults are tuned for uninstrumented workloads, and keeping
+// them would oversubscribe the machine — starving exactly the wall-clock
+// budget verdicts that must stay trustworthy. An explicit --parallel or
+// --compile-parallel always wins over this heuristic.
+func SanitizerActive(buildFlags []string) bool {
+	for _, f := range buildFlags {
+		if f == "-race" || f == "-msan" || f == "-asan" {
+			return true
+		}
+	}
+	return false
 }
 
 func CompilePackagesStream(ctx context.Context, packages []string, overlayFlag string, buildFlags []string, outputDir string, compileParallel int) <-chan CompileOutcome {

--- a/internal/gotestrunner/compile.go
+++ b/internal/gotestrunner/compile.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 )
 
 // CompileResult holds the result of compiling a single test package.
@@ -50,6 +52,8 @@ func compilePackage(ctx context.Context, pkgPath, overlayFlag string, buildFlags
 	cmd := exec.CommandContext(ctx, "go", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
+
+	defer logSlowBuild(os.Stderr, "test binary for "+pkgPath, slowBuildThreshold)()
 
 	mp := NewManagedProcess(cmd, ProcessConfig{Grace: GraceKill})
 	if err := mp.Start(); err != nil {
@@ -162,4 +166,27 @@ func sanitizePkgName(pkgPath string) string {
 	parts := strings.Split(pkgPath, "/")
 	short := parts[len(parts)-1]
 	return fmt.Sprintf("%s_%x", short, h[:4])
+}
+
+// slowBuildThreshold is when a single build is called out as unexpectedly
+// long. Deliberately a log line, never a verdict: a first-ever -race build
+// recompiles the stdlib's instrumented variant and legitimately runs for
+// minutes — a hard cap here would be a number the user did not choose.
+const slowBuildThreshold = 15 * time.Second
+
+// logSlowBuild arms a one-shot notice for a long-running build and returns a
+// done func: past threshold it logs that the build is still running, and on
+// completion past threshold it logs the effective duration — so slowness is
+// visible without ever being failed.
+func logSlowBuild(w io.Writer, what string, threshold time.Duration) (done func()) {
+	start := time.Now()
+	timer := time.AfterFunc(threshold, func() {
+		fmt.Fprintf(w, "gotest: %s has been building for %s and is still running\n", what, threshold)
+	})
+	return func() {
+		timer.Stop()
+		if d := time.Since(start); d >= threshold {
+			fmt.Fprintf(w, "gotest: %s finished building after %s\n", what, d.Round(time.Second))
+		}
+	}
 }

--- a/internal/gotestrunner/export_test.go
+++ b/internal/gotestrunner/export_test.go
@@ -66,3 +66,5 @@ func ExportNewSharedFixtureProcess(sharedDir string, state map[string]json.RawMe
 		state:     state,
 	}
 }
+
+var ExportSortTargetIndices = sortTargetIndices

--- a/internal/gotestrunner/export_test.go
+++ b/internal/gotestrunner/export_test.go
@@ -68,3 +68,4 @@ func ExportNewSharedFixtureProcess(sharedDir string, state map[string]json.RawMe
 }
 
 var ExportSortTargetIndices = sortTargetIndices
+var ExportComputeDispatchConcurrency = computeDispatchConcurrency

--- a/internal/gotestrunner/export_test.go
+++ b/internal/gotestrunner/export_test.go
@@ -68,4 +68,5 @@ func ExportNewSharedFixtureProcess(sharedDir string, state map[string]json.RawMe
 }
 
 var ExportSortTargetIndices = sortTargetIndices
+var ExportLogSlowBuild = logSlowBuild
 var ExportComputeDispatchConcurrency = computeDispatchConcurrency

--- a/internal/gotestrunner/export_test.go
+++ b/internal/gotestrunner/export_test.go
@@ -67,6 +67,12 @@ func ExportNewSharedFixtureProcess(sharedDir string, state map[string]json.RawMe
 	}
 }
 
+type ExportFixtureWindows = fixtureWindows
+
+var ExportPlanFixtureWindows = planFixtureWindows
+var ExportPlanSuitePhases = planSuitePhases
+var ExportAliveFixtureKeys = aliveFixtureKeys
+
 var ExportSortTargetIndices = sortTargetIndices
 var ExportLogSlowBuild = logSlowBuild
 var ExportComputeDispatchConcurrency = computeDispatchConcurrency

--- a/internal/gotestrunner/fixturewindow.go
+++ b/internal/gotestrunner/fixturewindow.go
@@ -3,6 +3,7 @@ package gotestrunner
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/mvrahden/go-test/internal/gotestgen"
 )
@@ -39,13 +40,46 @@ func planFixtureWindows(overlay *OverlayResult, userRunFilter string) fixtureWin
 		Tail: aliveFixtureKeys(tail, overlay.SuiteRequiredSharedFixtureKeys, overlay.SharedFixtures),
 	}
 	for i := range overlay.SharedFixtures {
-		if key := sharedFixtureKey(&overlay.SharedFixtures[i]); w.Bulk[key] || w.Tail[key] {
+		key := sharedFixtureKey(&overlay.SharedFixtures[i])
+		switch {
+		case w.Bulk[key]:
 			w.Fixtures = append(w.Fixtures, overlay.SharedFixtures[i])
-		} else {
+		case w.Tail[key]:
+			// Tail-only fixtures ride along deferred: compiled into the setup
+			// program, started by StartKeys at the bulk→tail barrier.
+			sf := overlay.SharedFixtures[i]
+			sf.Deferred = true
+			w.Fixtures = append(w.Fixtures, sf)
+		default:
 			w.Skipped++
 		}
 	}
 	return w
+}
+
+// aliveFromTargets computes the alive set for one phase's actual targets —
+// the plan narrowed by compile results. Targets carry test function names in
+// SuiteName, matching the required-keys maps.
+func aliveFromTargets(targets []SuiteTarget, reqKeys map[string]map[string][]string, fixtures []gotestgen.SharedFixtureInfo) map[string]bool {
+	phase := map[string][]string{}
+	for i := range targets {
+		phase[targets[i].Package] = append(phase[targets[i].Package], targets[i].SuiteName)
+	}
+	return aliveFixtureKeys(phase, reqKeys, fixtures)
+}
+
+// diffKeys returns set ∖ minus, sorted for deterministic commands and
+// messages. Execution order is the subprocess's job — it applies its
+// generated (reverse-)topological order regardless of the order sent.
+func diffKeys(set, minus map[string]bool) []string {
+	var out []string
+	for k := range set {
+		if !minus[k] {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // reportSkipped emits the one debug line for fixtures the plan never starts.

--- a/internal/gotestrunner/fixturewindow.go
+++ b/internal/gotestrunner/fixturewindow.go
@@ -1,0 +1,114 @@
+package gotestrunner
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mvrahden/go-test/internal/gotestgen"
+)
+
+// Fixture window scheduling.
+//
+// Doctrine: fixtures are never speculative — a shared fixture is resident
+// exactly while a scheduled suite needs it. A run has two dispatch phases:
+// the parallel bulk, then the exclusive serial tail (SuiteTarget.Exclusive).
+// Alive(phase) is the DAG-closure of the union of the phase targets' required
+// shared fixture keys. Fixtures in neither alive set never start — and can
+// therefore never fail the run. Alive(bulk) starts up-front, concurrent with
+// compile; run-end teardown owns everything still resident.
+
+// fixtureWindows is one run's shared fixture residency plan, computed from
+// the overlay and the user's -run filter before any fixture starts.
+type fixtureWindows struct {
+	Bulk map[string]bool // Alive(bulk): state keys the parallel bulk needs
+	Tail map[string]bool // Alive(tail): state keys the exclusive tail needs
+	// Fixtures is Alive(bulk) ∪ Alive(tail) in the overlay's topological
+	// order — the only fixtures the setup subprocess is generated with.
+	Fixtures []gotestgen.SharedFixtureInfo
+	// Skipped counts overlay fixtures no scheduled suite requires.
+	Skipped int
+}
+
+// planFixtureWindows computes the residency plan for a run. The suite
+// selection mirrors BuildSuiteTargets minus compile results, which do not
+// exist yet: fixtures must not wait for the compiler.
+func planFixtureWindows(overlay *OverlayResult, userRunFilter string) fixtureWindows {
+	bulk, tail := planSuitePhases(overlay.SuitesByPkg, overlay.ExclusiveSuitesByPkg, userRunFilter)
+	w := fixtureWindows{
+		Bulk: aliveFixtureKeys(bulk, overlay.SuiteRequiredSharedFixtureKeys, overlay.SharedFixtures),
+		Tail: aliveFixtureKeys(tail, overlay.SuiteRequiredSharedFixtureKeys, overlay.SharedFixtures),
+	}
+	for i := range overlay.SharedFixtures {
+		if key := sharedFixtureKey(&overlay.SharedFixtures[i]); w.Bulk[key] || w.Tail[key] {
+			w.Fixtures = append(w.Fixtures, overlay.SharedFixtures[i])
+		} else {
+			w.Skipped++
+		}
+	}
+	return w
+}
+
+// reportSkipped emits the one debug line for fixtures the plan never starts.
+func (w *fixtureWindows) reportSkipped() {
+	if w.Skipped > 0 {
+		fmt.Fprintf(os.Stderr, "gotest: %d shared fixture(s) not started (no scheduled suite requires them)\n", w.Skipped)
+	}
+}
+
+// planSuitePhases splits the suites the run will dispatch into the two phases.
+// Values are test function names ("Test" + suite name) — the keying
+// SuiteRequiredSharedFixtureKeys uses.
+func planSuitePhases(suitesByPkg map[string][]string, exclusiveByPkg map[string]map[string]bool, userRunFilter string) (bulk, tail map[string][]string) {
+	bulk, tail = map[string][]string{}, map[string][]string{}
+	for pkg, suites := range suitesByPkg {
+		for _, suiteName := range suites {
+			testFuncName := "Test" + suiteName
+			if userRunFilter != "" && !matchesSuiteFunc(userRunFilter, testFuncName) {
+				continue
+			}
+			phase := bulk
+			if exclusiveByPkg[pkg][suiteName] {
+				phase = tail
+			}
+			phase[pkg] = append(phase[pkg], testFuncName)
+		}
+	}
+	return bulk, tail
+}
+
+// aliveFixtureKeys computes Alive(phase): the DAG-closure of the union of the
+// phase suites' required shared fixture keys. Per-suite keys are already
+// transitive; closing over fixture dependencies here keeps the invariant
+// local — an alive fixture's dependencies are alive, whatever produced the
+// per-suite sets.
+func aliveFixtureKeys(phaseSuites map[string][]string, reqKeys map[string]map[string][]string, fixtures []gotestgen.SharedFixtureInfo) map[string]bool {
+	deps := make(map[string][]string, len(fixtures))
+	for i := range fixtures {
+		deps[sharedFixtureKey(&fixtures[i])] = fixtures[i].Dependencies
+	}
+	alive := map[string]bool{}
+	var claim func(key string)
+	claim = func(key string) {
+		if alive[key] {
+			return
+		}
+		alive[key] = true
+		for _, dep := range deps[key] {
+			claim(dep)
+		}
+	}
+	for pkg, suites := range phaseSuites {
+		for _, suite := range suites {
+			for _, key := range reqKeys[pkg][suite] {
+				claim(key)
+			}
+		}
+	}
+	return alive
+}
+
+// sharedFixtureKey returns the fixture's state key — the identity every map
+// in the shared fixture protocol is keyed by.
+func sharedFixtureKey(sf *gotestgen.SharedFixtureInfo) string {
+	return sf.PkgPath + "." + sf.Identifier
+}

--- a/internal/gotestrunner/fixturewindow_suite_test.go
+++ b/internal/gotestrunner/fixturewindow_suite_test.go
@@ -1,0 +1,188 @@
+package gotestrunner_test
+
+import (
+	"github.com/mvrahden/go-test/internal/gotestgen"
+	"github.com/mvrahden/go-test/internal/gotestrunner"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// FixtureWindowTestSuite pins the alive-set math behind fixture window
+// scheduling: which shared fixtures a run keeps resident, per phase, given
+// the suites it will actually dispatch.
+type FixtureWindowTestSuite struct {
+	cleanup func()
+}
+
+func (s *FixtureWindowTestSuite) AfterEach(_ *gotest.T) {
+	if s.cleanup != nil {
+		s.cleanup()
+		s.cleanup = nil
+	}
+}
+
+const winFixturePkg = "example.com/fix"
+
+func winFixture(id string, deps ...string) gotestgen.SharedFixtureInfo {
+	return gotestgen.SharedFixtureInfo{
+		Identifier:   id,
+		PkgPath:      winFixturePkg,
+		PkgName:      "fix",
+		Dependencies: deps,
+	}
+}
+
+func winKey(id string) string { return winFixturePkg + "." + id }
+
+// windowOverlay builds a synthetic overlay: fixtures Alpha, Beta,
+// Chain (depends on Alpha), and Orphan (required by nobody). Suites:
+//
+//	pkg/a: AlphaSuite  → Alpha        MultiSuite → Alpha, Beta
+//	pkg/b: ChainSuite  → Chain (deliberately non-transitive: closure's job)
+//	       TimingSuite → Beta, Exclusive
+func windowOverlay() *gotestrunner.OverlayResult {
+	return &gotestrunner.OverlayResult{
+		SharedFixtures: []gotestgen.SharedFixtureInfo{
+			winFixture("Alpha"),
+			winFixture("Beta"),
+			winFixture("Chain", winKey("Alpha")),
+			winFixture("Orphan"),
+		},
+		SuitesByPkg: map[string][]string{
+			"pkg/a": {"AlphaSuite", "MultiSuite"},
+			"pkg/b": {"ChainSuite", "TimingSuite"},
+		},
+		ExclusiveSuitesByPkg: map[string]map[string]bool{
+			"pkg/b": {"TimingSuite": true},
+		},
+		SuiteRequiredSharedFixtureKeys: map[string]map[string][]string{
+			"pkg/a": {
+				"TestAlphaSuite": {winKey("Alpha")},
+				"TestMultiSuite": {winKey("Alpha"), winKey("Beta")},
+			},
+			"pkg/b": {
+				"TestChainSuite":  {winKey("Chain")},
+				"TestTimingSuite": {winKey("Beta")},
+			},
+		},
+	}
+}
+
+func fixtureIdentifiers(fixtures []gotestgen.SharedFixtureInfo) []string {
+	ids := make([]string, 0, len(fixtures))
+	for i := range fixtures {
+		ids = append(ids, fixtures[i].Identifier)
+	}
+	return ids
+}
+
+func (s *FixtureWindowTestSuite) TestAliveSets(t *gotest.T) {
+	overlay := windowOverlay()
+
+	t.When("no run filter is set", func(w *gotest.T) {
+		win := gotestrunner.ExportPlanFixtureWindows(overlay, "")
+
+		w.It("keeps every required fixture alive in its phase, DAG-closed", func(it *gotest.T) {
+			gotest.Equal(it, map[string]bool{winKey("Alpha"): true, winKey("Beta"): true, winKey("Chain"): true}, win.Bulk)
+			gotest.Equal(it, map[string]bool{winKey("Beta"): true}, win.Tail)
+		})
+
+		w.It("never starts the fixture no suite requires", func(it *gotest.T) {
+			gotest.Equal(it, []string{"Alpha", "Beta", "Chain"}, fixtureIdentifiers(win.Fixtures), "topological overlay order, Orphan dropped")
+			gotest.Equal(it, 1, win.Skipped)
+		})
+	})
+
+	t.When("the run filter selects one bulk suite", func(w *gotest.T) {
+		win := gotestrunner.ExportPlanFixtureWindows(overlay, "TestAlphaSuite")
+
+		w.It("keeps only that suite's fixtures", func(it *gotest.T) {
+			gotest.Equal(it, map[string]bool{winKey("Alpha"): true}, win.Bulk)
+			gotest.Empty(it, win.Tail)
+			gotest.Equal(it, []string{"Alpha"}, fixtureIdentifiers(win.Fixtures))
+			gotest.Equal(it, 3, win.Skipped)
+		})
+	})
+
+	t.When("the run filter selects only the exclusive suite", func(w *gotest.T) {
+		win := gotestrunner.ExportPlanFixtureWindows(overlay, "TestTimingSuite")
+
+		w.It("plans its fixture for the tail phase only", func(it *gotest.T) {
+			gotest.Empty(it, win.Bulk)
+			gotest.Equal(it, map[string]bool{winKey("Beta"): true}, win.Tail)
+			gotest.Equal(it, []string{"Beta"}, fixtureIdentifiers(win.Fixtures))
+		})
+	})
+
+	t.When("the run filter carries a subtest segment", func(w *gotest.T) {
+		win := gotestrunner.ExportPlanFixtureWindows(overlay, "TestChainSuite/TestSomething")
+
+		w.It("matches the suite on the first segment and closes over the DAG", func(it *gotest.T) {
+			gotest.Equal(it, map[string]bool{winKey("Chain"): true, winKey("Alpha"): true}, win.Bulk, "Alpha claimed through Chain's dependency edge")
+		})
+	})
+}
+
+func (s *FixtureWindowTestSuite) TestPhasePlanning(t *gotest.T) {
+	overlay := windowOverlay()
+
+	t.When("splitting the dispatch plan into phases", func(w *gotest.T) {
+		bulk, tail := gotestrunner.ExportPlanSuitePhases(overlay.SuitesByPkg, overlay.ExclusiveSuitesByPkg, "")
+
+		w.It("routes exclusive suites to the tail and the rest to the bulk", func(it *gotest.T) {
+			gotest.ElementsMatch(it, []string{"TestAlphaSuite", "TestMultiSuite"}, bulk["pkg/a"])
+			gotest.Equal(it, []string{"TestChainSuite"}, bulk["pkg/b"])
+			gotest.Equal(it, []string{"TestTimingSuite"}, tail["pkg/b"])
+		})
+	})
+
+	t.When("a phase has no suites", func(w *gotest.T) {
+		_, tail := gotestrunner.ExportPlanSuitePhases(overlay.SuitesByPkg, overlay.ExclusiveSuitesByPkg, "TestAlphaSuite")
+
+		w.It("yields an empty alive set", func(it *gotest.T) {
+			gotest.Empty(it, gotestrunner.ExportAliveFixtureKeys(tail, overlay.SuiteRequiredSharedFixtureKeys, overlay.SharedFixtures))
+		})
+	})
+}
+
+// TestRealOverlayFiltering runs the planner over the real tests/sharedfixture
+// packages — the same overlay the pipeline computes — so the filtering path is
+// pinned against genuine discovery output, not hand-built maps.
+func (s *FixtureWindowTestSuite) TestRealOverlayFiltering(t *gotest.T) {
+	loaded, broken, err := gotestgen.LoadPackages([]string{
+		"github.com/mvrahden/go-test/tests/sharedfixture/standalone/...",
+		"github.com/mvrahden/go-test/tests/sharedfixture/fixturebound/...",
+	}, nil)
+	gotest.NoError(t, err)
+	gotest.Empty(t, broken)
+
+	overlay, cleanup, err := gotestrunner.GenerateOverlay(loaded, nil, false, true)
+	gotest.NoError(t, err)
+	s.cleanup = cleanup
+
+	t.When("the run filter matches only the fixture-free suite", func(w *gotest.T) {
+		win := gotestrunner.ExportPlanFixtureWindows(overlay, "TestPlainTestSuite")
+
+		w.It("starts no shared fixture at all", func(it *gotest.T) {
+			gotest.Empty(it, win.Fixtures)
+			gotest.Equal(it, 3, win.Skipped, "Alpha, Beta, and Gamma all skipped")
+		})
+	})
+
+	t.When("the run filter matches the Gamma suite", func(w *gotest.T) {
+		win := gotestrunner.ExportPlanFixtureWindows(overlay, "TestGammaTestSuite")
+
+		w.It("keeps Gamma plus its Alpha dependency, drops Beta", func(it *gotest.T) {
+			gotest.ElementsMatch(it, []string{"AlphaSharedFixture", "GammaSharedFixture"}, fixtureIdentifiers(win.Fixtures))
+			gotest.Equal(it, 1, win.Skipped)
+		})
+	})
+
+	t.When("no run filter is set", func(w *gotest.T) {
+		win := gotestrunner.ExportPlanFixtureWindows(overlay, "")
+
+		w.It("keeps every fixture some suite requires", func(it *gotest.T) {
+			gotest.Len(it, win.Fixtures, 3)
+			gotest.Zero(it, win.Skipped)
+		})
+	})
+}

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mvrahden/go-test/internal/about"
@@ -1518,10 +1519,30 @@ func normalizeJSON(raw string) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
+// lockedWriter is a mutex-guarded string sink: logSlowBuild's AfterFunc
+// goroutine writes it while the test reads it, and timer.Stop provides no
+// happens-before edge between the two.
+type lockedWriter struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (w *lockedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *lockedWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
 func (s *GotestrunnerTestSuite) TestLogSlowBuild(t *gotest.T) {
 	t.When("a build outlives the threshold", func(w *gotest.T) {
 		w.It("logs the breach while running and the effective duration after", func(it *gotest.T) {
-			var buf strings.Builder
+			var buf lockedWriter
 			done := gotestrunner.ExportLogSlowBuild(&buf, "test binary for example.com/pkg", 10*time.Millisecond)
 			time.Sleep(40 * time.Millisecond)
 			done()
@@ -1532,7 +1553,7 @@ func (s *GotestrunnerTestSuite) TestLogSlowBuild(t *gotest.T) {
 
 	t.When("a build finishes under the threshold", func(w *gotest.T) {
 		w.It("stays silent — fast builds are the expected case", func(it *gotest.T) {
-			var buf strings.Builder
+			var buf lockedWriter
 			done := gotestrunner.ExportLogSlowBuild(&buf, "x", time.Minute)
 			done()
 			gotest.Zero(it, buf.String())

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -800,8 +800,8 @@ func (s *GotestrunnerTestSuite) TestExclusiveDispatch(t *gotest.T) {
 
 		w.It("carries the flag on exactly that suite's target", func(it *gotest.T) {
 			byName := map[string]bool{}
-			for _, tg := range targets {
-				byName[tg.SuiteName] = tg.Exclusive
+			for i := range targets {
+				byName[targets[i].SuiteName] = targets[i].Exclusive
 			}
 			gotest.True(it, byName["TestTimingTestSuite"])
 			gotest.False(it, byName["TestPlainTestSuite"])

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/mvrahden/go-test/internal/about"
@@ -1519,30 +1518,13 @@ func normalizeJSON(raw string) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
-// lockedWriter is a mutex-guarded string sink: logSlowBuild's AfterFunc
-// goroutine writes it while the test reads it, and timer.Stop provides no
-// happens-before edge between the two.
-type lockedWriter struct {
-	mu  sync.Mutex
-	buf strings.Builder
-}
-
-func (w *lockedWriter) Write(p []byte) (int, error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return w.buf.Write(p)
-}
-
-func (w *lockedWriter) String() string {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	return w.buf.String()
-}
-
 func (s *GotestrunnerTestSuite) TestLogSlowBuild(t *gotest.T) {
 	t.When("a build outlives the threshold", func(w *gotest.T) {
 		w.It("logs the breach while running and the effective duration after", func(it *gotest.T) {
-			var buf lockedWriter
+			// A plain strings.Builder is the point: logSlowBuild owns the
+			// synchronization between its timer goroutine and done(), so a
+			// non-concurrent-safe writer must be race-free under -race.
+			var buf strings.Builder
 			done := gotestrunner.ExportLogSlowBuild(&buf, "test binary for example.com/pkg", 10*time.Millisecond)
 			time.Sleep(40 * time.Millisecond)
 			done()
@@ -1553,7 +1535,7 @@ func (s *GotestrunnerTestSuite) TestLogSlowBuild(t *gotest.T) {
 
 	t.When("a build finishes under the threshold", func(w *gotest.T) {
 		w.It("stays silent — fast builds are the expected case", func(it *gotest.T) {
-			var buf lockedWriter
+			var buf strings.Builder
 			done := gotestrunner.ExportLogSlowBuild(&buf, "x", time.Minute)
 			done()
 			gotest.Zero(it, buf.String())

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -1518,6 +1518,28 @@ func normalizeJSON(raw string) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
+func (s *GotestrunnerTestSuite) TestLogSlowBuild(t *gotest.T) {
+	t.When("a build outlives the threshold", func(w *gotest.T) {
+		w.It("logs the breach while running and the effective duration after", func(it *gotest.T) {
+			var buf strings.Builder
+			done := gotestrunner.ExportLogSlowBuild(&buf, "test binary for example.com/pkg", 10*time.Millisecond)
+			time.Sleep(40 * time.Millisecond)
+			done()
+			gotest.Contains(it, buf.String(), "has been building for 10ms and is still running")
+			gotest.Contains(it, buf.String(), "finished building after")
+		})
+	})
+
+	t.When("a build finishes under the threshold", func(w *gotest.T) {
+		w.It("stays silent — fast builds are the expected case", func(it *gotest.T) {
+			var buf strings.Builder
+			done := gotestrunner.ExportLogSlowBuild(&buf, "x", time.Minute)
+			done()
+			gotest.Zero(it, buf.String())
+		})
+	})
+}
+
 func (s *GotestrunnerTestSuite) TestSanitizerAwareDispatch(t *gotest.T) {
 	procs := runtime.GOMAXPROCS(0)
 

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -791,6 +791,37 @@ func (s *GotestrunnerTestSuite) TestBuildSuiteCmd(t *gotest.T) {
 
 // --- OutputCollector tests ---
 
+func (s *GotestrunnerTestSuite) TestExclusiveDispatch(t *gotest.T) {
+	t.When("BuildSuiteTargets sees a suite marked exclusive", func(w *gotest.T) {
+		compiled := []gotestrunner.CompileResult{{Package: "example.com/pkg", BinaryPath: "/tmp/pkg.test"}}
+		suitesByPkg := map[string][]string{"example.com/pkg": {"TimingTestSuite", "PlainTestSuite"}}
+		exclusiveByPkg := map[string]map[string]bool{"example.com/pkg": {"TimingTestSuite": true}}
+		targets := gotestrunner.BuildSuiteTargets(compiled, suitesByPkg, map[string]string{"example.com/pkg": "/src"}, exclusiveByPkg, nil, "")
+
+		w.It("carries the flag on exactly that suite's target", func(it *gotest.T) {
+			byName := map[string]bool{}
+			for _, tg := range targets {
+				byName[tg.SuiteName] = tg.Exclusive
+			}
+			gotest.True(it, byName["TestTimingTestSuite"])
+			gotest.False(it, byName["TestPlainTestSuite"])
+		})
+	})
+
+	t.When("ordering exclusive targets for serial dispatch", func(w *gotest.T) {
+		w.It("sorts deterministically by package then suite name", func(it *gotest.T) {
+			targets := []gotestrunner.SuiteTarget{
+				{SuiteSpec: gotestrunner.SuiteSpec{Package: "b", SuiteName: "TestZ"}},
+				{SuiteSpec: gotestrunner.SuiteSpec{Package: "a", SuiteName: "TestB"}},
+				{SuiteSpec: gotestrunner.SuiteSpec{Package: "a", SuiteName: "TestA"}},
+			}
+			idx := []int{0, 1, 2}
+			gotestrunner.ExportSortTargetIndices(targets, idx)
+			gotest.Equal(it, []int{2, 1, 0}, idx)
+		})
+	})
+}
+
 func (s *GotestrunnerTestSuite) TestOutputCollector(t *gotest.T) {
 	pass := func(d time.Duration) gotestrunner.SuiteResult {
 		return gotestrunner.SuiteResult{Stdout: []byte("PASS\n"), ExitCode: 0, Duration: d}

--- a/internal/gotestrunner/gotestrunner_suite_test.go
+++ b/internal/gotestrunner/gotestrunner_suite_test.go
@@ -1518,6 +1518,36 @@ func normalizeJSON(raw string) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
+func (s *GotestrunnerTestSuite) TestSanitizerAwareDispatch(t *gotest.T) {
+	procs := runtime.GOMAXPROCS(0)
+
+	t.When("an instrumentation build flag is active with default parallelism", func(w *gotest.T) {
+		w.It("halves the process cap so instrumented suites keep scheduling headroom", func(it *gotest.T) {
+			runFlags := []string{}
+			got := gotestrunner.ExportComputeDispatchConcurrency(&runFlags, 0, 64, true)
+			gotest.Equal(it, max(1, procs/2), got)
+		})
+
+		w.It("keeps an explicit --parallel budget untouched — the user's number wins", func(it *gotest.T) {
+			runFlags := []string{}
+			withRace := gotestrunner.ExportComputeDispatchConcurrency(&runFlags, 10, 64, true)
+			runFlags = []string{}
+			without := gotestrunner.ExportComputeDispatchConcurrency(&runFlags, 10, 64, false)
+			gotest.Equal(it, without, withRace)
+		})
+	})
+
+	t.When("detecting instrumentation from build flags", func(w *gotest.T) {
+		w.It("recognizes -race, -msan and -asan and nothing else", func(it *gotest.T) {
+			gotest.True(it, gotestrunner.SanitizerActive([]string{"-tags=integration", "-race"}))
+			gotest.True(it, gotestrunner.SanitizerActive([]string{"-msan"}))
+			gotest.True(it, gotestrunner.SanitizerActive([]string{"-asan"}))
+			gotest.False(it, gotestrunner.SanitizerActive([]string{"-tags=integration", "-cover"}))
+			gotest.False(it, gotestrunner.SanitizerActive(nil))
+		})
+	})
+}
+
 func (s *GotestrunnerTestSuite) TestOutputGolden(t *gotest.T) {
 	t.When("text non-verbose", func(w *gotest.T) {
 		w.It("single passing package", func(it *gotest.T) {

--- a/internal/gotestrunner/overlay.go
+++ b/internal/gotestrunner/overlay.go
@@ -29,6 +29,7 @@ type OverlayResult struct {
 	NoSuitePackages                []string
 	StdlibTestsByPkg               map[string]int // stdlib func TestX counts per package — gotest reports but does not run them
 	SuitesByPkg                    map[string][]string
+	ExclusiveSuitesByPkg           map[string]map[string]bool
 	DirsByPkg                      map[string]string
 	SkippedSuitesByPkg             map[string][]string
 	FixtureDepSuites               map[string]map[string]bool
@@ -73,6 +74,7 @@ func GenerateOverlay(loaded []*gotestgen.LoadResult, broken []gotestgen.BrokenPa
 	suitesByPkg := map[string][]string{}
 	dirsByPkg := map[string]string{}
 	skippedSuitesByPkg := map[string][]string{}
+	exclusiveSuitesByPkg := map[string]map[string]bool{}
 	fixtureDepSuites := map[string]map[string]bool{}
 	suiteReqKeys := map[string]map[string][]string{}
 	for _, r := range allResults {
@@ -92,6 +94,13 @@ func GenerateOverlay(loaded []*gotestgen.LoadResult, broken []gotestgen.BrokenPa
 		}
 		if len(r.SkippedSuiteNames) > 0 {
 			skippedSuitesByPkg[r.PkgPath] = r.SkippedSuiteNames
+		}
+		if len(r.ExclusiveSuiteNames) > 0 {
+			ex := make(map[string]bool, len(r.ExclusiveSuiteNames))
+			for _, name := range r.ExclusiveSuiteNames {
+				ex[name] = true
+			}
+			exclusiveSuitesByPkg[r.PkgPath] = ex
 		}
 		if len(r.FixtureDepSuites) > 0 {
 			s := make(map[string]bool, len(r.FixtureDepSuites))
@@ -115,6 +124,7 @@ func GenerateOverlay(loaded []*gotestgen.LoadResult, broken []gotestgen.BrokenPa
 		NoSuitePackages:                noSuitePkgs,
 		StdlibTestsByPkg:               stdlibByPkg,
 		SuitesByPkg:                    suitesByPkg,
+		ExclusiveSuitesByPkg:           exclusiveSuitesByPkg,
 		DirsByPkg:                      dirsByPkg,
 		SkippedSuitesByPkg:             skippedSuitesByPkg,
 		FixtureDepSuites:               fixtureDepSuites,

--- a/internal/gotestrunner/pipeline.go
+++ b/internal/gotestrunner/pipeline.go
@@ -187,12 +187,14 @@ func buildBaseEnv(cfg PipelineConfig) []string {
 	return env
 }
 
-// prepareTestRun compiles the suite packages and starts shared fixtures
-// concurrently. Per-package compile failures are package verdicts, not run
-// aborts: they are returned for booking and do not stop the fixtures or the
-// packages that did compile. Only a fixture setup failure is fatal — without
-// the fixtures no surviving suite can run.
-func prepareTestRun(ctx context.Context, overlay *OverlayResult, buildFlags []string, setupTimeout time.Duration, compileParallel int) ([]CompileResult, []BuildFailure, *SharedFixtureProcess, context.CancelFunc, error) {
+// prepareTestRun compiles the suite packages and starts the given shared
+// fixtures concurrently. fixtures is the run's residency plan (see
+// planFixtureWindows), not the full overlay set: a fixture no scheduled suite
+// requires never starts. Per-package compile failures are package verdicts,
+// not run aborts: they are returned for booking and do not stop the fixtures
+// or the packages that did compile. Only a fixture setup failure is fatal —
+// without the fixtures no surviving suite can run.
+func prepareTestRun(ctx context.Context, overlay *OverlayResult, fixtures []gotestgen.SharedFixtureInfo, buildFlags []string, setupTimeout time.Duration, compileParallel int) ([]CompileResult, []BuildFailure, *SharedFixtureProcess, context.CancelFunc, error) {
 	setupTimeout = resolveSetupTimeout(setupTimeout)
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -208,11 +210,11 @@ func prepareTestRun(ctx context.Context, overlay *OverlayResult, buildFlags []st
 		compiled, compileFailures = CompilePackages(ctx, overlay.SuitePackages, overlay.OverlayFlag, buildFlags, overlay.WorkDir, compileParallel)
 	}()
 
-	if len(overlay.SharedFixtures) > 0 {
+	if len(fixtures) > 0 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			setupProc, setupErr = StartSharedFixtures(ctx, overlay.WorkDir, overlay.SharedFixtures, setupTimeout)
+			setupProc, setupErr = StartSharedFixtures(ctx, overlay.WorkDir, fixtures, setupTimeout)
 			if setupErr != nil {
 				cancel()
 				return
@@ -276,7 +278,9 @@ func setupCoverage(targets []SuiteTarget, overlay *OverlayResult, userCoverProfi
 }
 
 func runBatch(ctx context.Context, cfg PipelineConfig, overlay *OverlayResult, pf ParsedFlags) (result PipelineResult, err error) { //nolint:gocritic // hugeParam: stable API
-	compiled, compileFailures, setupProc, cancelPrepare, err := prepareTestRun(ctx, overlay, pf.BuildFlags, cfg.SetupTimeout, cfg.CompileParallel)
+	win := planFixtureWindows(overlay, pf.UserRunFilter)
+	win.reportSkipped()
+	compiled, compileFailures, setupProc, cancelPrepare, err := prepareTestRun(ctx, overlay, win.Fixtures, pf.BuildFlags, cfg.SetupTimeout, cfg.CompileParallel)
 	if err != nil {
 		return PipelineResult{ExitCode: 2}, err
 	}
@@ -344,6 +348,9 @@ func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResul
 	resolvedSetupTimeout := resolveSetupTimeout(cfg.SetupTimeout)
 	baseEnv := buildBaseEnv(cfg)
 
+	win := planFixtureWindows(overlay, pf.UserRunFilter)
+	win.reportSkipped()
+
 	// Exclusive suites collected during the stream, run serially after it.
 	type deferredTarget struct {
 		t   SuiteTarget
@@ -360,7 +367,7 @@ func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResul
 	streamCtx, streamCancel := context.WithCancel(ctx)
 	defer streamCancel()
 
-	if len(overlay.SharedFixtures) > 0 {
+	if len(win.Fixtures) > 0 {
 		fixtureWg.Add(1)
 		go func() {
 			defer fixtureWg.Done()
@@ -371,7 +378,7 @@ func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResul
 			// owner of shutdown, and it runs only after every suite has stopped.
 			// The pipeline ctx stays attached as the safety net so an abnormal
 			// runner death still releases the process group.
-			setupProc, err = StartSharedFixtures(ctx, overlay.WorkDir, overlay.SharedFixtures, resolvedSetupTimeout)
+			setupProc, err = StartSharedFixtures(ctx, overlay.WorkDir, win.Fixtures, resolvedSetupTimeout)
 			if err != nil {
 				fixtureStartErr = err
 				sharedSetupFailed.Store(true)

--- a/internal/gotestrunner/pipeline.go
+++ b/internal/gotestrunner/pipeline.go
@@ -3,6 +3,7 @@ package gotestrunner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -94,6 +95,34 @@ func applyTeardownFailure(result *PipelineResult, err error) {
 	if result.CapturedJSON != nil {
 		result.CapturedJSON = appendRunFailureEvents(result.CapturedJSON, "shared fixtures", err.Error())
 	}
+}
+
+// fixtureBarrier performs the bulk→tail window transition on the setup
+// process: release what only the bulk needed (the subprocess applies
+// reverse-DAG order), then start what only the tail needs (DAG order).
+// Skipped entirely on cancellation — the terminal Teardown owns shutdown.
+// refreshStateFile is batch mode's concern: its suites read the one global
+// state file, which must gain the late-started fixtures' state.
+func fixtureBarrier(ctx context.Context, proc *SharedFixtureProcess, bulkAlive, tailAlive map[string]bool, setupTimeout time.Duration, refreshStateFile bool) error {
+	if proc == nil || ctx.Err() != nil {
+		return nil
+	}
+	var errs []error
+	if release := diffKeys(bulkAlive, tailAlive); len(release) > 0 {
+		if err := proc.TeardownKeys(release, proc.teardownBudget()); err != nil {
+			errs = append(errs, fmt.Errorf("early shared fixture teardown: %w", err))
+		}
+	}
+	if acquire := diffKeys(tailAlive, bulkAlive); len(acquire) > 0 {
+		err := proc.StartKeys(acquire, setupTimeout)
+		if err == nil && refreshStateFile {
+			err = proc.RefreshStateFile()
+		}
+		if err != nil {
+			errs = append(errs, fmt.Errorf("shared fixture start for exclusive tail: %w", err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // stageFailurePkg names the synthetic package under which a build failure
@@ -285,8 +314,11 @@ func runBatch(ctx context.Context, cfg PipelineConfig, overlay *OverlayResult, p
 		return PipelineResult{ExitCode: 2}, err
 	}
 	defer cancelPrepare()
+	// barrierErr collects window-boundary failures (early teardown, tail
+	// start); they merge with the terminal Teardown's verdict below.
+	var barrierErr error
 	if setupProc != nil {
-		defer func() { applyTeardownFailure(&result, setupProc.Teardown()) }()
+		defer func() { applyTeardownFailure(&result, errors.Join(barrierErr, setupProc.Teardown())) }()
 	}
 
 	select {
@@ -329,7 +361,25 @@ func runBatch(ctx context.Context, cfg PipelineConfig, overlay *OverlayResult, p
 		defer mergeCoverProfiles(targets, pf.UserCoverProfile)
 	}
 
-	RunSuites(ctx, targets, extraEnv, maxParallel, collector)
+	// The barrier re-windows shared fixtures between the parallel bulk and
+	// the exclusive tail. Alive(tail) comes from the actual exclusive targets
+	// — the plan narrowed by compile results — so a fixture whose only tail
+	// suite never became runnable is released, not started.
+	var tailTargets []SuiteTarget
+	for i := range targets {
+		if targets[i].Exclusive {
+			tailTargets = append(tailTargets, targets[i])
+		}
+	}
+	barrier := func() {
+		if len(tailTargets) == 0 {
+			return // nothing dispatches after the bulk; run-end teardown owns the rest
+		}
+		tailAlive := aliveFromTargets(tailTargets, overlay.SuiteRequiredSharedFixtureKeys, win.Fixtures)
+		barrierErr = fixtureBarrier(ctx, setupProc, win.Bulk, tailAlive, resolveSetupTimeout(cfg.SetupTimeout), true)
+	}
+
+	RunSuites(ctx, targets, extraEnv, maxParallel, collector, barrier)
 	collector.Finalize(overlay.NoSuitePackages)
 
 	return PipelineResult{
@@ -573,6 +623,21 @@ loop:
 
 	wg.Wait()
 
+	// Bulk→tail barrier: re-window shared fixtures for the exclusive tail.
+	// Alive(tail) comes from the actual deferred targets — suites whose
+	// packages never compiled are not in it. Skipped entirely on cancellation
+	// or when nothing dispatches after the bulk: the terminal Teardown owns
+	// whatever is still resident.
+	var barrierErr error
+	if len(deferredExclusive) > 0 && setupProc != nil && !sharedSetupFailed.Load() {
+		tailTargets := make([]SuiteTarget, 0, len(deferredExclusive))
+		for i := range deferredExclusive {
+			tailTargets = append(tailTargets, deferredExclusive[i].t)
+		}
+		tailAlive := aliveFromTargets(tailTargets, overlay.SuiteRequiredSharedFixtureKeys, win.Fixtures)
+		barrierErr = fixtureBarrier(streamCtx, setupProc, win.Bulk, tailAlive, resolvedSetupTimeout, false)
+	}
+
 	// Exclusive suites own the machine: after the stream has fully drained,
 	// one at a time, in deterministic order. Shared fixture processes stay up
 	// — they are infrastructure the suites talk to, not competing suites —
@@ -615,7 +680,7 @@ loop:
 	// its own from one that simply obeyed the signal it never sent.
 	var teardownErr error
 	if setupProc != nil {
-		teardownErr = setupProc.Teardown()
+		teardownErr = errors.Join(barrierErr, setupProc.Teardown())
 	}
 	streamCancel()
 

--- a/internal/gotestrunner/pipeline.go
+++ b/internal/gotestrunner/pipeline.go
@@ -577,7 +577,8 @@ loop:
 		}
 		return ta.SuiteName < tb.SuiteName
 	}) //nolint:gocritic // mirror of sortTargetIndices over a local pair type
-	for _, d := range deferredExclusive {
+	for i := range deferredExclusive {
+		d := &deferredExclusive[i]
 		if streamCtx.Err() != nil {
 			collector.RecordResult(d.t.Package, d.idx, SuiteResult{ExitCode: 1})
 			continue

--- a/internal/gotestrunner/pipeline.go
+++ b/internal/gotestrunner/pipeline.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -283,8 +284,7 @@ func runBatch(ctx context.Context, cfg PipelineConfig, overlay *OverlayResult, p
 		runFlags = append(append([]string(nil), runFlags...), "-v")
 	}
 	maxParallel := computeDispatchConcurrency(&runFlags, cfg.Parallel, totalSuites)
-
-	targets := BuildSuiteTargets(compiled, overlay.SuitesByPkg, overlay.DirsByPkg, runFlags, pf.UserRunFilter)
+	targets := BuildSuiteTargets(compiled, overlay.SuitesByPkg, overlay.DirsByPkg, overlay.ExclusiveSuitesByPkg, runFlags, pf.UserRunFilter)
 
 	collector := NewOutputCollector(cfg.OutputMode, pf.Verbose)
 	collector.StdlibTestsByPkg = overlay.StdlibTestsByPkg
@@ -325,6 +325,13 @@ func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResul
 
 	resolvedSetupTimeout := resolveSetupTimeout(cfg.SetupTimeout)
 	baseEnv := buildBaseEnv(cfg)
+
+	// Exclusive suites collected during the stream, run serially after it.
+	type deferredTarget struct {
+		t   SuiteTarget
+		idx int
+	}
+	var deferredExclusive []deferredTarget
 
 	fixtureStarted := make(chan struct{})
 	var setupProc *SharedFixtureProcess
@@ -436,7 +443,7 @@ loop:
 
 		singleCompiled := []CompileResult{cr}
 		singleSuites := map[string][]string{cr.Package: overlay.SuitesByPkg[cr.Package]}
-		targets := BuildSuiteTargets(singleCompiled, singleSuites, overlay.DirsByPkg, pf.RunFlags, pf.UserRunFilter)
+		targets := BuildSuiteTargets(singleCompiled, singleSuites, overlay.DirsByPkg, overlay.ExclusiveSuitesByPkg, pf.RunFlags, pf.UserRunFilter)
 
 		if len(targets) == 0 {
 			continue
@@ -457,6 +464,14 @@ loop:
 
 		for i := range targets { //nolint:gocritic // hugeParam: stable API
 			target := targets[i]
+			if target.Exclusive {
+				// Deferred past the stream: exclusive suites run strictly
+				// alone, after every concurrent suite has drained. Their
+				// slot in the collector's per-package count is already
+				// registered above; the index travels with them.
+				deferredExclusive = append(deferredExclusive, deferredTarget{t: target, idx: i})
+				continue
+			}
 			wg.Add(1)
 			go func(t SuiteTarget, idx int) {
 				defer wg.Done()
@@ -532,6 +547,39 @@ loop:
 	}
 
 	wg.Wait()
+
+	// Exclusive suites own the machine: after the stream has fully drained,
+	// one at a time, in deterministic order. Shared fixture processes stay up
+	// — they are infrastructure the suites talk to, not competing suites —
+	// and tear down only after the last exclusive finishes.
+	sort.Slice(deferredExclusive, func(a, b int) bool {
+		ta, tb := deferredExclusive[a].t, deferredExclusive[b].t
+		if ta.Package != tb.Package {
+			return ta.Package < tb.Package
+		}
+		return ta.SuiteName < tb.SuiteName
+	}) //nolint:gocritic // mirror of sortTargetIndices over a local pair type
+	for _, d := range deferredExclusive {
+		if streamCtx.Err() != nil {
+			collector.RecordResult(d.t.Package, d.idx, SuiteResult{ExitCode: 1})
+			continue
+		}
+		env := baseEnv
+		if requiredKeys := overlay.SuiteRequiredSharedFixtureKeys[d.t.Package][d.t.SuiteName]; len(requiredKeys) > 0 && setupProc != nil {
+			stateFile, err := setupProc.WriteStateFileForKeys(d.t.SuiteName, requiredKeys)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "WARN: write state file for %s: %s\n", d.t.SuiteName, err)
+				collector.RecordResult(d.t.Package, d.idx, SuiteResult{ExitCode: 1})
+				continue
+			}
+			env = make([]string, len(baseEnv), len(baseEnv)+1)
+			copy(env, baseEnv)
+			env = append(env, protocol.EnvSharedStateFile+"="+stateFile)
+		}
+		r := RunSingleSuite(streamCtx, d.t, env, collector.UsesTest2JSON())
+		collector.RecordResult(d.t.Package, d.idx, r)
+	}
+
 	fixtureWg.Wait()
 
 	// Teardown owns the shared fixture process's shutdown: it signals, then

--- a/internal/gotestrunner/pipeline.go
+++ b/internal/gotestrunner/pipeline.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/mvrahden/go-test/internal/gotestgen"
 	"github.com/mvrahden/go-test/internal/protocol"
+	"github.com/mvrahden/go-test/internal/schedinfo"
 )
 
 const DefaultSetupTimeout = 2 * time.Minute
@@ -230,7 +231,9 @@ func prepareTestRun(ctx context.Context, overlay *OverlayResult, buildFlags []st
 		if setupProc != nil {
 			_ = setupProc.Teardown()
 		}
-		return nil, nil, nil, nil, fmt.Errorf("shared fixture setup: %w", setupErr)
+		// Scheduling context: fixture setup deadlines are wall-clock verdicts
+		// too, and a starved build looks exactly like a broken one.
+		return nil, nil, nil, nil, fmt.Errorf("shared fixture setup: %w %s", setupErr, schedinfo.Summary())
 	}
 
 	return compiled, compileFailures, setupProc, cancel, nil

--- a/internal/gotestrunner/pipeline.go
+++ b/internal/gotestrunner/pipeline.go
@@ -30,14 +30,29 @@ func resolveSetupTimeout(d time.Duration) time.Duration {
 	}
 }
 
-func computeDispatchConcurrency(runFlags *[]string, budget, totalSuites int) int {
+func computeDispatchConcurrency(runFlags *[]string, budget, totalSuites int, sanitized bool) int {
 	userParallel := ExtractParallelValue(*runFlags)
 
 	if userParallel > 0 && budget == 0 {
+		// The user pinned intra-process parallelism; the process count is
+		// still ours to choose — halved under instrumentation like every
+		// other default (see SanitizerActive).
+		if sanitized {
+			return runtime.GOMAXPROCS(0)
+		}
 		return 2 * runtime.GOMAXPROCS(0)
 	}
 
-	inter, intra := ComputeConcurrency(budget, totalSuites, runtime.GOMAXPROCS(0))
+	procs := runtime.GOMAXPROCS(0)
+	if sanitized && budget == 0 {
+		// Halve both dimensions: the budget (total concurrent test methods)
+		// and the process cap. Halving the budget alone would not reduce the
+		// process count — ComputeConcurrency caps inter at procs first — and
+		// the OS process running an instrumented binary is the costly unit.
+		budget = procs
+		procs = max(1, procs/2)
+	}
+	inter, intra := ComputeConcurrency(budget, totalSuites, procs)
 	if userParallel == 0 {
 		*runFlags = InjectParallel(*runFlags, intra)
 	}
@@ -283,7 +298,7 @@ func runBatch(ctx context.Context, cfg PipelineConfig, overlay *OverlayResult, p
 	if cfg.OutputMode == RunCaptureJSON {
 		runFlags = append(append([]string(nil), runFlags...), "-v")
 	}
-	maxParallel := computeDispatchConcurrency(&runFlags, cfg.Parallel, totalSuites)
+	maxParallel := computeDispatchConcurrency(&runFlags, cfg.Parallel, totalSuites, SanitizerActive(pf.BuildFlags))
 	targets := BuildSuiteTargets(compiled, overlay.SuitesByPkg, overlay.DirsByPkg, overlay.ExclusiveSuitesByPkg, runFlags, pf.UserRunFilter)
 
 	collector := NewOutputCollector(cfg.OutputMode, pf.Verbose)
@@ -393,7 +408,7 @@ func runStreaming(ctx context.Context, cfg PipelineConfig, overlay *OverlayResul
 	for _, suites := range overlay.SuitesByPkg {
 		totalSuites += len(suites)
 	}
-	maxParallel := computeDispatchConcurrency(&pf.RunFlags, cfg.Parallel, totalSuites)
+	maxParallel := computeDispatchConcurrency(&pf.RunFlags, cfg.Parallel, totalSuites, SanitizerActive(pf.BuildFlags))
 	sem := make(chan struct{}, maxParallel)
 	var wg sync.WaitGroup
 	anyTargets := false

--- a/internal/gotestrunner/sharedfixture.go
+++ b/internal/gotestrunner/sharedfixture.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -45,6 +46,10 @@ type SharedFixtureProcess struct {
 	allDone  chan struct{}
 	setupErr error
 	waitErr  error // exit status of the subprocess; valid once done is closed
+
+	stdin   io.WriteCloser // command channel for window verbs (StartKeys/TeardownKeys)
+	cmdMu   sync.Mutex     // serializes commands: one in flight, one _cmd ack each
+	cmdResp chan string    // _cmd ack payloads (error text, "" on success)
 }
 
 // StateFile returns the path to the shared fixture state JSON file.
@@ -185,6 +190,89 @@ func (p *SharedFixtureProcess) WriteStateFileForKeys(name string, keys []string)
 	return path, nil
 }
 
+// StartKeys asks the setup subprocess to start the given fixtures now — the
+// opening half of a window boundary. The subprocess runs them in dependency
+// order under the same per-fixture retry and budget policy as the up-front
+// phase, and streams their state lines before acknowledging. Blocks until the
+// acknowledgement; timeout 0 means no deadline.
+func (p *SharedFixtureProcess) StartKeys(keys []string, timeout time.Duration) error {
+	return p.command("start", keys, timeout)
+}
+
+// TeardownKeys asks the setup subprocess to tear down the given fixtures now,
+// in reverse dependency order — the releasing half of a window boundary.
+// Teardown (the terminal owner) later skips keys already released here.
+// Blocks until the acknowledgement; timeout 0 means no deadline.
+func (p *SharedFixtureProcess) TeardownKeys(keys []string, timeout time.Duration) error {
+	return p.command("teardown", keys, timeout)
+}
+
+func (p *SharedFixtureProcess) command(verb string, keys []string, timeout time.Duration) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	if p.stdin == nil {
+		return fmt.Errorf("shared fixture process has no command channel")
+	}
+	p.cmdMu.Lock()
+	defer p.cmdMu.Unlock()
+
+	// Drain a stale ack a timed-out predecessor left behind: every command
+	// gets exactly one ack, and it must be its own.
+	select {
+	case <-p.cmdResp:
+	default:
+	}
+
+	line, err := json.Marshal(struct {
+		Verb string   `json:"verb"`
+		Keys []string `json:"keys"`
+	}{Verb: verb, Keys: keys})
+	if err != nil {
+		return err
+	}
+	if _, err := p.stdin.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("send %s to shared fixture process: %w", verb, err)
+	}
+
+	var deadline <-chan time.Time
+	if timeout > 0 {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		deadline = timer.C
+	}
+	select {
+	case msg := <-p.cmdResp:
+		if msg != "" {
+			return fmt.Errorf("shared fixture %s: %s", verb, msg)
+		}
+		return nil
+	case <-p.done:
+		return fmt.Errorf("shared fixture process exited before acknowledging %s", verb)
+	case <-deadline:
+		return fmt.Errorf("shared fixture %s timed out after %v", verb, timeout)
+	}
+}
+
+// RefreshStateFile rewrites the global state file (the one WaitAllReady wrote
+// and every batch suite's env points at) from the current accumulated state —
+// after StartKeys added late fixtures, the file must contain them.
+func (p *SharedFixtureProcess) RefreshStateFile() error {
+	if p.stateFile == "" {
+		return nil
+	}
+	p.mu.Lock()
+	data, err := json.Marshal(p.state)
+	p.mu.Unlock()
+	if err != nil {
+		return fmt.Errorf("re-marshal shared fixture state: %w", err)
+	}
+	if err := os.WriteFile(p.stateFile, data, 0600); err != nil {
+		return fmt.Errorf("refresh shared fixture state file: %w", err)
+	}
+	return nil
+}
+
 // Teardown signals the shared fixture subprocess to shut down and waits for it
 // to complete within its teardown budget (30 seconds if none was reported). A
 // process that outlives the budget is forcibly killed, and that is reported as
@@ -303,6 +391,10 @@ func StartSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestge
 	if err != nil {
 		return nil, err
 	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
 
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("start shared fixture process: %w", err)
@@ -327,6 +419,8 @@ func StartSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestge
 		ready:           ready,
 		state:           state,
 		allDone:         allDone,
+		stdin:           stdin,
+		cmdResp:         make(chan string, 1),
 	}
 
 	go func() {
@@ -335,8 +429,12 @@ func StartSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestge
 			close(waitDone)
 		}()
 		closedReady := make(map[string]bool, len(ready))
+		doneSeen := false
 		scanner := bufio.NewScanner(stdout)
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		// The scan outlives _done: window verbs keep the stream alive with
+		// late state lines (deferred StartKeys) and _cmd acknowledgements,
+		// until EOF at process exit.
 		for scanner.Scan() {
 			var entry fixtureStateEntry
 			if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
@@ -355,8 +453,18 @@ func StartSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestge
 						proc.mu.Unlock()
 					}
 				}
+				doneSeen = true
 				close(allDone)
-				return
+				continue
+			}
+			if entry.Key == "_cmd" {
+				// Ack for the one in-flight command; drop it if no one waits
+				// (the commander timed out) rather than stall the scan.
+				select {
+				case proc.cmdResp <- entry.Error:
+				default:
+				}
+				continue
 			}
 			proc.mu.Lock()
 			state[entry.Key] = entry.State
@@ -365,6 +473,9 @@ func StartSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestge
 				close(ch)
 				closedReady[entry.Key] = true
 			}
+		}
+		if doneSeen {
+			return
 		}
 		if err := scanner.Err(); err != nil {
 			proc.setupErr = fmt.Errorf("reading subprocess stdout: %w", err)

--- a/internal/gotestrunner/sharedfixture.go
+++ b/internal/gotestrunner/sharedfixture.go
@@ -278,6 +278,7 @@ func StartSharedFixtures(ctx context.Context, tmpDir string, fixtures []gotestge
 	if runtime.GOOS == "windows" {
 		setupBin += ".exe"
 	}
+	defer logSlowBuild(os.Stderr, "shared fixture setup binary", slowBuildThreshold)()
 	buildCmd := exec.CommandContext(ctx, "go", "build", "-o", setupBin, setupFile)
 	buildCmd.Stderr = os.Stderr
 	buildMp := NewManagedProcess(buildCmd, ProcessConfig{Grace: GraceKill})

--- a/internal/gotestrunner/sharedfixture_teardown_suite_test.go
+++ b/internal/gotestrunner/sharedfixture_teardown_suite_test.go
@@ -23,6 +23,13 @@ import (
 // which t.Setenv forbids sharing with parallel tests.
 type SharedFixtureTeardownTestSuite struct{}
 
+// SuiteConfig: Exclusive because every method builds and force-kills real
+// subprocesses against configured budgets — the one workload that must not
+// share the machine with concurrent compiles.
+func (s *SharedFixtureTeardownTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{Exclusive: true}
+}
+
 // slowTeardownFixture is the fixture description the generator would produce for
 // tests/sharedfixture/fixtures.SlowTeardownSharedFixture.
 func slowTeardownFixture() []gotestgen.SharedFixtureInfo {

--- a/internal/gotestrunner/sharedfixture_teardown_suite_test.go
+++ b/internal/gotestrunner/sharedfixture_teardown_suite_test.go
@@ -2,6 +2,7 @@ package gotestrunner_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"time"
@@ -116,6 +117,81 @@ func (s *SharedFixtureTeardownTestSuite) TestTeardownGetsItsConfiguredBudget(t *
 				"AfterAll never finished: the fixture was killed part-way through and whatever it held is leaked")
 			gotest.NoError(it, err)
 		})
+	})
+}
+
+// windowFixtures pairs an up-front Alpha with a deferred Beta — the smallest
+// input that exercises both window verbs against a real subprocess.
+func windowFixtures() []gotestgen.SharedFixtureInfo {
+	return []gotestgen.SharedFixtureInfo{
+		{
+			Identifier:     "AlphaSharedFixture",
+			PkgPath:        "github.com/mvrahden/go-test/tests/sharedfixture/fixtures",
+			PkgName:        "fixtures",
+			QualifiedType:  "fixtures.AlphaSharedFixture",
+			TransferFields: []string{"DataPath"},
+		},
+		{
+			Identifier:     "BetaSharedFixture",
+			PkgPath:        "github.com/mvrahden/go-test/tests/sharedfixture/fixtures",
+			PkgName:        "fixtures",
+			QualifiedType:  "fixtures.BetaSharedFixture",
+			TransferFields: []string{"Label", "Count"},
+			Deferred:       true,
+		},
+	}
+}
+
+func (s *SharedFixtureTeardownTestSuite) TestWindowVerbs(t *gotest.T) {
+	const (
+		alphaKey = "github.com/mvrahden/go-test/tests/sharedfixture/fixtures.AlphaSharedFixture"
+		betaKey  = "github.com/mvrahden/go-test/tests/sharedfixture/fixtures.BetaSharedFixture"
+	)
+
+	t.When("a deferred fixture rides along an up-front one", func(w *gotest.T) {
+		ctx, cancel := context.WithCancel(w.Context())
+
+		proc, err := gotestrunner.StartSharedFixtures(ctx, w.TempDir(), windowFixtures(), 30*time.Second)
+		gotest.NoError(w, err, "starting the shared fixture subprocess")
+		gotest.NoError(w, proc.WaitAllReady(ctx, 30*time.Second), "waiting for the up-front phase")
+
+		var alphaState struct{ DataPath string }
+		gotest.NoError(w, json.Unmarshal(proc.State([]string{alphaKey})[alphaKey], &alphaState))
+		gotest.NotEmpty(w, alphaState.DataPath)
+
+		w.It("holds the deferred fixture out of the up-front phase", func(it *gotest.T) {
+			_, hasBeta := proc.State([]string{betaKey})[betaKey]
+			gotest.False(it, hasBeta, "a deferred fixture must not start before its window opens")
+		})
+
+		w.It("starts it on StartKeys and streams its state", func(it *gotest.T) {
+			gotest.NoError(it, proc.StartKeys([]string{betaKey}, 30*time.Second))
+
+			var betaState struct {
+				Label string
+				Count int
+			}
+			raw, hasBeta := proc.State([]string{betaKey})[betaKey]
+			gotest.True(it, hasBeta, "StartKeys must not acknowledge before the state line")
+			gotest.NoError(it, json.Unmarshal(raw, &betaState))
+			gotest.Equal(it, "beta-shared", betaState.Label)
+			gotest.Equal(it, 42, betaState.Count)
+		})
+
+		w.It("releases early keys on TeardownKeys", func(it *gotest.T) {
+			gotest.NoError(it, proc.TeardownKeys([]string{alphaKey}, 30*time.Second))
+			_, statErr := os.Stat(alphaState.DataPath)
+			gotest.Error(it, statErr, "Alpha's AfterAll must have removed its data file")
+		})
+
+		w.It("leaves exactly the remainder to the terminal Teardown", func(it *gotest.T) {
+			// A clean exit doubles as the single-ownership proof: if the
+			// epilogue re-ran Alpha's AfterAll, the second os.Remove would
+			// fail and flip the exit status to teardown-failed.
+			gotest.NoError(it, proc.Teardown())
+		})
+
+		cancel()
 	})
 }
 

--- a/internal/gotestrunner/suiterun.go
+++ b/internal/gotestrunner/suiterun.go
@@ -66,7 +66,10 @@ const (
 // RunSuites executes each suite target in its own subprocess with bounded
 // concurrency. Results are recorded via the collector, which handles
 // mode-specific output formatting, JSON event filtering, and package ordering.
-func RunSuites(ctx context.Context, targets []SuiteTarget, extraEnv map[string]string, maxParallel int, collector *OutputCollector) {
+// barrier, when non-nil, runs at the bulk→tail boundary — after every
+// parallel suite has drained, before the first exclusive suite dispatches —
+// so the caller can re-window shared fixtures.
+func RunSuites(ctx context.Context, targets []SuiteTarget, extraEnv map[string]string, maxParallel int, collector *OutputCollector, barrier func()) {
 	if maxParallel <= 0 {
 		maxParallel = 2 * runtime.GOMAXPROCS(0)
 	}
@@ -115,6 +118,10 @@ func RunSuites(ctx context.Context, targets []SuiteTarget, extraEnv map[string]s
 		}(i, target)
 	}
 	wg.Wait()
+
+	if barrier != nil {
+		barrier()
+	}
 
 	// Exclusive suites own the machine: strictly after the parallel bulk,
 	// one at a time, in deterministic order. Their verdicts measure

--- a/internal/gotestrunner/suiterun.go
+++ b/internal/gotestrunner/suiterun.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"regexp"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -32,6 +33,7 @@ type SuiteTarget struct {
 	RunFlags     []string // test binary flags (with -test. prefix)
 	CoverProfile string   // per-suite cover profile path (empty if no -coverprofile)
 	BudgetFile   string   // sidecar path for teardown budget (empty = use default)
+	Exclusive    bool     // SuiteConfig{Exclusive: true}: dispatched strictly alone, after every non-exclusive suite
 }
 
 // SuiteResult holds the output from running a single suite subprocess.
@@ -93,7 +95,12 @@ func RunSuites(ctx context.Context, targets []SuiteTarget, extraEnv map[string]s
 		env = append(env, k+"="+v)
 	}
 
+	var exclusiveIdx []int
 	for i, target := range targets { //nolint:gocritic // rangeValCopy: intentional
+		if target.Exclusive {
+			exclusiveIdx = append(exclusiveIdx, i)
+			continue
+		}
 		wg.Add(1)
 		go func(idx int, t SuiteTarget) {
 			defer wg.Done()
@@ -108,6 +115,19 @@ func RunSuites(ctx context.Context, targets []SuiteTarget, extraEnv map[string]s
 		}(i, target)
 	}
 	wg.Wait()
+
+	// Exclusive suites own the machine: strictly after the parallel bulk,
+	// one at a time, in deterministic order. Their verdicts measure
+	// wall-clock behavior — timing budgets, contended resources — that
+	// concurrently running suites would corrupt.
+	sortTargetIndices(targets, exclusiveIdx)
+	for _, i := range exclusiveIdx {
+		if ctx.Err() != nil {
+			return
+		}
+		r := RunSingleSuite(ctx, targets[i], env, useTest2JSON)
+		collector.RecordResult(targets[i].Package, localIdx[i], r)
+	}
 }
 
 func buildSuiteCmd(ctx context.Context, target SuiteTarget, env []string, test2json bool) *exec.Cmd { //nolint:gocritic // hugeParam: stable API
@@ -243,7 +263,11 @@ func WritePackageSummary(pkg string, failed bool, d time.Duration, verbose bool)
 //
 // If userRunFilter is non-empty, only suites whose test function name
 // matches the filter regex are included.
-func BuildSuiteTargets(compiled []CompileResult, suitesByPkg map[string][]string, dirsByPkg map[string]string, runFlags []string, userRunFilter string) []SuiteTarget {
+//
+// exclusiveByPkg (import path → suite struct name → true) marks suites with
+// SuiteConfig{Exclusive: true}; their targets carry Exclusive and are
+// dispatched strictly alone, after every non-exclusive suite (see RunSuites).
+func BuildSuiteTargets(compiled []CompileResult, suitesByPkg map[string][]string, dirsByPkg map[string]string, exclusiveByPkg map[string]map[string]bool, runFlags []string, userRunFilter string) []SuiteTarget {
 	binByPkg := make(map[string]string, len(compiled))
 	for _, cr := range compiled {
 		binByPkg[cr.Package] = cr.BinaryPath
@@ -273,6 +297,7 @@ func BuildSuiteTargets(compiled []CompileResult, suitesByPkg map[string][]string
 				},
 				BinaryPath: bin,
 				RunFlags:   translatedFlags,
+				Exclusive:  exclusiveByPkg[pkg][suiteName],
 			}
 			if rf := suiteRunFilter(userRunFilter, testFuncName); rf != "" {
 				target.RunFilter = rf
@@ -281,6 +306,18 @@ func BuildSuiteTargets(compiled []CompileResult, suitesByPkg map[string][]string
 		}
 	}
 	return targets
+}
+
+// sortTargetIndices orders target indices by (Package, SuiteName) so
+// exclusive dispatch is deterministic run over run.
+func sortTargetIndices(targets []SuiteTarget, idx []int) {
+	sort.Slice(idx, func(a, b int) bool {
+		ta, tb := targets[idx[a]], targets[idx[b]]
+		if ta.Package != tb.Package {
+			return ta.Package < tb.Package
+		}
+		return ta.SuiteName < tb.SuiteName
+	})
 }
 
 // matchesSuiteFunc checks if the user's -run regex could match a given

--- a/internal/lint/fixturefields.go
+++ b/internal/lint/fixturefields.go
@@ -1,0 +1,123 @@
+package lint
+
+import (
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"github.com/mvrahden/go-test/internal/protocol"
+)
+
+// Fixture-field discovery shared by the suite-scoped fixture rules: the
+// syntactic layer finds a suite's declared fixture-typed pointer fields,
+// the type layer expands them into the DAG-closure of named fixture types
+// the generator would wire for that suite.
+
+// structFixtureFieldNames returns the names of typ's (a suite's
+// TypeSpec.Type) fields that are typed as a pointer to something whose
+// name ends in "Fixture" (which also covers the "SharedFixture" naming
+// convention, since that suffix ends in "Fixture" too). An embedded
+// fixture field (no explicit name) is keyed under its type name, since
+// that is how Go addresses it (s.CacheFixture). Returns nil if typ isn't a
+// struct or has no fixture-typed fields.
+func structFixtureFieldNames(typ ast.Expr) map[string]bool {
+	st, ok := typ.(*ast.StructType)
+	if !ok || st.Fields == nil {
+		return nil
+	}
+	var fields map[string]bool
+	for _, field := range st.Fields.List {
+		typeName := fixtureFieldTypeName(field.Type)
+		if typeName == "" {
+			continue
+		}
+		if fields == nil {
+			fields = map[string]bool{}
+		}
+		if len(field.Names) == 0 {
+			fields[typeName] = true
+			continue
+		}
+		for _, name := range field.Names {
+			fields[name.Name] = true
+		}
+	}
+	return fields
+}
+
+// fixtureFieldTypeName returns the name of the pointed-to type if expr is
+// a pointer to something whose name ends in "Fixture", or "" otherwise.
+func fixtureFieldTypeName(expr ast.Expr) string {
+	star, ok := expr.(*ast.StarExpr)
+	if !ok {
+		return ""
+	}
+
+	var name string
+	switch t := star.X.(type) {
+	case *ast.Ident:
+		name = t.Name
+	case *ast.SelectorExpr:
+		name = t.Sel.Name
+	case *ast.IndexExpr:
+		if id, ok := t.X.(*ast.Ident); ok {
+			name = id.Name
+		}
+	case *ast.IndexListExpr:
+		if id, ok := t.X.(*ast.Ident); ok {
+			name = id.Name
+		}
+	}
+
+	if !strings.HasSuffix(name, protocol.SuffixFixture) {
+		return ""
+	}
+	return name
+}
+
+// fixtureNamedType returns the pointed-to named type when t is a pointer
+// to a named type whose name ends in "Fixture" ("SharedFixture" included),
+// or nil otherwise.
+func fixtureNamedType(t types.Type) *types.Named {
+	ptr, ok := types.Unalias(t).(*types.Pointer)
+	if !ok {
+		return nil
+	}
+	named, ok := types.Unalias(ptr.Elem()).(*types.Named)
+	if !ok || !strings.HasSuffix(named.Obj().Name(), protocol.SuffixFixture) {
+		return nil
+	}
+	return named
+}
+
+// declaredFixtureClosure expands a suite's declared fixture fields into
+// the DAG-closure of named fixture types reachable from them: each
+// declared pointer field named in declared, then every fixture-typed
+// field of those fixtures' structs, transitively — the same walk the
+// resolver performs when it wires a suite's required fixtures.
+func declaredFixtureClosure(st *types.Struct, declared map[string]bool) map[*types.TypeName]bool {
+	closure := map[*types.TypeName]bool{}
+	var walk func(s *types.Struct, keep map[string]bool)
+	walk = func(s *types.Struct, keep map[string]bool) {
+		for i := 0; i < s.NumFields(); i++ {
+			f := s.Field(i)
+			if keep != nil && !keep[f.Name()] {
+				continue
+			}
+			named := fixtureNamedType(f.Type())
+			if named == nil {
+				continue
+			}
+			tn := named.Obj()
+			if closure[tn] {
+				continue
+			}
+			closure[tn] = true
+			if inner, ok := named.Underlying().(*types.Struct); ok {
+				walk(inner, nil)
+			}
+		}
+	}
+	walk(st, declared)
+	return closure
+}

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -97,6 +97,17 @@ func Known(r Rule) bool {
 	return ok
 }
 
+// RuleIDs returns every registered rule ID, sorted — the registry surface
+// drift guards compare against documentation.
+func RuleIDs() []Rule {
+	ids := make([]Rule, 0, len(ruleMeta))
+	for r := range ruleMeta {
+		ids = append(ids, r)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
 // SkippableRules is derived from the tier table: every non-integrity rule
 // supports opt-out via a skip flag (and .gotest.yml lint.skip).
 var SkippableRules = func() map[Rule]bool {

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -38,6 +38,10 @@ const (
 	AssertionRedundant Rule = "assertion-redundant"
 	TEscape            Rule = "t-escape"
 	SuiteLifecycle     Rule = "suite-lifecycle"
+	// SharedFixtureUndeclared is integrity: window scheduling starts only
+	// the fixtures scheduled suites declare, so an undeclared read may hit
+	// a fixture that never started or is already released.
+	SharedFixtureUndeclared Rule = "shared-fixture-undeclared"
 )
 
 // Tier classifies what breaks when a rule's finding is ignored, and derives
@@ -83,6 +87,8 @@ var ruleMeta = map[Rule]struct {
 	TEscape:            {TierExpressiveness, ScopeSuites},
 	SuiteLifecycle:     {TierIntegrity, ScopeSuites},
 	FailGuard:          {TierExpressiveness, ScopeGotestFiles},
+
+	SharedFixtureUndeclared: {TierIntegrity, ScopeSuites},
 }
 
 // Known reports whether the rule ID exists.
@@ -143,6 +149,7 @@ func run(pass *analysis.Pass) (any, error) {
 		checkMethods(pass, insp, suites)
 		checkFocusPrefixes(pass, suites)
 		checkLifecyclePairs(pass, suites)
+		checkSharedFixtureUndeclared(pass, insp, suites)
 	}
 
 	checkOrphanedFiles(pass)

--- a/internal/lint/lint_suite_test.go
+++ b/internal/lint/lint_suite_test.go
@@ -87,6 +87,12 @@ func (s *LintTestSuite) TestAnalyzer(t *gotest.T) {
 			analysistest.Run(it.T(), testdata, lint.Analyzer, "withnolint_file")
 		})
 	})
+
+	t.When("shared fixture declarations", func(w *gotest.T) {
+		w.It("flags undeclared shared fixture reads and exempts local construction", func(it *gotest.T) {
+			analysistest.Run(it.T(), testdata, lint.Analyzer, "withsharedfixture")
+		})
+	})
 }
 
 func (s *LintTestSuite) TestDisableNolintFlag(t *gotest.T) {
@@ -106,7 +112,7 @@ func (s *LintTestSuite) TestTierPolicy(t *gotest.T) {
 				gotest.NotZero(it, lint.Analyzer.Flags.Lookup("skip-"+string(rule)), "missing skip flag for %s", rule)
 				gotest.True(it, lint.SkippableRules[rule], "rule %s should be skippable", rule)
 			}
-			for _, rule := range []lint.Rule{lint.Focus, lint.PollScope, lint.TestSignature, lint.SuiteLifecycle} {
+			for _, rule := range []lint.Rule{lint.Focus, lint.PollScope, lint.TestSignature, lint.SuiteLifecycle, lint.SharedFixtureUndeclared} {
 				gotest.Zero(it, lint.Analyzer.Flags.Lookup("skip-"+string(rule)), "unexpected skip flag for %s", rule)
 				gotest.False(it, lint.SkippableRules[rule], "integrity rule %s must not be skippable", rule)
 			}

--- a/internal/lint/sharedfixture.go
+++ b/internal/lint/sharedfixture.go
@@ -1,0 +1,142 @@
+package lint
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strings"
+
+	"github.com/mvrahden/go-test/internal/protocol"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// checkSharedFixtureUndeclared flags suite-method uses of a value whose
+// type is a named *...SharedFixture the suite never declared. Window
+// scheduling starts only the fixtures scheduled suites require through
+// their declared pointer fields (directly or via the fixture DAG), so an
+// undeclared read may hit a fixture that was never started or is already
+// released — it compiles, and then lies at run time. Locally-constructed
+// values (composite literals and constructor results in the same function)
+// are exempt: a fixture's own self-test builds and drives the fixture
+// without any window.
+func checkSharedFixtureUndeclared(pass *analysis.Pass, insp *inspector.Inspector, suites map[string]*suiteInfo) {
+	closures := map[string]map[*types.TypeName]bool{}
+	insp.Preorder([]ast.Node{(*ast.TypeSpec)(nil)}, func(n ast.Node) {
+		ts := n.(*ast.TypeSpec)
+		if _, ok := suites[ts.Name.Name]; !ok {
+			return
+		}
+		obj, ok := pass.TypesInfo.Defs[ts.Name].(*types.TypeName)
+		if !ok {
+			return
+		}
+		st, ok := obj.Type().Underlying().(*types.Struct)
+		if !ok {
+			return
+		}
+		closures[ts.Name.Name] = declaredFixtureClosure(st, structFixtureFieldNames(ts.Type))
+	})
+
+	insp.Preorder([]ast.Node{(*ast.FuncDecl)(nil)}, func(n ast.Node) {
+		fd := n.(*ast.FuncDecl)
+		if fd.Body == nil || fd.Recv == nil || len(fd.Recv.List) == 0 {
+			return
+		}
+		recvName := receiverTypeName(fd.Recv)
+		closure, ok := closures[recvName]
+		if !ok {
+			return
+		}
+		constructed := locallyConstructed(pass, fd.Body)
+		reported := map[*types.TypeName]bool{}
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			id, ok := n.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			obj, ok := pass.TypesInfo.Uses[id].(*types.Var)
+			if !ok || constructed[obj] {
+				return true
+			}
+			named := fixtureNamedType(obj.Type())
+			if named == nil || !strings.HasSuffix(named.Obj().Name(), protocol.SuffixSharedFixture) {
+				return true
+			}
+			tn := named.Obj()
+			if closure[tn] || reported[tn] {
+				return true
+			}
+			reported[tn] = true
+			report(pass, SharedFixtureUndeclared, id.Pos(),
+				"suite %s uses *%s without declaring it — window scheduling starts only declared fixtures, so it may be absent (never started, or already released); declare a pointer field for it or reach it through a declared fixture",
+				recvName, tn.Name())
+			return true
+		})
+	})
+}
+
+// locallyConstructed collects the variables body assigns from a composite
+// literal or a call result — values built inside this function rather than
+// handed over by the scheduler — plus direct aliases of those.
+func locallyConstructed(pass *analysis.Pass, body *ast.BlockStmt) map[*types.Var]bool {
+	local := map[*types.Var]bool{}
+	obj := func(id *ast.Ident) *types.Var {
+		if v, ok := pass.TypesInfo.Defs[id].(*types.Var); ok {
+			return v
+		}
+		if v, ok := pass.TypesInfo.Uses[id].(*types.Var); ok {
+			return v
+		}
+		return nil
+	}
+	mark := func(lhs ast.Expr) {
+		id, ok := lhs.(*ast.Ident)
+		if !ok {
+			return
+		}
+		if v := obj(id); v != nil {
+			local[v] = true
+		}
+	}
+	isConstructed := func(rhs ast.Expr) bool {
+		switch e := rhs.(type) {
+		case *ast.CompositeLit, *ast.CallExpr:
+			return true
+		case *ast.UnaryExpr:
+			_, lit := e.X.(*ast.CompositeLit)
+			return e.Op == token.AND && lit
+		case *ast.Ident:
+			v := obj(e)
+			return v != nil && local[v]
+		}
+		return false
+	}
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			if len(node.Rhs) == 1 && len(node.Lhs) > 1 {
+				// Multi-value form: one constructor call feeds every LHS.
+				if isConstructed(node.Rhs[0]) {
+					for _, lhs := range node.Lhs {
+						mark(lhs)
+					}
+				}
+				return true
+			}
+			for i, rhs := range node.Rhs {
+				if i < len(node.Lhs) && isConstructed(rhs) {
+					mark(node.Lhs[i])
+				}
+			}
+		case *ast.ValueSpec:
+			for i, v := range node.Values {
+				if i < len(node.Names) && isConstructed(v) {
+					mark(node.Names[i])
+				}
+			}
+		}
+		return true
+	})
+	return local
+}

--- a/internal/lint/testdata/src/withsharedfixture/withsharedfixture_test.go
+++ b/internal/lint/testdata/src/withsharedfixture/withsharedfixture_test.go
@@ -1,0 +1,76 @@
+package withsharedfixture
+
+import (
+	"context"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// CacheSharedFixture is reachable through QueueSharedFixture's DAG below.
+type CacheSharedFixture struct {
+	Addr string
+}
+
+func (f *CacheSharedFixture) BeforeAll(_ context.Context) error { return nil }
+func (f *CacheSharedFixture) AfterAll(_ context.Context) error  { return nil }
+
+// QueueSharedFixture depends on the cache via a fixture-typed field.
+type QueueSharedFixture struct {
+	Addr  string
+	Cache *CacheSharedFixture
+}
+
+func (f *QueueSharedFixture) BeforeAll(_ context.Context) error { return nil }
+func (f *QueueSharedFixture) AfterAll(_ context.Context) error  { return nil }
+
+func NewCacheSharedFixture() *CacheSharedFixture { return &CacheSharedFixture{} }
+
+var packageCache = &CacheSharedFixture{Addr: "localhost:0"}
+
+var packageQueue = &QueueSharedFixture{}
+
+// DeclaredTestSuite reaches both fixtures through its declared field.
+type DeclaredTestSuite struct {
+	Queue *QueueSharedFixture
+}
+
+func (s *DeclaredTestSuite) TestReachesDeclaredDAG(t *gotest.T) {
+	gotest.NotZero(t, s.Queue.Addr)
+	gotest.NotZero(t, s.Queue.Cache.Addr)
+	cache := s.Queue.Cache
+	gotest.NotZero(t, cache.Addr)
+}
+
+// UndeclaredTestSuite declares no fixture fields at all.
+type UndeclaredTestSuite struct{}
+
+func (s *UndeclaredTestSuite) TestReadsPackageFixture(t *gotest.T) {
+	gotest.NotZero(t, packageCache.Addr) // want `suite UndeclaredTestSuite uses \*CacheSharedFixture without declaring it`
+}
+
+func (s *UndeclaredTestSuite) TestSuppressed(t *gotest.T) {
+	gotest.NotZero(t, packageCache.Addr) //nolint:shared-fixture-undeclared
+}
+
+// PartialTestSuite declares the cache but also reads the queue.
+type PartialTestSuite struct {
+	Cache *CacheSharedFixture
+}
+
+func (s *PartialTestSuite) TestReadsUndeclaredQueue(t *gotest.T) {
+	gotest.NotZero(t, s.Cache.Addr)
+	gotest.NotZero(t, packageQueue.Addr) // want `suite PartialTestSuite uses \*QueueSharedFixture without declaring it`
+}
+
+// FixtureSelfTestSuite builds the fixture it tests — locally-constructed
+// values never need a window.
+type FixtureSelfTestSuite struct{}
+
+func (s *FixtureSelfTestSuite) TestConstructsItsOwn(t *gotest.T) {
+	lit := &CacheSharedFixture{Addr: "localhost:1"}
+	gotest.NotZero(t, lit.Addr)
+	built := NewCacheSharedFixture()
+	gotest.NotZero(t, built.Addr)
+	alias := lit
+	gotest.NotZero(t, alias.Addr)
+}

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -16,6 +16,8 @@ const (
 	SuffixTestSuite     = "TestSuite"
 	PrefixFocused       = "F_"
 	PrefixExcluded      = "X_"
+	PrefixBenchmark     = "Benchmark"
+	PrefixFuzz          = "Fuzz"
 )
 
 func BudgetFilePath(binaryPath string) string {

--- a/internal/schedinfo/export_test.go
+++ b/internal/schedinfo/export_test.go
@@ -1,0 +1,3 @@
+package schedinfo
+
+var ExportHistogramPercentiles = histogramPercentiles

--- a/internal/schedinfo/schedinfo.go
+++ b/internal/schedinfo/schedinfo.go
@@ -1,0 +1,109 @@
+// Package schedinfo renders one line of best-effort scheduling context for
+// budget-verdict failures. A wall-clock verdict taken on a starved machine is
+// indistinguishable from a real hang without this: the smoking gun is a
+// runnable-but-unscheduled goroutine, and that only shows up in a full dump.
+// Everything here is diagnosis-only — read on failure paths, never able to
+// fail anything itself, stdlib-only.
+package schedinfo
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/metrics"
+	"strings"
+	"time"
+)
+
+// starvedLatency is the p99 scheduling latency above which the hint fires.
+// Healthy schedulers sit in the microseconds; 100ms of time-to-run means the
+// machine, not the code, was the bottleneck.
+const starvedLatency = 100 * time.Millisecond
+
+// Summary returns a single parenthesized line of scheduling context, e.g.
+// "(gomaxprocs=6 goroutines=124 loadavg=11.42 sched-p50=1ms sched-p99=1.2s)".
+// Fields that cannot be read on this platform are omitted.
+func Summary() string {
+	parts := []string{
+		fmt.Sprintf("gomaxprocs=%d", runtime.GOMAXPROCS(0)),
+		fmt.Sprintf("goroutines=%d", runtime.NumGoroutine()),
+	}
+	if load := loadAvg(); load != "" {
+		parts = append(parts, "loadavg="+load)
+	}
+	if p50, p99, ok := schedLatency(); ok {
+		parts = append(parts,
+			"sched-p50="+p50.Round(time.Microsecond).String(),
+			"sched-p99="+p99.Round(time.Microsecond).String())
+	}
+	return "(" + strings.Join(parts, " ") + ")"
+}
+
+// StarvationHint returns a one-sentence hint when the process-lifetime p99
+// scheduling latency is pathological, and "" otherwise. Cumulative, not
+// windowed — so it suggests, never proves.
+func StarvationHint() string {
+	if _, p99, ok := schedLatency(); ok && p99 >= starvedLatency {
+		return "high scheduler latency suggests CPU starvation, not a hang"
+	}
+	return ""
+}
+
+// loadAvg reads the 1-minute load average, best-effort (Linux only).
+func loadAvg() string {
+	data, err := os.ReadFile("/proc/loadavg")
+	if err != nil {
+		return ""
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+// schedLatency reads /sched/latencies:seconds — how long goroutines waited
+// in a runnable state before running, cumulative over the process lifetime.
+func schedLatency() (p50, p99 time.Duration, ok bool) {
+	const name = "/sched/latencies:seconds"
+	sample := []metrics.Sample{{Name: name}}
+	metrics.Read(sample)
+	if sample[0].Value.Kind() != metrics.KindFloat64Histogram {
+		return 0, 0, false
+	}
+	h := sample[0].Value.Float64Histogram()
+	p50s, p99s, hok := histogramPercentiles(h.Counts, h.Buckets, 0.50, 0.99)
+	if !hok {
+		return 0, 0, false
+	}
+	return time.Duration(p50s * float64(time.Second)), time.Duration(p99s * float64(time.Second)), true
+}
+
+// histogramPercentiles resolves two percentiles from a runtime/metrics-shaped
+// histogram: counts[i] falls into (buckets[i], buckets[i+1]]. Each percentile
+// reports its bucket's upper bound — an honest over-estimate.
+func histogramPercentiles(counts []uint64, buckets []float64, q1, q2 float64) (v1, v2 float64, ok bool) {
+	var total uint64
+	for _, c := range counts {
+		total += c
+	}
+	if total == 0 {
+		return 0, 0, false
+	}
+	resolve := func(q float64) float64 {
+		target := uint64(q * float64(total))
+		var seen uint64
+		for i, c := range counts {
+			seen += c
+			if seen > target {
+				upper := buckets[i+1]
+				if upper > 1e18 { // +Inf bucket: fall back to its lower bound
+					upper = buckets[i]
+				}
+				return upper
+			}
+		}
+		return buckets[len(buckets)-1]
+	}
+	return resolve(q1), resolve(q2), true
+}

--- a/internal/schedinfo/schedinfo_suite_test.go
+++ b/internal/schedinfo/schedinfo_suite_test.go
@@ -1,0 +1,62 @@
+package schedinfo_test
+
+import (
+	"math"
+
+	"github.com/mvrahden/go-test/internal/schedinfo"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// SchedinfoTestSuite tests the scheduling-context diagnosis line: the
+// percentile math on synthetic histograms and the summary's shape.
+type SchedinfoTestSuite struct{}
+
+func (s *SchedinfoTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{Parallel: true}
+}
+
+func (s *SchedinfoTestSuite) TestHistogramPercentiles(t *gotest.T) {
+	t.When("counts concentrate in one bucket", func(w *gotest.T) {
+		w.It("reports that bucket's upper bound for both percentiles", func(it *gotest.T) {
+			p50, p99, ok := schedinfo.ExportHistogramPercentiles(
+				[]uint64{0, 100, 0}, []float64{0, 0.001, 0.01, 0.1}, 0.50, 0.99)
+			gotest.True(it, ok)
+			gotest.InDelta(it, 0.01, p50, 1e-9)
+			gotest.InDelta(it, 0.01, p99, 1e-9)
+		})
+	})
+
+	t.When("a heavy tail exists", func(w *gotest.T) {
+		w.It("separates p50 from p99", func(it *gotest.T) {
+			p50, p99, ok := schedinfo.ExportHistogramPercentiles(
+				[]uint64{90, 0, 10}, []float64{0, 0.001, 0.01, 1.0}, 0.50, 0.99)
+			gotest.True(it, ok)
+			gotest.InDelta(it, 0.001, p50, 1e-9)
+			gotest.InDelta(it, 1.0, p99, 1e-9)
+		})
+	})
+
+	t.When("the top bucket is +Inf", func(w *gotest.T) {
+		w.It("falls back to the finite lower bound instead of reporting infinity", func(it *gotest.T) {
+			_, p99, ok := schedinfo.ExportHistogramPercentiles(
+				[]uint64{1, 1}, []float64{0, 0.001, math.Inf(1)}, 0.50, 0.99)
+			gotest.True(it, ok)
+			gotest.InDelta(it, 0.001, p99, 1e-9)
+		})
+	})
+
+	t.When("the histogram is empty", func(w *gotest.T) {
+		w.It("reports not-ok rather than a fabricated zero", func(it *gotest.T) {
+			_, _, ok := schedinfo.ExportHistogramPercentiles(nil, []float64{0}, 0.50, 0.99)
+			gotest.False(it, ok)
+		})
+	})
+}
+
+func (s *SchedinfoTestSuite) TestSummary(t *gotest.T) {
+	t.It("always carries the scheduler dimensions", func(it *gotest.T) {
+		summary := schedinfo.Summary()
+		gotest.Regexp(it, `^\(gomaxprocs=\d+ goroutines=\d+`, summary)
+		gotest.Regexp(it, `\)$`, summary)
+	})
+}

--- a/pkg/gotest/b.go
+++ b/pkg/gotest/b.go
@@ -1,0 +1,25 @@
+package gotest
+
+import (
+	"context"
+	"testing"
+)
+
+// B wraps *testing.B for benchmark methods on gotest suites. It satisfies
+// the same assertion contract as *T and *R (Errorf + FailNow), so the full
+// assertion library works inside benchmarks.
+type B struct {
+	b *testing.B
+}
+
+func NewB(b *testing.B) *B { return &B{b: b} }
+
+func (b *B) B() *testing.B                       { return b.b }
+func (b *B) Loop() bool                          { return b.b.Loop() }
+func (b *B) ReportAllocs()                       { b.b.ReportAllocs() }
+func (b *B) SetBytes(n int64)                    { b.b.SetBytes(n) }
+func (b *B) ReportMetric(n float64, unit string) { b.b.ReportMetric(n, unit) }
+func (b *B) Context() context.Context            { return b.b.Context() }
+func (b *B) Errorf(format string, args ...any)   { b.b.Errorf(format, args...) }
+func (b *B) FailNow()                            { b.b.FailNow() }
+func (b *B) Skipf(format string, args ...any)    { b.b.Skipf(format, args...) }

--- a/pkg/gotest/b_suite_test.go
+++ b/pkg/gotest/b_suite_test.go
@@ -1,0 +1,23 @@
+package gotest_test
+
+import (
+	"testing"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+type BWrapperTestSuite struct{}
+
+func (s *BWrapperTestSuite) TestNewB(t *gotest.T) {
+	t.It("exposes the underlying *testing.B and satisfies assertions", func(it *gotest.T) {
+		res := testing.Benchmark(func(b *testing.B) {
+			gb := gotest.NewB(b)
+			gotest.NotZero(it, gb.B())
+			gotest.Equal(it, b, gb.B())
+			for gb.Loop() {
+				_ = 1 + 1
+			}
+		})
+		gotest.Greater(it, res.N, 0)
+	})
+}

--- a/pkg/gotest/config.go
+++ b/pkg/gotest/config.go
@@ -44,6 +44,15 @@ type SuiteConfig struct {
 	// Parallel runs test methods concurrently. Requires a returning BeforeEach
 	// so each parallel test gets its own isolated state. Default: false.
 	Parallel bool
+	// Exclusive schedules the suite's process strictly alone: after every
+	// non-exclusive suite has finished, one exclusive suite at a time, in
+	// deterministic order. For suites whose verdicts depend on wall-clock
+	// behavior or contended resources (timing budgets, containers, ports,
+	// heavy child builds) — a budget verdict taken on a saturated machine is
+	// not a verdict you can act on. Resolved statically by the generator,
+	// like Parallel; scheduling-only, no effect inside the suite process.
+	// Default: false.
+	Exclusive bool
 }
 
 // DefaultFixtureConfig returns a baseline configuration for package fixtures:

--- a/pkg/gotest/each_filter_suite_test.go
+++ b/pkg/gotest/each_filter_suite_test.go
@@ -21,8 +21,8 @@ import (
 // The suite is sequential: each case owns the child process it spawns.
 type EachFilterTestSuite struct{}
 
-const eachChildTimeout = 15 * time.Second
-const eachChildWallClock = 90 * time.Second
+const eachChildTimeout = 60 * time.Second
+const eachChildWallClock = 120 * time.Second
 
 const eachChildSource = `package eachchild
 

--- a/pkg/gotest/snapshot.go
+++ b/pkg/gotest/snapshot.go
@@ -129,7 +129,7 @@ func matchSnapshot(t testingT, callerSkip int, value any, name ...string) {
 	named, ok := t.(interface{ Name() string })
 	if !ok {
 		gt, ok := t.(*T)
-		if ok {
+		if ok && gt.T() != nil {
 			named = gt.T()
 		}
 	}

--- a/pkg/gotest/snapshot_suite_test.go
+++ b/pkg/gotest/snapshot_suite_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"testing"
 
 	"github.com/mvrahden/go-test/internal/protocol"
 	"github.com/mvrahden/go-test/pkg/gotest"
@@ -326,5 +327,37 @@ func (s *SnapshotTestSuite) TestSnapshotContent(t *gotest.T) {
 			gotest.True(it, m.Failed())
 			gotest.Contains(it, m.Message(), "unsupported snapshot type")
 		})
+	})
+}
+
+// SnapshotTBBackedTestSuite tests snapshot behavior with TB-backed T from benchmarks.
+type SnapshotTBBackedTestSuite struct{ snapPath string }
+
+func (s *SnapshotTBBackedTestSuite) BeforeEach(_ *gotest.T) {
+	s.snapPath = filepath.Join("testdata", "__snapshots__", "TestSnapshotTBBackedTestSuite_ext.snap")
+}
+
+func (s *SnapshotTBBackedTestSuite) AfterEach(_ *gotest.T) {
+	os.Remove(s.snapPath)
+	os.Remove(filepath.Join("testdata", "__snapshots__", "unknown_ext.snap"))
+}
+
+func (s *SnapshotTBBackedTestSuite) TestMatchSnapshotWithTBBacked(t *gotest.T) {
+	t.Setenv(protocol.EnvCI, "0")
+
+	t.It("does not panic on TB-backed T", func(it *gotest.T) {
+		recovered := ""
+		testing.Benchmark(func(b *testing.B) {
+			defer func() {
+				if r := recover(); r != nil {
+					recovered = fmt.Sprintf("%v", r)
+				}
+			}()
+			tb := gotest.NewTFromTB(b)
+			gotest.MatchSnapshot(tb, "snapshot-value", "tb_backed")
+			for b.Loop() {
+			}
+		})
+		gotest.Zero(it, recovered)
 	})
 }

--- a/pkg/gotest/t.go
+++ b/pkg/gotest/t.go
@@ -11,11 +11,18 @@ import (
 )
 
 func NewT(t *testing.T) *T {
-	return &T{t: t}
+	return &T{t: t, tb: t}
 }
+
+// NewTFromTB adapts a non-*testing.T testing type (*testing.B, *testing.F)
+// so suite lifecycle hooks written against *gotest.T can run under
+// benchmarks and fuzz targets. T() returns nil and It/When panic on a
+// TB-backed T; the collector statically rejects suites that would hit either.
+func NewTFromTB(tb testing.TB) *T { return &T{tb: tb} }
 
 type T struct {
 	t   *testing.T
+	tb  testing.TB
 	ctx context.Context
 }
 
@@ -23,11 +30,18 @@ func (t *T) T() *testing.T {
 	return t.t
 }
 
+func (t *T) testingTB() testing.TB {
+	if t.t != nil {
+		return t.t
+	}
+	return t.tb
+}
+
 func (t *T) Context() context.Context {
 	if t.ctx != nil {
 		return t.ctx
 	}
-	return t.t.Context()
+	return t.testingTB().Context()
 }
 
 // NewTWithDeadline wraps t with a context that expires after timeout, so a test
@@ -36,7 +50,7 @@ func (t *T) Context() context.Context {
 func NewTWithDeadline(t *testing.T, timeout time.Duration) *T {
 	ctx, cancel := context.WithTimeout(t.Context(), timeout)
 	t.Cleanup(cancel)
-	return &T{t: t, ctx: ctx}
+	return &T{t: t, tb: t, ctx: ctx}
 }
 
 // NewTWithContext wraps t, overriding what [T.Context] reports. Use it when the
@@ -50,26 +64,28 @@ func NewTWithContext(t *testing.T, ctx context.Context) *T {
 
 func (t *T) Errorf(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
-	if goFrame := assert.SkipInternalFrames(t.t); goFrame != "" {
-		msg = strings.TrimPrefix(msg, goFrame+": ")
+	if t.t != nil {
+		if goFrame := assert.SkipInternalFrames(t.t); goFrame != "" {
+			msg = strings.TrimPrefix(msg, goFrame+": ")
+		}
 	}
-	t.t.Errorf("%s", msg)
+	t.testingTB().Errorf("%s", msg)
 }
 
 func (t *T) FailNow() {
-	t.t.FailNow()
+	t.testingTB().FailNow()
 }
 
 func (t *T) Skipf(format string, args ...any) {
-	t.t.Skipf(format, args...)
+	t.testingTB().Skipf(format, args...)
 }
 
 func (t *T) Setenv(key, value string) {
-	t.t.Setenv(key, value)
+	t.testingTB().Setenv(key, value)
 }
 
 func (t *T) TempDir() string {
-	return t.t.TempDir()
+	return t.testingTB().TempDir()
 }
 
 //go:noinline
@@ -90,12 +106,18 @@ func (t *T) sub(tt *testing.T) *T {
 }
 
 func (t *T) It(description string, testFn func(it *T)) {
+	if t.t == nil {
+		panic("gotest: It/When are unavailable in benchmark/fuzz lifecycle hooks")
+	}
 	t.t.Run(description, func(tt *testing.T) {
 		execTestFn(testFn, t.sub(tt))
 	})
 }
 
 func (t *T) When(description string, fn func(w *T)) {
+	if t.t == nil {
+		panic("gotest: It/When are unavailable in benchmark/fuzz lifecycle hooks")
+	}
 	t.t.Run(description, func(tt *testing.T) {
 		execTestFn(fn, t.sub(tt))
 	})

--- a/pkg/gotest/t_suite_test.go
+++ b/pkg/gotest/t_suite_test.go
@@ -2,6 +2,7 @@ package gotest_test
 
 import (
 	"context"
+	"testing"
 	"time"
 
 	"github.com/mvrahden/go-test/pkg/gotest"
@@ -140,5 +141,27 @@ func (s *TTestSuite) TestNestedBehaviorContext(t *gotest.T) {
 				gotest.NoError(ni, ni.Context().Err())
 			})
 		})
+	})
+}
+
+func (s *TTestSuite) TestNewTFromTB(t *gotest.T) {
+	t.It("routes helpers through the TB and nils T()", func(it *gotest.T) {
+		res := testing.Benchmark(func(b *testing.B) {
+			tb := gotest.NewTFromTB(b)
+			gotest.Zero(it, tb.T())
+			gotest.NotZero(it, tb.Context())
+			gotest.Equal(it, "recovered", func() (r string) {
+				defer func() {
+					if recover() != nil {
+						r = "recovered"
+					}
+				}()
+				tb.It("nope", func(*gotest.T) {})
+				return "no panic"
+			}())
+			for b.Loop() {
+			}
+		})
+		gotest.Greater(it, res.N, 0)
 	})
 }

--- a/pkg/gotestruntime/harness.go
+++ b/pkg/gotestruntime/harness.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mvrahden/go-test/internal/schedinfo"
 	"github.com/mvrahden/go-test/pkg/gotest"
 )
 
@@ -118,9 +119,17 @@ func watchDeadline(t *gotest.T, timeout time.Duration, what, budget string, done
 	// output when it does — so if the process is later killed by go test
 	// -timeout, this line is the only trace that a budget was blown, and which
 	// one.
-	fmt.Fprintf(os.Stderr, "gotest: %s %sexceeded its configured %s of %s and is still running\n",
-		t.T().Name(), what, budget, timeout)
-	t.Errorf("%sexceeded its configured %s of %s and is still running", what, budget, timeout)
+	// One line of scheduling context, because this verdict has a known false
+	// positive: on a saturated machine a phase can be runnable yet never
+	// scheduled, and without this the dump reads like a deadlock.
+	sched := schedinfo.Summary()
+	suffix := "\n" + sched
+	if hint := schedinfo.StarvationHint(); hint != "" {
+		suffix += "\n" + hint
+	}
+	fmt.Fprintf(os.Stderr, "gotest: %s %sexceeded its configured %s of %s and is still running %s\n",
+		t.T().Name(), what, budget, timeout, sched)
+	t.Errorf("%sexceeded its configured %s of %s and is still running%s", what, budget, timeout, suffix)
 }
 
 // testScopedT applies the timeout convention shared by the phases that run while

--- a/skills/writing-gotest-tests/SKILL.md
+++ b/skills/writing-gotest-tests/SKILL.md
@@ -33,6 +33,13 @@ applies EXCEPT these four, which fail there:
    `-test.timeout` kills it with no teardown, and so does any entry after
    a `-failfast` trip. Filter whole suites or methods only there.
 
+Sections tagged **v1.27+** below need v1.27.0 or newer and fail hard on
+v1.26.x rather than degrading: `SuiteConfig.Exclusive` is an unknown
+field there (compile error) and the `shared-fixture-undeclared` lint rule
+does not exist (its findings are simply never reported — do not rely on
+the linter for fixture-window mistakes on v1.26.x). Skip those sections
+on v1.26.x and earlier.
+
 Exit codes on v1.25.x are weaker than they look — never treat a green
 gotest exit alone as proof there: a package failing to compile mid-run, a
 suite binary killed by a signal, and `spec --input` on a failing stream
@@ -155,6 +162,14 @@ parallel suites, or structural problems — those are your job, below.
    linter flags it. Reach for `t.T()` only when nothing on `gotest.T`
    (`It`, `When`, `Context`, `TempDir`, `Setenv`, `Skipf`, `Errorf`,
    `FailNow`) covers the need.
+7. **Ask "why is this wall-clock-asserting suite NOT Exclusive?"
+   (v1.27+)** — the counterpart to rule 4. A suite whose assertions or
+   timeout budgets measure elapsed time (latency bounds, timing budgets,
+   contended ports/containers) cannot share a saturated machine: mark it
+   `SuiteConfig{Exclusive: true}` (statically parsed like `Parallel` —
+   boolean literal only; see `reference/config.md`) and it dispatches
+   strictly alone after all other suites finish. A budget verdict taken
+   under load is not a verdict you can act on.
 
 ## Restructuring existing suites (the blue phase)
 

--- a/skills/writing-gotest-tests/reference/ci.md
+++ b/skills/writing-gotest-tests/reference/ci.md
@@ -53,6 +53,14 @@ jobs:
   needed; exit codes are unchanged.
 - Gate formatting too (`gofmt -l`, goimports): `lint -fix` edits are
   textual and unformatted — see SKILL.md's write loop.
+- **v1.27+:** `Exclusive` suites run as a serial tail after the parallel
+  bulk, so CI wall-clock time grows by the SUM of exclusive suite
+  durations — keep the exclusive set small and its suites short. Under
+  `-race`/`-msan`/`-asan` the dispatch and compile concurrency defaults
+  are additionally auto-halved (instrumented code costs ≥2× CPU per
+  instruction stream); an explicit width always wins — pass it through
+  the action's `flags` input (e.g. `flags: "--parallel 8"`) when a CI
+  runner's shape is known and the halved default wastes it.
 
 ## gotest-exclusive projects: drop the stdlib step
 

--- a/skills/writing-gotest-tests/reference/config.md
+++ b/skills/writing-gotest-tests/reference/config.md
@@ -34,3 +34,18 @@ copying default-restating markers between suites is an observed failure).
 Fixtures use the same literal rule via `FixtureConfig()` /
 `SharedFixtureConfig()` markers: no marker → `DefaultFixtureConfig()` (2m);
 `ContainerFixtureConfig()` (5m, 1 retry) suits container startups.
+
+## Exclusive suites (v1.27+)
+
+`SuiteConfig{Exclusive: true}` is parsed statically exactly like
+`Parallel` — assign a boolean literal (the compose form works:
+`cfg.Exclusive = true`). Exclusive suites are held back until every
+non-exclusive suite has finished, then dispatched strictly alone, one at
+a time, in deterministic (package, suite) order — batch and streaming
+runs alike. Use it for suites whose *verdicts* measure wall-clock
+behavior or that fight over machine-wide resources (timing budgets,
+containers, ports, per-invocation child builds): a budget verdict taken
+on a saturated machine is not a verdict you can act on. Shared fixtures
+stay up across the exclusive tail — they are infrastructure, not
+competing suites. Exclusive is not a serialization tool for shared
+mutable state; use non-parallel suites for that.

--- a/skills/writing-gotest-tests/reference/fixtures.md
+++ b/skills/writing-gotest-tests/reference/fixtures.md
@@ -38,3 +38,21 @@ resources) but its `AfterAll` still runs, because what it built exists.
 Parallel suites + fixtures: a shared fixture means a shared live resource
 across processes. `-race` cannot see two tests mutating the same rows.
 Parallelize only with per-test keys/schemas/transactions or read-only use.
+
+## Fixture windows (v1.27+)
+
+Shared fixture start is never speculative: a fixture is resident exactly
+while a scheduled suite that DECLARES it (as a pointer field, directly or
+through the fixture DAG) needs it. Two consequences:
+
+- A fixture no scheduled suite requires never starts — and can therefore
+  never fail the run. Do not "test" a fixture by leaving it wired to
+  nothing; nothing will execute it.
+- A shared fixture you read without declaring may be absent: never
+  started, or already torn down at the bulk→exclusive-tail barrier.
+  Reaching one through a package-level variable or another struct
+  compiles and then lies at run time. Declare a pointer field for every
+  fixture a suite touches (or reach it through a declared fixture); the
+  `shared-fixture-undeclared` lint rule (integrity tier) flags undeclared
+  reads. Fixture self-tests that construct the fixture locally are
+  exempt.

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -66,6 +66,7 @@ func (s *E2ETestSuite) TestT(t *gotest.T) {
 	tmp := t.TempDir()
 	excludedPaths := append(append([]string(nil), testutils.DefaultExcludePaths...),
 		"pkg/gotest/assertions_suite_test.go",
+		"pkg/gotest/b_suite_test.go",
 		"pkg/gotest/config_suite_test.go",
 		"pkg/gotest/each_filter_suite_test.go",
 		"pkg/gotest/each_suite_test.go",

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -29,6 +29,16 @@ type E2ETestSuite struct {
 	workDir string
 }
 
+// SuiteConfig: Exclusive — every test method here shells the built CLI,
+// which compiles packages (often with -race) per invocation. That load must
+// never run beside the timing-budget harnesses. Keep invocations frugal
+// too: one CLI run per distinct pipeline behavior, assertions merged into
+// it, binaries and module copies built once in BeforeAll, workloads pinned
+// tiny (-benchtime=10x scale).
+func (s *E2ETestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{Exclusive: true}
+}
+
 func (s *E2ETestSuite) BeforeAll(t *gotest.T) {
 	absRoot, err := filepath.Abs("../..")
 	gotest.NoError(t, err)

--- a/tests/sharedfixture/exclusive/suite_test.go
+++ b/tests/sharedfixture/exclusive/suite_test.go
@@ -1,0 +1,22 @@
+package exclusive
+
+import (
+	"github.com/mvrahden/go-test/pkg/gotest"
+	"github.com/mvrahden/go-test/tests/sharedfixture/fixtures"
+)
+
+// ExclusiveDeltaTestSuite runs in the serial tail and is the only suite that
+// references DeltaSharedFixture. The runner therefore defers Delta past the
+// parallel bulk and starts it at the bulk→tail barrier — this suite passing
+// in a whole-repo run is the end-to-end proof of window scheduling.
+type ExclusiveDeltaTestSuite struct {
+	Delta *fixtures.DeltaSharedFixture
+}
+
+func (s *ExclusiveDeltaTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{Exclusive: true}
+}
+
+func (s *ExclusiveDeltaTestSuite) TestDeltaAvailable(t *gotest.T) {
+	gotest.Equal(t, "delta-shared", s.Delta.Stamp)
+}

--- a/tests/sharedfixture/fixtures/delta.go
+++ b/tests/sharedfixture/fixtures/delta.go
@@ -1,0 +1,17 @@
+package fixtures
+
+import "context"
+
+// DeltaSharedFixture is referenced only by the exclusive tail suite
+// (tests/sharedfixture/exclusive): under window scheduling the runner defers
+// it past the parallel bulk and starts it at the bulk→tail barrier.
+type DeltaSharedFixture struct {
+	Stamp string
+}
+
+func (f *DeltaSharedFixture) BeforeAll(ctx context.Context) error {
+	f.Stamp = "delta-shared"
+	return nil
+}
+
+func (f *DeltaSharedFixture) AfterAll(ctx context.Context) error { return nil }

--- a/vscode-gotest/package.json
+++ b/vscode-gotest/package.json
@@ -236,6 +236,7 @@
   "scripts": {
     "compile": "node esbuild.config.mjs",
     "watch": "node esbuild.config.mjs --watch",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "format": "prettier --write 'src/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts'",


### PR DESCRIPTION
Test suites that measure time or fight over resources can now ask to run alone, so their results stay trustworthy even on a fully loaded machine. Slow builds announce themselves instead of failing silently, and when a time budget is exceeded, the failure message now explains whether the machine - not the code - was the likely culprit.
Also fixes a small command-line parsing bug and tightens CI checks.