### PR TITLE
keep syncing the spec view when the run had failures

### DIFF
--- a/vscode-gotest/src/specView.test.ts
+++ b/vscode-gotest/src/specView.test.ts
@@ -12,7 +12,7 @@ vi.mock("vscode", () => ({
   commands: {},
 }));
 
-import { specDataToReport } from "./specView.js";
+import { specDataToReport, interpretSpecExit } from "./specView.js";
 
 function leaf(
   name: string,
@@ -346,5 +346,72 @@ describe("specDataToReport broken packages", () => {
     const report = specDataToReport(data, ["example.com"]);
     expect(report).not.toContain("1 failed,");
     expect(report).toContain("1 passed");
+  });
+});
+
+describe("interpretSpecExit", () => {
+  const SPEC_JSON = '{"packages":[],"stats":{}}';
+
+  it("keeps the rendered spec when the stream carried failures", () => {
+    // `gotest spec --input=-` exits 1 to report "this tree has failures".
+    // That is a verdict about the tests, not a failure to render.
+    const outcome = interpretSpecExit(1, SPEC_JSON, "");
+    expect(outcome).toEqual({ ok: true, stdout: SPEC_JSON });
+  });
+
+  it("keeps the rendered spec when go run appends its exit status epilogue", () => {
+    // The extension resolves the CLI through `go run` by default, which
+    // prints "exit status 1" on stderr whenever the child exits non-zero.
+    const outcome = interpretSpecExit(1, SPEC_JSON, "exit status 1\n");
+    expect(outcome).toEqual({ ok: true, stdout: SPEC_JSON });
+  });
+
+  it("keeps the rendered spec on a clean run", () => {
+    const outcome = interpretSpecExit(0, SPEC_JSON, "");
+    expect(outcome).toEqual({ ok: true, stdout: SPEC_JSON });
+  });
+
+  it("reports an operational failure that produced no spec", () => {
+    const outcome = interpretSpecExit(
+      2,
+      "",
+      "FAIL: parsing test events: unexpected EOF\n",
+    );
+    expect(outcome).toEqual({
+      ok: false,
+      message:
+        "gotest spec exited with code 2: FAIL: parsing test events: unexpected EOF",
+    });
+  });
+
+  it("reports a go run build failure instead of swallowing it as a verdict", () => {
+    // `go run` also exits 1 when the module fails to build. There is no spec
+    // on stdout, so this must not be mistaken for a failing test tree.
+    const outcome = interpretSpecExit(1, "", "spec.go:12:2: undefined: Foo\n");
+    expect(outcome).toEqual({
+      ok: false,
+      message: "gotest spec exited with code 1: spec.go:12:2: undefined: Foo",
+    });
+  });
+
+  it("strips the go run epilogue from a reported failure", () => {
+    const outcome = interpretSpecExit(
+      2,
+      "",
+      "FAIL: opening input file: no such file\nexit status 2\n",
+    );
+    expect(outcome).toEqual({
+      ok: false,
+      message:
+        "gotest spec exited with code 2: FAIL: opening input file: no such file",
+    });
+  });
+
+  it("reports a signal death that left no spec behind", () => {
+    const outcome = interpretSpecExit(null, "", "");
+    expect(outcome).toEqual({
+      ok: false,
+      message: "gotest spec exited with code null",
+    });
   });
 });

--- a/vscode-gotest/src/specView.ts
+++ b/vscode-gotest/src/specView.ts
@@ -326,10 +326,11 @@ ${SCRIPT}
         stderr += data.toString();
       });
       child.on("close", (code) => {
-        if (code !== 0 && stderr) {
-          reject(new Error(`gotest spec exited with code ${code}: ${stderr}`));
+        const outcome = interpretSpecExit(code, stdout, stderr);
+        if (outcome.ok) {
+          resolve(outcome.stdout);
         } else {
-          resolve(stdout);
+          reject(new Error(outcome.message));
         }
       });
       child.on("error", (err: Error) => {
@@ -341,6 +342,36 @@ ${SCRIPT}
       child.stdin.end();
     });
   }
+}
+
+export type SpecExitOutcome =
+  | { ok: true; stdout: string }
+  | { ok: false; message: string };
+
+// interpretSpecExit decides whether a finished `gotest spec --input=-` left a
+// usable spec behind. Exit 1 means the piped stream carried failures — a
+// verdict about the tests, not a rendering error — so the spec on stdout still
+// stands. Only an exit that produced no spec is an error worth reporting.
+export function interpretSpecExit(
+  code: number | null,
+  stdout: string,
+  stderr: string,
+): SpecExitOutcome {
+  if (code === 0 || (code === 1 && stdout.trim() !== "")) {
+    return { ok: true, stdout };
+  }
+  // `go run` echoes "exit status N" after any non-zero child; it restates the
+  // code we already have and would otherwise bury the real diagnostic.
+  const detail = stderr
+    .split("\n")
+    .filter((line) => !/^exit status \d+$/.test(line.trim()))
+    .join("\n")
+    .trim();
+  const suffix = detail ? `: ${detail}` : "";
+  return {
+    ok: false,
+    message: `gotest spec exited with code ${code}${suffix}`,
+  };
 }
 
 // --- Types ---


### PR DESCRIPTION
Since v1.26.0, `gotest spec --input=-` exits 1 on any failing tree. The
extension resolves the CLI via `go run`, which adds "exit status 1" to
stderr, so the spec view rejected on `code !== 0 && stderr` and discarded
valid JSON already on stdout — the panel froze on exactly the runs you
most want to look at.

Exit 1 with a rendered spec is now treated as a verdict, not an error.
Empty stdout still reports, so `go run` build failures aren't swallowed.