### PR TITLE
Behavior descriptions render as defined

### DIFF
--- a/cmd/gotest/declarations.go
+++ b/cmd/gotest/declarations.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"golang.org/x/tools/go/packages"
+
+	"github.com/mvrahden/go-test/internal/gotestast"
+	"github.com/mvrahden/go-test/internal/gotestgen"
+	"github.com/mvrahden/go-test/internal/gotestspec"
+)
+
+// buildDeclarationIndex reads what every declared behavior is called, keyed by
+// the test path go test will print for it. A run's event stream says which
+// subtests happened, but not what the developer called them: by the time a
+// description has become a subtest name, every space in it is an underscore and
+// the ones that were already underscores are indistinguishable.
+//
+// Behaviors that source cannot enumerate — a When inside a condition, a table
+// that is not a literal — are simply absent, and their labels are reconstructed
+// from their names as before. That is the same floor `behaviorsComplete`
+// reports, not a separate failure.
+func buildDeclarationIndex(loadResults []*gotestgen.LoadResult) gotestspec.DeclarationIndex {
+	idx := gotestspec.DeclarationIndex{}
+	collector := gotestgen.NewCollector()
+
+	for _, lr := range loadResults {
+		for _, pkg := range []*packages.Package{lr.Ptest, lr.Pxtest} {
+			if pkg == nil {
+				continue
+			}
+			result := collector.CollectSuiteSpecs(pkg)
+			if len(result.Errs) > 0 {
+				continue
+			}
+			for _, suite := range result.Suites {
+				suitePath := "Test" + suite.Identifier()
+				for _, method := range suite.TestCases() {
+					methodPath := suitePath + "/" + method.Identifier()
+					indexBehaviors(idx, lr.PkgPath, methodPath, suite.BehaviorsOf(method).Behaviors)
+				}
+			}
+		}
+	}
+
+	if len(idx) == 0 {
+		return nil
+	}
+	return idx
+}
+
+func indexBehaviors(idx gotestspec.DeclarationIndex, pkgPath, parentPath string, behaviors []*gotestast.Behavior) {
+	for _, b := range behaviors {
+		// A declared behavior carries the exact go test segment, "#01" and all.
+		// The tree keys duplicates under the name the developer wrote, so the
+		// index drops the suffix the same way — otherwise the second of two
+		// same-named siblings would find no declaration and read differently
+		// from the first.
+		path := parentPath + "/" + gotestspec.StripDuplicateSuffix(b.Name)
+		paths := idx[pkgPath]
+		if paths == nil {
+			paths = map[string]gotestspec.Declaration{}
+			idx[pkgPath] = paths
+		}
+		paths[path] = gotestspec.Declaration{Label: b.Display}
+		indexBehaviors(idx, pkgPath, path, b.Children)
+	}
+}

--- a/cmd/gotest/discover.go
+++ b/cmd/gotest/discover.go
@@ -73,10 +73,15 @@ type discoverMethod struct {
 
 // discoverBehavior mirrors one node of the specification a method declares.
 // Name is the subtest segment go test will produce, so it lines up with the
-// runtime tree byte for byte; Display is the text the developer wrote.
+// runtime tree byte for byte; Display is the text the developer wrote, the same
+// string `gotest spec` renders for this node. Kind names the call it came from,
+// which the names cannot say: a context and an expectation both arrive as
+// subtests, and a consumer that wants to tell them apart has nowhere else to
+// look.
 type discoverBehavior struct {
 	Name     string             `json:"name"`
 	Display  string             `json:"display"`
+	Kind     string             `json:"kind"`
 	Line     int                `json:"line"`
 	Children []discoverBehavior `json:"children,omitempty"`
 }
@@ -267,9 +272,23 @@ func discoverBehaviors(in []*gotestast.Behavior) []discoverBehavior {
 		out = append(out, discoverBehavior{
 			Name:     b.Name,
 			Display:  b.Display,
+			Kind:     behaviorKindString(b.Kind),
 			Line:     b.Line,
 			Children: discoverBehaviors(b.Children),
 		})
 	}
 	return out
+}
+
+func behaviorKindString(k gotestast.BehaviorKind) string {
+	switch k {
+	case gotestast.BehaviorWhen:
+		return "when"
+	case gotestast.BehaviorIt:
+		return "it"
+	case gotestast.BehaviorEach:
+		return "each"
+	default:
+		return ""
+	}
 }

--- a/cmd/gotest/spec.go
+++ b/cmd/gotest/spec.go
@@ -136,7 +136,7 @@ func runSpec(inv Invocation) int { //nolint:gocritic // hugeParam: stable API
 		return 2
 	}
 
-	tree := gotestspec.BuildTree(events)
+	tree := gotestspec.BuildTree(events, gotestspec.WithDeclarations(buildDeclarationIndex(loaded)))
 
 	var w io.Writer = os.Stdout
 	if output != "" {

--- a/cmd/gotest/staticspec.go
+++ b/cmd/gotest/staticspec.go
@@ -110,7 +110,10 @@ func staticBehaviorNodes(behaviors []*gotestast.Behavior) []*gotestspec.Node {
 		// because that is what an observed result is keyed by. The tree shows
 		// duplicates under the name the developer wrote, so it drops the
 		// suffix here exactly as the stream parser does.
-		node := &gotestspec.Node{Name: gotestspec.StripDuplicateSuffix(b.Name)}
+		node := &gotestspec.Node{
+			Name:        gotestspec.StripDuplicateSuffix(b.Name),
+			SourceLabel: b.Display,
+		}
 		node.Children = staticBehaviorNodes(b.Children)
 		out = append(out, node)
 	}

--- a/cmd/gotest/summary.go
+++ b/cmd/gotest/summary.go
@@ -124,7 +124,7 @@ func runSummary(inv Invocation) int { //nolint:gocritic // hugeParam: stable API
 		return 2
 	}
 
-	tree := gotestspec.BuildTree(events)
+	tree := gotestspec.BuildTree(events, gotestspec.WithDeclarations(buildDeclarationIndex(loaded)))
 
 	if coverageProfile == "" {
 		for _, arg := range goTestArgs {

--- a/cmd/gotest/watch.go
+++ b/cmd/gotest/watch.go
@@ -169,6 +169,14 @@ func watchRunOnce(ctx context.Context, cfg ExecConfig, jsonMode, specMode bool) 
 		}
 	}
 
+	// Only the spec view renders a tree, and reading the declarations costs a
+	// second walk of every test file — not something to repeat on each save
+	// when nothing will consume it.
+	var decls gotestspec.DeclarationIndex
+	if specMode {
+		decls = buildDeclarationIndex(loaded)
+	}
+
 	overlay, cleanup, err := gotestrunner.GenerateOverlay(loaded, broken, cfg.Debug, cfg.NoCache)
 	if err != nil {
 		if jsonMode {
@@ -226,7 +234,7 @@ func watchRunOnce(ctx context.Context, cfg ExecConfig, jsonMode, specMode bool) 
 			fmt.Fprintf(os.Stderr, "FAIL: parsing test events: %s\n", perr)
 			return 2
 		}
-		gotestspec.RenderTerminal(os.Stdout, gotestspec.BuildTree(events))
+		gotestspec.RenderTerminal(os.Stdout, gotestspec.BuildTree(events, gotestspec.WithDeclarations(decls)))
 	}
 	return result.ExitCode
 }

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -1151,7 +1151,7 @@ $ gotest discover ./...
 Emits the static suite model as JSON — the integration surface for editors and AI tooling (the VS Code extension's test explorer runs on it).
 No tests are executed.
 
-`behaviors` carries the `When`/`It` tree each method declares, read from source: `name` is the subtest segment `go test` will produce (so it matches an observed run byte for byte), `display` is the text the developer wrote, and `line` locates it. Two rewrites the source does not spell out are applied so that `name` really does match: a description repeated among its siblings gains the `#01` suffix the testing package appends, and a description containing a single slash becomes one node per level (a run of slashes, as in `https://`, is not a separator and stays within one level). `behaviorsComplete` reports whether that tree is exhaustive — `false` means the method declares behaviors whose names or existence depend on runtime values (a condition, a loop, a non-literal description, a table that is not a literal), so the list is a floor rather than a total and the remainder appears only once the method has run. Consumers must not present an incomplete list as the whole specification.
+`behaviors` carries the `When`/`It` tree each method declares, read from source: `name` is the subtest segment `go test` will produce (so it matches an observed run byte for byte), `display` is the text the developer wrote — the same string `gotest spec` renders for this node, so an editor showing both never spells one behavior two ways — `kind` names the call it came from (`when`, `it`, `each`), and `line` locates it. Two rewrites the source does not spell out are applied so that `name` really does match: a description repeated among its siblings gains the `#01` suffix the testing package appends, and a description containing a single slash becomes one node per level (a run of slashes, as in `https://`, is not a separator and stays within one level). `behaviorsComplete` reports whether that tree is exhaustive — `false` means the method declares behaviors whose names or existence depend on runtime values (a condition, a loop, a non-literal description, a table that is not a literal), so the list is a floor rather than a total and the remainder appears only once the method has run. Consumers must not present an incomplete list as the whole specification.
 
 ```
 { "packages": [ {
@@ -1163,7 +1163,7 @@ No tests are executed.
       "fixtures": ["E2ESetupFixture", …],
       "methods": [ { "name": …, "file": …, "line": …, "col": …,
                      "focused": bool, "excluded": bool, "parallel": bool,
-                     "behaviors": [ { "name": …, "display": …, "line": …,
+                     "behaviors": [ { "name": …, "display": …, "kind": …, "line": …,
                                       "children": [ … ] } ],
                      "behaviorsComplete": bool } ]
     } ]

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -1091,6 +1091,8 @@ UserService
 
 Internally runs `go test -json`, parses the event stream, reconstructs the suite→method→When/It hierarchy from `/`-separated test paths, and strips Go naming conventions for display.
 
+**Labels come from the source.** A subtest name cannot be turned back into the description that produced it: `go test` writes an underscore for every space, so `returns snake_case keys` and `returns snake case keys` arrive as the same name. The renderer therefore reads the declared descriptions from source — the same walker that backs `--static` and `discover` — and shows each behavior under the words the developer actually wrote. Behaviors source cannot enumerate (a `When` behind a condition, a table that is not a literal), and streams rendered with `--input` where there is no source to read, fall back to reconstructing the label from the name, exactly as before. Subtest *names* are untouched either way, so `-run` filters, snapshot keys and saved baselines are unaffected.
+
 Output formats:
 
 ```bash

--- a/internal/gotestspec/declarations_test.go
+++ b/internal/gotestspec/declarations_test.go
@@ -1,0 +1,79 @@
+package gotestspec //nolint:stdlib-test
+
+import (
+	"strings"
+	"testing"
+)
+
+// The description contains an underscore, so its subtest name cannot be turned
+// back into it: go test wrote underscores for the spaces, and nothing in the
+// name says which ones were already there.
+const declStream = `{"Action":"run","Package":"example.com/pkg","Test":"TestKeysTestSuite"}
+{"Action":"run","Package":"example.com/pkg","Test":"TestKeysTestSuite/TestEncode"}
+{"Action":"run","Package":"example.com/pkg","Test":"TestKeysTestSuite/TestEncode/returns_snake_case_keys"}
+{"Action":"pass","Package":"example.com/pkg","Test":"TestKeysTestSuite/TestEncode/returns_snake_case_keys","Elapsed":0.001}
+{"Action":"pass","Package":"example.com/pkg","Test":"TestKeysTestSuite/TestEncode","Elapsed":0.002}
+{"Action":"pass","Package":"example.com/pkg","Test":"TestKeysTestSuite","Elapsed":0.003}
+{"Action":"pass","Package":"example.com/pkg","Elapsed":0.004}
+`
+
+func declTree(t *testing.T, opts ...BuildOption) *Node {
+	t.Helper()
+	events, err := ParseEvents(strings.NewReader(declStream))
+	if err != nil {
+		t.Fatalf("ParseEvents: %v", err)
+	}
+	pkgs := BuildTree(events, opts...)
+	if len(pkgs) != 1 {
+		t.Fatalf("expected 1 package, got %d", len(pkgs))
+	}
+	return pkgs[0].Nodes[0].Children[0].Children[0]
+}
+
+func declsOf(pkg string, entries map[string]Declaration) DeclarationIndex {
+	return DeclarationIndex{pkg: entries}
+}
+
+func TestBuildTree_ShowsTheDeclaredLabel(t *testing.T) {
+	node := declTree(t, WithDeclarations(declsOf("example.com/pkg", map[string]Declaration{
+		"TestKeysTestSuite/TestEncode/returns_snake_case_keys": {Label: "returns snake_case keys"},
+	})))
+
+	if node.Display != "returns snake_case keys" {
+		t.Errorf("display = %q, want %q", node.Display, "returns snake_case keys")
+	}
+}
+
+// Without a declaration there is nothing to prefer, and reconstructing from the
+// name is the honest best effort — the rendering every stream got before.
+func TestBuildTree_FallsBackToTheReconstructedLabel(t *testing.T) {
+	node := declTree(t)
+
+	if node.Display != "returns snake case keys" {
+		t.Errorf("display = %q, want %q", node.Display, "returns snake case keys")
+	}
+}
+
+// The index is keyed per package: a path that matches in one package must not
+// hand its label to an identically-named path in another.
+func TestBuildTree_DeclarationsAreScopedToTheirPackage(t *testing.T) {
+	node := declTree(t, WithDeclarations(declsOf("example.com/other", map[string]Declaration{
+		"TestKeysTestSuite/TestEncode/returns_snake_case_keys": {Label: "returns snake_case keys"},
+	})))
+
+	if node.Display != "returns snake case keys" {
+		t.Errorf("display = %q, want %q", node.Display, "returns snake case keys")
+	}
+}
+
+// The label is what a human reads. The name is what -run filters, snapshot keys
+// and saved baselines are keyed by, and it must not move.
+func TestBuildTree_DeclarationsLeaveNamesAlone(t *testing.T) {
+	node := declTree(t, WithDeclarations(declsOf("example.com/pkg", map[string]Declaration{
+		"TestKeysTestSuite/TestEncode/returns_snake_case_keys": {Label: "returns snake_case keys"},
+	})))
+
+	if node.Name != "returns_snake_case_keys" {
+		t.Errorf("name = %q, want %q", node.Name, "returns_snake_case_keys")
+	}
+}

--- a/internal/gotestspec/tree.go
+++ b/internal/gotestspec/tree.go
@@ -28,17 +28,56 @@ const (
 	KindTest
 )
 
+// Declaration is what the source says about a subtest. Today that is the
+// description as the developer wrote it; a run cannot report it, because by the
+// time a subtest has a name the description has already been rewritten.
+type Declaration struct {
+	Label string
+}
+
+// DeclarationIndex maps a package's test paths ("TestUserServiceTestSuite/
+// TestCreate/email_is_valid") to what source declares about them. The paths are
+// the ones go test prints, which is what lets a declaration and an observation
+// of the same behavior be one node rather than two.
+type DeclarationIndex map[string]map[string]Declaration
+
+func (i DeclarationIndex) lookup(pkgPath, testPath string) Declaration {
+	if i == nil {
+		return Declaration{}
+	}
+	return i[pkgPath][testPath]
+}
+
+type buildConfig struct {
+	decls DeclarationIndex
+}
+
+type BuildOption func(*buildConfig)
+
+// WithDeclarations supplies what the source declares, so the tree can show the
+// developer's own words. Without it the tree falls back to reconstructing a
+// label from the subtest name, which is lossy.
+func WithDeclarations(idx DeclarationIndex) BuildOption {
+	return func(c *buildConfig) { c.decls = idx }
+}
+
 type Node struct {
-	Name     string
-	Display  string
-	Kind     NodeKind
-	Status   Status
-	Duration time.Duration
-	Output   []string
-	Children []*Node
-	Focused  bool
-	Excluded bool
-	External bool
+	Name    string
+	Display string
+	Kind    NodeKind
+	// SourceLabel is the description as written, when it is known from source.
+	// Rendering prefers it over reconstructing a label from Name: go test turns
+	// every space in a description into an underscore, so the name cannot say
+	// which underscores the developer typed. Empty for anything only a run
+	// revealed.
+	SourceLabel string
+	Status      Status
+	Duration    time.Duration
+	Output      []string
+	Children    []*Node
+	Focused     bool
+	Excluded    bool
+	External    bool
 	// Incomplete marks a node whose children are known not to be the whole
 	// list — a statically read method that declares behaviors whose names or
 	// existence depend on runtime values. A tree stream never sets it, because
@@ -74,7 +113,12 @@ func (s Stats) Total() int {
 	return s.Passed + s.Failed + s.Skipped
 }
 
-func BuildTree(events []TestEvent) []*Package {
+func BuildTree(events []TestEvent, opts ...BuildOption) []*Package {
+	var cfg buildConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	pkgs := map[string]*Package{}
 	nodes := map[string]map[string]*Node{}
 	// Track top-level test run counts per package to detect ptest/pxtest duplicates.
@@ -124,6 +168,14 @@ func BuildTree(events []TestEvent) []*Package {
 			resolvedSegments = resolveDuplicateSegments(segments, nmap)
 		}
 
+		// The index is keyed by the path go test would print for a first,
+		// undisambiguated run, so duplicate bookkeeping is stripped before
+		// lookup: a suite that runs twice declares its behaviors once.
+		cleanSegments := make([]string, len(resolvedSegments))
+		for i, seg := range resolvedSegments {
+			cleanSegments[i] = stripDuplicateSuffix(strings.TrimSuffix(seg, "\x00dup"))
+		}
+
 		for i := range resolvedSegments {
 			path := strings.Join(resolvedSegments[:i+1], "/")
 			if nmap[path] != nil {
@@ -132,7 +184,10 @@ func BuildTree(events []TestEvent) []*Package {
 			name := resolvedSegments[i]
 			// Strip #NN suffix from display for children of duplicate runs.
 			cleanName := stripDuplicateSuffix(name)
-			n := &Node{Name: cleanName}
+			n := &Node{
+				Name:        cleanName,
+				SourceLabel: cfg.decls.lookup(ev.Package, strings.Join(cleanSegments[:i+1], "/")).Label,
+			}
 			nmap[path] = n
 			if i == 0 {
 				pkg.Nodes = append(pkg.Nodes, n)
@@ -361,7 +416,14 @@ func classify(n *Node, topLevel bool) {
 			n.Display = strings.TrimSuffix(name, protocol.SuffixTestSuite)
 		default:
 			n.Kind = KindBlock
-			n.Display = strings.ReplaceAll(name, "_", " ")
+			// Prefer the description as written. Reconstructing it from the
+			// name turns every underscore into a space, which is right for the
+			// ones go test put there and wrong for the ones the developer did.
+			if n.SourceLabel != "" {
+				n.Display = n.SourceLabel
+			} else {
+				n.Display = strings.ReplaceAll(name, "_", " ")
+			}
 		}
 	}
 

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -337,15 +337,23 @@ func (s *E2ETestSuite) TestOutputFormatGolden(t *gotest.T) {
 	})
 
 	t.When("json", func(w *gotest.T) {
-		w.It("single passing package", func(it *gotest.T) {
-			cmd := exec.Command(s.binary, "github.com/mvrahden/go-test/examples/auth", "-json", "-parallel", "1") //nolint:gosec // G204: controlled binary with fixed args
-			cmd.Dir = filepath.Join(s.workDir, "examples")
-			out, err := cmd.CombinedOutput()
+		cmd := exec.Command(s.binary, "github.com/mvrahden/go-test/examples/auth", "-json", "-parallel", "1") //nolint:gosec // G204: controlled binary with fixed args
+		cmd.Dir = filepath.Join(s.workDir, "examples")
+		out, err := cmd.CombinedOutput()
 
+		w.It("single passing package", func(it *gotest.T) {
 			gotest.NoError(it, err, "auth should pass: %s", string(out))
 			gotest.MatchSnapshot(it, normalizeJSONOutput(string(out)))
 		})
 
+		// -json is a contract with editors and CI parsers. Anything gotest
+		// invents for its own rendering has to stay out of it: a stray log line
+		// becomes a phantom diagnostic in somebody's editor, and the snapshot
+		// above would happily record it as expected.
+		w.It("carries nothing but the tests' own output", func(it *gotest.T) {
+			gotest.NotContains(it, string(out), "ƒƒ", "gotest bookkeeping leaked into -json")
+			gotest.NotContains(it, string(out), "GOTEST_", "gotest bookkeeping leaked into -json")
+		})
 	})
 
 	t.When("verbose", func(w *gotest.T) {

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -172,6 +173,127 @@ func (s *E2ETestSuite) TestSharedFixtureExitTiming(t *gotest.T) {
 	})
 }
 
+// Discovery and spec rendering reach a behavior's label by different routes:
+// one reads the description from source, the other reconstructs it from the
+// subtest name go test printed. An editor shows both at once — the test tree
+// from discovery, the panel from the spec — so they have to agree. The
+// descriptions below are the ones where a reconstruction cannot: an underscore
+// the developer typed looks exactly like a space go test replaced.
+func (s *E2ETestSuite) TestDiscoveryAndSpecSpellBehaviorsTheSameWay(t *gotest.T) {
+	dir := filepath.Join(s.workDir, "examples", "declared_labels")
+	gotest.NoError(t, os.MkdirAll(dir, 0o755))
+	defer os.RemoveAll(dir)
+	gotest.NoError(t, os.WriteFile(filepath.Join(dir, "ptest_test.go"), []byte(`package declaredlabels
+
+import "github.com/mvrahden/go-test/pkg/gotest"
+
+type KeysTestSuite struct{}
+
+func (s *KeysTestSuite) TestEncode(t *gotest.T) {
+	t.When("the payload uses snake_case", func(w *gotest.T) {
+		w.It("returns snake_case keys", func(it *gotest.T) { gotest.Equal(it, 1, 1) })
+		w.It("leaves CamelCase alone", func(it *gotest.T) { gotest.Equal(it, 1, 1) })
+	})
+}
+`), 0o600))
+
+	run := func(args ...string) []byte {
+		cmd := exec.Command(s.binary, args...) //nolint:gosec // G204: controlled binary with fixed args
+		cmd.Dir = filepath.Join(s.workDir, "examples")
+		out, _ := cmd.CombinedOutput()
+		return out
+	}
+
+	var discovered struct {
+		Packages []struct {
+			Suites []struct {
+				Methods []struct {
+					Behaviors []discoveredBehavior `json:"behaviors"`
+				} `json:"methods"`
+			} `json:"suites"`
+		} `json:"packages"`
+	}
+	raw := run("discover", "./declared_labels")
+	gotest.NoError(t, json.Unmarshal(raw, &discovered), "discover output: %s", string(raw))
+
+	var declared []string
+	var kinds []string
+	for _, p := range discovered.Packages {
+		for _, su := range p.Suites {
+			for _, m := range su.Methods {
+				collectBehaviors(m.Behaviors, &declared, &kinds)
+			}
+		}
+	}
+	gotest.NotEmpty(t, declared, "discover reported no behaviors: %s", string(raw))
+
+	observed := specLabels(string(run("spec", "--no-color", "./declared_labels")))
+	static := specLabels(string(run("spec", "--static", "--no-color", "./declared_labels")))
+
+	t.It("renders a run under the labels discovery declared", func(it *gotest.T) {
+		for _, label := range declared {
+			gotest.True(it, observed[label],
+				"discovery shows %q, which a run never renders; it shows %v", label, sortedKeys(observed))
+		}
+	})
+
+	t.It("renders a static spec under those same labels", func(it *gotest.T) {
+		for _, label := range declared {
+			gotest.True(it, static[label],
+				"discovery shows %q, which --static never renders; it shows %v", label, sortedKeys(static))
+		}
+	})
+
+	t.It("says which call declared each behavior", func(it *gotest.T) {
+		gotest.Contains(it, kinds, "when", "no When behavior reported: %v", kinds)
+		gotest.Contains(it, kinds, "it", "no It behavior reported: %v", kinds)
+	})
+}
+
+type discoveredBehavior struct {
+	Display  string               `json:"display"`
+	Kind     string               `json:"kind"`
+	Children []discoveredBehavior `json:"children"`
+}
+
+func collectBehaviors(bs []discoveredBehavior, labels, kinds *[]string) {
+	for _, b := range bs {
+		*labels = append(*labels, b.Display)
+		*kinds = append(*kinds, b.Kind)
+		collectBehaviors(b.Children, labels, kinds)
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// specLabels reduces rendered spec output to the set of labels it shows,
+// dropping indentation, status glyphs, durations and the summary line.
+func specLabels(out string) map[string]bool {
+	labels := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimLeft(line, "✓✗~ ")
+		if i := strings.LastIndex(line, " ("); i > 0 {
+			line = line[:i]
+		}
+		line = strings.TrimSuffix(line, " — SKIPPED")
+		line = strings.TrimSuffix(line, " — EXCLUDED")
+		line = strings.TrimSuffix(line, " — INCOMPLETE")
+		if line == "" || strings.Contains(line, "behaviors:") || strings.HasPrefix(line, "===") {
+			continue
+		}
+		labels[line] = true
+	}
+	return labels
+}
+
 func (s *E2ETestSuite) TestOutputFormatGolden(t *gotest.T) {
 	t.When("non-verbose", func(w *gotest.T) {
 		w.It("single passing package", func(it *gotest.T) {
@@ -223,6 +345,7 @@ func (s *E2ETestSuite) TestOutputFormatGolden(t *gotest.T) {
 			gotest.NoError(it, err, "auth should pass: %s", string(out))
 			gotest.MatchSnapshot(it, normalizeJSONOutput(string(out)))
 		})
+
 	})
 
 	t.When("verbose", func(w *gotest.T) {

--- a/vscode-gotest/src/types.ts
+++ b/vscode-gotest/src/types.ts
@@ -59,7 +59,12 @@ export interface DiscoverBehavior {
   // which is what lets a declared behavior and an observed one be the same
   // tree node rather than two.
   name: string;
+  // The label to show: the description as the developer wrote it, and the same
+  // string `gotest spec` renders for this node. Do not re-derive it from the
+  // name here, or the test tree and the spec view will drift apart.
   display: string;
+  // Which call declared it: "when" | "it" | "each".
+  kind?: string;
   line: number;
   children?: DiscoverBehavior[];
 }


### PR DESCRIPTION
A behavior described as returns snake_case keys was showing up in the spec as "returns snake case keys" — the underscore quietly became a space. Descriptions now appear exactly as written, in the terminal, the markdown export and the JSON output alike.

That also settles a disagreement in VS Code, where the test tree and the spec panel were spelling the same behavior two different ways. They match now, and discovery reports which behaviors are conditions and which are expectations, so editors and other tools can tell them apart.

Test names are untouched, so existing filters, snapshots and saved baselines keep working.