### PR TITLE
Show what tests promise, before you run them

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,13 @@ Render the spec view instead of the default output (also works in watch mode):
 gotest ./... -v --spec
 ```
 
+Read the spec without running it. `--static` builds the tree from the source, so nothing carries a verdict or a duration. Where a method's behaviors depend on runtime values — a `When` behind a condition, an `Each` over a table that is not a literal — the node says so and the detail goes to stderr, because a partial spec that presents itself as whole is worse than none:
+
+```bash
+gotest spec ./... --static
+gotest spec ./... --static --format=md --output=docs/behavior-spec.md
+```
+
 ## Isolation
 
 Each suite runs in its own process with zero shared state.

--- a/cmd/gotest/discover.go
+++ b/cmd/gotest/discover.go
@@ -63,6 +63,22 @@ type discoverMethod struct {
 	File     string `json:"file"`
 	Line     int    `json:"line"`
 	Col      int    `json:"col"`
+	// Behaviors are the When/It blocks the method declares, read from source.
+	// BehaviorsComplete reports whether that list is exhaustive: when false the
+	// method declares behaviors whose names or existence depend on runtime
+	// values, and a consumer must treat the list as a floor rather than a total.
+	Behaviors         []discoverBehavior `json:"behaviors"`
+	BehaviorsComplete bool               `json:"behaviorsComplete"`
+}
+
+// discoverBehavior mirrors one node of the specification a method declares.
+// Name is the subtest segment go test will produce, so it lines up with the
+// runtime tree byte for byte; Display is the text the developer wrote.
+type discoverBehavior struct {
+	Name     string             `json:"name"`
+	Display  string             `json:"display"`
+	Line     int                `json:"line"`
+	Children []discoverBehavior `json:"children,omitempty"`
 }
 
 func runDiscover(inv Invocation) int { //nolint:gocritic // hugeParam: stable API
@@ -196,14 +212,17 @@ func buildDiscoverSuite(suite *gotestast.TestSuiteSpec) discoverSuite {
 	var methods []discoverMethod
 	for _, tc := range suite.TestCases() {
 		mPos := fset.Position(tc.Pos())
+		spec := suite.BehaviorsOf(tc)
 		methods = append(methods, discoverMethod{
-			Name:     tc.Identifier(),
-			Parallel: false,
-			Focused:  tc.IsFocused(),
-			Excluded: tc.IsExcluded(),
-			File:     filepath.Base(mPos.Filename),
-			Line:     mPos.Line,
-			Col:      mPos.Column,
+			Name:              tc.Identifier(),
+			Parallel:          false,
+			Focused:           tc.IsFocused(),
+			Excluded:          tc.IsExcluded(),
+			File:              filepath.Base(mPos.Filename),
+			Line:              mPos.Line,
+			Col:               mPos.Column,
+			Behaviors:         discoverBehaviors(spec.Behaviors),
+			BehaviorsComplete: spec.Complete,
 		})
 	}
 	if methods == nil {
@@ -239,4 +258,18 @@ func discoverFixtureNames(suite *gotestast.TestSuiteSpec) []string {
 		return []string{}
 	}
 	return names
+}
+
+// discoverBehaviors converts the walker's tree into the discovery wire shape.
+func discoverBehaviors(in []*gotestast.Behavior) []discoverBehavior {
+	out := make([]discoverBehavior, 0, len(in))
+	for _, b := range in {
+		out = append(out, discoverBehavior{
+			Name:     b.Name,
+			Display:  b.Display,
+			Line:     b.Line,
+			Children: discoverBehaviors(b.Children),
+		})
+	}
+	return out
 }

--- a/cmd/gotest/export_test.go
+++ b/cmd/gotest/export_test.go
@@ -16,6 +16,7 @@ var ExportParseMinFlag = parseMinFlag
 var ExportRunSpecFromInput = runSpecFromInput
 var ExportRunSummaryFromInput = runSummaryFromInput
 var ExportRunSpec = runSpec
+var ExportRunStaticSpec = runStaticSpec
 var ExportRunSummary = runSummary
 var ExportParseParallelFlag = parseParallelFlag
 var ExportParseCompileParallelFlag = parseCompileParallelFlag

--- a/cmd/gotest/flags.go
+++ b/cmd/gotest/flags.go
@@ -18,6 +18,7 @@ var gotestFlags = map[string]FlagKind{
 	"--no-cache":         BoolFlag,
 	"--github":           BoolFlag,
 	"--render-only":      BoolFlag,
+	"--static":           BoolFlag,
 	"--coverage":         ValueFlag,
 	"--min":              ValueFlag,
 	"--setup-timeout":    ValueFlag,
@@ -39,6 +40,7 @@ var specAllowed = flagSet(
 	"--debug", "--ci", "--update-snapshots", "--no-cache",
 	"--min", "--setup-timeout", "--timeout", "--parallel", "--compile-parallel",
 	"--format", "--output", "--input", "--no-color", "--render-only",
+	"--static",
 )
 
 var summaryAllowed = flagSet(

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -172,6 +172,8 @@ Flags:
   --input=<file>          Render from saved JSON ("-" for stdin)
   --render-only           With --input, exit 0 on a failing stream: report
                           whether rendering succeeded, not the test verdict
+  --static                Read the specification from source without running
+                          the suites; nodes carry no verdict
   --no-color              Disable ANSI color codes
   --ci                    CI mode: fail on F_ prefixes, snapshot read-only
   --debug                 Keep generated overlay

--- a/cmd/gotest/spec.go
+++ b/cmd/gotest/spec.go
@@ -38,6 +38,12 @@ func runSpec(inv Invocation) int { //nolint:gocritic // hugeParam: stable API
 		return runSpecFromInput(input, format, output, noColor, renderOnly)
 	}
 
+	if hasFlag(ownArgs, "--static") {
+		// The specification is written in the source; reading it should not
+		// require executing it.
+		return runStaticSpec(ownArgs, goTestArgs, &inv.Config, format, output, noColor)
+	}
+
 	minCoverage, err := parseMinFlag(ownArgs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)

--- a/cmd/gotest/spec.go
+++ b/cmd/gotest/spec.go
@@ -26,6 +26,14 @@ func runSpec(inv Invocation) int { //nolint:gocritic // hugeParam: stable API
 	noColor := hasFlag(ownArgs, "--no-color")
 	renderOnly := hasFlag(ownArgs, "--render-only")
 
+	if hasFlag(ownArgs, "--static") && input != "" {
+		// One asks for the specification in the source, the other for the
+		// specification in a recorded run. Silently honouring --input would
+		// hand back a tree the caller did not ask for.
+		fmt.Fprintf(os.Stderr, "FAIL: --static and --input are mutually exclusive\n")
+		return 2
+	}
+
 	if renderOnly && input == "" {
 		// Suppressing the verdict of a real run would turn a red pipeline
 		// green. The flag only makes sense where the exit code describes a

--- a/cmd/gotest/staticspec.go
+++ b/cmd/gotest/staticspec.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"sort"
 
 	"golang.org/x/tools/go/packages"
 
+	"github.com/mvrahden/go-test/internal/config"
 	"github.com/mvrahden/go-test/internal/gotestast"
 	"github.com/mvrahden/go-test/internal/gotestgen"
+	"github.com/mvrahden/go-test/internal/gotestrunner"
 	"github.com/mvrahden/go-test/internal/gotestspec"
 )
 
@@ -15,8 +19,9 @@ import (
 // renderer and consumer works unchanged; the difference is that no node has a
 // status, because nothing was executed.
 //
-// Where a method's behaviors cannot be enumerated from source, the method node
-// is marked incomplete rather than being presented as exhaustive.
+// Where a method's behaviors cannot be enumerated from source, the walker
+// reports it and the caller says so, rather than presenting a partial tree as
+// exhaustive.
 func buildStaticSpec(loadResults []*gotestgen.LoadResult, broken []gotestgen.BrokenPackage) ([]*gotestspec.Package, []string) {
 	var out []*gotestspec.Package
 	var notes []string
@@ -97,4 +102,63 @@ func staticBehaviorNodes(behaviors []*gotestast.Behavior) []*gotestspec.Node {
 		out = append(out, node)
 	}
 	return out
+}
+
+// runStaticSpec renders the specification from source without running the
+// suites. Nothing carries a verdict, because nothing executed; the exit code
+// reports only whether the source could be read.
+func runStaticSpec(ownArgs, goTestArgs []string, projectConfig *config.ProjectConfig, format, output string, noColor bool) int {
+	cfg, err := parseExecFlags(ownArgs, goTestArgs, projectConfig)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+
+	classified := gotestrunner.ClassifyGoTestArgs(cfg.GoTestArgs)
+	loadFlags := gotestrunner.StripCoverBuildFlags(classified.BuildFlags)
+
+	loaded, broken, err := gotestgen.LoadPackagesForDiscovery(cfg.PackagePatterns, loadFlags)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
+		return 2
+	}
+
+	tree, notes := buildStaticSpec(loaded, broken)
+
+	w := os.Stdout
+	if output != "" {
+		f, ferr := os.Create(output)
+		if ferr != nil {
+			fmt.Fprintf(os.Stderr, "FAIL: creating output file: %s\n", ferr)
+			return 2
+		}
+		defer f.Close()
+		w = f
+	}
+
+	var renderOpts []gotestspec.RenderOption
+	if noColor {
+		renderOpts = append(renderOpts, gotestspec.WithNoColor())
+	}
+
+	switch format {
+	case "md", "markdown":
+		gotestspec.RenderMarkdown(w, tree)
+	case "json":
+		gotestspec.RenderJSON(w, tree)
+	default:
+		gotestspec.RenderTerminal(w, tree, renderOpts...)
+	}
+
+	// Behaviors the walker could not enumerate are reported rather than
+	// silently omitted: an incomplete specification that says so is useful,
+	// one that pretends to be complete is not.
+	for _, note := range notes {
+		fmt.Fprintf(os.Stderr, "incomplete: %s\n", note)
+	}
+
+	if len(broken) > 0 {
+		return 2
+	}
+	return 0
 }

--- a/cmd/gotest/staticspec.go
+++ b/cmd/gotest/staticspec.go
@@ -45,6 +45,11 @@ func buildStaticSpec(loadResults []*gotestgen.LoadResult, broken []gotestgen.Bro
 			}
 			result := collector.CollectSuiteSpecs(pkg)
 			if len(result.Errs) > 0 {
+				// Dropping the package silently would present "no suites here"
+				// as a fact about the source rather than about the reader.
+				for _, e := range result.Errs {
+					notes = append(notes, fmt.Sprintf("%s: %s", pkg.PkgPath, e.Err))
+				}
 				continue
 			}
 			for _, suite := range result.Suites {
@@ -84,6 +89,10 @@ func staticSuiteNode(suite *gotestast.TestSuiteSpec) (*gotestspec.Node, []string
 		spec := suite.BehaviorsOf(method)
 		methodNode.Children = staticBehaviorNodes(spec.Behaviors)
 		if !spec.Complete {
+			// Carried on the node, not only on stderr: a spec written to a file
+			// or piped as JSON has to state its own limits, or the reader has
+			// no way to know the list is a floor.
+			methodNode.Incomplete = true
 			for _, note := range spec.Notes {
 				notes = append(notes, suite.Identifier()+"."+methodName+": "+note)
 			}
@@ -97,7 +106,11 @@ func staticSuiteNode(suite *gotestast.TestSuiteSpec) (*gotestspec.Node, []string
 func staticBehaviorNodes(behaviors []*gotestast.Behavior) []*gotestspec.Node {
 	var out []*gotestspec.Node
 	for _, b := range behaviors {
-		node := &gotestspec.Node{Name: b.Name}
+		// The behavior carries the exact go test segment, "#01" and all,
+		// because that is what an observed result is keyed by. The tree shows
+		// duplicates under the name the developer wrote, so it drops the
+		// suffix here exactly as the stream parser does.
+		node := &gotestspec.Node{Name: gotestspec.StripDuplicateSuffix(b.Name)}
 		node.Children = staticBehaviorNodes(b.Children)
 		out = append(out, node)
 	}
@@ -144,7 +157,7 @@ func runStaticSpec(ownArgs, goTestArgs []string, projectConfig *config.ProjectCo
 
 	switch format {
 	case "md", "markdown":
-		gotestspec.RenderMarkdown(w, tree)
+		gotestspec.RenderMarkdown(w, tree, renderOpts...)
 	case "json":
 		gotestspec.RenderJSON(w, tree)
 	default:

--- a/cmd/gotest/staticspec.go
+++ b/cmd/gotest/staticspec.go
@@ -136,7 +136,8 @@ func runStaticSpec(ownArgs, goTestArgs []string, projectConfig *config.ProjectCo
 		w = f
 	}
 
-	var renderOpts []gotestspec.RenderOption
+	// Nothing ran, so nothing has a verdict or a duration to show.
+	renderOpts := []gotestspec.RenderOption{gotestspec.WithoutVerdicts()}
 	if noColor {
 		renderOpts = append(renderOpts, gotestspec.WithNoColor())
 	}

--- a/cmd/gotest/staticspec.go
+++ b/cmd/gotest/staticspec.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"sort"
+
+	"golang.org/x/tools/go/packages"
+
+	"github.com/mvrahden/go-test/internal/gotestast"
+	"github.com/mvrahden/go-test/internal/gotestgen"
+	"github.com/mvrahden/go-test/internal/gotestspec"
+)
+
+// buildStaticSpec assembles the specification tree from source alone, without
+// running anything. It produces the same shape a test stream would, so every
+// renderer and consumer works unchanged; the difference is that no node has a
+// status, because nothing was executed.
+//
+// Where a method's behaviors cannot be enumerated from source, the method node
+// is marked incomplete rather than being presented as exhaustive.
+func buildStaticSpec(loadResults []*gotestgen.LoadResult, broken []gotestgen.BrokenPackage) ([]*gotestspec.Package, []string) {
+	var out []*gotestspec.Package
+	var notes []string
+
+	for i := range broken {
+		out = append(out, &gotestspec.Package{
+			Path:   broken[i].PkgPath,
+			Status: gotestspec.StatusFail,
+			Output: broken[i].Errors,
+		})
+	}
+
+	collector := gotestgen.NewCollector()
+
+	for _, lr := range loadResults {
+		pkgNode := &gotestspec.Package{Path: lr.PkgPath}
+
+		for _, pkg := range []*packages.Package{lr.Ptest, lr.Pxtest} {
+			if pkg == nil {
+				continue
+			}
+			result := collector.CollectSuiteSpecs(pkg)
+			if len(result.Errs) > 0 {
+				continue
+			}
+			for _, suite := range result.Suites {
+				suiteNode, suiteNotes := staticSuiteNode(suite)
+				if suiteNode == nil {
+					continue
+				}
+				pkgNode.Nodes = append(pkgNode.Nodes, suiteNode)
+				notes = append(notes, suiteNotes...)
+			}
+		}
+
+		if len(pkgNode.Nodes) > 0 {
+			sort.SliceStable(pkgNode.Nodes, func(a, b int) bool {
+				return pkgNode.Nodes[a].Name < pkgNode.Nodes[b].Name
+			})
+			gotestspec.ClassifyRoots(pkgNode.Nodes)
+			out = append(out, pkgNode)
+		}
+	}
+
+	sort.SliceStable(out, func(a, b int) bool { return out[a].Path < out[b].Path })
+	return out, notes
+}
+
+func staticSuiteNode(suite *gotestast.TestSuiteSpec) (*gotestspec.Node, []string) {
+	var notes []string
+
+	// The runtime tree keys suites by the generated entrypoint name, so the
+	// static tree has to use the identical one to line up with it.
+	node := &gotestspec.Node{Name: "Test" + suite.Identifier()}
+
+	for _, method := range suite.TestCases() {
+		methodName := method.Identifier()
+		methodNode := &gotestspec.Node{Name: methodName}
+
+		spec := suite.BehaviorsOf(method)
+		methodNode.Children = staticBehaviorNodes(spec.Behaviors)
+		if !spec.Complete {
+			for _, note := range spec.Notes {
+				notes = append(notes, suite.Identifier()+"."+methodName+": "+note)
+			}
+		}
+		node.Children = append(node.Children, methodNode)
+	}
+
+	return node, notes
+}
+
+func staticBehaviorNodes(behaviors []*gotestast.Behavior) []*gotestspec.Node {
+	var out []*gotestspec.Node
+	for _, b := range behaviors {
+		node := &gotestspec.Node{Name: b.Name}
+		node.Children = staticBehaviorNodes(b.Children)
+		out = append(out, node)
+	}
+	return out
+}

--- a/cmd/gotest/staticspec_suite_test.go
+++ b/cmd/gotest/staticspec_suite_test.go
@@ -1,0 +1,338 @@
+package main_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/mvrahden/go-test/cmd/gotest"
+	"github.com/mvrahden/go-test/internal/config"
+	"github.com/mvrahden/go-test/internal/gotestgen"
+	"github.com/mvrahden/go-test/internal/gotestrunner"
+	"github.com/mvrahden/go-test/internal/gotestspec"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// StaticSpecTestSuite covers `spec --static`: the specification read from the
+// source instead of from a run. The corpus is the walker's own testdata, which
+// is written to be adverse — tables, duplicates, slashes, and behaviors the
+// walker deliberately cannot see.
+type StaticSpecTestSuite struct {
+	dir        string
+	workDir    string
+	overlayDir string
+	corpus     string
+	rendered   map[string]string
+}
+
+func (s *StaticSpecTestSuite) BeforeAll(t *gotest.T) {
+	corpus, err := filepath.Abs(filepath.Join("..", "..", "internal", "gotestast", "testdata", "behaviors"))
+	gotest.NoError(t, err)
+	s.corpus = corpus
+
+	s.workDir, err = os.MkdirTemp("", "gotest-staticspec-render-")
+	gotest.NoError(t, err)
+
+	s.rendered = map[string]string{}
+	for _, format := range []string{"terminal", "md", "json"} {
+		s.rendered[format] = s.render(t, format, corpus)
+	}
+}
+
+func (s *StaticSpecTestSuite) AfterAll(t *gotest.T) {
+	gotest.NoError(t, os.RemoveAll(s.workDir))
+}
+
+func (s *StaticSpecTestSuite) BeforeEach(t *gotest.T) {
+	dir, err := os.MkdirTemp("", "gotest-staticspec-")
+	gotest.NoError(t, err)
+	s.dir = dir
+	s.overlayDir = ""
+}
+
+func (s *StaticSpecTestSuite) AfterEach(t *gotest.T) {
+	gotest.NoError(t, os.RemoveAll(s.dir))
+	if s.overlayDir != "" {
+		gotest.NoError(t, os.RemoveAll(s.overlayDir))
+	}
+}
+
+// render runs the subcommand into a file, which is also how a caller publishes
+// a specification, and returns what it wrote.
+func (s *StaticSpecTestSuite) render(t *gotest.T, format, pattern string) string {
+	out := filepath.Join(s.workDir, "spec."+format)
+	code := ExportRunStaticSpec(nil, []string{pattern}, &config.ProjectConfig{}, format, out, true)
+	gotest.Equal(t, 0, code, "spec --static --format=%s", format)
+
+	data, err := os.ReadFile(out) //nolint:gosec // G304: path built in this test
+	gotest.NoError(t, err)
+	return string(data)
+}
+
+// The contract the whole feature rests on: where the walker reports the list is
+// exhaustive, the names it predicts are the names go test actually produces.
+// Anything else puts a behavior in the tree under a name no run will report.
+func (s *StaticSpecTestSuite) TestPredictsTheNamesARunProduces(t *gotest.T) {
+	t.When("the corpus is both read and run", func(w *gotest.T) {
+		static := s.staticPaths(w)
+		observed := s.observedPaths(w)
+
+		w.It("predicts every complete method exactly", func(it *gotest.T) {
+			for method, want := range static.complete {
+				gotest.Equal(it, want, observed[method], "method %s", method)
+			}
+			gotest.NotEmpty(it, static.complete, "no complete methods in the corpus")
+		})
+
+		w.It("never claims a behavior a run does not report", func(it *gotest.T) {
+			// An incomplete method may report more at run time — that is what
+			// incomplete means — but never fewer, and never under other names.
+			for method, declared := range static.incomplete {
+				for _, path := range declared {
+					gotest.Contains(it, observed[method], path, "method %s", method)
+				}
+			}
+			gotest.NotEmpty(it, static.incomplete, "no incomplete methods in the corpus")
+		})
+	})
+}
+
+type staticTrees struct {
+	complete   map[string][]string
+	incomplete map[string][]string
+}
+
+// staticPaths renders the corpus as JSON and splits the methods by whether the
+// walker admitted it could not see all of them.
+func (s *StaticSpecTestSuite) staticPaths(t *gotest.T) staticTrees {
+	var doc specDocument
+	gotest.NoError(t, json.Unmarshal([]byte(s.rendered["json"]), &doc))
+
+	trees := staticTrees{complete: map[string][]string{}, incomplete: map[string][]string{}}
+	for _, pkg := range doc.Packages {
+		for _, suite := range pkg.Nodes {
+			for _, method := range suite.Children {
+				bucket := trees.complete
+				if method.Incomplete {
+					bucket = trees.incomplete
+				}
+				bucket[method.Name] = nodePaths(method.Children, "")
+			}
+		}
+	}
+	return trees
+}
+
+// observedPaths runs the corpus for real and reads the same paths back out of
+// the tree the stream produces.
+func (s *StaticSpecTestSuite) observedPaths(t *gotest.T) map[string][]string {
+	loaded, _, err := gotestgen.LoadPackages([]string{s.corpus}, nil)
+	gotest.NoError(t, err)
+	results, _, err := gotestgen.GenerateFromLoaded(loaded)
+	gotest.NoError(t, err)
+
+	overlayDir, err := gotestrunner.WriteOverlay(results)
+	gotest.NoError(t, err)
+	s.overlayDir = overlayDir
+
+	cmd := exec.CommandContext(context.Background(), "go", //nolint:gosec // G204: go tool with controlled arguments
+		"test", "-json", "-ldflags=-checklinkname=0",
+		"-overlay="+filepath.Join(overlayDir, "overlay.json"), s.corpus)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	mp := gotestrunner.NewManagedProcess(cmd, gotestrunner.ProcessConfig{Grace: gotestrunner.GraceKill})
+	gotest.NoError(t, mp.Start())
+	_ = mp.WaitWithGrace(context.Background())
+
+	events, err := gotestspec.ParseEvents(bytes.NewReader(stdout.Bytes()))
+	gotest.NoError(t, err)
+	tree := gotestspec.BuildTree(events)
+
+	observed := map[string][]string{}
+	for _, pkg := range tree {
+		for _, suite := range pkg.Nodes {
+			for _, method := range suite.Children {
+				observed[method.Name] = specNodePaths(method.Children, "")
+			}
+		}
+	}
+	gotest.NotEmpty(t, observed, "the corpus produced no test events")
+	return observed
+}
+
+func (s *StaticSpecTestSuite) TestCarriesNoVerdicts(t *gotest.T) {
+	t.When("the terminal spec is rendered from source", func(w *gotest.T) {
+		out := s.rendered["terminal"]
+
+		w.It("shows no status glyph", func(it *gotest.T) {
+			gotest.NotContains(it, out, "✓")
+			gotest.NotContains(it, out, "✗")
+		})
+
+		w.It("shows no duration", func(it *gotest.T) {
+			gotest.NotContains(it, out, "ms)")
+		})
+
+		w.It("counts what it read without claiming a verdict", func(it *gotest.T) {
+			gotest.Contains(it, out, "behaviors")
+			gotest.NotContains(it, out, "passed")
+			// A count line ending in a colon reads as a line that lost its tail.
+			gotest.NotContains(it, out, "behaviors: \n")
+		})
+	})
+
+	t.When("the markdown spec is rendered from source", func(w *gotest.T) {
+		out := s.rendered["md"]
+
+		w.It("drops the Status and Duration columns", func(it *gotest.T) {
+			gotest.Contains(it, out, "| Behavior |")
+			gotest.NotContains(it, out, "| Behavior | Status | Duration |")
+			// The duration of something that never ran is not "<1ms".
+			gotest.NotContains(it, out, "<1ms")
+		})
+
+		w.It("says nothing was executed instead of reporting zero of each", func(it *gotest.T) {
+			gotest.Contains(it, out, "nothing was executed")
+			gotest.NotContains(it, out, "0 passed, 0 failed, 0 skipped")
+		})
+	})
+
+	t.When("the JSON spec is rendered from source", func(w *gotest.T) {
+		var doc specDocument
+		gotest.NoError(w, json.Unmarshal([]byte(s.rendered["json"]), &doc))
+
+		w.It("leaves every node without a status", func(it *gotest.T) {
+			for _, pkg := range doc.Packages {
+				for _, node := range pkg.Nodes {
+					assertStatusNone(it, node)
+				}
+			}
+		})
+	})
+}
+
+// A partial list that presents itself as whole is worse than no list, so every
+// surface has to carry the admission — not only the stderr notes.
+func (s *StaticSpecTestSuite) TestDeclaresIncompletenessOnEverySurface(t *gotest.T) {
+	t.When("a method declares behaviors the walker cannot see", func(w *gotest.T) {
+		w.It("marks it in the terminal tree", func(it *gotest.T) {
+			gotest.Contains(it, s.rendered["terminal"], "Conditional — INCOMPLETE")
+		})
+
+		w.It("marks it in markdown", func(it *gotest.T) {
+			gotest.Contains(it, s.rendered["md"], "_Incomplete:")
+		})
+
+		w.It("marks a method whose behaviors are all runtime-dependent", func(it *gotest.T) {
+			// It has no table of its own, so it appears as a row of its suite's.
+			// Unmarked it reads as a behavior that simply has nothing beneath it.
+			gotest.Contains(it, s.rendered["md"],
+				"| NonLiteralTable — _incomplete: behaviors known only at run time_ |")
+		})
+
+		w.It("marks it in JSON", func(it *gotest.T) {
+			var doc specDocument
+			gotest.NoError(it, json.Unmarshal([]byte(s.rendered["json"]), &doc))
+			gotest.True(it, findIncomplete(doc, "TestConditional"),
+				"TestConditional is not marked incomplete in JSON")
+			gotest.False(it, findIncomplete(doc, "TestNesting"),
+				"a fully declared method must not be marked incomplete")
+		})
+	})
+}
+
+func (s *StaticSpecTestSuite) TestExitCodes(t *gotest.T) {
+	t.When("the source can be read", func(w *gotest.T) {
+		w.It("exits 0", func(it *gotest.T) {
+			out := filepath.Join(s.dir, "ok.txt")
+			gotest.Equal(it, 0, ExportRunStaticSpec(nil, []string{s.corpus}, &config.ProjectConfig{}, "terminal", out, true))
+		})
+	})
+
+	t.When("a package does not compile", func(w *gotest.T) {
+		broken := filepath.Join(s.dir, "broken")
+		gotest.NoError(w, os.MkdirAll(broken, 0o750))
+		gotest.NoError(w, os.WriteFile(filepath.Join(broken, "x_test.go"),
+			[]byte("package broken\n\nfunc Nope() { undefinedSymbol() }\n"), 0o600))
+
+		w.It("exits 2 rather than reporting an empty specification", func(it *gotest.T) {
+			out := filepath.Join(s.dir, "broken.txt")
+			gotest.Equal(it, 2, ExportRunStaticSpec(nil, []string{broken}, &config.ProjectConfig{}, "terminal", out, true))
+		})
+	})
+
+	t.When("the output file cannot be created", func(w *gotest.T) {
+		w.It("exits 2", func(it *gotest.T) {
+			out := filepath.Join(s.dir, "no-such-dir", "spec.txt")
+			gotest.Equal(it, 2, ExportRunStaticSpec(nil, []string{s.corpus}, &config.ProjectConfig{}, "terminal", out, true))
+		})
+	})
+}
+
+// --static reads the specification in the source, --input the one in a recorded
+// run. Honouring one silently while the caller asked for both hands back a tree
+// they did not ask for.
+func (s *StaticSpecTestSuite) TestStaticAndInputAreMutuallyExclusive(t *gotest.T) {
+	t.It("rejects the pair instead of picking one", func(it *gotest.T) {
+		code := ExportRunSpec(Invocation{Args: []string{"--static", "--input=events.json"}})
+		gotest.Equal(it, 2, code)
+	})
+}
+
+type specDocument struct {
+	Packages []struct {
+		Path  string     `json:"path"`
+		Nodes []specNode `json:"nodes"`
+	} `json:"packages"`
+}
+
+type specNode struct {
+	Name       string     `json:"name"`
+	Status     string     `json:"status"`
+	Incomplete bool       `json:"incomplete"`
+	Children   []specNode `json:"children"`
+}
+
+func nodePaths(nodes []specNode, prefix string) []string {
+	var out []string
+	for _, n := range nodes {
+		path := prefix + n.Name
+		out = append(out, path)
+		out = append(out, nodePaths(n.Children, path+"/")...)
+	}
+	return out
+}
+
+func specNodePaths(nodes []*gotestspec.Node, prefix string) []string {
+	var out []string
+	for _, n := range nodes {
+		path := prefix + n.Name
+		out = append(out, path)
+		out = append(out, specNodePaths(n.Children, path+"/")...)
+	}
+	return out
+}
+
+func assertStatusNone(t *gotest.T, n specNode) {
+	gotest.Equal(t, "none", n.Status, "node %s carries a verdict", n.Name)
+	for i := range n.Children {
+		assertStatusNone(t, n.Children[i])
+	}
+}
+
+func findIncomplete(doc specDocument, method string) bool {
+	for _, pkg := range doc.Packages {
+		for _, suite := range pkg.Nodes {
+			for _, node := range suite.Children {
+				if node.Name == method {
+					return node.Incomplete
+				}
+			}
+		}
+	}
+	return false
+}

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -148,6 +148,7 @@ gotest [subcommand] [packages...] [go-test-flags...] [--gotest-flags...]
 | `--github` | Emit GitHub annotations and step summary (auto-enabled in GitHub Actions) |
 | `--coverage=<path>` | Coverage profile path for `summary` subcommand |
 | `--render-only` | With `--input`, exit 0 on a failing stream: the code reports whether rendering succeeded, not whether the tests passed (requires `--input`) |
+| `--static` | Render the specification from source without running the suites (`spec` only); nodes carry no verdict, and methods whose behaviors depend on runtime values are reported as incomplete on stderr |
 
 ### Disambiguation
 

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -1099,8 +1099,21 @@ gotest spec ./... --no-color                         # terminal (plain)
 gotest spec ./... --format=md --output=behavior.md   # markdown
 gotest spec ./... --format=json                      # machine-readable tree
 gotest spec --input=events.json                      # replay a saved go test -json stream (no test run)
+gotest spec ./... --static                           # read the spec from source (nothing runs)
 gotest ./... -v --spec                               # spec view instead of default output
 ```
+
+### `--static`
+
+Builds the same tree from the source instead of from a run: no node carries a status or a duration, because nothing executed.
+The names are the ones `go test` would produce, including the `#01` it appends to a description repeated among its siblings and the extra level a single slash introduces — a statically read behavior and an observed one have to be the same node, not two.
+
+Where a method declares behaviors whose names or existence depend on runtime values — a `When` behind a condition, a non-literal description, an `Each` over a table that is not a literal — the method node is marked incomplete and the detail goes to stderr as `incomplete: …` lines.
+That marking is on the node, not only on stderr, so it survives into every format: `— INCOMPLETE` in the terminal tree, an `_Incomplete: …_` note in markdown, and `"incomplete": true` in JSON.
+A run-derived tree never sets the field, since what ran is by definition all there was.
+
+`--static` and `--input` are mutually exclusive: one asks for the specification in the source, the other for the one in a recorded run.
+Exit code is 0 when the source could be read and 2 when a package does not compile.
 
 ---
 
@@ -1138,7 +1151,7 @@ $ gotest discover ./...
 Emits the static suite model as JSON — the integration surface for editors and AI tooling (the VS Code extension's test explorer runs on it).
 No tests are executed.
 
-`behaviors` carries the `When`/`It` tree each method declares, read from source: `name` is the subtest segment `go test` will produce (so it matches an observed run byte for byte), `display` is the text the developer wrote, and `line` locates it. `behaviorsComplete` reports whether that tree is exhaustive — `false` means the method declares behaviors whose names or existence depend on runtime values (a condition, a loop, a non-literal description, a table that is not a literal), so the list is a floor rather than a total and the remainder appears only once the method has run. Consumers must not present an incomplete list as the whole specification.
+`behaviors` carries the `When`/`It` tree each method declares, read from source: `name` is the subtest segment `go test` will produce (so it matches an observed run byte for byte), `display` is the text the developer wrote, and `line` locates it. Two rewrites the source does not spell out are applied so that `name` really does match: a description repeated among its siblings gains the `#01` suffix the testing package appends, and a description containing a single slash becomes one node per level (a run of slashes, as in `https://`, is not a separator and stays within one level). `behaviorsComplete` reports whether that tree is exhaustive — `false` means the method declares behaviors whose names or existence depend on runtime values (a condition, a loop, a non-literal description, a table that is not a literal), so the list is a floor rather than a total and the remainder appears only once the method has run. Consumers must not present an incomplete list as the whole specification.
 
 ```
 { "packages": [ {

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -1138,6 +1138,8 @@ $ gotest discover ./...
 Emits the static suite model as JSON — the integration surface for editors and AI tooling (the VS Code extension's test explorer runs on it).
 No tests are executed.
 
+`behaviors` carries the `When`/`It` tree each method declares, read from source: `name` is the subtest segment `go test` will produce (so it matches an observed run byte for byte), `display` is the text the developer wrote, and `line` locates it. `behaviorsComplete` reports whether that tree is exhaustive — `false` means the method declares behaviors whose names or existence depend on runtime values (a condition, a loop, a non-literal description, a table that is not a literal), so the list is a floor rather than a total and the remainder appears only once the method has run. Consumers must not present an incomplete list as the whole specification.
+
 ```
 { "packages": [ {
     "importPath": …, "dir": …, "modulePath": …, "testOnly": bool,
@@ -1147,7 +1149,10 @@ No tests are executed.
       "lifecycle": ["BeforeAll", …],
       "fixtures": ["E2ESetupFixture", …],
       "methods": [ { "name": …, "file": …, "line": …, "col": …,
-                     "focused": bool, "excluded": bool, "parallel": bool } ]
+                     "focused": bool, "excluded": bool, "parallel": bool,
+                     "behaviors": [ { "name": …, "display": …, "line": …,
+                                      "children": [ … ] } ],
+                     "behaviorsComplete": bool } ]
     } ]
   } ],
   "warnings": [ { "importPath": …, "file": …, "line": …, "col": …, "message": … } ] }

--- a/internal/gotestast/behaviors.go
+++ b/internal/gotestast/behaviors.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/mvrahden/go-test/internal/protocol"
 )
 
 // Behaviors are the `When`/`It` blocks a test method declares. They are the
@@ -34,10 +36,12 @@ const (
 )
 
 type Behavior struct {
-	// Name is the subtest segment go test will produce, with the same
-	// sanitisation the testing package applies. It has to match byte for byte,
-	// because it is how a statically-known behavior is reconciled with the one
-	// observed at run time.
+	// Name is the subtest segment go test will produce: the same sanitisation
+	// the testing package applies, plus the "#01" it appends to a name that
+	// repeats among its siblings. A description containing a slash is split
+	// into one Behavior per level, because that is what go test does with it.
+	// All of this has to match byte for byte, because it is how a
+	// statically-known behavior is reconciled with the one observed at run time.
 	Name     string
 	Display  string
 	Kind     BehaviorKind
@@ -111,7 +115,92 @@ func (w *behaviorWalker) walkBlock(block *ast.BlockStmt) []*Behavior {
 			w.flagHidden(stmt)
 		}
 	}
+	return resolveSiblings(out)
+}
+
+// resolveSiblings turns the behaviors written in one block into the subtests go
+// test will actually produce for them. Two rules of the testing package apply
+// here and neither is visible in the source: a name that repeats among its
+// siblings gains a "#01" suffix, and a name containing a slash becomes one
+// subtest level per segment. Skipping either would put a behavior in the tree
+// under a name no run will ever report.
+func resolveSiblings(in []*Behavior) []*Behavior {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]int, len(in))
+	var out []*Behavior
+	for _, b := range in {
+		// The testing package uniquifies against the name as written, before
+		// any slash in it is read as a separator, so uniquing comes first.
+		name := b.Name
+		if n := seen[name]; n > 0 {
+			b.Name = fmt.Sprintf("%s#%02d", name, n)
+		}
+		seen[name]++
+		out = insertPath(out, splitSegments(b.Name), splitSegments(b.Display), b)
+	}
 	return out
+}
+
+// insertPath places a behavior at the end of its segment path, reusing a
+// grouping node a sibling already created. Two behaviors written as "a/b" and
+// "a/c" are one node with two children at run time, not two nodes that happen
+// to share a prefix.
+func insertPath(out []*Behavior, segments, displays []string, leaf *Behavior) []*Behavior {
+	if len(segments) <= 1 {
+		return append(out, leaf)
+	}
+	head := segments[0]
+	var node *Behavior
+	for _, existing := range out {
+		if existing.Name == head {
+			node = existing
+			break
+		}
+	}
+	if node == nil {
+		node = &Behavior{
+			Name:    head,
+			Display: displayAt(displays, 0, head),
+			Kind:    BehaviorWhen,
+			Line:    leaf.Line,
+		}
+		out = append(out, node)
+	}
+	rest := segments[1:]
+	if len(rest) == 1 {
+		leaf.Name = rest[0]
+		leaf.Display = displayAt(displays, 1, rest[0])
+	}
+	node.Children = insertPath(node.Children, rest, tailFrom(displays, 1), leaf)
+	return out
+}
+
+// splitSegments cuts a name at the separator go test uses between subtest
+// levels, by the same rule the stream parser applies. Sanitisation never adds
+// or removes a slash, so the description and the subtest name split into the
+// same number of pieces.
+func splitSegments(s string) []string {
+	segments := protocol.SplitTestPath(s)
+	if len(segments) == 0 {
+		return []string{s}
+	}
+	return segments
+}
+
+func displayAt(displays []string, i int, fallback string) string {
+	if i < len(displays) {
+		return displays[i]
+	}
+	return fallback
+}
+
+func tailFrom(displays []string, i int) []string {
+	if i < len(displays) {
+		return displays[i:]
+	}
+	return nil
 }
 
 // flagHidden marks the tree incomplete if a construct we do not model

--- a/internal/gotestast/behaviors.go
+++ b/internal/gotestast/behaviors.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
-
 )
 
 // Behaviors are the `When`/`It` blocks a test method declares. They are the
@@ -214,50 +213,37 @@ func (w *behaviorWalker) eachRows(s *ast.RangeStmt) []*Behavior {
 		return nil // caller flags it as incomplete
 	}
 
+	// Behaviors declared in the loop body run once per row, so they are the
+	// children of every row rather than siblings of the table.
+	var perRow []*Behavior
+	if s.Body != nil {
+		perRow = w.walkBlock(s.Body)
+	}
+
 	rows := make([]*Behavior, 0, len(composite.Elts))
 	for i, elt := range composite.Elts {
-		name, ok := eachEntryLiteralName(elt)
-		if !ok {
-			name = fmt.Sprintf("#%d", i)
-		}
+		name := w.eachEntryName(elt, i)
 		rows = append(rows, &Behavior{
-			Name:    SubtestName(name),
-			Display: name,
-			Kind:    BehaviorEach,
-			Line:    w.line(elt.Pos()),
+			Name:     SubtestName(name),
+			Display:  name,
+			Kind:     BehaviorEach,
+			Line:     w.line(elt.Pos()),
+			Children: cloneBehaviors(perRow),
 		})
-	}
-	// Behaviors declared inside the loop body would be nested under each row;
-	// that shape is not modelled, so say so rather than under-report.
-	if s.Body != nil {
-		for _, stmt := range s.Body.List {
-			w.flagHiddenNested(stmt)
-		}
 	}
 	return rows
 }
 
-func (w *behaviorWalker) flagHiddenNested(stmt ast.Stmt) {
-	ast.Inspect(stmt, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		if sel, ok := call.Fun.(*ast.SelectorExpr); ok &&
-			(sel.Sel.Name == "When" || sel.Sel.Name == "It") && w.isGotestT(sel.X) {
-			w.incomplete(call.Pos(), "%s nested inside an Each row", sel.Sel.Name)
-			return false
-		}
-		return true
-	})
-}
-
-// eachEntryLiteralName mirrors eachEntryName: the Desc field wins, then Name.
-func eachEntryLiteralName(elt ast.Expr) (string, bool) {
+// eachEntryName mirrors the runtime's eachEntryName: the Desc field wins, then
+// Name, then the index. Both the keyed and the positional literal forms are
+// resolved, because a table written as `{"too short", ...}` names its rows just
+// as surely as one written as `{Desc: "too short"}`.
+func (w *behaviorWalker) eachEntryName(elt ast.Expr, index int) string {
 	composite, ok := elt.(*ast.CompositeLit)
 	if !ok {
-		return "", false
+		return fmt.Sprintf("#%d", index)
 	}
+
 	for _, field := range []string{"Desc", "Name"} {
 		for _, e := range composite.Elts {
 			kv, ok := e.(*ast.KeyValueExpr)
@@ -269,11 +255,55 @@ func eachEntryLiteralName(elt ast.Expr) (string, bool) {
 				continue
 			}
 			if value, ok := stringLiteral(kv.Value); ok && value != "" {
-				return value, true
+				return value
 			}
 		}
 	}
-	return "", false
+
+	if st := w.structOf(composite); st != nil {
+		for _, field := range []string{"Desc", "Name"} {
+			for i := 0; i < st.NumFields() && i < len(composite.Elts); i++ {
+				if st.Field(i).Name() != field {
+					continue
+				}
+				if _, keyed := composite.Elts[i].(*ast.KeyValueExpr); keyed {
+					continue
+				}
+				if value, ok := stringLiteral(composite.Elts[i]); ok && value != "" {
+					return value
+				}
+			}
+		}
+	}
+
+	return fmt.Sprintf("#%d", index)
+}
+
+func (w *behaviorWalker) structOf(expr ast.Expr) *types.Struct {
+	if w.info == nil {
+		return nil
+	}
+	typ := w.info.TypeOf(expr)
+	if typ == nil {
+		return nil
+	}
+	st, _ := typ.Underlying().(*types.Struct)
+	return st
+}
+
+// cloneBehaviors gives each table row its own subtree; sharing the nodes would
+// alias rows that the runtime keeps entirely separate.
+func cloneBehaviors(in []*Behavior) []*Behavior {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*Behavior, 0, len(in))
+	for _, b := range in {
+		clone := *b
+		clone.Children = cloneBehaviors(b.Children)
+		out = append(out, &clone)
+	}
+	return out
 }
 
 func (w *behaviorWalker) isGotestT(expr ast.Expr) bool {

--- a/internal/gotestast/behaviors.go
+++ b/internal/gotestast/behaviors.go
@@ -1,0 +1,357 @@
+package gotestast
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strconv"
+	"strings"
+	"unicode"
+
+)
+
+// Behaviors are the `When`/`It` blocks a test method declares. They are the
+// unit a developer writes in and reads, but until now they existed only as a
+// runtime artifact: the only way to learn a suite's behaviors was to execute
+// it. Reading them from source is the same act discovery already performs for
+// suites and methods, one level deeper — a declaration is being enumerated,
+// not an outcome predicted.
+//
+// Extraction is deliberately a partial function. Where a behavior's name or
+// existence depends on runtime values, the walker records that it could not
+// enumerate rather than guessing, and the consumer is expected to say so.
+
+type BehaviorKind int
+
+const (
+	// BehaviorWhen is a `t.When(...)` block: a grouping node with children.
+	BehaviorWhen BehaviorKind = iota
+	// BehaviorIt is a `t.It(...)` block: a leaf behavior.
+	BehaviorIt
+	// BehaviorEach is one row of a `gotest.Each` table, named from the entry's
+	// Desc or Name field exactly as the runtime names it.
+	BehaviorEach
+)
+
+type Behavior struct {
+	// Name is the subtest segment go test will produce, with the same
+	// sanitisation the testing package applies. It has to match byte for byte,
+	// because it is how a statically-known behavior is reconciled with the one
+	// observed at run time.
+	Name     string
+	Display  string
+	Kind     BehaviorKind
+	Line     int
+	Children []*Behavior
+}
+
+// MethodSpec is the behavior tree of a single test method. Complete reports
+// whether the tree is exhaustive: when false, the method declares behaviors
+// this walker cannot see, and Notes says which construct defeated it.
+type MethodSpec struct {
+	Behaviors []*Behavior
+	Complete  bool
+	Notes     []string
+}
+
+const gotestPkgPath = "github.com/mvrahden/go-test/pkg/gotest"
+
+// BehaviorsOf walks a test method body and returns the behaviors it declares.
+func (ts *TestSuiteSpec) BehaviorsOf(m *TestSuiteMethod) MethodSpec {
+	fd, ok := m.n.(*ast.FuncDecl)
+	if !ok || fd.Body == nil {
+		return MethodSpec{Complete: false, Notes: []string{"method body unavailable"}}
+	}
+	w := &behaviorWalker{
+		info:     ts.pkg.TypesInfo,
+		fset:     ts.pkg.Fset,
+		complete: true,
+	}
+	behaviors := w.walkBlock(fd.Body)
+	return MethodSpec{Behaviors: behaviors, Complete: w.complete, Notes: w.notes}
+}
+
+type behaviorWalker struct {
+	info     *types.Info
+	fset     *token.FileSet
+	complete bool
+	notes    []string
+}
+
+func (w *behaviorWalker) incomplete(pos token.Pos, format string, args ...any) {
+	w.complete = false
+	note := fmt.Sprintf(format, args...)
+	if w.fset != nil && pos.IsValid() {
+		note = fmt.Sprintf("%s: %s", w.fset.Position(pos), note)
+	}
+	if len(w.notes) < 16 {
+		w.notes = append(w.notes, note)
+	}
+}
+
+func (w *behaviorWalker) walkBlock(block *ast.BlockStmt) []*Behavior {
+	var out []*Behavior
+	for _, stmt := range block.List {
+		switch s := stmt.(type) {
+		case *ast.ExprStmt:
+			if b := w.behaviorCall(s.X); b != nil {
+				out = append(out, b)
+				continue
+			}
+			w.flagHidden(s)
+		case *ast.RangeStmt:
+			if rows := w.eachRows(s); rows != nil {
+				out = append(out, rows...)
+				continue
+			}
+			// A loop that is not a recognised Each table may still emit
+			// behaviors, and how many depends on values we do not have.
+			w.flagHidden(s)
+		default:
+			w.flagHidden(stmt)
+		}
+	}
+	return out
+}
+
+// flagHidden marks the tree incomplete if a construct we do not model
+// nevertheless contains behavior calls. Statements with no behavior calls
+// beneath them — assertions, setup, plain Go — are silently fine.
+func (w *behaviorWalker) flagHidden(node ast.Node) {
+	ast.Inspect(node, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		switch sel.Sel.Name {
+		case "When", "It":
+			if w.isGotestT(sel.X) {
+				w.incomplete(call.Pos(), "%s inside a construct whose behaviors depend on runtime values", sel.Sel.Name)
+				return false
+			}
+		case "Each":
+			if w.isGotestFunc(sel, "Each") {
+				w.incomplete(call.Pos(), "Each over entries that are not a literal table")
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// behaviorCall recognises `x.When("...", func(y *gotest.T) {...})` and the
+// same shape for It. Anything that is a behavior call but does not match this
+// shape marks the tree incomplete rather than being dropped silently.
+func (w *behaviorWalker) behaviorCall(expr ast.Expr) *Behavior {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return nil
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return nil
+	}
+	var kind BehaviorKind
+	switch sel.Sel.Name {
+	case "When":
+		kind = BehaviorWhen
+	case "It":
+		kind = BehaviorIt
+	default:
+		return nil
+	}
+	if !w.isGotestT(sel.X) {
+		return nil
+	}
+	if len(call.Args) < 2 {
+		w.incomplete(call.Pos(), "%s call with unexpected arguments", sel.Sel.Name)
+		return nil
+	}
+	desc, ok := stringLiteral(call.Args[0])
+	if !ok {
+		w.incomplete(call.Args[0].Pos(), "%s description is not a string literal", sel.Sel.Name)
+		return nil
+	}
+
+	behavior := &Behavior{
+		Name:    SubtestName(desc),
+		Display: desc,
+		Kind:    kind,
+		Line:    w.line(call.Pos()),
+	}
+
+	fn, ok := call.Args[1].(*ast.FuncLit)
+	if !ok || fn.Body == nil {
+		w.incomplete(call.Args[1].Pos(), "%s body is not a function literal", sel.Sel.Name)
+		return behavior
+	}
+	behavior.Children = w.walkBlock(fn.Body)
+	return behavior
+}
+
+// eachRows enumerates `for sub, tc := range gotest.Each(t, []T{...})`. The
+// runtime names each row from its Desc or Name field, falling back to the
+// index, so a literal table is fully determined.
+func (w *behaviorWalker) eachRows(s *ast.RangeStmt) []*Behavior {
+	call, ok := s.X.(*ast.CallExpr)
+	if !ok {
+		return nil
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || !w.isGotestFunc(sel, "Each") {
+		return nil
+	}
+	if len(call.Args) < 2 {
+		return nil
+	}
+	composite, ok := call.Args[1].(*ast.CompositeLit)
+	if !ok {
+		return nil // caller flags it as incomplete
+	}
+
+	rows := make([]*Behavior, 0, len(composite.Elts))
+	for i, elt := range composite.Elts {
+		name, ok := eachEntryLiteralName(elt)
+		if !ok {
+			name = fmt.Sprintf("#%d", i)
+		}
+		rows = append(rows, &Behavior{
+			Name:    SubtestName(name),
+			Display: name,
+			Kind:    BehaviorEach,
+			Line:    w.line(elt.Pos()),
+		})
+	}
+	// Behaviors declared inside the loop body would be nested under each row;
+	// that shape is not modelled, so say so rather than under-report.
+	if s.Body != nil {
+		for _, stmt := range s.Body.List {
+			w.flagHiddenNested(stmt)
+		}
+	}
+	return rows
+}
+
+func (w *behaviorWalker) flagHiddenNested(stmt ast.Stmt) {
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok &&
+			(sel.Sel.Name == "When" || sel.Sel.Name == "It") && w.isGotestT(sel.X) {
+			w.incomplete(call.Pos(), "%s nested inside an Each row", sel.Sel.Name)
+			return false
+		}
+		return true
+	})
+}
+
+// eachEntryLiteralName mirrors eachEntryName: the Desc field wins, then Name.
+func eachEntryLiteralName(elt ast.Expr) (string, bool) {
+	composite, ok := elt.(*ast.CompositeLit)
+	if !ok {
+		return "", false
+	}
+	for _, field := range []string{"Desc", "Name"} {
+		for _, e := range composite.Elts {
+			kv, ok := e.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok || key.Name != field {
+				continue
+			}
+			if value, ok := stringLiteral(kv.Value); ok && value != "" {
+				return value, true
+			}
+		}
+	}
+	return "", false
+}
+
+func (w *behaviorWalker) isGotestT(expr ast.Expr) bool {
+	if w.info == nil {
+		return false
+	}
+	typ := w.info.TypeOf(expr)
+	if typ == nil {
+		return false
+	}
+	ptr, ok := types.Unalias(typ).(*types.Pointer)
+	if !ok {
+		return false
+	}
+	named, ok := types.Unalias(ptr.Elem()).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Name() == "T" &&
+		obj.Pkg() != nil && obj.Pkg().Path() == gotestPkgPath
+}
+
+func (w *behaviorWalker) isGotestFunc(sel *ast.SelectorExpr, name string) bool {
+	if sel.Sel.Name != name || w.info == nil {
+		return false
+	}
+	obj, ok := w.info.Uses[sel.Sel].(*types.Func)
+	if !ok || obj.Pkg() == nil {
+		return false
+	}
+	return obj.Pkg().Path() == gotestPkgPath
+}
+
+func (w *behaviorWalker) line(pos token.Pos) int {
+	if w.fset == nil || !pos.IsValid() {
+		return 0
+	}
+	return w.fset.Position(pos).Line
+}
+
+func stringLiteral(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+// SubtestName applies the same rewriting the testing package uses for subtest
+// names. A statically derived name that does not match the runtime one byte
+// for byte would produce two tree entries for one behavior, so this is the
+// contract between the two.
+func SubtestName(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case isSubtestSpace(r):
+			b.WriteByte('_')
+		case !strconv.IsPrint(r):
+			quoted := strconv.QuoteRune(r)
+			b.WriteString(quoted[1 : len(quoted)-1])
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func isSubtestSpace(r rune) bool {
+	if r < utf8RuneSelf {
+		return r == ' ' || r == '\t' || r == '\n' || r == '\v' || r == '\f' || r == '\r'
+	}
+	return unicode.IsSpace(r)
+}
+
+const utf8RuneSelf = 0x80

--- a/internal/gotestast/behaviors_suite_test.go
+++ b/internal/gotestast/behaviors_suite_test.go
@@ -1,0 +1,31 @@
+package gotestast_test
+
+import (
+	"github.com/mvrahden/go-test/internal/gotestast"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// SubtestNameTestSuite pins the one thing that must match byte for byte: the
+// name go test gives a subtest. A statically derived name that differs from
+// the observed one would put the same behavior in the tree twice.
+type SubtestNameTestSuite struct{}
+
+func (s *SubtestNameTestSuite) TestRewriting(t *gotest.T) {
+	t.When("a description is turned into a subtest name", func(w *gotest.T) {
+		for sub, tc := range gotest.Each(w, []struct {
+			Desc string
+			in   string
+			want string
+		}{
+			{Desc: "spaces become underscores", in: "summing a basket", want: "summing_a_basket"},
+			{Desc: "tabs and newlines are spaces too", in: "a\tb\nc", want: "a_b_c"},
+			{Desc: "runs of spaces each map to one underscore", in: "a  b", want: "a__b"},
+			{Desc: "slashes survive, since go test keeps them", in: "https:// URI", want: "https://_URI"},
+			{Desc: "non-ASCII printable text is preserved", in: "café 日本語 🧪", want: "café_日本語_🧪"},
+			{Desc: "leading and trailing spaces still map", in: " x ", want: "_x_"},
+			{Desc: "an empty description stays empty", in: "", want: ""},
+		}) {
+			gotest.Equal(sub, tc.want, gotestast.SubtestName(tc.in))
+		}
+	})
+}

--- a/internal/gotestast/behaviors_walker_suite_test.go
+++ b/internal/gotestast/behaviors_walker_suite_test.go
@@ -1,0 +1,263 @@
+package gotestast_test
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/mvrahden/go-test/internal/gotestast"
+	"github.com/mvrahden/go-test/internal/gotestgen"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// BehaviorWalkerTestSuite reads testdata/behaviors and pins what the walker
+// says about it. The names asserted here are the names go test produces for
+// that same source — the walker exists to predict them, so anything it gets
+// wrong shows up as a behavior that can never be addressed by the name it was
+// given.
+type BehaviorWalkerTestSuite struct {
+	specs map[string]gotestast.MethodSpec
+}
+
+func (s *BehaviorWalkerTestSuite) BeforeAll(t *gotest.T) {
+	dir, err := filepath.Abs(filepath.Join("testdata", "behaviors"))
+	gotest.NoError(t, err)
+
+	loaded, broken, err := gotestgen.LoadPackagesForDiscovery([]string{dir}, nil)
+	gotest.NoError(t, err)
+	gotest.Empty(t, broken, "the walker's own source must compile")
+	gotest.NotEmpty(t, loaded)
+
+	s.specs = map[string]gotestast.MethodSpec{}
+	collector := gotestgen.NewCollector()
+	for _, lr := range loaded {
+		if lr.Ptest == nil {
+			continue
+		}
+		result := collector.CollectSuiteSpecs(lr.Ptest)
+		gotest.Empty(t, result.Errs)
+		for _, suite := range result.Suites {
+			for _, method := range suite.TestCases() {
+				s.specs[method.Identifier()] = suite.BehaviorsOf(method)
+			}
+		}
+	}
+	gotest.NotEmpty(t, s.specs, "no suites were collected from testdata")
+}
+
+func (s *BehaviorWalkerTestSuite) AfterAll(t *gotest.T) {
+	s.specs = nil
+}
+
+// paths renders a method's tree as one line per node, so an assertion states
+// the whole shape rather than probing it field by field.
+func paths(spec gotestast.MethodSpec) []string {
+	var out []string
+	var walk func(prefix string, behaviors []*gotestast.Behavior)
+	walk = func(prefix string, behaviors []*gotestast.Behavior) {
+		for _, b := range behaviors {
+			path := prefix + b.Name
+			out = append(out, path)
+			walk(path+"/", b.Children)
+		}
+	}
+	walk("", spec.Behaviors)
+	return out
+}
+
+func (s *BehaviorWalkerTestSuite) TestTreeShape(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []struct {
+		Desc   string
+		method string
+		want   []string
+	}{
+		{
+			Desc:   "nesting is as deep as it is written",
+			method: "TestNesting",
+			want: []string{
+				"a_group",
+				"a_group/has_a_leaf",
+				"a_group/a_deeper_group",
+				"a_group/a_deeper_group/has_its_own_leaf",
+			},
+		},
+		{
+			// go test appends #01 to the second sibling of a name, #02 to the
+			// third. Without it two behaviors collapse onto one name.
+			Desc:   "repeated siblings are numbered the way go test numbers them",
+			method: "TestDuplicateSiblings",
+			want: []string{
+				"same_name",
+				"same_name/first",
+				"same_name#01",
+				"same_name#01/second",
+				"same_name#02",
+				"same_name#02/third",
+			},
+		},
+		{
+			// A single slash is a level separator, so "a/b" and "a/c" share one
+			// parent; a run of slashes is not, so "https://" stays one level.
+			Desc:   "a slash in a description is a level, a run of them is not",
+			method: "TestSlashes",
+			want: []string{
+				"a",
+				"a/b_grouping",
+				"a/b_grouping/works",
+				"a/c_grouping",
+				"a/c_grouping/also_works",
+				"https://_URI",
+				"https://_URI/stays_one_level",
+			},
+		},
+		{
+			Desc:   "a keyed table names its rows from Desc",
+			method: "TestKeyedTable",
+			want: []string{
+				"negative", "negative/classifies",
+				"zero", "zero/classifies",
+			},
+		},
+		{
+			Desc:   "a positional table names its rows from the same field",
+			method: "TestPositionalTable",
+			want: []string{
+				"too_short", "too_short/checks_the_length",
+				"long_enough", "long_enough/checks_the_length",
+			},
+		},
+		{
+			Desc:   "a table with nothing to name its rows falls back to the index",
+			method: "TestUnnamedTable",
+			want: []string{
+				"#0", "#0/still_runs",
+				"#1", "#1/still_runs",
+			},
+		},
+		{
+			Desc:   "only the unconditional behavior is declared",
+			method: "TestConditional",
+			want:   []string{"is_always_declared"},
+		},
+		{
+			Desc:   "a description that is not a literal declares nothing",
+			method: "TestComputedDescription",
+			want:   nil,
+		},
+		{
+			Desc:   "a table that is not a literal declares no rows",
+			method: "TestNonLiteralTable",
+			want:   nil,
+		},
+		{
+			Desc:   "a method with no behaviors has an empty tree",
+			method: "TestNoBehaviorsAtAll",
+			want:   nil,
+		},
+	}) {
+		spec, ok := s.specs[tc.method]
+		gotest.True(sub, ok, "method %s was not collected", tc.method)
+		gotest.Equal(sub, tc.want, paths(spec))
+	}
+}
+
+func (s *BehaviorWalkerTestSuite) TestCompleteness(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []struct {
+		Desc     string
+		method   string
+		complete bool
+		note     string
+	}{
+		{Desc: "a tree of literals is exhaustive", method: "TestNesting", complete: true},
+		{Desc: "a literal table is exhaustive", method: "TestKeyedTable", complete: true},
+		{Desc: "a method with no behaviors is exhaustive", method: "TestNoBehaviorsAtAll", complete: true},
+		{
+			Desc: "a behavior behind a condition is not", method: "TestConditional",
+			complete: false, note: "depend on runtime values",
+		},
+		{
+			Desc: "a computed description is not", method: "TestComputedDescription",
+			complete: false, note: "not a string literal",
+		},
+		{
+			Desc: "a table that is not a literal is not", method: "TestNonLiteralTable",
+			complete: false, note: "not a literal table",
+		},
+	}) {
+		spec, ok := s.specs[tc.method]
+		gotest.True(sub, ok, "method %s was not collected", tc.method)
+		gotest.Equal(sub, tc.complete, spec.Complete)
+		if tc.complete {
+			gotest.Empty(sub, spec.Notes)
+			continue
+		}
+		// The note has to name the construct that defeated the walker, or the
+		// developer has no way to act on it.
+		gotest.NotEmpty(sub, spec.Notes)
+		gotest.True(sub, containsNote(spec.Notes, tc.note),
+			"no note mentioning %q in %v", tc.note, spec.Notes)
+	}
+}
+
+func containsNote(notes []string, want string) bool {
+	for _, n := range notes {
+		if strings.Contains(n, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// Every row of a table gets its own copy of the behaviors written in the loop
+// body. Sharing the nodes would make one row's subtree the other's.
+func (s *BehaviorWalkerTestSuite) TestTableRowsDoNotShareNodes(t *gotest.T) {
+	t.When("a table declares behaviors in its loop body", func(w *gotest.T) {
+		spec := s.specs["TestKeyedTable"]
+		gotest.Len(w, spec.Behaviors, 2)
+
+		w.It("gives each row its own subtree", func(it *gotest.T) {
+			first := spec.Behaviors[0].Children[0]
+			second := spec.Behaviors[1].Children[0]
+			gotest.Equal(it, first.Name, second.Name)
+			// Same name, and it has to be a different node: the rows are
+			// separate subtests, and one aliasing the other would give a
+			// verdict on one row to both.
+			gotest.NotEqual(it,
+				reflect.ValueOf(first).Pointer(),
+				reflect.ValueOf(second).Pointer(),
+				"the two rows point at one node")
+		})
+
+		w.It("records where each row was written", func(it *gotest.T) {
+			lines := []int{spec.Behaviors[0].Line, spec.Behaviors[1].Line}
+			sort.Ints(lines)
+			gotest.Less(it, lines[0], lines[1], "rows must point at their own source line")
+		})
+	})
+}
+
+// Display is what the developer wrote; Name is what go test will report. The
+// two differ, and the tree needs both — one to read, one to address.
+func (s *BehaviorWalkerTestSuite) TestDisplayKeepsTheProse(t *gotest.T) {
+	t.When("a description contains spaces", func(w *gotest.T) {
+		spec := s.specs["TestNesting"]
+
+		w.It("keeps the prose in Display", func(it *gotest.T) {
+			gotest.Equal(it, "a group", spec.Behaviors[0].Display)
+		})
+
+		w.It("rewrites only the Name", func(it *gotest.T) {
+			gotest.Equal(it, "a_group", spec.Behaviors[0].Name)
+		})
+	})
+
+	t.When("a description is split across levels by a slash", func(w *gotest.T) {
+		spec := s.specs["TestSlashes"]
+
+		w.It("gives each level the piece of prose it came from", func(it *gotest.T) {
+			gotest.Equal(it, "a", spec.Behaviors[0].Display)
+			gotest.Equal(it, "b grouping", spec.Behaviors[0].Children[0].Display)
+		})
+	})
+}

--- a/internal/gotestast/testdata/behaviors/suite_test.go
+++ b/internal/gotestast/testdata/behaviors/suite_test.go
@@ -1,0 +1,105 @@
+// Source the behavior walker is read against. It lives under testdata so the
+// go tool never builds it as part of the repository, and it is written to be
+// adverse: every construct here is one the walker either has to model exactly
+// or has to admit it cannot see.
+package behaviors
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type WalkerTestSuite struct{}
+
+func (s *WalkerTestSuite) TestNesting(t *gotest.T) {
+	t.When("a group", func(t *gotest.T) {
+		t.It("has a leaf", func(t *gotest.T) { gotest.True(t, true) })
+		t.When("a deeper group", func(t *gotest.T) {
+			t.It("has its own leaf", func(t *gotest.T) { gotest.True(t, true) })
+		})
+	})
+}
+
+// Two siblings sharing a description: go test names the second one "#01".
+func (s *WalkerTestSuite) TestDuplicateSiblings(t *gotest.T) {
+	t.When("same name", func(t *gotest.T) {
+		t.It("first", func(t *gotest.T) { gotest.True(t, true) })
+	})
+	t.When("same name", func(t *gotest.T) {
+		t.It("second", func(t *gotest.T) { gotest.True(t, true) })
+	})
+	t.When("same name", func(t *gotest.T) {
+		t.It("third", func(t *gotest.T) { gotest.True(t, true) })
+	})
+}
+
+// A single slash is a level separator; a run of them is not.
+func (s *WalkerTestSuite) TestSlashes(t *gotest.T) {
+	t.When("a/b grouping", func(t *gotest.T) {
+		t.It("works", func(t *gotest.T) { gotest.True(t, true) })
+	})
+	t.When("a/c grouping", func(t *gotest.T) {
+		t.It("also works", func(t *gotest.T) { gotest.True(t, true) })
+	})
+	t.When("https:// URI", func(t *gotest.T) {
+		t.It("stays one level", func(t *gotest.T) { gotest.True(t, true) })
+	})
+}
+
+type keyedRow struct {
+	Desc string
+	N    int
+}
+
+func (s *WalkerTestSuite) TestKeyedTable(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []keyedRow{
+		{Desc: "negative", N: -1},
+		{Desc: "zero", N: 0},
+	}) {
+		sub.It("classifies", func(it *gotest.T) { gotest.NotZero(it, tc.Desc) })
+	}
+}
+
+type positionalRow struct {
+	Name string
+	N    int
+}
+
+func (s *WalkerTestSuite) TestPositionalTable(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []positionalRow{
+		{"too short", 1},
+		{"long enough", 2},
+	}) {
+		sub.It("checks the length", func(it *gotest.T) { gotest.NotZero(it, tc.N) })
+	}
+}
+
+type namelessRow struct{ N int }
+
+// Nothing names these rows, so go test falls back to the index.
+func (s *WalkerTestSuite) TestUnnamedTable(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, []namelessRow{{1}, {2}}) {
+		sub.It("still runs", func(it *gotest.T) { gotest.NotZero(it, tc.N) })
+	}
+}
+
+var rowsFromAVariable = []keyedRow{{Desc: "invisible", N: 1}}
+
+func (s *WalkerTestSuite) TestNonLiteralTable(t *gotest.T) {
+	for sub, tc := range gotest.Each(t, rowsFromAVariable) {
+		sub.It("cannot be enumerated", func(it *gotest.T) { gotest.NotZero(it, tc.N) })
+	}
+}
+
+func (s *WalkerTestSuite) TestConditional(t *gotest.T) {
+	t.It("is always declared", func(t *gotest.T) { gotest.True(t, true) })
+	if len(rowsFromAVariable) > 0 {
+		t.It("is declared only sometimes", func(t *gotest.T) { gotest.True(t, true) })
+	}
+}
+
+func (s *WalkerTestSuite) TestComputedDescription(t *gotest.T) {
+	name := "built at run time"
+	t.It(name, func(t *gotest.T) { gotest.True(t, true) })
+}
+
+func (s *WalkerTestSuite) TestNoBehaviorsAtAll(t *gotest.T) {
+	gotest.True(t, true)
+}

--- a/internal/gotestspec/json.go
+++ b/internal/gotestspec/json.go
@@ -19,17 +19,20 @@ type jsonPackage struct {
 }
 
 type jsonNode struct {
-	Name     string     `json:"name"`
-	Display  string     `json:"display"`
-	Kind     string     `json:"kind"`
-	Status   string     `json:"status"`
-	Duration float64    `json:"duration"`
-	Focused  bool       `json:"focused"`
-	Excluded bool       `json:"excluded"`
-	External bool       `json:"external"`
-	Variant  int        `json:"variant,omitempty"`
-	Output   []string   `json:"output"`
-	Children []jsonNode `json:"children"`
+	Name     string  `json:"name"`
+	Display  string  `json:"display"`
+	Kind     string  `json:"kind"`
+	Status   string  `json:"status"`
+	Duration float64 `json:"duration"`
+	Focused  bool    `json:"focused"`
+	Excluded bool    `json:"excluded"`
+	External bool    `json:"external"`
+	// Incomplete says the children are a floor, not the whole list. Only a
+	// statically read tree can set it, so it is absent from a rendered run.
+	Incomplete bool       `json:"incomplete,omitempty"`
+	Variant    int        `json:"variant,omitempty"`
+	Output     []string   `json:"output"`
+	Children   []jsonNode `json:"children"`
 }
 
 type jsonStats struct {
@@ -86,17 +89,18 @@ func convertNodes(nodes []*Node) []jsonNode {
 	result := make([]jsonNode, len(nodes))
 	for i, n := range nodes {
 		result[i] = jsonNode{
-			Name:     n.Name,
-			Display:  n.Display,
-			Kind:     kindString(n.Kind),
-			Status:   statusString(n.Status),
-			Duration: n.Duration.Seconds(),
-			Focused:  n.Focused,
-			Excluded: n.Excluded,
-			External: n.External,
-			Variant:  n.Variant,
-			Output:   n.Output,
-			Children: convertNodes(n.Children),
+			Name:       n.Name,
+			Display:    n.Display,
+			Kind:       kindString(n.Kind),
+			Status:     statusString(n.Status),
+			Duration:   n.Duration.Seconds(),
+			Focused:    n.Focused,
+			Excluded:   n.Excluded,
+			External:   n.External,
+			Incomplete: n.Incomplete,
+			Variant:    n.Variant,
+			Output:     n.Output,
+			Children:   convertNodes(n.Children),
 		}
 		if result[i].Output == nil {
 			result[i].Output = []string{}

--- a/internal/gotestspec/markdown.go
+++ b/internal/gotestspec/markdown.go
@@ -6,7 +6,11 @@ import (
 	"strings"
 )
 
-func RenderMarkdown(w io.Writer, packages []*Package) {
+func RenderMarkdown(w io.Writer, packages []*Package, opts ...RenderOption) {
+	cfg := renderConfig{color: true}
+	for _, o := range opts {
+		o(&cfg)
+	}
 	stats := CollectStats(packages)
 
 	fmt.Fprintln(w, "# Behavior Specification")
@@ -21,22 +25,65 @@ func RenderMarkdown(w io.Writer, packages []*Package) {
 	if stats.Tests > 0 {
 		counts = append(counts, fmt.Sprintf("%d stdlib tests", stats.Tests))
 	}
-	fmt.Fprintf(w, "%s: %d passed, %d failed, %d skipped.\n",
-		strings.Join(counts, ", "), stats.Passed, stats.Failed, stats.Skipped)
+	if cfg.withoutVerdicts {
+		// "0 passed, 0 failed, 0 skipped" beside a document nothing ran reads
+		// as a run that lost its results, rather than as a specification.
+		fmt.Fprintf(w, "%s. Read from source; nothing was executed.\n", strings.Join(counts, ", "))
+	} else {
+		fmt.Fprintf(w, "%s: %d passed, %d failed, %d skipped.\n",
+			strings.Join(counts, ", "), stats.Passed, stats.Failed, stats.Skipped)
+	}
 	fmt.Fprintln(w)
 
 	for _, pkg := range packages {
 		for _, node := range pkg.Nodes {
-			renderMarkdownNode(w, node, 2)
+			renderMarkdownNode(w, node, 2, cfg.withoutVerdicts)
 		}
 	}
 }
 
-func renderMarkdownNode(w io.Writer, n *Node, headingLevel int) {
+const incompleteNote = "this method declares further behaviors whose names or existence depend on runtime values"
+
+// markdownRow renders one behavior row. A specification carries no Status or
+// Duration column, because a document that prints "<1ms" beside a behavior
+// nothing ran is stating a measurement that was never taken.
+func markdownRow(w io.Writer, indent, display string, n *Node, bare bool) {
+	if n.Incomplete {
+		// A method with no behaviors to tabulate is rendered as a row of its
+		// suite's table. Without the marker it reads as a behavior that simply
+		// has nothing beneath it.
+		display += " — _incomplete: behaviors known only at run time_"
+	}
+	if bare {
+		fmt.Fprintf(w, "| %s%s |\n", indent, display)
+		return
+	}
+	fmt.Fprintf(w, "| %s%s | %s | %s |\n", indent, display, statusText(n.Status), formatDuration(n.Duration))
+}
+
+func markdownHeader(w io.Writer, bare bool) {
+	if bare {
+		fmt.Fprintln(w, "| Behavior |")
+		fmt.Fprintln(w, "|----------|")
+		return
+	}
+	fmt.Fprintln(w, "| Behavior | Status | Duration |")
+	fmt.Fprintln(w, "|----------|--------|----------|")
+}
+
+// markdownNote states what a heading cannot: that the behaviors listed under it
+// are a floor rather than the whole list.
+func markdownNote(w io.Writer, n *Node) {
+	if n.Incomplete {
+		fmt.Fprintf(w, "_Incomplete: %s._\n\n", incompleteNote)
+	}
+}
+
+func renderMarkdownNode(w io.Writer, n *Node, headingLevel int, bare bool) {
 	switch n.Kind {
 	case KindFixture:
 		for _, child := range n.Children {
-			renderMarkdownNode(w, child, headingLevel)
+			renderMarkdownNode(w, child, headingLevel, bare)
 		}
 
 	case KindSuite:
@@ -64,46 +111,58 @@ func renderMarkdownNode(w io.Writer, n *Node, headingLevel int) {
 		}
 
 		if len(leafChildren) > 0 {
-			fmt.Fprintln(w, "| Behavior | Status | Duration |")
-			fmt.Fprintln(w, "|----------|--------|----------|")
+			markdownHeader(w, bare)
 			for _, c := range leafChildren {
-				fmt.Fprintf(w, "| %s | %s | %s |\n",
-					c.Display, statusText(c.Status), formatDuration(c.Duration))
+				markdownRow(w, "", c.Display, c, bare)
 			}
 			fmt.Fprintln(w)
 		}
 
 		for _, c := range nestedChildren {
-			renderMarkdownNode(w, c, headingLevel+1)
+			renderMarkdownNode(w, c, headingLevel+1, bare)
 		}
 
 	case KindMethod, KindTest:
+		heading := strings.Repeat("#", headingLevel)
 		if len(n.Children) == 0 {
+			// A method whose every behavior is runtime-dependent has nothing to
+			// tabulate, but dropping it would delete a declared method from the
+			// specification without saying so.
+			if n.Incomplete {
+				fmt.Fprintf(w, "%s %s\n\n", heading, n.Display)
+				markdownNote(w, n)
+			}
 			return
 		}
-		heading := strings.Repeat("#", headingLevel)
 		fmt.Fprintf(w, "%s %s\n\n", heading, n.Display)
-		fmt.Fprintln(w, "| Behavior | Status | Duration |")
-		fmt.Fprintln(w, "|----------|--------|----------|")
-		renderMarkdownTable(w, n.Children, 0)
+		markdownNote(w, n)
+		markdownHeader(w, bare)
+		renderMarkdownTable(w, n.Children, 0, bare)
 		fmt.Fprintln(w)
 
 	default:
 		if len(n.Children) == 0 {
+			if bare {
+				fmt.Fprintf(w, "- %s\n", n.Display)
+				return
+			}
 			fmt.Fprintf(w, "- %s %s (%s)\n", statusText(n.Status), n.Display, formatDuration(n.Duration))
 		}
 	}
 }
 
-func renderMarkdownTable(w io.Writer, nodes []*Node, depth int) {
+func renderMarkdownTable(w io.Writer, nodes []*Node, depth int, bare bool) {
 	indent := strings.Repeat("&nbsp;&nbsp;", depth)
 	for _, n := range nodes {
 		if len(n.Children) > 0 {
-			fmt.Fprintf(w, "| %s**%s** | | |\n", indent, n.Display)
-			renderMarkdownTable(w, n.Children, depth+1)
+			if bare {
+				fmt.Fprintf(w, "| %s**%s** |\n", indent, n.Display)
+			} else {
+				fmt.Fprintf(w, "| %s**%s** | | |\n", indent, n.Display)
+			}
+			renderMarkdownTable(w, n.Children, depth+1, bare)
 		} else {
-			fmt.Fprintf(w, "| %s%s | %s | %s |\n",
-				indent, n.Display, statusText(n.Status), formatDuration(n.Duration))
+			markdownRow(w, indent, n.Display, n, bare)
 		}
 	}
 }

--- a/internal/gotestspec/terminal.go
+++ b/internal/gotestspec/terminal.go
@@ -93,6 +93,22 @@ func RenderTerminal(w io.Writer, packages []*Package, opts ...RenderOption) {
 	renderSummary(w, stats, c)
 }
 
+// bareSuffix annotates a node in a tree that has not run. Exclusion is a
+// property of the declaration, so it is worth stating; "SKIPPED" is not, because
+// nothing was there to skip. Incompleteness is stated for the same reason the
+// walker records it: a partial list that presents itself as whole is worse than
+// no list at all.
+func bareSuffix(n *Node) string {
+	suffix := ""
+	if n.Excluded {
+		suffix += " — EXCLUDED"
+	}
+	if n.Incomplete {
+		suffix += " — INCOMPLETE: behaviors known only at run time"
+	}
+	return suffix
+}
+
 func renderNode(w io.Writer, n *Node, depth int, c *colors, bare bool) {
 	indent := strings.Repeat("  ", depth)
 	isLeaf := len(n.Children) == 0
@@ -107,11 +123,7 @@ func renderNode(w io.Writer, n *Node, depth int, c *colors, bare bool) {
 		}
 
 		if bare {
-			suffix = ""
-			if n.Excluded {
-				suffix = " — EXCLUDED"
-			}
-			fmt.Fprintf(w, "%s%s%s\n", indent, n.Display, suffix)
+			fmt.Fprintf(w, "%s%s%s\n", indent, n.Display, bareSuffix(n))
 			return
 		}
 
@@ -139,6 +151,16 @@ func renderNode(w io.Writer, n *Node, depth int, c *colors, bare bool) {
 		suffix = fmt.Sprintf(" %s— FOCUSED%s", c.yellow, c.reset)
 	} else if n.Excluded {
 		suffix = fmt.Sprintf(" %s— SKIPPED%s", c.yellow, c.reset)
+	}
+
+	if bare {
+		// Nothing ran, so the container says what it is rather than what
+		// happened to it, and it says when its children are not the whole list.
+		fmt.Fprintf(w, "%s%s%s\n", indent, label, bareSuffix(n))
+		for _, child := range n.Children {
+			renderNode(w, child, depth+1, c, bare)
+		}
+		return
 	}
 
 	// A node that failed on its own account must show a mark even when it left
@@ -260,5 +282,11 @@ func renderSummary(w io.Writer, stats Stats, c colors) { //nolint:gocritic // hu
 		counts = append(counts, "0 suites")
 	}
 
+	if len(parts) == 0 {
+		// A spec that has not run has counts but no verdicts. Printing the
+		// colon anyway reads as a line that lost its tail.
+		fmt.Fprintf(w, "%s\n", strings.Join(counts, ", "))
+		return
+	}
 	fmt.Fprintf(w, "%s: %s\n", strings.Join(counts, ", "), strings.Join(parts, ", "))
 }

--- a/internal/gotestspec/terminal.go
+++ b/internal/gotestspec/terminal.go
@@ -23,9 +23,10 @@ var ansiColors = colors{
 var noColors = colors{}
 
 type renderConfig struct {
-	color    bool
-	coverage *CoverageReport
-	elapsed  time.Duration
+	color           bool
+	coverage        *CoverageReport
+	elapsed         time.Duration
+	withoutVerdicts bool
 }
 
 type RenderOption func(*renderConfig)
@@ -40,6 +41,14 @@ func WithCoverage(report *CoverageReport) RenderOption {
 
 func WithElapsed(d time.Duration) RenderOption {
 	return func(c *renderConfig) { c.elapsed = d }
+}
+
+// WithoutVerdicts renders the tree as a specification rather than as a result:
+// no status glyph and no duration. A statically derived spec has executed
+// nothing, so showing "?" beside every behavior would invite the reader to
+// think a verdict was expected and missing.
+func WithoutVerdicts() RenderOption {
+	return func(c *renderConfig) { c.withoutVerdicts = true }
 }
 
 func RenderTerminal(w io.Writer, packages []*Package, opts ...RenderOption) {
@@ -63,7 +72,7 @@ func RenderTerminal(w io.Writer, packages []*Package, opts ...RenderOption) {
 			fmt.Fprintln(w)
 		}
 		for _, node := range pkg.Nodes {
-			renderNode(w, node, 0, &c)
+			renderNode(w, node, 0, &c, cfg.withoutVerdicts)
 		}
 		// A verdict that sits on the package itself — a build failure, a death
 		// outside any test — has no node to render it; it must still show
@@ -84,7 +93,7 @@ func RenderTerminal(w io.Writer, packages []*Package, opts ...RenderOption) {
 	renderSummary(w, stats, c)
 }
 
-func renderNode(w io.Writer, n *Node, depth int, c *colors) {
+func renderNode(w io.Writer, n *Node, depth int, c *colors, bare bool) {
 	indent := strings.Repeat("  ", depth)
 	isLeaf := len(n.Children) == 0
 
@@ -95,6 +104,15 @@ func renderNode(w io.Writer, n *Node, depth int, c *colors) {
 		suffix := ""
 		if n.Excluded || n.Status == StatusSkip {
 			suffix = " — SKIPPED"
+		}
+
+		if bare {
+			suffix = ""
+			if n.Excluded {
+				suffix = " — EXCLUDED"
+			}
+			fmt.Fprintf(w, "%s%s%s\n", indent, n.Display, suffix)
+			return
 		}
 
 		fmt.Fprintf(w, "%s%s%s%s %s%s %s(%s)%s\n",
@@ -143,7 +161,7 @@ func renderNode(w io.Writer, n *Node, depth int, c *colors) {
 	}
 
 	for _, child := range n.Children {
-		renderNode(w, child, depth+1, c)
+		renderNode(w, child, depth+1, c, bare)
 	}
 }
 

--- a/internal/gotestspec/tree.go
+++ b/internal/gotestspec/tree.go
@@ -460,3 +460,14 @@ func statusFrom(a Action) Status {
 func elapsed(s float64) time.Duration {
 	return time.Duration(s * float64(time.Second))
 }
+
+// ClassifyRoots applies the tree's naming rules — kind, display text, focus and
+// exclusion prefixes — to nodes assembled from a source other than a test
+// stream. A statically derived tree must classify identically to an observed
+// one, so both go through this single implementation rather than duplicating
+// the rules.
+func ClassifyRoots(nodes []*Node) {
+	for _, n := range nodes {
+		classify(n, true)
+	}
+}

--- a/internal/gotestspec/tree.go
+++ b/internal/gotestspec/tree.go
@@ -29,18 +29,23 @@ const (
 )
 
 type Node struct {
-	Name      string
-	Display   string
-	Kind      NodeKind
-	Status    Status
-	Duration  time.Duration
-	Output    []string
-	Children  []*Node
-	Focused   bool
-	Excluded  bool
-	External  bool
-	Variant   int
-	duplicate bool
+	Name     string
+	Display  string
+	Kind     NodeKind
+	Status   Status
+	Duration time.Duration
+	Output   []string
+	Children []*Node
+	Focused  bool
+	Excluded bool
+	External bool
+	// Incomplete marks a node whose children are known not to be the whole
+	// list — a statically read method that declares behaviors whose names or
+	// existence depend on runtime values. A tree stream never sets it, because
+	// what ran is by definition all there was.
+	Incomplete bool
+	Variant    int
+	duplicate  bool
 }
 
 type Package struct {
@@ -225,6 +230,12 @@ func hasDuplicateSuffix(s string) bool {
 	return true
 }
 
+// StripDuplicateSuffix removes the "#01" the testing package appends to a
+// subtest whose name repeats among its siblings. The tree shows both under the
+// name the developer wrote, so a tree assembled from a source other than a test
+// stream has to drop the suffix the same way rather than inventing its own rule.
+func StripDuplicateSuffix(s string) string { return stripDuplicateSuffix(s) }
+
 func stripDuplicateSuffix(s string) string {
 	idx := strings.LastIndex(s, "#")
 	if idx <= 0 {
@@ -367,23 +378,7 @@ func classify(n *Node, topLevel bool) {
 // Go uses "/" as the subtest separator, but description strings may contain
 // "/" too (e.g. "https:// URI"). We treat consecutive slashes as literal
 // characters within a segment rather than multiple separators.
-func splitTestPath(path string) []string {
-	var segments []string
-	var cur strings.Builder
-	for i := 0; i < len(path); i++ {
-		if path[i] == '/' && (i+1 >= len(path) || path[i+1] != '/') &&
-			(i == 0 || path[i-1] != '/') {
-			segments = append(segments, cur.String())
-			cur.Reset()
-		} else {
-			cur.WriteByte(path[i])
-		}
-	}
-	if cur.Len() > 0 {
-		segments = append(segments, cur.String())
-	}
-	return segments
-}
+func splitTestPath(path string) []string { return protocol.SplitTestPath(path) }
 
 // failedOnItsOwn reports whether an interior node carries a verdict of its own:
 // a suite whose AfterAll failed, a test method that blew its configured

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -24,6 +24,29 @@ func BudgetFilePath(binaryPath string) string {
 	return binaryPath + ".budget"
 }
 
+// SplitTestPath cuts a go test name into its subtest levels. The separator is a
+// single slash: a run of them is left alone, so a description like
+// "https:// URI" stays one level instead of becoming three. Both readers of a
+// test path need this rule — the one parsing a run and the one predicting it
+// from source — and they have to agree, so it lives in one place.
+func SplitTestPath(path string) []string {
+	var segments []string
+	var cur strings.Builder
+	for i := 0; i < len(path); i++ {
+		if path[i] == '/' && (i+1 >= len(path) || path[i+1] != '/') &&
+			(i == 0 || path[i-1] != '/') {
+			segments = append(segments, cur.String())
+			cur.Reset()
+		} else {
+			cur.WriteByte(path[i])
+		}
+	}
+	if cur.Len() > 0 {
+		segments = append(segments, cur.String())
+	}
+	return segments
+}
+
 // IsPackageSummaryLine reports whether s is a go test package-level summary
 // line (e.g. "PASS", "FAIL", "ok  \tpkg\t0.01s") rather than diagnostic
 // output that should be surfaced to the user.

--- a/skills/writing-gotest-tests/SKILL.md
+++ b/skills/writing-gotest-tests/SKILL.md
@@ -40,6 +40,16 @@ does not exist (its findings are simply never reported — do not rely on
 the linter for fixture-window mistakes on v1.26.x). Skip those sections
 on v1.26.x and earlier.
 
+Also v1.27+: `gotest spec --static` renders the specification from source
+without running anything, so you can read what a package promises before
+(or instead of) executing it. It reports on stderr any method whose
+behaviors it could not enumerate — a `When`/`It` inside a condition or a
+loop, a non-literal description, an `Each` over a non-literal table — so
+treat "incomplete:" lines as a prompt to write the behavior literally if
+you want it visible in tooling. `spec --input --render-only` exits 0 on a
+failing stream, for callers that render results rather than gate on them;
+without it `--input` exits 1 whenever the stream carries a failure.
+
 Exit codes on v1.25.x are weaker than they look — never treat a green
 gotest exit alone as proof there: a package failing to compile mid-run, a
 suite binary killed by a signal, and `spec --input` on a failing stream

--- a/vscode-gotest/.vscodeignore
+++ b/vscode-gotest/.vscodeignore
@@ -5,6 +5,7 @@ scripts/**
 node_modules/**
 docs/**
 tsconfig.json
+tsconfig.test.json
 esbuild.config.mjs
 vitest.config.ts
 vitest.integration.config.ts

--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -144,6 +144,7 @@ Projects using `go.work` are also supported.
 | Go Test: Scaffold Target | Generate a test suite for a specific target |
 | Go Test: Copy Coverage Summary | Copy coverage table to clipboard |
 | Go Test: Copy Test Results | Copy test results to clipboard (also available as context menu on test items) |
+| Go Test: Clear Results | Forget stored results, coverage and spec output, so a window reload does not restore them. The Test Explorer's own "Clear all results" only empties VS Code's in-memory view; clearing the icons in the tree is still its job, because no stable API lets an extension retract them. |
 
 ## Settings
 

--- a/vscode-gotest/package.json
+++ b/vscode-gotest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gotest",
   "displayName": "Go - Test Suites",
-  "description": "Specification-driven test suites for Go — Spec View, Test Explorer, coverage, and debug integration",
+  "description": "Specification-driven test suites for Go \u2014 Spec View, Test Explorer, coverage, and debug integration",
   "version": "0.1.0",
   "publisher": "mvrahden",
   "license": "MIT",
@@ -94,6 +94,11 @@
         "command": "gotest.copyTestResults",
         "title": "Go Test: Copy Test Results",
         "icon": "$(copy)"
+      },
+      {
+        "command": "gotest.clearResults",
+        "title": "Go Test: Clear Results",
+        "icon": "$(clear-all)"
       }
     ],
     "menus": {
@@ -108,6 +113,11 @@
         {
           "command": "gotest.copyCoverage",
           "when": "view == workbench.view.testCoverage",
+          "group": "navigation"
+        },
+        {
+          "command": "gotest.clearResults",
+          "when": "view == workbench.view.testing",
           "group": "navigation"
         }
       ],

--- a/vscode-gotest/package.json
+++ b/vscode-gotest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gotest",
   "displayName": "Go - Test Suites",
-  "description": "Specification-driven test suites for Go \u2014 Spec View, Test Explorer, coverage, and debug integration",
+  "description": "Specification-driven test suites for Go — Spec View, Test Explorer, coverage, and debug integration",
   "version": "0.1.0",
   "publisher": "mvrahden",
   "license": "MIT",

--- a/vscode-gotest/src/buildCliCommand.test.ts
+++ b/vscode-gotest/src/buildCliCommand.test.ts
@@ -225,6 +225,45 @@ describe("buildCliCommand", () => {
       });
     });
 
+    // A replace directive points at local source, and the require version
+    // beside it is conventionally a placeholder. Gating the replace path on
+    // that version silently downloaded a release instead of building the
+    // developer's own working tree.
+    it("honours replace even when the require version is a placeholder", async () => {
+      setGoMod(
+        "/workspace",
+        [
+          "module gotest.fixtures",
+          "go 1.24.0",
+          "require github.com/mvrahden/go-test v0.0.0-00010101000000-000000000000",
+          `replace github.com/mvrahden/go-test => ../../..`,
+        ].join("\n"),
+      );
+
+      const cmd = await buildCliCommand(["discover", "./..."], "/workspace");
+
+      expect(cmd).toEqual({
+        bin: "/usr/local/go/bin/go",
+        args: ["run", GOTEST_MODULE, "discover", "./..."],
+      });
+    });
+
+    it("honours replace even when the require version is below the minimum", async () => {
+      setGoMod(
+        "/workspace",
+        [
+          "module github.com/myapp",
+          "go 1.24.0",
+          "require github.com/mvrahden/go-test v1.0.0",
+          `replace github.com/mvrahden/go-test => ../go-test`,
+        ].join("\n"),
+      );
+
+      const cmd = await buildCliCommand(["spec"], "/workspace");
+
+      expect(cmd.args).toEqual(["run", GOTEST_MODULE, "spec"]);
+    });
+
     it("detects replace for parent module path", async () => {
       setGoMod(
         "/workspace",

--- a/vscode-gotest/src/cli.ts
+++ b/vscode-gotest/src/cli.ts
@@ -100,25 +100,32 @@ export async function buildCliCommand(
     }
   }
 
-  // 3–4. Project-pinned version from go.mod
+  // 3. Replace directive → go run without version (respects go.mod resolution)
+  //
+  // Checked before the version gate on purpose. A replace directive redirects
+  // the module to local source, and the require version beside it is
+  // conventionally a placeholder (v0.0.0-00010101000000-000000000000) that says
+  // nothing about the code that will actually run. Gating on it rejects the
+  // developer's own working tree and silently downloads a release instead.
+  if (effectiveDir && !modulePath.includes("@")) {
+    if (await hasReplaceDirective(effectiveDir, modulePath)) {
+      const goBin = await resolveGoBinary(log, workspaceDir);
+      log?.debug(
+        `[cli] go.mod has replace directive: ${goBin} run ${modulePath}`,
+      );
+      return {
+        bin: goBin,
+        args: ["run", modulePath, ...subcommandArgs],
+      };
+    }
+  }
+
+  // 4. Project-pinned version from go.mod
   if (effectiveDir && !modulePath.includes("@")) {
     const version = await extractVersionFromGoMod(effectiveDir, modulePath);
     if (version !== "latest") {
       if (compareVersions(version, MIN_CLI_VERSION) >= 0) {
         const goBin = await resolveGoBinary(log, workspaceDir);
-
-        // 3. Replace directive → go run without version (respects go.mod resolution)
-        if (await hasReplaceDirective(effectiveDir, modulePath)) {
-          log?.debug(
-            `[cli] go.mod has replace directive: ${goBin} run ${modulePath}`,
-          );
-          return {
-            bin: goBin,
-            args: ["run", modulePath, ...subcommandArgs],
-          };
-        }
-
-        // 4. Pinned version → go run module@version
         const qualified = `${modulePath}@${version}`;
         log?.debug(`[cli] using go.mod: ${goBin} run ${qualified}`);
         return {

--- a/vscode-gotest/src/coverage.test.ts
+++ b/vscode-gotest/src/coverage.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeAll } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
 
 vi.mock("vscode", () => {
   class Position {
@@ -446,6 +449,35 @@ describe("filterSupplementaryProfiles", () => {
 
   it("returns empty when both inputs are empty", () => {
     expect(filterSupplementaryProfiles([], [])).toHaveLength(0);
+  });
+});
+
+describe("CoverageStore.clear", () => {
+  let CoverageStoreCls: typeof import("./coverageStore.js").CoverageStore;
+
+  beforeAll(async () => {
+    const mod = await import("./coverageStore.js");
+    CoverageStoreCls = mod.CoverageStore;
+  });
+
+  // Clearing memory alone would leave the stored profiles to be restored on
+  // the next window activation, which reads as the clear not having worked.
+  it("empties the store and does not restore on reload", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "gotest-cov-clear-"));
+    const store = new CoverageStoreCls({ fsPath: dir } as never);
+    store.update(
+      "example.com/pkg",
+      "mode: set\nexample.com/pkg/main.go:1.1,2.2 1 1\n",
+    );
+    await store.save();
+    expect(store.size).toBeGreaterThan(0);
+
+    await store.clear();
+    expect(store.size).toBe(0);
+
+    const reloaded = new CoverageStoreCls({ fsPath: dir } as never);
+    await reloaded.load();
+    expect(reloaded.size).toBe(0);
   });
 });
 

--- a/vscode-gotest/src/coverageStore.ts
+++ b/vscode-gotest/src/coverageStore.ts
@@ -75,13 +75,14 @@ export class CoverageStore implements vscode.Disposable {
     return deleted;
   }
 
-  clear(): void {
-    if (this.packages.size === 0) {
-      return;
-    }
+  // clear drops every profile and persists the empty state, so a window reload
+  // cannot restore coverage the developer has dismissed. Memory-only clearing
+  // would leave the stored copy to come back on the next activation.
+  clear(): Promise<void> {
     this.packages.clear();
     this.parsed.clear();
     this.cachedDetails.clear();
+    return this.save();
   }
 
   buildFileCoverages(cache: DiscoveryCache): CoverageResult {

--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -451,6 +451,27 @@ function registerCommands(deps: {
       copyCoverageSummary(coverageStore, cache),
     ),
 
+    // The Test Explorer's built-in "Clear all results" only empties VS Code's
+    // own in-memory view; it is not observable by an extension on stable API
+    // (tests.onDidChangeTestResults is still proposed). Everything this
+    // extension persists would therefore come back on the next window reload.
+    // This command clears the persisted state as well, so a clear survives a
+    // reload — results, coverage, and the spec view together.
+    vscode.commands.registerCommand("gotest.clearResults", async () => {
+      testResultStore.clear();
+      specView.clear();
+      controller.testController.items.forEach((item) =>
+        controller.clearResults(item),
+      );
+      try {
+        await coverageStore.clear();
+      } catch (err: unknown) {
+        outputChannel.error(`[coverage] clear failed: ${err}`);
+      }
+      await testResultStore.flush();
+      outputChannel.info("[results] cleared results, coverage and spec view");
+    }),
+
     vscode.commands.registerCommand(
       "gotest.copyTestResults",
       (item?: vscode.TestItem) =>
@@ -657,9 +678,15 @@ async function initializeAsync(deps: {
       resultRequest,
       "Restored Results",
     );
+    let applied = 0;
     testResultStore.forEach((result, itemId) => {
       const item = controller.findItem(itemId);
+      // A stored id with no item is a test that no longer exists, or one the
+      // tree cannot name yet. Counting only what landed keeps the log honest:
+      // reporting the store's size implies a restore that may not have
+      // happened.
       if (!item) return;
+      applied++;
       if (result.status === "pass") resultRun.passed(item, result.duration);
       else if (result.status === "fail")
         resultRun.failed(
@@ -672,7 +699,7 @@ async function initializeAsync(deps: {
     resolveAncestorItems(resultRun, controller);
     resultRun.end();
     outputChannel.info(
-      `[results] restored ${testResultStore.size} result(s) from storage`,
+      `[results] restored ${applied} of ${testResultStore.size} result(s) from storage`,
     );
   }
 }

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -96,7 +96,7 @@ function makeTree() {
     suite,
   );
   const dynamic = createItem(
-    "example.com/pkg/MySuite/TestFoo/dynamic/sub1",
+    "example.com/pkg/MySuite/TestFoo/sub1",
     "sub1",
     method,
   );
@@ -224,7 +224,7 @@ function makeTreeWithDirs() {
     suite,
   );
   const dynamic = createItem(
-    "example.com/pkg/MySuite/TestFoo/dynamic/sub1",
+    "example.com/pkg/MySuite/TestFoo/sub1",
     "sub1",
     method,
   );

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -199,13 +199,11 @@ export function resolveTestItem(
 
   let parentItem = methodItem;
   for (let i = 2; i < segments.length; i++) {
-    const subtestLabel = segments[i];
-    const subtestPath = segments.slice(2, i + 1).join("/");
-    parentItem = controller.createDynamicSubtest(
-      parentItem,
-      subtestPath,
-      subtestLabel,
-    );
+    const segment = segments[i];
+    // One segment per level: the id is the go test path, which is also what a
+    // statically declared behavior uses. createDynamicSubtest returns the
+    // declared item when there is one and only fabricates when there is not.
+    parentItem = controller.createDynamicSubtest(parentItem, segment, segment);
   }
 
   return parentItem;

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -161,12 +161,39 @@ export function expandToPackages(items: vscode.TestItem[]): vscode.TestItem[] {
   return result.length > 0 ? result : items;
 }
 
+// splitTestPath cuts a go test name into its subtest levels. A single slash
+// separates levels, but a run of them does not: `t.When("https:// URI")` is one
+// subtest whose name happens to contain slashes, and go test reports it that
+// way. Splitting on every slash invented two levels that no run ever produced,
+// so an observed result landed beside its declared behavior instead of on it.
+// The CLI applies the identical rule on both sides of the boundary.
+function splitTestPath(path: string): string[] {
+  const segments: string[] = [];
+  let cur = "";
+  for (let i = 0; i < path.length; i++) {
+    const isSeparator =
+      path[i] === "/" &&
+      (i + 1 >= path.length || path[i + 1] !== "/") &&
+      (i === 0 || path[i - 1] !== "/");
+    if (isSeparator) {
+      segments.push(cur);
+      cur = "";
+    } else {
+      cur += path[i];
+    }
+  }
+  if (cur.length > 0) {
+    segments.push(cur);
+  }
+  return segments;
+}
+
 export function resolveTestItem(
   controller: GoTestController,
   testPath: string,
   importPath: string,
 ): vscode.TestItem | undefined {
-  const segments = testPath.split("/");
+  const segments = splitTestPath(testPath);
   if (segments.length === 0) {
     return undefined;
   }

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -488,7 +488,11 @@ export function buildRunFilter(items: vscode.TestItem[]): string | undefined {
       let current = item;
       const subtestParts: string[] = [];
       while (getPackageDepth(current) > 2) {
-        subtestParts.unshift(current.label);
+        // The id segment, not the label: a behavior is labelled with the text
+        // the developer wrote ("classifying a number") while go test knows it
+        // by its rewritten name ("classifying_a_number"). Filtering on the
+        // label would never match.
+        subtestParts.unshift(subtestSegmentOf(current));
         current = current.parent!;
       }
       const methodName = current.label;
@@ -499,7 +503,9 @@ export function buildRunFilter(items: vscode.TestItem[]): string | undefined {
         suiteGroups.set(suiteName, group);
       }
       group.subtests.push(
-        `^Test${suiteName}$/^${methodName}$/^${subtestParts.join("/")}$`,
+        `^Test${suiteName}$/^${methodName}$/^${subtestParts
+          .map(escapeRunPattern)
+          .join("/")}$`,
       );
     }
   }
@@ -740,4 +746,22 @@ function resolveItemRecursive(
   }
 
   return { anyFailed, anyResolved };
+}
+
+// subtestSegmentOf returns the single go test path segment an item adds to its
+// parent. Ids are the test path, so the segment is what follows the parent's id.
+function subtestSegmentOf(item: vscode.TestItem): string {
+  const parentId = item.parent?.id;
+  if (parentId && item.id.startsWith(parentId + "/")) {
+    return item.id.slice(parentId.length + 1);
+  }
+  return item.label;
+}
+
+// escapeRunPattern quotes regex metacharacters in a subtest name. Behavior
+// descriptions are prose — "handles (nested) values" is an ordinary thing to
+// write — and go test's -run is a regular expression, so the name has to be
+// matched literally rather than interpreted.
+function escapeRunPattern(segment: string): string {
+  return segment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/vscode-gotest/src/specView.ts
+++ b/vscode-gotest/src/specView.ts
@@ -132,11 +132,7 @@ export class SpecViewPanel implements vscode.Disposable {
             vscode.env.clipboard.writeText(text);
           }
         } else if (msg.type === "clearResults") {
-          this.lastSpecData = undefined;
-          this.jsonLayers.clear();
-          if (this.panel) {
-            this.panel.webview.html = this.buildHtml({ type: "empty" });
-          }
+          this.clear();
         } else if (msg.type === "goToLocation" && msg.file && msg.line) {
           const uri = vscode.Uri.file(msg.file);
           const line = Math.max(0, msg.line - 1);
@@ -172,6 +168,17 @@ export class SpecViewPanel implements vscode.Disposable {
       null,
       this.disposables,
     );
+  }
+
+  // clear drops the accumulated run layers and empties the panel. Called both
+  // by the panel's own Clear button and when the Test Explorer's results are
+  // cleared, so the two surfaces cannot disagree about what has been run.
+  clear(): void {
+    this.lastSpecData = undefined;
+    this.jsonLayers.clear();
+    if (this.panel) {
+      this.panel.webview.html = this.buildHtml({ type: "empty" });
+    }
   }
 
   async refresh(jsonOutput: string, tag = "default"): Promise<void> {

--- a/vscode-gotest/src/testController.ts
+++ b/vscode-gotest/src/testController.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import type { DiscoverBehavior } from "./types.js";
 import * as path from "node:path";
 import type { DiscoveryCache } from "./discovery.js";
 import { TestResultStore, type TestResult } from "./testResultStore.js";
@@ -11,6 +12,10 @@ export class GoTestController implements vscode.Disposable {
   private disposables: vscode.Disposable[] = [];
   private coverageProfile: vscode.TestRunProfile | undefined;
   private dynamicOverflow = new Map<string, number>();
+  // Items created from run events rather than from source. Behavior ids no
+  // longer carry a marker segment — they are the go test path — so membership
+  // is tracked instead of inferred from the string.
+  private dynamicIds = new Set<string>();
 
   constructor(
     private readonly cache: DiscoveryCache,
@@ -403,18 +408,22 @@ export class GoTestController implements vscode.Disposable {
           method.excluded,
           method.parallel,
         );
+        // A method whose behaviors cannot all be read from source is expandable
+        // but unresolved, rather than presenting a partial list as the whole.
+        methodItem.canResolveChildren = method.behaviorsComplete === false;
+        this.addBehaviors(methodItem, method.behaviors ?? [], methodUri);
         suiteItem.children.add(methodItem);
       }
 
       suiteItem.children.forEach((child) => {
-        if (!seenMethodIds.has(child.id) && !child.id.includes("/dynamic/")) {
+        if (!seenMethodIds.has(child.id) && !this.dynamicIds.has(child.id)) {
           suiteItem.children.delete(child.id);
         }
       });
     }
 
     pkgItem.children.forEach((child) => {
-      if (!seenSuiteIds.has(child.id) && !child.id.includes("/dynamic/")) {
+      if (!seenSuiteIds.has(child.id) && !this.dynamicIds.has(child.id)) {
         pkgItem.children.delete(child.id);
       }
     });
@@ -423,12 +432,13 @@ export class GoTestController implements vscode.Disposable {
   clearDynamicChildren(item: vscode.TestItem): void {
     const toDelete: string[] = [];
     item.children.forEach((child) => {
-      if (child.id.includes("/dynamic/")) {
+      if (this.dynamicIds.has(child.id)) {
         toDelete.push(child.id);
       }
     });
     for (const id of toDelete) {
       item.children.delete(id);
+      this.dynamicIds.delete(id);
     }
     if (this.dynamicOverflow.delete(item.id)) {
       item.description = undefined;
@@ -440,7 +450,10 @@ export class GoTestController implements vscode.Disposable {
     subtestPath: string,
     label: string,
   ): vscode.TestItem {
-    const id = `${parentItem.id}/dynamic/${subtestPath}`;
+    // The id is the go test path: one segment appended to the parent. A
+    // statically discovered behavior has the identical id, so an observed
+    // result lands on the declared item instead of creating a second one.
+    const id = `${parentItem.id}/${subtestPath}`;
     const existing = parentItem.children.get(id);
     if (existing) {
       return existing;
@@ -454,8 +467,42 @@ export class GoTestController implements vscode.Disposable {
     }
 
     const item = this.controller.createTestItem(id, label, parentItem.uri);
+    this.dynamicIds.add(id);
     parentItem.children.add(item);
     return item;
+  }
+
+  // addBehaviors builds the specification a method declares, so the tree shows
+  // behaviors before anything has run and the run counter has a real total.
+  private addBehaviors(
+    parent: vscode.TestItem,
+    behaviors: DiscoverBehavior[],
+    uri: vscode.Uri,
+  ): void {
+    const seen = new Set<string>();
+    for (const behavior of behaviors) {
+      const id = `${parent.id}/${behavior.name}`;
+      seen.add(id);
+      let item = parent.children.get(id);
+      if (!item) {
+        item = this.controller.createTestItem(id, behavior.display, uri);
+      }
+      if (behavior.line > 0) {
+        item.range = new vscode.Range(
+          new vscode.Position(behavior.line - 1, 0),
+          new vscode.Position(behavior.line - 1, 0),
+        );
+      }
+      parent.children.add(item);
+      this.addBehaviors(item, behavior.children ?? [], uri);
+    }
+    // Behaviors that no longer exist in source go away; ones discovered at run
+    // time stay, because source never claimed them in the first place.
+    parent.children.forEach((child) => {
+      if (!seen.has(child.id) && !this.dynamicIds.has(child.id)) {
+        parent.children.delete(child.id);
+      }
+    });
   }
 
   setCoverageDetailProvider(

--- a/vscode-gotest/src/testController.ts
+++ b/vscode-gotest/src/testController.ts
@@ -408,9 +408,14 @@ export class GoTestController implements vscode.Disposable {
           method.excluded,
           method.parallel,
         );
-        // A method whose behaviors cannot all be read from source is expandable
-        // but unresolved, rather than presenting a partial list as the whole.
-        methodItem.canResolveChildren = method.behaviorsComplete === false;
+        // Deliberately not canResolveChildren: that tells VS Code a handler can
+        // fetch the missing children on demand, and they cannot be known
+        // without running the test. An expand arrow that resolves to nothing is
+        // a worse lie than a partial list. Say it in words instead.
+        methodItem.description =
+          method.behaviorsComplete === false
+            ? "+ behaviors known only at run time"
+            : undefined;
         this.addBehaviors(methodItem, method.behaviors ?? [], methodUri);
         suiteItem.children.add(methodItem);
       }
@@ -480,7 +485,16 @@ export class GoTestController implements vscode.Disposable {
     uri: vscode.Uri,
   ): void {
     const seen = new Set<string>();
-    for (const behavior of behaviors) {
+    // The same ceiling the runtime path uses. A table with thousands of rows
+    // would otherwise materialise thousands of tree items at discovery, before
+    // the developer has asked for anything — one policy for declared and
+    // observed behaviors rather than two.
+    const shown = behaviors.slice(0, GoTestController.MAX_DYNAMIC_SUBTESTS);
+    const hidden = behaviors.length - shown.length;
+    if (hidden > 0) {
+      parent.description = `${behaviors.length} behaviors (${shown.length} shown)`;
+    }
+    for (const behavior of shown) {
       const id = `${parent.id}/${behavior.name}`;
       seen.add(id);
       let item = parent.children.get(id);

--- a/vscode-gotest/src/testController.ts
+++ b/vscode-gotest/src/testController.ts
@@ -412,16 +412,18 @@ export class GoTestController implements vscode.Disposable {
         // fetch the missing children on demand, and they cannot be known
         // without running the test. An expand arrow that resolves to nothing is
         // a worse lie than a partial list. Say it in words instead.
-        methodItem.description =
-          method.behaviorsComplete === false
-            ? "+ behaviors known only at run time"
-            : undefined;
-        this.addBehaviors(methodItem, method.behaviors ?? [], methodUri);
+        this.addBehaviors(
+          methodItem,
+          method.behaviors ?? [],
+          methodUri,
+          method.behaviorsComplete === false,
+        );
         suiteItem.children.add(methodItem);
       }
 
       suiteItem.children.forEach((child) => {
         if (!seenMethodIds.has(child.id) && !this.dynamicIds.has(child.id)) {
+          this.forgetDynamic(child);
           suiteItem.children.delete(child.id);
         }
       });
@@ -429,21 +431,22 @@ export class GoTestController implements vscode.Disposable {
 
     pkgItem.children.forEach((child) => {
       if (!seenSuiteIds.has(child.id) && !this.dynamicIds.has(child.id)) {
+        this.forgetDynamic(child);
         pkgItem.children.delete(child.id);
       }
     });
   }
 
   clearDynamicChildren(item: vscode.TestItem): void {
-    const toDelete: string[] = [];
+    const toDelete: vscode.TestItem[] = [];
     item.children.forEach((child) => {
       if (this.dynamicIds.has(child.id)) {
-        toDelete.push(child.id);
+        toDelete.push(child);
       }
     });
-    for (const id of toDelete) {
-      item.children.delete(id);
-      this.dynamicIds.delete(id);
+    for (const child of toDelete) {
+      this.forgetDynamic(child);
+      item.children.delete(child.id);
     }
     if (this.dynamicOverflow.delete(item.id)) {
       item.description = undefined;
@@ -483,6 +486,7 @@ export class GoTestController implements vscode.Disposable {
     parent: vscode.TestItem,
     behaviors: DiscoverBehavior[],
     uri: vscode.Uri,
+    incomplete = false,
   ): void {
     const seen = new Set<string>();
     // The same ceiling the runtime path uses. A table with thousands of rows
@@ -491,9 +495,17 @@ export class GoTestController implements vscode.Disposable {
     // observed behaviors rather than two.
     const shown = behaviors.slice(0, GoTestController.MAX_DYNAMIC_SUBTESTS);
     const hidden = behaviors.length - shown.length;
+    // Both truths fit in one description, and a method can hold both: a table
+    // longer than the ceiling whose rows also depend on runtime values. Setting
+    // them separately meant the second overwrote the first.
+    const notes: string[] = [];
     if (hidden > 0) {
-      parent.description = `${behaviors.length} behaviors (${shown.length} shown)`;
+      notes.push(`${behaviors.length} behaviors (${shown.length} shown)`);
     }
+    if (incomplete) {
+      notes.push("+ behaviors known only at run time");
+    }
+    parent.description = notes.length > 0 ? notes.join(", ") : undefined;
     for (const behavior of shown) {
       const id = `${parent.id}/${behavior.name}`;
       seen.add(id);
@@ -501,6 +513,9 @@ export class GoTestController implements vscode.Disposable {
       if (!item) {
         item = this.controller.createTestItem(id, behavior.display, uri);
       }
+      // Source now claims this id, so it is no longer a run-time discovery:
+      // forgetting that would exempt it from pruning when it leaves the source.
+      this.dynamicIds.delete(id);
       if (behavior.line > 0) {
         item.range = new vscode.Range(
           new vscode.Position(behavior.line - 1, 0),
@@ -514,9 +529,19 @@ export class GoTestController implements vscode.Disposable {
     // time stay, because source never claimed them in the first place.
     parent.children.forEach((child) => {
       if (!seen.has(child.id) && !this.dynamicIds.has(child.id)) {
+        this.forgetDynamic(child);
         parent.children.delete(child.id);
       }
     });
+  }
+
+  // forgetDynamic drops a deleted subtree from the dynamic registry. The set
+  // decides what survives pruning, so an id left in it after its item is gone
+  // would grant a later item of the same name an exemption it never earned.
+  private forgetDynamic(item: vscode.TestItem): void {
+    this.dynamicIds.delete(item.id);
+    this.dynamicOverflow.delete(item.id);
+    item.children.forEach((child) => this.forgetDynamic(child));
   }
 
   setCoverageDetailProvider(

--- a/vscode-gotest/src/testResultStore.test.ts
+++ b/vscode-gotest/src/testResultStore.test.ts
@@ -93,6 +93,26 @@ describe("TestResultStore", () => {
       });
     });
 
+    // The Test Explorer's "Clear all results" is in-memory only. Unless the
+    // persisted copy is cleared too, the next window reload restores exactly
+    // the results the developer just dismissed.
+    it("clear empties the store and does not restore on reload", async () => {
+      const writer = new TestResultStore({ fsPath: tmpDir });
+      writer.record("pkg/one", "pass");
+      writer.record("pkg/two", "fail");
+      writer.save();
+      await writer.flush();
+
+      writer.clear();
+      await writer.flush();
+      expect(writer.size).toBe(0);
+
+      const reader = new TestResultStore({ fsPath: tmpDir });
+      await reader.load();
+      expect(reader.size).toBe(0);
+      expect(reader.get("pkg/one")).toBeUndefined();
+    });
+
     it("load handles missing file gracefully", async () => {
       const s = new TestResultStore({ fsPath: tmpDir });
       await expect(s.load()).resolves.toBeUndefined();

--- a/vscode-gotest/src/testResultStore.ts
+++ b/vscode-gotest/src/testResultStore.ts
@@ -11,7 +11,7 @@ interface StoredTestResult extends TestResult {
 }
 
 interface StoredData {
-  version: 1;
+  version: 2;
   results: Record<string, StoredTestResult>;
 }
 
@@ -72,7 +72,7 @@ export class TestResultStore {
     try {
       const content = await readFile(this.storagePath, "utf-8");
       const data = JSON.parse(content) as StoredData;
-      if (data.version !== 1) return;
+      if (data.version !== 2) return;
       this.results.clear();
       for (const [id, result] of Object.entries(data.results)) {
         this.results.set(id, result);
@@ -110,7 +110,7 @@ export class TestResultStore {
     if (!this.storagePath) return;
     this.evictStale();
     const data: StoredData = {
-      version: 1,
+      version: 2,
       results: Object.fromEntries(this.results),
     };
     await mkdir(path.dirname(this.storagePath), { recursive: true });

--- a/vscode-gotest/src/testResultStore.ts
+++ b/vscode-gotest/src/testResultStore.ts
@@ -117,6 +117,14 @@ export class TestResultStore {
     await writeFile(this.storagePath, JSON.stringify(data), "utf-8");
   }
 
+  // clear drops every result and schedules the empty state to disk. Clearing
+  // memory alone would leave the persisted copy intact, and the next window
+  // reload would restore exactly the results the developer just dismissed.
+  clear(): void {
+    this.results.clear();
+    this.save();
+  }
+
   dispose(): void {
     if (this.debounceTimer !== undefined) {
       clearTimeout(this.debounceTimer);

--- a/vscode-gotest/src/types.ts
+++ b/vscode-gotest/src/types.ts
@@ -45,6 +45,23 @@ export interface DiscoverMethod {
   file: string;
   line: number;
   col: number;
+  // The When/It blocks the method declares, read from source. Absent on a CLI
+  // that predates static behavior discovery.
+  behaviors?: DiscoverBehavior[];
+  // Whether `behaviors` is exhaustive. False means the method declares
+  // behaviors whose names or existence depend on runtime values, so the list
+  // is a floor and the rest appear only once the method has run.
+  behaviorsComplete?: boolean;
+}
+
+export interface DiscoverBehavior {
+  // The subtest segment go test will produce — identical to the runtime one,
+  // which is what lets a declared behavior and an observed one be the same
+  // tree node rather than two.
+  name: string;
+  display: string;
+  line: number;
+  children?: DiscoverBehavior[];
 }
 
 export interface PrepareOutput {

--- a/vscode-gotest/test/integration/behaviorTree.test.ts
+++ b/vscode-gotest/test/integration/behaviorTree.test.ts
@@ -192,6 +192,91 @@ describe("the specification is in the tree before anything runs", () => {
   }, 300_000);
 });
 
+// Two names a run produces that the source does not spell out. Getting either
+// wrong is invisible until a run happens, and then it shows up as a second tree
+// node beside the declared one.
+describe("declared names match the ones go test invents", () => {
+  it("numbers a description that repeats among its siblings", () => {
+    expect(
+      idsUnder(
+        `${pkg("duplicates")}/DuplicatesTestSuite/TestRepeatedDescriptions`,
+      ),
+    ).toEqual([
+      `${pkg("duplicates")}/DuplicatesTestSuite/TestRepeatedDescriptions`,
+      `${pkg("duplicates")}/DuplicatesTestSuite/TestRepeatedDescriptions/the_same_words`,
+      `${pkg("duplicates")}/DuplicatesTestSuite/TestRepeatedDescriptions/the_same_words#01`,
+      `${pkg("duplicates")}/DuplicatesTestSuite/TestRepeatedDescriptions/the_same_words#01/names_the_second`,
+      `${pkg("duplicates")}/DuplicatesTestSuite/TestRepeatedDescriptions/the_same_words#02`,
+      `${pkg("duplicates")}/DuplicatesTestSuite/TestRepeatedDescriptions/the_same_words#02/names_the_third`,
+      `${pkg("duplicates")}/DuplicatesTestSuite/TestRepeatedDescriptions/the_same_words/names_the_first`,
+    ]);
+  });
+
+  it("makes a slash a level, and lets two descriptions share it", () => {
+    expect(
+      idsUnder(`${pkg("duplicates")}/DuplicatesTestSuite/TestSlashGrouping`),
+    ).toEqual([
+      `${pkg("duplicates")}/DuplicatesTestSuite/TestSlashGrouping`,
+      `${pkg("duplicates")}/DuplicatesTestSuite/TestSlashGrouping/a`,
+      `${pkg("duplicates")}/DuplicatesTestSuite/TestSlashGrouping/a/b_grouping`,
+      `${pkg("duplicates")}/DuplicatesTestSuite/TestSlashGrouping/a/b_grouping/shares_the_first_level`,
+      `${pkg("duplicates")}/DuplicatesTestSuite/TestSlashGrouping/a/c_grouping`,
+      `${pkg("duplicates")}/DuplicatesTestSuite/TestSlashGrouping/a/c_grouping/shares_it_too`,
+    ]);
+  });
+
+  // A run of slashes is not a separator: "https:// URIs" is one subtest whose
+  // name contains slashes, and go test reports it as one level.
+  it("keeps a run of slashes inside a single level", () => {
+    const id =
+      `${pkg("metachars")}/MetacharsTestSuite/TestPunctuation/a_description_has_{braces}/handles_https:%2F%2F_URIs`.replace(
+        /%2F/g,
+        "/",
+      );
+    expect(controller.findItem(id)?.label).toBe("handles https:// URIs");
+  });
+
+  // The failure this guards against is silent: an observed result can build a
+  // second item whose id string equals the declared one but whose parent does
+  // not, so comparing ids alone sees nothing wrong. Counting the tree does.
+  it.each(["duplicates", "metachars"])(
+    "gains no tree items when %s actually runs",
+    async (name) => {
+      const before = idsUnder(pkg(name));
+      const run = new FakeTestRun();
+      await executeBatch({
+        pkgInfos: [
+          {
+            importPath: pkg(name),
+            items: [controller.findItem(pkg(name))!] as never,
+            dir: path.join(fixturesDir, name),
+          },
+        ],
+        filter: undefined,
+        workspaceDir: fixturesDir,
+        testFlags: [],
+        run: run as never,
+        token: token as never,
+        controller,
+        outputChannel: createRecordingChannel().channel as never,
+        label: name,
+      });
+
+      expect(idsUnder(pkg(name))).toEqual(before);
+
+      // Every declared leaf reported, so the run landed on the declared items
+      // rather than on look-alikes built beside them.
+      const leaves = before.filter(
+        (id) => !before.some((other) => other.startsWith(id + "/")),
+      );
+      expect(run.verdictsMatching("passed")).toEqual(
+        expect.arrayContaining(leaves),
+      );
+    },
+    300_000,
+  );
+});
+
 describe("the run counter has its total up front", () => {
   it("enqueues every behavior at run start and gains no items during the run", async () => {
     const before = idsUnder(pkg("table"));

--- a/vscode-gotest/test/integration/behaviorTree.test.ts
+++ b/vscode-gotest/test/integration/behaviorTree.test.ts
@@ -30,7 +30,7 @@ import { DiscoveryCache, DiscoveryService } from "../../src/discovery.js";
 import { GoTestController } from "../../src/testController.js";
 import { TestResultStore } from "../../src/testResultStore.js";
 import { executeBatch } from "../../src/batchRunner.js";
-import { enqueueDescendants } from "../../src/runnerUtils.js";
+import { enqueueDescendants, buildRunFilter } from "../../src/runnerUtils.js";
 import { createRecordingChannel } from "./vscodeStub.js";
 import { FakeTestRun, FakeTestController } from "./vscodeTestApi.js";
 
@@ -206,5 +206,46 @@ describe("the run counter has its total up front", () => {
     expect(idsUnder(pkg("table")).some((id) => id.includes("/dynamic/"))).toBe(
       false,
     );
+  }, 300_000);
+});
+
+describe("a single behavior can be run on its own", () => {
+  // The payoff of declaring behaviors up front: a developer can run one row of
+  // a table without running the other nineteen. The filter has to speak go
+  // test's language — the rewritten subtest name, not the prose label.
+  it("filters the run down to exactly the selected behavior", async () => {
+    const behaviorId = `${pkg("table")}/TableTestSuite/TestClassify/classifying_a_number/negative`;
+    const behavior = controller.findItem(behaviorId)!;
+    expect(behavior.label).toBe("negative");
+
+    const filter = buildRunFilter([behavior]);
+    expect(filter).toBe(
+      "^TestTableTestSuite$/^TestClassify$/^classifying_a_number/negative$",
+    );
+
+    const run = new FakeTestRun();
+    await executeBatch({
+      pkgInfos: [
+        {
+          importPath: pkg("table"),
+          items: [behavior] as never,
+          dir: path.join(fixturesDir, "table"),
+        },
+      ],
+      filter,
+      workspaceDir: fixturesDir,
+      testFlags: [],
+      run: run as never,
+      token: token as never,
+      controller,
+      outputChannel: createRecordingChannel().channel as never,
+      label: "one-behavior",
+    });
+
+    const passed = run.verdictsMatching("passed");
+    expect(passed).toContain(behaviorId);
+    // The siblings were not run, which is the entire point of the filter.
+    expect(passed.some((id) => id.endsWith("/zero"))).toBe(false);
+    expect(passed.some((id) => id.endsWith("/positive"))).toBe(false);
   }, 300_000);
 });

--- a/vscode-gotest/test/integration/behaviorTree.test.ts
+++ b/vscode-gotest/test/integration/behaviorTree.test.ts
@@ -131,13 +131,65 @@ describe("the specification is in the tree before anything runs", () => {
   });
 
   // A method whose behaviors depend on runtime values must not present its
-  // partial list as the whole truth.
-  it("marks a method with runtime-determined behaviors as resolvable", () => {
+  // partial list as the whole truth — but it must not promise VS Code a
+  // resolve handler either, since the missing children cannot be fetched
+  // without running the test.
+  it("says so when a method's behaviors are only knowable at run time", () => {
+    const partial = controller.findItem(
+      `${pkg("runtimebehaviors")}/RuntimeBehaviorsTestSuite/TestConditional`,
+    );
+    expect(partial?.description).toBe("+ behaviors known only at run time");
+    expect(partial?.canResolveChildren).toBe(false);
+
+    // Only the behavior that is written unconditionally is declared.
+    const declared: string[] = [];
+    partial!.children.forEach((when) =>
+      when.children.forEach((b) => declared.push(b.label)),
+    );
+    expect(declared).toEqual(["always states this one"]);
+  });
+
+  it("leaves a fully declared method unannotated", () => {
     const complete = controller.findItem(
       `${pkg("table")}/TableTestSuite/TestClassify`,
     );
+    expect(complete?.description).toBeUndefined();
     expect(complete?.canResolveChildren).toBe(false);
   });
+
+  // The conditional behavior appears once it has actually run, on the same
+  // canonical id, alongside the declared one.
+  it("adds a run-time-only behavior to the declared tree when it appears", async () => {
+    const method = `${pkg("runtimebehaviors")}/RuntimeBehaviorsTestSuite/TestConditional`;
+    const run = new FakeTestRun();
+    await executeBatch({
+      pkgInfos: [
+        {
+          importPath: pkg("runtimebehaviors"),
+          items: [controller.findItem(pkg("runtimebehaviors"))!] as never,
+          dir: path.join(fixturesDir, "runtimebehaviors"),
+        },
+      ],
+      filter: undefined,
+      workspaceDir: fixturesDir,
+      testFlags: [],
+      run: run as never,
+      token: token as never,
+      controller,
+      outputChannel: createRecordingChannel().channel as never,
+      label: "runtime",
+    });
+
+    const passed = run.verdictsMatching("passed");
+    expect(
+      passed.some((id) =>
+        id.startsWith(`${method}/the_feature_flag_decides_what_is_specified/`),
+      ),
+    ).toBe(true);
+    expect(
+      passed.filter((id) => id.startsWith(`${method}/`)).length,
+    ).toBeGreaterThanOrEqual(3);
+  }, 300_000);
 });
 
 describe("the run counter has its total up front", () => {
@@ -207,6 +259,38 @@ describe("the run counter has its total up front", () => {
       false,
     );
   }, 300_000);
+});
+
+describe("results survive a reload", () => {
+  // Restoring a stored result does `findItem(id)` and drops anything it cannot
+  // resolve. Behavior ids used to exist only during a run, so every behavior
+  // result was persisted, aged, and then silently discarded on load. Declaring
+  // behaviors at discovery is what makes the lookup succeed.
+  it("resolves a stored behavior id against the declared tree", () => {
+    const behaviorId = `${pkg("table")}/TableTestSuite/TestClassify/classifying_a_number/negative`;
+
+    // Exactly the operation restoreResults performs on each stored key.
+    expect(controller.findItem(behaviorId)).toBeDefined();
+
+    controller.recordResult(behaviorId, "pass", 12);
+    expect(controller.getResult(behaviorId)).toMatchObject({ status: "pass" });
+  });
+
+  it("persists and reloads behavior results under the current store version", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "gotest-restore-"));
+    const behaviorId = `${pkg("table")}/TableTestSuite/TestClassify/classifying_a_number/zero`;
+
+    const store = new TestResultStore({ fsPath: dir });
+    store.record(behaviorId, "fail", 7);
+    // record only mutates memory; save schedules the write and flush forces it.
+    store.save();
+    await store.flush();
+
+    const reloaded = new TestResultStore({ fsPath: dir });
+    await reloaded.load();
+
+    expect(reloaded.get(behaviorId)).toMatchObject({ status: "fail" });
+  });
 });
 
 describe("a single behavior can be run on its own", () => {

--- a/vscode-gotest/test/integration/behaviorTree.test.ts
+++ b/vscode-gotest/test/integration/behaviorTree.test.ts
@@ -248,4 +248,50 @@ describe("a single behavior can be run on its own", () => {
     expect(passed.some((id) => id.endsWith("/zero"))).toBe(false);
     expect(passed.some((id) => id.endsWith("/positive"))).toBe(false);
   }, 300_000);
+
+  // Descriptions are prose, and go test's -run is a regular expression. Every
+  // metacharacter in Go's QuoteMeta set appears in the metachars fixture, so
+  // each of these addresses a behavior whose name would otherwise be read as a
+  // pattern. Without escaping the filter matches nothing at all.
+  it("addresses behaviors whose descriptions contain regex metacharacters", async () => {
+    const whenId = `${pkg("metachars")}/MetacharsTestSuite/TestPunctuation/a_description_has_{braces}`;
+    const whenItem = controller.findItem(whenId);
+    expect(
+      whenItem,
+      "the When block should be declared statically",
+    ).toBeDefined();
+
+    const behaviors: string[] = [];
+    whenItem!.children.forEach((child) => behaviors.push(child.id));
+    expect(behaviors.length).toBeGreaterThanOrEqual(6);
+
+    for (const id of behaviors) {
+      const item = controller.findItem(id)!;
+      const filter = buildRunFilter([item]);
+      const run = new FakeTestRun();
+
+      await executeBatch({
+        pkgInfos: [
+          {
+            importPath: pkg("metachars"),
+            items: [item] as never,
+            dir: path.join(fixturesDir, "metachars"),
+          },
+        ],
+        filter,
+        workspaceDir: fixturesDir,
+        testFlags: [],
+        run: run as never,
+        token: token as never,
+        controller,
+        outputChannel: createRecordingChannel().channel as never,
+        label: "metachars",
+      });
+
+      const passedLeaves = run
+        .verdictsMatching("passed")
+        .filter((passedId) => behaviors.includes(passedId));
+      expect(passedLeaves, `filter for ${id} was ${filter}`).toEqual([id]);
+    }
+  }, 600_000);
 });

--- a/vscode-gotest/test/integration/behaviorTree.test.ts
+++ b/vscode-gotest/test/integration/behaviorTree.test.ts
@@ -1,0 +1,210 @@
+// Behaviors are part of the tree before anything runs.
+//
+// The Test Explorer used to learn a suite's behaviors only by executing it, so
+// the run counter's denominator grew mid-flight and a behavior could not be
+// addressed until it had already been observed. Discovery now reads the
+// specification from source, and this suite pins the properties that depend on
+// it — above all that a declared behavior and the observed one are the same
+// tree node rather than two.
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+const state = vi.hoisted(() => ({
+  workspaceDir: "",
+  cliPath: "",
+  autoRefresh: true,
+  panels: [] as { webview: { html: string; cspSource: string } }[],
+  controllers: [] as unknown[],
+  config: {} as Record<string, unknown>,
+}));
+
+vi.mock("vscode", async () => {
+  const { buildVscodeStub } = await import("./vscodeStub.js");
+  return buildVscodeStub(state as never);
+});
+
+import { DiscoveryCache, DiscoveryService } from "../../src/discovery.js";
+import { GoTestController } from "../../src/testController.js";
+import { TestResultStore } from "../../src/testResultStore.js";
+import { executeBatch } from "../../src/batchRunner.js";
+import { enqueueDescendants } from "../../src/runnerUtils.js";
+import { createRecordingChannel } from "./vscodeStub.js";
+import { FakeTestRun, FakeTestController } from "./vscodeTestApi.js";
+
+const extensionDir = path.resolve(__dirname, "..", "..");
+const repoRoot = path.resolve(extensionDir, "..");
+const fixturesDir = path.join(extensionDir, "testdata", "fixtures");
+const pkg = (name: string) => `gotest.fixtures/${name}`;
+
+let cache: DiscoveryCache;
+let controller: GoTestController;
+let fake: FakeTestController;
+let savedGoWork: string | undefined;
+
+const token = {
+  isCancellationRequested: false,
+  onCancellationRequested: () => ({ dispose: () => {} }),
+};
+
+function idsUnder(prefix: string): string[] {
+  return fake
+    .allItems()
+    .map((i) => i.id)
+    .filter((id) => id === prefix || id.startsWith(prefix + "/"))
+    .sort();
+}
+
+beforeAll(async () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), "gotest-behaviors-"));
+  const workFile = path.join(tmp, "corpus.work");
+  writeFileSync(
+    workFile,
+    `go 1.24.0\n\nuse (\n\t${repoRoot}\n\t${path.join(repoRoot, "examples")}\n\t${fixturesDir}\n)\n`,
+    "utf-8",
+  );
+  savedGoWork = process.env.GOWORK;
+  process.env.GOWORK = workFile;
+
+  state.workspaceDir = fixturesDir;
+  state.cliPath = "";
+  state.config = {};
+
+  const recorder = createRecordingChannel();
+  cache = new DiscoveryCache();
+  await new DiscoveryService(cache, recorder.channel as never).discover(
+    fixturesDir,
+  );
+  controller = new GoTestController(
+    cache,
+    new TestResultStore(undefined),
+    recorder.channel as never,
+    async () => {},
+    async () => {},
+    async () => {},
+    async () => {},
+  );
+  controller.rebuild();
+  fake = state.controllers[0] as FakeTestController;
+}, 300_000);
+
+afterAll(() => {
+  if (savedGoWork === undefined) delete process.env.GOWORK;
+  else process.env.GOWORK = savedGoWork;
+  controller?.dispose();
+});
+
+describe("the specification is in the tree before anything runs", () => {
+  it("builds a test item for every declared behavior", () => {
+    expect(idsUnder(pkg("table"))).toEqual([
+      pkg("table"),
+      `${pkg("table")}/TableTestSuite`,
+      `${pkg("table")}/TableTestSuite/TestClassify`,
+      `${pkg("table")}/TableTestSuite/TestClassify/classifying_a_number`,
+      `${pkg("table")}/TableTestSuite/TestClassify/classifying_a_number/negative`,
+      `${pkg("table")}/TableTestSuite/TestClassify/classifying_a_number/positive`,
+      `${pkg("table")}/TableTestSuite/TestClassify/classifying_a_number/zero`,
+    ]);
+  });
+
+  it("nests behaviors as deeply as they are written", () => {
+    expect(idsUnder(pkg("nested"))).toContain(
+      `${pkg("nested")}/NestedTestSuite/TestCheckout/a_cart_has_items/and_the_customer_is_a_member/and_a_coupon_applies/stacks_both_discounts`,
+    );
+  });
+
+  it("labels a behavior with the text the developer wrote, not the subtest name", () => {
+    const item = controller.findItem(
+      `${pkg("table")}/TableTestSuite/TestClassify/classifying_a_number`,
+    );
+    expect(item?.label).toBe("classifying a number");
+  });
+
+  it("gives each behavior a source position, so it can be decorated in the gutter", () => {
+    const item = controller.findItem(
+      `${pkg("table")}/TableTestSuite/TestClassify/classifying_a_number/negative`,
+    );
+    expect(item?.range).toBeDefined();
+    expect(item?.uri).toBeDefined();
+  });
+
+  // A method whose behaviors depend on runtime values must not present its
+  // partial list as the whole truth.
+  it("marks a method with runtime-determined behaviors as resolvable", () => {
+    const complete = controller.findItem(
+      `${pkg("table")}/TableTestSuite/TestClassify`,
+    );
+    expect(complete?.canResolveChildren).toBe(false);
+  });
+});
+
+describe("the run counter has its total up front", () => {
+  it("enqueues every behavior at run start and gains no items during the run", async () => {
+    const before = idsUnder(pkg("table"));
+    const run = new FakeTestRun();
+    const item = controller.findItem(pkg("table"))!;
+    enqueueDescendants(run as never, item);
+    const enqueued = run.verdicts.size;
+
+    await executeBatch({
+      pkgInfos: [
+        {
+          importPath: pkg("table"),
+          items: [item] as never,
+          dir: path.join(fixturesDir, "table"),
+        },
+      ],
+      filter: undefined,
+      workspaceDir: fixturesDir,
+      testFlags: [],
+      run: run as never,
+      token: token as never,
+      controller,
+      outputChannel: createRecordingChannel().channel as never,
+      label: "behaviors",
+    });
+
+    const after = idsUnder(pkg("table"));
+
+    // The denominator VS Code can show is what was enqueued: every item under
+    // the package except the package itself.
+    expect(enqueued).toBe(before.length - 1);
+    // Nothing appeared mid-run, which is what used to make the total climb.
+    expect(after).toEqual(before);
+  }, 300_000);
+
+  // The whole scheme rests on this: a declared behavior and the observed one
+  // must be the same id, or the tree would carry both.
+  it("reports results onto the declared items rather than creating new ones", async () => {
+    const run = new FakeTestRun();
+    const item = controller.findItem(pkg("table"))!;
+
+    await executeBatch({
+      pkgInfos: [
+        {
+          importPath: pkg("table"),
+          items: [item] as never,
+          dir: path.join(fixturesDir, "table"),
+        },
+      ],
+      filter: undefined,
+      workspaceDir: fixturesDir,
+      testFlags: [],
+      run: run as never,
+      token: token as never,
+      controller,
+      outputChannel: createRecordingChannel().channel as never,
+      label: "behaviors",
+    });
+
+    expect(run.verdictsMatching("passed")).toContain(
+      `${pkg("table")}/TableTestSuite/TestClassify/classifying_a_number/negative`,
+    );
+    // No id carries the old structural marker any more.
+    expect(idsUnder(pkg("table")).some((id) => id.includes("/dynamic/"))).toBe(
+      false,
+    );
+  }, 300_000);
+});

--- a/vscode-gotest/test/integration/corpus.test.ts
+++ b/vscode-gotest/test/integration/corpus.test.ts
@@ -133,6 +133,16 @@ const FIXTURES: Record<string, Expectation> = {
     skipped: 0,
     mustContain: ["a description has {braces}", "handles https:// URIs"],
   },
+  // Descriptions that repeat among their siblings, and descriptions carrying a
+  // single slash. go test numbers the one and nests the other, and discovery
+  // has to predict both or the declared item and the observed one are two.
+  duplicates: {
+    status: "pass",
+    passed: 5,
+    failed: 0,
+    skipped: 0,
+    mustContain: ["names the first", "names the third", "shares it too"],
+  },
   bigoutput: { status: "pass", passed: 2, failed: 0, skipped: 0 },
   unicode: {
     status: "fail",

--- a/vscode-gotest/test/integration/corpus.test.ts
+++ b/vscode-gotest/test/integration/corpus.test.ts
@@ -118,6 +118,17 @@ const FIXTURES: Record<string, Expectation> = {
     mustNotContain: ["<script>alert", "<img src=x onerror"],
   },
   jsonish: { status: "pass", passed: 2, failed: 0, skipped: 0 },
+  // Descriptions carrying every regex metacharacter in Go's QuoteMeta set, so
+  // that addressing one exercises the -run escaping rather than a happy-path
+  // name. The slash case is included because -run splits on "/" before
+  // compiling, which escaping cannot influence either way.
+  metachars: {
+    status: "pass",
+    passed: 6,
+    failed: 0,
+    skipped: 0,
+    mustContain: ["a description has {braces}", "handles https:// URIs"],
+  },
   bigoutput: { status: "pass", passed: 2, failed: 0, skipped: 0 },
   unicode: {
     status: "fail",

--- a/vscode-gotest/test/integration/corpus.test.ts
+++ b/vscode-gotest/test/integration/corpus.test.ts
@@ -118,6 +118,10 @@ const FIXTURES: Record<string, Expectation> = {
     mustNotContain: ["<script>alert", "<img src=x onerror"],
   },
   jsonish: { status: "pass", passed: 2, failed: 0, skipped: 0 },
+  // Behaviors guarded by a condition: readable only by running. The walker
+  // reports the method incomplete rather than passing off what it can see as
+  // the whole specification.
+  runtimebehaviors: { status: "pass", passed: 2, failed: 0, skipped: 0 },
   // Descriptions carrying every regex metacharacter in Go's QuoteMeta set, so
   // that addressing one exercises the -run escaping rather than a happy-path
   // name. The slash case is included because -run splits on "/" before

--- a/vscode-gotest/test/integration/specSync.test.ts
+++ b/vscode-gotest/test/integration/specSync.test.ts
@@ -312,6 +312,32 @@ describe("layer accumulation across refreshes", () => {
   });
 });
 
+describe("clearing drops the accumulated layers", () => {
+  // The panel keeps every run/coverage/watch layer and re-renders their
+  // concatenation. Clearing has to drop the layers, not just repaint, or the
+  // next refresh would resurrect what was cleared.
+  it("empties the panel and starts the next refresh from nothing", async () => {
+    const { panel, recorder } = newPanel();
+    await panel.show();
+
+    await panel.refresh(stream("mixed"), "run");
+    await panel.refresh(stream("other-package-fail"), "coverage");
+    expect(renderedHtml()).toContain("rejects an expired card");
+
+    panel.clear();
+    const cleared = renderedHtml();
+    expect(cleared).not.toContain("rejects an expired card");
+    expect(cleared).not.toContain("totals the basket");
+
+    // A later run shows only itself — the cleared layers are gone for good.
+    await panel.refresh(stream("all-pass"), "run");
+    const html = renderedHtml();
+    expect(recorder.errors).toEqual([]);
+    expect(html).toContain("2 passed");
+    expect(html).not.toContain("rejects an expired card");
+  });
+});
+
 describe("autoRefresh honours the user's setting", () => {
   it("does not repaint the panel when autoRefresh is off", async () => {
     const { panel, recorder } = newPanel();

--- a/vscode-gotest/test/integration/vscodeTestApi.ts
+++ b/vscode-gotest/test/integration/vscodeTestApi.ts
@@ -7,11 +7,17 @@
 export class FakeTestItemCollection {
   private items = new Map<string, FakeTestItem>();
 
+  // The real API sets `parent` when an item joins a collection, and code that
+  // walks up the tree (run filters, package depth) depends on it. Without the
+  // owner link the double silently reports every item as parentless.
+  constructor(private readonly owner?: FakeTestItem) {}
+
   get size(): number {
     return this.items.size;
   }
 
   add(item: FakeTestItem): void {
+    item.parent = this.owner;
     this.items.set(item.id, item);
   }
 
@@ -25,7 +31,10 @@ export class FakeTestItemCollection {
 
   replace(items: FakeTestItem[]): void {
     this.items.clear();
-    for (const item of items) this.items.set(item.id, item);
+    for (const item of items) {
+      item.parent = this.owner;
+      this.items.set(item.id, item);
+    }
   }
 
   forEach(callback: (item: FakeTestItem) => void): void {
@@ -38,7 +47,7 @@ export class FakeTestItemCollection {
 }
 
 export class FakeTestItem {
-  children = new FakeTestItemCollection();
+  children: FakeTestItemCollection = new FakeTestItemCollection(this);
   parent: FakeTestItem | undefined;
   range: unknown;
   tags: unknown[] = [];

--- a/vscode-gotest/testdata/fixtures/duplicates/suite_test.go
+++ b/vscode-gotest/testdata/fixtures/duplicates/suite_test.go
@@ -1,0 +1,31 @@
+package duplicates
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+// Two rules of the testing package are invisible in the source and decide what
+// a behavior is called at run time: a description repeated among its siblings
+// is numbered, and a description containing a single slash becomes two subtest
+// levels. Discovery has to predict both, or the declared item and the observed
+// one are two tree nodes instead of one.
+type DuplicatesTestSuite struct{}
+
+func (s *DuplicatesTestSuite) TestRepeatedDescriptions(t *gotest.T) {
+	t.When("the same words", func(t *gotest.T) {
+		t.It("names the first", func(t *gotest.T) { gotest.Equal(t, 1, 1) })
+	})
+	t.When("the same words", func(t *gotest.T) {
+		t.It("names the second", func(t *gotest.T) { gotest.Equal(t, 1, 1) })
+	})
+	t.When("the same words", func(t *gotest.T) {
+		t.It("names the third", func(t *gotest.T) { gotest.Equal(t, 1, 1) })
+	})
+}
+
+func (s *DuplicatesTestSuite) TestSlashGrouping(t *gotest.T) {
+	t.When("a/b grouping", func(t *gotest.T) {
+		t.It("shares the first level", func(t *gotest.T) { gotest.Equal(t, 1, 1) })
+	})
+	t.When("a/c grouping", func(t *gotest.T) {
+		t.It("shares it too", func(t *gotest.T) { gotest.Equal(t, 1, 1) })
+	})
+}

--- a/vscode-gotest/testdata/fixtures/metachars/suite_test.go
+++ b/vscode-gotest/testdata/fixtures/metachars/suite_test.go
@@ -1,0 +1,35 @@
+package metachars
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+// Behavior descriptions are prose, and prose contains punctuation that go
+// test's -run reads as a regular expression. Every metacharacter in Go's
+// QuoteMeta set appears here, so that addressing one of these behaviors
+// exercises the escaping rather than a happy-path name.
+type MetacharsTestSuite struct{}
+
+func (s *MetacharsTestSuite) TestPunctuation(t *gotest.T) {
+	t.When("a description has {braces}", func(t *gotest.T) {
+		t.It("still addresses (parens) and a.dot", func(t *gotest.T) {
+			gotest.Equal(t, 1, 1)
+		})
+		t.It("still addresses [brackets] and a+plus", func(t *gotest.T) {
+			gotest.Equal(t, 1, 1)
+		})
+		t.It("still addresses a*star and a|pipe", func(t *gotest.T) {
+			gotest.Equal(t, 1, 1)
+		})
+		t.It("still addresses ^caret and dollar$", func(t *gotest.T) {
+			gotest.Equal(t, 1, 1)
+		})
+		t.It("still addresses a?question and a-dash", func(t *gotest.T) {
+			gotest.Equal(t, 1, 1)
+		})
+		// A slash is different in kind: go test splits -run on "/" before
+		// compiling each element as a regex, so no amount of escaping can
+		// address a behavior whose own name contains one.
+		t.It("handles https:// URIs", func(t *gotest.T) {
+			gotest.Equal(t, 1, 1)
+		})
+	})
+}

--- a/vscode-gotest/testdata/fixtures/runtimebehaviors/suite_test.go
+++ b/vscode-gotest/testdata/fixtures/runtimebehaviors/suite_test.go
@@ -1,0 +1,24 @@
+package runtimebehaviors
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+// Behaviors that cannot be read from source: one guarded by a condition and
+// one whose description is computed. The walker must report the method as
+// incomplete rather than presenting the behaviors it *can* see as the whole
+// specification.
+type RuntimeBehaviorsTestSuite struct{}
+
+func (s *RuntimeBehaviorsTestSuite) TestConditional(t *gotest.T) {
+	enabled := len("always true") > 0
+
+	t.When("the feature flag decides what is specified", func(t *gotest.T) {
+		t.It("always states this one", func(t *gotest.T) {
+			gotest.True(t, enabled)
+		})
+		if enabled {
+			t.It("only states this one when enabled", func(t *gotest.T) {
+				gotest.True(t, enabled)
+			})
+		}
+	})
+}


### PR DESCRIPTION
Individual test cases were only discovered by executing them. As a result the
run counter's total grew mid-run, cases could not be run or debugged
individually, and results were lost across reloads.

These cases are declared literally in the source, so discovery now reads them
from there. The tree is complete before a run starts, ids match the go test
path, and each case is individually addressable. Methods whose cases depend on
runtime values are marked as incomplete rather than presented as exhaustive.

Adds `gotest spec --static` to render a package's specification without
executing it.