### PR TITLE
Report the time each test actually took

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ gotest spec ./pkg/user
 ```
 
 ```
-UserService
-  Create
-    ✓ creates a user with valid input
-    when email already exists
-      ✓ returns ErrDuplicate
+UserService (12ms)
+  Create (12ms)
+    ✓ creates a user with valid input (11ms)
+    when email already exists (<1ms)
+      ✓ returns ErrDuplicate (<1ms)
 
 1 suites, 2 behaviors: 2 passed
 ```
@@ -159,19 +159,21 @@ gotest spec ./pkg/user -v
 ```
 
 ```
-UserService
-  Create
-    when email is valid
+UserService (133ms)
+  Create (128ms)
+    when email is valid (128ms)
       ✓ creates the user (8ms)
       ✓ sends a welcome email (120ms)
-    when email already exists
+    when email already exists (<1ms)
       ✓ returns ErrDuplicate (<1ms)
-  Delete
+  Delete (5ms)
     ✓ soft-deletes the user (5ms)
-    ~ hard-deletes after 30 days — SKIPPED
+    ~ hard-deletes after 30 days — SKIPPED (<1ms)
 
 2 suites, 5 behaviors: 4 passed, 1 skipped
 ```
+
+Every row shows the wall clock it occupied, never the sum of the rows beneath it — so a row that exceeds its children is time it held itself, and one that falls short of their total is children that overlapped.
 
 Generate a markdown specification document:
 

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -1075,14 +1075,14 @@ Anything the tool cannot convert is annotated in place, so nothing is silently s
 ```
 $ gotest spec ./pkg/user
 
-UserService
-  Create
-    when email is valid
+UserService (133ms)
+  Create (128ms)
+    when email is valid (128ms)
       ✓ creates the user (8ms)
       ✓ sends a welcome email (120ms)
-    when email already exists
+    when email already exists (<1ms)
       ✓ returns ErrDuplicate (<1ms)
-  Delete
+  Delete (5ms)
     ✓ soft-deletes the user (5ms)
     ~ hard-deletes after 30 days — SKIPPED (<1ms)
 
@@ -1092,6 +1092,22 @@ UserService
 Internally runs `go test -json`, parses the event stream, reconstructs the suite→method→When/It hierarchy from `/`-separated test paths, and strips Go naming conventions for display.
 
 **Labels come from the source.** A subtest name cannot be turned back into the description that produced it: `go test` writes an underscore for every space, so `returns snake_case keys` and `returns snake case keys` arrive as the same name. The renderer therefore reads the declared descriptions from source — the same walker that backs `--static` and `discover` — and shows each behavior under the words the developer actually wrote. Behaviors source cannot enumerate (a `When` behind a condition, a table that is not a literal), and streams rendered with `--input` where there is no source to read, fall back to reconstructing the label from the name, exactly as before. Subtest *names* are untouched either way, so `-run` filters, snapshot keys and saved baselines are unaffected.
+
+### Durations
+
+Every row carries the wall clock it occupied, and never the sum of the rows beneath it.
+A sum is an integral over occupancy rather than an interval, so under parallelism it reports more time than the clock did: three 50ms methods sharing 58ms of one suite cost 58ms, not 160ms.
+The difference between a row and its children is therefore information — time the row held itself (the subprocess a `When` starts before its assertions), or children that overlapped.
+
+Which of a node's two measures says that depends on one fact about it.
+A node that called `t.Parallel` reports what `go test` measured, because its own bracket in the event stream is unusable twice over: it opens when the node was registered rather than when it began, and `go test` flushes a parked test's report through its parent, which can delay the close by however long a slower sibling runs — measured at 55s on a test that executed for 300ms.
+Every other node reports its bracket, because a measure that stops when the function returns cannot see parallel children — a suite of parallel methods measures ~0 — while the bracket encloses the whole subtree.
+Descendants of a parked node keep clean timestamps; only the parked node's own terminal event is delayed.
+
+A package row is not something that executes, so it is worth the clock during which one of its suites was running: the union of their windows, overlap counted once, which also drops the gap between windows when a tree holds results from more than one run.
+No row is ever shorter than what it contains — `go test` reports a parked node's measure to 10ms while a child's bracket is exact, so a row is floored by its children, which can only repair that rounding and never invent time.
+
+The same numbers reach `--format=md` and the `duration` field of `--format=json`, in seconds.
 
 Output formats:
 

--- a/internal/gotestgen/generator_suite_test.go
+++ b/internal/gotestgen/generator_suite_test.go
@@ -26,33 +26,55 @@ func (s *GeneratorTestSuite) TestStdlibPackageReturnsEmpty(t *gotest.T) {
 // --- E2E tests (folded from generator_e2e_test.go) ---
 
 func (s *GeneratorTestSuite) TestE2ECLI(t *gotest.T) {
+	cases := []struct {
+		Desc    string
+		dirName string
+		hasPX   bool
+	}{
+		{"no testsuite", "no_testsuite", true},
+		{"simple testsuite", "testsuite", true},
+		{"suite guard", "suite_guard", false},
+		{"fixture lifecycle", "fixture_lifecycle", false},
+		{"multi fixture", "multi_fixture", false},
+	}
+
+	// One load for every directory. Loading them one at a time re-type-checked
+	// the same dependency graph per case, and a single call is what the CLI
+	// itself does for a multi-package pattern.
+	cwd, err := os.Getwd()
+	gotest.NoError(t, err)
+	dirs := make([]string, len(cases))
+	for i, tC := range cases {
+		dirs[i] = filepath.Join(cwd, "testdata_e2e", tC.dirName)
+	}
+
+	loaded, broken, err := gotestgen.LoadPackages(dirs, nil)
+	gotest.NoError(t, err)
+	gotest.Empty(t, broken)
+	results, _, err := gotestgen.GenerateFromLoaded(loaded)
+	gotest.NoError(t, err)
+	gotest.Len(t, results, len(cases), "every directory must generate exactly one result")
+
+	byPath := make(map[string]int, len(results))
+	for i, r := range results {
+		byPath[r.AbsPath] = i
+	}
+
 	t.When("CLI-level generation", func(w *gotest.T) {
-		for sub, tC := range gotest.Each(w, []struct {
-			Desc    string
-			dirName string
-			hasPX   bool
-		}{
-			{"no testsuite", "no_testsuite", true},
-			{"simple testsuite", "testsuite", true},
-			{"suite guard", "suite_guard", false},
-			{"fixture lifecycle", "fixture_lifecycle", false},
-			{"multi fixture", "multi_fixture", false},
-		}) {
-			cwd, err := os.Getwd()
-			gotest.NoError(sub, err)
-
+		for sub, tC := range gotest.Each(w, cases) {
 			dirPath := filepath.Join(cwd, "testdata_e2e", tC.dirName)
-			loaded, broken, err := gotestgen.LoadPackages([]string{dirPath}, nil)
-			gotest.NoError(sub, err)
-			gotest.Empty(sub, broken)
-			results, _, err := gotestgen.GenerateFromLoaded(loaded)
-			gotest.NoError(sub, err)
-			gotest.Equal(sub, dirPath, results[0].AbsPath)
-			gotest.Equal(sub, "github.com/mvrahden/go-test/internal/gotestgen/testdata_e2e/"+tC.dirName, results[0].PkgPath)
+			i, ok := byPath[dirPath]
+			gotest.True(sub, ok, "no generated result for %s", dirPath)
+			if !ok {
+				continue
+			}
 
-			gotest.MatchSnapshot(sub, string(results[0].PTest), tC.dirName+"-ptest")
+			gotest.Equal(sub, dirPath, results[i].AbsPath)
+			gotest.Equal(sub, "github.com/mvrahden/go-test/internal/gotestgen/testdata_e2e/"+tC.dirName, results[i].PkgPath)
+
+			gotest.MatchSnapshot(sub, string(results[i].PTest), tC.dirName+"-ptest")
 			if tC.hasPX {
-				gotest.MatchSnapshot(sub, string(results[0].PXTest), tC.dirName+"-pxtest")
+				gotest.MatchSnapshot(sub, string(results[i].PXTest), tC.dirName+"-pxtest")
 			}
 		}
 	})
@@ -70,7 +92,9 @@ func (s *GeneratorTestSuite) TestE2ENoTestSuites(t *gotest.T) {
 			// result: a typo'd path must never report a passing run.
 			{"non-existent path is broken", "testdata_e2e/nothing-here", 1},
 			{"stdlib package returns empty", "strings", 0},
-			{"stdlib nested package returns empty", "net/http", 0},
+			// Any nested path proves the point, so pick one whose import graph
+			// is nearly empty — net/http cost a second of loading to say this.
+			{"stdlib nested package returns empty", "container/heap", 0},
 		}) {
 			loaded, broken, err := gotestgen.LoadPackages([]string{tC.arg}, nil)
 			gotest.NoError(sub, err)

--- a/internal/gotestgen/panic_resilience_suite_test.go
+++ b/internal/gotestgen/panic_resilience_suite_test.go
@@ -179,7 +179,8 @@ func (s *PanicResilienceTestSuite) TestSetupTimeoutOverrun(t *gotest.T) {
 
 func (s *PanicResilienceTestSuite) TestSetupThatNeverReturns(t *gotest.T) {
 	t.When("BeforeAll hangs past its configured SetupTimeout", func(w *gotest.T) {
-		run := runGeneratedSuite(w, "TestLifecycle_SetupHang")
+		// This child can only be ended by its alarm, so it runs on a short one.
+		run := runGeneratedSuite(w, "TestLifecycle_SetupHang", hangTimeout)
 
 		w.It("names the budget it blew", func(it *gotest.T) {
 			// A setup that returns late can be judged once it returns. One that
@@ -187,12 +188,19 @@ func (s *PanicResilienceTestSuite) TestSetupThatNeverReturns(t *gotest.T) {
 			// with nothing but the -timeout dump, which names no budget at all.
 			// The verdict has to be written while the setup is still stuck.
 			gotest.Contains(it, run.output, "BeforeAll exceeded its configured SetupTimeout of 200ms",
-				"a hung BeforeAll must still report the budget it blew:\n%s", run.output)
+				"a hung BeforeAll must still report the budget it blew; the child ran %s of its %s alarm, "+
+					"so if those are equal the alarm beat the verdict and this is a margin problem, not a regression:\n%s",
+				run.elapsed, run.timeout, run.output)
 			gotest.Contains(it, run.output, "MARK:setup entered", run.output)
 		})
 
 		w.It("fails the run", func(it *gotest.T) {
 			gotest.False(it, run.passed, "a hung setup must not pass:\n%s", run.output)
+		})
+
+		w.It("never reaches the tests it guards", func(it *gotest.T) {
+			gotest.NotContains(it, run.output, "MARK:test ran",
+				"BeforeAll never returned, so no test method may have run:\n%s", run.output)
 		})
 	})
 }

--- a/internal/gotestgen/parallel_lifecycle_suite_test.go
+++ b/internal/gotestgen/parallel_lifecycle_suite_test.go
@@ -21,6 +21,13 @@ import (
 // hang, and must not be executed by this backstop alarm.
 const childTimeout = 60 * time.Second
 
+// hangTimeout is the alarm for a child that can only be ended by it. A BeforeAll
+// that never returns wedges the binary, so unlike childTimeout this value is paid
+// in full on every run. 1s: the verdict lands at ~250ms — a 200ms budget plus
+// scheduling — and only that scheduling slack varies, because the two-step compile
+// below keeps build time out of the window.
+const hangTimeout = 1 * time.Second
+
 // childWallClock bounds the whole subprocess, so even a child that ignores its
 // own timeout cannot stall the parent run.
 const childWallClock = 90 * time.Second
@@ -45,11 +52,17 @@ type childRun struct {
 	output  string
 	elapsed time.Duration
 	passed  bool
+	timeout time.Duration
 }
 
 // runGeneratedSuite renders the harness for a testdata package, drops it next to
-// the sources inside the throwaway module and runs `go test` over it.
-func runGeneratedSuite(t *gotest.T, name string) childRun {
+// the sources inside the throwaway module and runs `go test` over it. The alarm
+// defaults to childTimeout; pass one only for a child that cannot exit on its own.
+func runGeneratedSuite(t *gotest.T, name string, timeout ...time.Duration) childRun {
+	limit := childTimeout
+	if len(timeout) > 0 {
+		limit = timeout[0]
+	}
 	dir := gotestgen.ExportTestPkgDir(t.T(), name)
 	pkg := gotestgen.ExportMustTestPkg(t.T(), name)
 
@@ -82,12 +95,12 @@ func runGeneratedSuite(t *gotest.T, name string) childRun {
 	defer cancel()
 
 	// -test.v keeps the suite's own stdout markers even when the child passes.
-	cmd := exec.CommandContext(ctx, bin, "-test.v", "-test.count=1", "-test.timeout="+childTimeout.String()) //nolint:gosec // G204: freshly compiled test binary
+	cmd := exec.CommandContext(ctx, bin, "-test.v", "-test.count=1", "-test.timeout="+limit.String()) //nolint:gosec // G204: freshly compiled test binary
 	cmd.Dir = dir
 
 	start := time.Now()
 	out, err := cmd.CombinedOutput()
-	run := childRun{output: string(out), elapsed: time.Since(start), passed: err == nil}
+	run := childRun{output: string(out), elapsed: time.Since(start), passed: err == nil, timeout: limit}
 
 	gotest.NoError(t, ctx.Err(), "child never exited on its own:\n%s", run.output)
 	return run
@@ -98,8 +111,8 @@ func runGeneratedSuite(t *gotest.T, name string) childRun {
 func assertNoDeadlock(t *gotest.T, run childRun) {
 	gotest.NotContains(t, run.output, "test timed out",
 		"suite cleanup deadlocked; the run was terminated by the -timeout alarm:\n%s", run.output)
-	gotest.Less(t, run.elapsed, childTimeout,
-		"child ran for %s, at or beyond its own -test.timeout of %s:\n%s", run.elapsed, childTimeout, run.output)
+	gotest.Less(t, run.elapsed, run.timeout,
+		"child ran for %s, at or beyond its own -test.timeout of %s:\n%s", run.elapsed, run.timeout, run.output)
 }
 
 func (s *ParallelLifecycleTestSuite) TestParallelSuccess(t *gotest.T) {

--- a/internal/gotestrunner/sharedfixture_teardown_suite_test.go
+++ b/internal/gotestrunner/sharedfixture_teardown_suite_test.go
@@ -107,7 +107,10 @@ func (s *SharedFixtureTeardownTestSuite) TestTeardownGetsItsConfiguredBudget(t *
 		// silently becomes the budget: a container fixture is given minutes to
 		// stop and gets killed part-way through instead, with the run still
 		// reporting success.
-		proc, marker, cancel := startSlowTeardown(w, 7*time.Second, 60*time.Second)
+		//
+		// 1s: long enough that the regression — a grace of zero — cannot let the
+		// teardown finish, and setup needs ~0.2s of the 10s budget.
+		proc, marker, cancel := startSlowTeardown(w, 1*time.Second, 10*time.Second)
 		cancel()
 		err := proc.Teardown()
 

--- a/internal/gotestspec/duration_suite_test.go
+++ b/internal/gotestspec/duration_suite_test.go
@@ -1,0 +1,232 @@
+package gotestspec_test
+
+import (
+	"bytes"
+	"strings"
+	"time"
+
+	"github.com/mvrahden/go-test/internal/gotestspec"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// DurationTestSuite covers what the tree says about time. Every row is an
+// interval — the wall clock a thing occupied — and never a sum of its children,
+// which is an integral over occupancy and reports more time than the clock did
+// as soon as anything runs in parallel.
+type DurationTestSuite struct{}
+
+var base = time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
+
+// at builds a node bracketed from offset to offset+span, measuring measured.
+func at(display string, offset, span, measured time.Duration, kids ...*gotestspec.Node) *gotestspec.Node {
+	return &gotestspec.Node{
+		Display:  display,
+		Status:   gotestspec.StatusPass,
+		Duration: measured,
+		Start:    base.Add(offset),
+		End:      base.Add(offset + span),
+		Children: kids,
+	}
+}
+
+// parked marks a node as one that called t.Parallel, which is what makes its
+// own bracket untrustworthy in both directions.
+func parked(n *gotestspec.Node) *gotestspec.Node {
+	n.Paused = true
+	return n
+}
+
+func (s *DurationTestSuite) TestParkedNodeReportsWhatItExecuted(t *gotest.T) {
+	t.When("a parallel leaf was parked before it ran", func(w *gotest.T) {
+		// Registered at once, resumed 50ms later, then done in a millisecond.
+		// The wait belongs to whatever set the concurrency, not to the test.
+		leaf := parked(at("matches correctly", 0, 51*time.Millisecond, time.Millisecond))
+
+		w.It("charges only its own execution", func(it *gotest.T) {
+			gotest.Equal(it, time.Millisecond, gotestspec.EffectiveDuration(leaf),
+				"a leaf that did nothing must not be billed for queueing")
+		})
+	})
+
+	t.When("a parked method's report was flushed late", func(w *gotest.T) {
+		// Measured against a real stream: the method resumed at 5.1s, ran for
+		// 300ms, and had its terminal event held behind a 60s sibling — so its
+		// bracket reads 60.7s for 300ms of work. Its children keep clean
+		// timestamps; only the parked node's own end is delayed.
+		method := parked(at("PanicInEachAfterRecordedFailure", 0, 60783*time.Millisecond, 300*time.Millisecond,
+			at("an Each entry records a failure and then panics", 5107*time.Millisecond, 300*time.Millisecond, 300*time.Millisecond),
+		))
+
+		w.It("ignores its bracket entirely", func(it *gotest.T) {
+			gotest.Equal(it, 300*time.Millisecond, gotestspec.EffectiveDuration(method),
+				"a 300ms method must not read as a minute because a sibling held the flush")
+		})
+
+		w.It("leaves the child on its own clean bracket", func(it *gotest.T) {
+			gotest.Equal(it, 300*time.Millisecond, gotestspec.EffectiveDuration(method.Children[0]))
+		})
+	})
+
+	t.When("its measure rounds below a child's", func(w *gotest.T) {
+		// go test reports a parked node's measure to 10ms while a child's
+		// bracket is exact, so a 15ms method can read 10ms beside its own 15ms
+		// child. A child runs inside its parent, so the parent is floored by it.
+		method := parked(at("GraceKill", 0, 9*time.Second, 10*time.Millisecond,
+			at("using GraceKill strategy", 0, 15*time.Millisecond, 15*time.Millisecond),
+		))
+
+		w.It("never reads shorter than what it contains", func(it *gotest.T) {
+			gotest.Equal(it, 15*time.Millisecond, gotestspec.EffectiveDuration(method))
+		})
+	})
+
+	t.When("a parked child's measure rounds above its suite's bracket", func(w *gotest.T) {
+		// The same rounding seen from the other side: the suite is not parked,
+		// so it reports an exact bracket, which its child can still exceed.
+		suite := at("Spec", 0, 229*time.Millisecond, 0,
+			parked(at("DetermineTestSuiteHarness", 0, 229*time.Millisecond, 230*time.Millisecond)),
+		)
+
+		w.It("lifts the suite to its child", func(it *gotest.T) {
+			gotest.Equal(it, 230*time.Millisecond, gotestspec.EffectiveDuration(suite))
+		})
+	})
+
+	t.When("a parked node is unioned with others", func(w *gotest.T) {
+		// Its Duration says how long it ran but neither endpoint says when, so
+		// it contributes nothing rather than a window in the wrong place.
+		pkg := &gotestspec.Package{Path: "p", Nodes: []*gotestspec.Node{
+			at("Alpha", 0, 100*time.Millisecond, 100*time.Millisecond),
+			parked(at("Beta", 0, 60*time.Second, time.Millisecond)),
+		}}
+
+		w.It("is left out rather than placed wrongly", func(it *gotest.T) {
+			gotest.Equal(it, 100*time.Millisecond, gotestspec.PackageDuration(pkg))
+		})
+	})
+}
+
+func (s *DurationTestSuite) TestContainerReportsItsBracket(t *gotest.T) {
+	t.When("its children ran in parallel", func(w *gotest.T) {
+		// go test stops a parent's clock when it returns, so the parent measures
+		// nothing, while its children together claim more than the clock passed.
+		suite := at("Gotestast", 0, 58*time.Millisecond, 0,
+			parked(at("DetermineFixtureHarness", 0, 58*time.Millisecond, 58*time.Millisecond)),
+			parked(at("FixtureValidation", 0, 50*time.Millisecond, 50*time.Millisecond)),
+			parked(at("ClassifyLocalFields", 0, 52*time.Millisecond, 52*time.Millisecond)),
+		)
+
+		w.It("reports the interval, not the sum", func(it *gotest.T) {
+			gotest.Equal(it, 58*time.Millisecond, gotestspec.EffectiveDuration(suite),
+				"three 50ms methods sharing 58ms of clock cost 58ms, not 160ms")
+		})
+	})
+
+	t.When("it held time its children never report", func(w *gotest.T) {
+		// The shape of a When that drives a subprocess: the work happens in the
+		// container and the leaves only assert on what it produced.
+		when := at("the setup never returns", 0, 60*time.Second, 60*time.Second,
+			at("names the budget", 60*time.Second, 0, 0),
+			at("fails the run", 60*time.Second, 0, 0),
+		)
+
+		w.It("still reports what it cost", func(it *gotest.T) {
+			gotest.Equal(it, 60*time.Second, gotestspec.EffectiveDuration(when))
+		})
+	})
+
+	t.When("the tree carries no timestamps", func(w *gotest.T) {
+		// A static spec or a hand-built fixture. The subtree is then bounded
+		// below by both the node's own measure and its children's.
+		held := &gotestspec.Node{Display: "held", Duration: 5 * time.Second,
+			Children: []*gotestspec.Node{{Display: "leaf", Status: gotestspec.StatusPass}}}
+		parallel := &gotestspec.Node{Display: "parallel",
+			Children: []*gotestspec.Node{
+				{Display: "a", Duration: 500 * time.Millisecond},
+				{Display: "b", Duration: 500 * time.Millisecond},
+			}}
+
+		w.It("falls back to whichever bound is larger", func(it *gotest.T) {
+			gotest.Equal(it, 5*time.Second, gotestspec.EffectiveDuration(held))
+			gotest.Equal(it, time.Second, gotestspec.EffectiveDuration(parallel))
+		})
+	})
+}
+
+func (s *DurationTestSuite) TestPackageUnionsWhatItsSuitesOccupied(t *gotest.T) {
+	t.When("its suites overlapped", func(w *gotest.T) {
+		// A package is not something that executes — the runner dispatches its
+		// suites among every other package's — so it is worth exactly the clock
+		// during which one of them was running.
+		pkg := &gotestspec.Package{Path: "p", Nodes: []*gotestspec.Node{
+			at("Alpha", 0, 100*time.Millisecond, 100*time.Millisecond,
+				at("one", 0, 100*time.Millisecond, 100*time.Millisecond)),
+			at("Beta", 50*time.Millisecond, 100*time.Millisecond, 100*time.Millisecond,
+				at("two", 50*time.Millisecond, 100*time.Millisecond, 100*time.Millisecond)),
+		}}
+
+		w.It("counts the overlap once", func(it *gotest.T) {
+			gotest.Equal(it, 150*time.Millisecond, gotestspec.PackageDuration(pkg),
+				"two 100ms suites overlapping by 50ms occupied 150ms of clock")
+		})
+	})
+}
+
+func (s *DurationTestSuite) TestTotalSkipsTheGapBetweenRuns(t *gotest.T) {
+	t.When("a tree holds results recorded hours apart", func(w *gotest.T) {
+		// The interval between two runs is nobody's cost. Unioning the windows
+		// rather than spanning them keeps the number honest without having to
+		// know which run each result came from.
+		morning := &gotestspec.Package{Path: "a", Nodes: []*gotestspec.Node{
+			at("Alpha", 0, time.Second, time.Second, at("one", 0, time.Second, time.Second))}}
+		afternoon := &gotestspec.Package{Path: "b", Nodes: []*gotestspec.Node{
+			at("Beta", 4*time.Hour, 2*time.Second, 2*time.Second,
+				at("two", 4*time.Hour, 2*time.Second, 2*time.Second))}}
+
+		w.It("totals the time something was running", func(it *gotest.T) {
+			gotest.Equal(it, 3*time.Second,
+				gotestspec.TotalDuration([]*gotestspec.Package{morning, afternoon}))
+		})
+	})
+}
+
+func (s *DurationTestSuite) TestRenderedTreeCarriesTheEffectiveTime(t *gotest.T) {
+	t.When("a parallel suite is rendered", func(w *gotest.T) {
+		var buf bytes.Buffer
+		gotestspec.RenderTerminal(&buf, []*gotestspec.Package{{Path: "p", Nodes: []*gotestspec.Node{
+			at("Parallel", 0, 300*time.Millisecond, 0,
+				at("first", 0, 300*time.Millisecond, 300*time.Millisecond),
+				at("second", 0, 300*time.Millisecond, 300*time.Millisecond),
+			)}}}, gotestspec.WithNoColor())
+		out := buf.String()
+
+		w.It("shows the clock the suite occupied", func(it *gotest.T) {
+			gotest.Contains(it, lineWith(out, "Parallel"), "(300ms)",
+				"the rendered row must not sum concurrent children:\n%s", out)
+		})
+	})
+
+	t.When("the tree is rendered as a specification", func(w *gotest.T) {
+		var buf bytes.Buffer
+		gotestspec.RenderTerminal(&buf, []*gotestspec.Package{{Path: "p", Nodes: []*gotestspec.Node{
+			at("Hangs", 0, 60*time.Second, 0, at("leaf", 0, 0, 0))}}},
+			gotestspec.WithNoColor(), gotestspec.WithoutVerdicts())
+		out := buf.String()
+
+		w.It("quotes no duration at all", func(it *gotest.T) {
+			gotest.NotContains(it, out, "60.0s",
+				"a spec has executed nothing and must claim no time:\n%s", out)
+		})
+	})
+}
+
+// lineWith returns the rendered row carrying substr, so an assertion can name
+// the row it means instead of searching the whole tree.
+func lineWith(output, substr string) string {
+	for line := range strings.SplitSeq(output, "\n") {
+		if strings.Contains(line, substr) {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/gotestspec/event.go
+++ b/internal/gotestspec/event.go
@@ -15,6 +15,10 @@ const (
 	ActionPass   Action = "pass"
 	ActionFail   Action = "fail"
 	ActionSkip   Action = "skip"
+	// A test that calls t.Parallel is parked and resumed, which is the one
+	// thing that makes its own timestamps untrustworthy — see Node.Paused.
+	ActionPause Action = "pause"
+	ActionCont  Action = "cont"
 )
 
 type TestEvent struct {

--- a/internal/gotestspec/json.go
+++ b/internal/gotestspec/json.go
@@ -71,7 +71,7 @@ func RenderJSON(w io.Writer, packages []*Package) {
 		root.Packages[i] = jsonPackage{
 			Path:     pkg.Path,
 			Status:   statusString(pkg.Status),
-			Duration: pkg.Duration.Seconds(),
+			Duration: PackageDuration(pkg).Seconds(),
 			Nodes:    convertNodes(pkg.Nodes),
 			Output:   output,
 		}
@@ -93,7 +93,7 @@ func convertNodes(nodes []*Node) []jsonNode {
 			Display:    n.Display,
 			Kind:       kindString(n.Kind),
 			Status:     statusString(n.Status),
-			Duration:   n.Duration.Seconds(),
+			Duration:   EffectiveDuration(n).Seconds(),
 			Focused:    n.Focused,
 			Excluded:   n.Excluded,
 			External:   n.External,

--- a/internal/gotestspec/markdown.go
+++ b/internal/gotestspec/markdown.go
@@ -58,7 +58,7 @@ func markdownRow(w io.Writer, indent, display string, n *Node, bare bool) {
 		fmt.Fprintf(w, "| %s%s |\n", indent, display)
 		return
 	}
-	fmt.Fprintf(w, "| %s%s | %s | %s |\n", indent, display, statusText(n.Status), formatDuration(n.Duration))
+	fmt.Fprintf(w, "| %s%s | %s | %s |\n", indent, display, statusText(n.Status), formatDuration(EffectiveDuration(n)))
 }
 
 func markdownHeader(w io.Writer, bare bool) {
@@ -146,7 +146,7 @@ func renderMarkdownNode(w io.Writer, n *Node, headingLevel int, bare bool) {
 				fmt.Fprintf(w, "- %s\n", n.Display)
 				return
 			}
-			fmt.Fprintf(w, "- %s %s (%s)\n", statusText(n.Status), n.Display, formatDuration(n.Duration))
+			fmt.Fprintf(w, "- %s %s (%s)\n", statusText(n.Status), n.Display, formatDuration(EffectiveDuration(n)))
 		}
 	}
 }

--- a/internal/gotestspec/summary.go
+++ b/internal/gotestspec/summary.go
@@ -33,7 +33,7 @@ func collectFailedLeaves(pkgPath string, n *Node, display []string, out *[]failu
 		*out = append(*out, failure{
 			Package:  pkgPath,
 			Display:  d,
-			Duration: n.Duration,
+			Duration: EffectiveDuration(n),
 			Output:   n.Output,
 		})
 	}
@@ -62,12 +62,12 @@ func collectPackageDiagnostics(packages []*Package) []packageDiagnostic {
 	return diags
 }
 
+// effectiveDuration prefers a wall clock the caller measured itself, because
+// that one also covers compiling: the event stream only starts once the first
+// test does. Without it, the union of what the packages occupied is the closest
+// the stream can get.
 func totalDuration(packages []*Package) time.Duration {
-	var d time.Duration
-	for _, pkg := range packages {
-		d += pkg.Duration
-	}
-	return d
+	return TotalDuration(packages)
 }
 
 func effectiveDuration(cfg renderConfig, packages []*Package) time.Duration {

--- a/internal/gotestspec/terminal.go
+++ b/internal/gotestspec/terminal.go
@@ -115,7 +115,7 @@ func renderNode(w io.Writer, n *Node, depth int, c *colors, bare bool) {
 
 	if isLeaf {
 		icon, clr := statusIcon(n.Status, c)
-		dur := formatDuration(n.Duration)
+		dur := formatDuration(EffectiveDuration(n))
 
 		suffix := ""
 		if n.Excluded || n.Status == StatusSkip {
@@ -172,7 +172,9 @@ func renderNode(w io.Writer, n *Node, depth int, c *colors, bare bool) {
 		suffix += fmt.Sprintf(" %s%s%s", clr, icon, c.reset)
 	}
 
-	fmt.Fprintf(w, "%s%s%s\n", indent, label, suffix)
+	fmt.Fprintf(w, "%s%s%s %s(%s)%s\n",
+		indent, label, suffix,
+		c.dim, formatDuration(EffectiveDuration(n)), c.reset)
 
 	if ownFailure {
 		if len(filterOutput(n.Output)) > 0 {

--- a/internal/gotestspec/tree.go
+++ b/internal/gotestspec/tree.go
@@ -72,12 +72,31 @@ type Node struct {
 	// revealed.
 	SourceLabel string
 	Status      Status
-	Duration    time.Duration
-	Output      []string
-	Children    []*Node
-	Focused     bool
-	Excluded    bool
-	External    bool
+	// Duration is what go test measured for this node alone. Start and End
+	// bracket it in the stream. Each is wrong in its own way and EffectiveDuration
+	// picks between them; see Paused.
+	Duration time.Duration
+	Start    time.Time
+	End      time.Time
+	// Paused records that the node called t.Parallel, so it was parked before it
+	// ran. That makes its own bracket meaningless twice over: Start is when it
+	// was registered rather than when it began, and go test flushes a parked
+	// test's report through its parent, which can delay End by however long a
+	// slower sibling runs — measured at 55s on a test that executed for 300ms.
+	// Its Duration is exact, though, because go test stops counting while parked.
+	//
+	// The inverse holds for a node that was never parked: its Duration stops
+	// when its function returns, which excludes any parallel children that run
+	// afterwards — a suite of parallel methods measures ~0 — while its bracket
+	// is clean, because go test reports a parent only once every descendant is
+	// done. Descendants of a parked node keep clean timestamps; only the parked
+	// node's own terminal event is delayed.
+	Paused   bool
+	Output   []string
+	Children []*Node
+	Focused  bool
+	Excluded bool
+	External bool
 	// Incomplete marks a node whose children are known not to be the whole
 	// list — a statically read method that declares behaviors whose names or
 	// existence depend on runtime values. A tree stream never sets it, because
@@ -154,7 +173,7 @@ func BuildTree(events []TestEvent, opts ...BuildOption) []*Package {
 			topRunCount[ev.Package][segments[0]]++
 			if topRunCount[ev.Package][segments[0]] > 1 {
 				// Create a duplicate node; children with #NN suffixes will attach here.
-				dup := &Node{Name: segments[0], duplicate: true}
+				dup := &Node{Name: segments[0], duplicate: true, Start: ev.Time}
 				dupPath := segments[0] + "\x00dup"
 				nmap[dupPath] = dup
 				pkg.Nodes = append(pkg.Nodes, dup)
@@ -208,9 +227,16 @@ func BuildTree(events []TestEvent, opts ...BuildOption) []*Package {
 		switch ev.Action {
 		case ActionOutput:
 			node.Output = append(node.Output, ev.Output)
+		case ActionRun:
+			if node.Start.IsZero() {
+				node.Start = ev.Time
+			}
+		case ActionPause, ActionCont:
+			node.Paused = true
 		case ActionPass, ActionFail, ActionSkip:
 			node.Status = statusFrom(ev.Action)
 			node.Duration = elapsed(ev.Elapsed)
+			node.End = ev.Time
 		}
 	}
 
@@ -516,6 +542,134 @@ func statusFrom(a Action) Status {
 
 func elapsed(s float64) time.Duration {
 	return time.Duration(s * float64(time.Second))
+}
+
+// EffectiveDuration is the wall clock a node occupied: an interval, never a sum
+// of its children, which is an integral over occupancy and exceeds the clock as
+// soon as anything runs in parallel.
+//
+// Which of the node's two measures to believe follows from why each one lies.
+// A parked node reports what go test measured, because its bracket carries the
+// wait for a slot and go test's delayed flush. Everything else reports its
+// bracket, because a measure that stops when the function returns cannot see
+// parallel children, while the bracket encloses the whole subtree — and covers
+// work the node did outside any child, such as the subprocess a When starts
+// before its assertions.
+func EffectiveDuration(n *Node) time.Duration {
+	if n.Paused {
+		return max(n.Duration, childFloor(n))
+	}
+	if d, ok := bracket(n); ok {
+		return max(d, childFloor(n))
+	}
+	if len(n.Children) == 0 {
+		return n.Duration
+	}
+	// A tree assembled from something other than a stream — a static spec, a
+	// hand-built fixture — carries no timestamps. The subtree is then bounded
+	// below by both the node's own measure and its children's.
+	sum := time.Duration(0)
+	for _, c := range n.Children {
+		sum += EffectiveDuration(c)
+	}
+	return max(n.Duration, sum)
+}
+
+// childFloor is the least a node can have cost. A child runs inside its parent,
+// so the parent is at least as long as any single one of them, and at least as
+// long as the clock its placeable children occupied between them. Flooring by
+// that repairs the rounding go test applies to a parked node's measure — it
+// reports to 10ms, while a child's bracket is exact — without ever inventing
+// time, because neither bound can exceed what the parent actually ran for.
+func childFloor(n *Node) time.Duration {
+	var floor time.Duration
+	for _, c := range n.Children {
+		floor = max(floor, EffectiveDuration(c))
+	}
+	if d, ok := unionOf(n.Children); ok {
+		floor = max(floor, d)
+	}
+	return floor
+}
+
+func bracket(n *Node) (time.Duration, bool) {
+	if n.Start.IsZero() || n.End.IsZero() || n.End.Before(n.Start) {
+		return 0, false
+	}
+	return n.End.Sub(n.Start), true
+}
+
+// interval is the window a node occupied, for rows that have to be assembled
+// out of several nodes. A parked node cannot be placed on the clock at all —
+// its Duration says how long it ran but both its endpoints are unreliable — so
+// it declines rather than contributing a window in the wrong place. Nothing is
+// lost by that: only top-level nodes are ever unioned, and a suite is not
+// parked, so the parked methods inside it sit within a window that is.
+func interval(n *Node) (start, end time.Time, ok bool) {
+	if n.Paused || n.Start.IsZero() || n.End.IsZero() || n.End.Before(n.Start) {
+		return
+	}
+	return n.Start, n.End, true
+}
+
+// PackageDuration is how long a package was busy. A package is not something
+// that executes, so it has no bracket of its own — the runner dispatches its
+// suites among every other package's, and the summary event it emits carries
+// the sum of their process times rather than any interval. What is left, and
+// what is true, is the union of the windows its suites occupied.
+func PackageDuration(pkg *Package) time.Duration {
+	if d, ok := unionOf(pkg.Nodes); ok {
+		return d
+	}
+	return pkg.Duration
+}
+
+// TotalDuration is the union across every package: the wall clock during which
+// this run was executing something. Gaps are excluded, which is what makes the
+// number survive a tree holding results from more than one run.
+func TotalDuration(packages []*Package) time.Duration {
+	all := make([]*Node, 0, len(packages))
+	for _, pkg := range packages {
+		all = append(all, pkg.Nodes...)
+	}
+	if d, ok := unionOf(all); ok {
+		return d
+	}
+	var sum time.Duration
+	for _, pkg := range packages {
+		sum += pkg.Duration
+	}
+	return sum
+}
+
+// unionOf merges the nodes' windows and totals what is left. Overlap is counted
+// once: two suites that ran side by side for a second cost a second, not two.
+func unionOf(nodes []*Node) (time.Duration, bool) {
+	type window struct{ start, end time.Time }
+	windows := make([]window, 0, len(nodes))
+	for _, n := range nodes {
+		if s, e, ok := interval(n); ok {
+			windows = append(windows, window{s, e})
+		}
+	}
+	if len(windows) == 0 {
+		return 0, false
+	}
+	sort.Slice(windows, func(i, j int) bool { return windows[i].start.Before(windows[j].start) })
+
+	var total time.Duration
+	cur := windows[0]
+	for _, w := range windows[1:] {
+		if w.start.After(cur.end) {
+			total += cur.end.Sub(cur.start)
+			cur = w
+			continue
+		}
+		if w.end.After(cur.end) {
+			cur.end = w.end
+		}
+	}
+	return total + cur.end.Sub(cur.start), true
 }
 
 // ClassifyRoots applies the tree's naming rules — kind, display text, focus and

--- a/internal/lint/lint_suite_test.go
+++ b/internal/lint/lint_suite_test.go
@@ -13,84 +13,51 @@ func (s *LintTestSuite) SuiteConfig() gotest.SuiteConfig {
 	return gotest.SuiteConfig{Parallel: true}
 }
 
-func (s *LintTestSuite) TestAnalyzer(t *gotest.T) {
-	testdata := analysistest.TestData()
+// analysistest type-checks the fixture package and everything it imports, which
+// dwarfs the analysis itself: a package loaded on its own measured ~2.2s against
+// ~0.2s marginal once batched into a shared load. So the rules are grouped by
+// call, not split by rule.
+//
+// Two calls because a call has one mode. Checking fixes over the whole set would
+// demand a .golden for every broad fixture, tying sample's expected rewrite to
+// the fix output of every rule that fires in it.
 
-	t.When("sample code", func(w *gotest.T) {
-		w.It("detects violations", func(it *gotest.T) {
-			analysistest.Run(it.T(), testdata, lint.Analyzer, "sample")
+// diagnosticFixtures are the packages whose want comments are the whole
+// expectation; none of them records a suggested fix.
+var diagnosticFixtures = []string{
+	"sample",
+	"withtestify",
+	"withnolint",
+	"withforeign",
+	"withpollscope",
+	"withcleanup",
+	"withdirectcalls",
+	"withnolint_file",
+	"withsharedfixture",
+}
+
+// rewriteFixtures are the packages that additionally pin the rewrite a rule
+// offers, each against its own .golden.
+var rewriteFixtures = []string{
+	"withsimplify",
+	"withfailguard",
+	"withfailguard_noimport",
+	"withredundant",
+	"withtescape",
+}
+
+func (s *LintTestSuite) TestDiagnostics(t *gotest.T) {
+	t.When("every rule's fixture package", func(w *gotest.T) {
+		w.It("reports exactly the diagnostics its want comments declare", func(it *gotest.T) {
+			analysistest.Run(it.T(), analysistest.TestData(), lint.Analyzer, diagnosticFixtures...)
 		})
 	})
+}
 
-	t.When("testify imports", func(w *gotest.T) {
-		w.It("detects testify usage", func(it *gotest.T) {
-			analysistest.Run(it.T(), testdata, lint.Analyzer, "withtestify")
-		})
-	})
-
-	t.When("nolint comments", func(w *gotest.T) {
-		w.It("respects inline nolint", func(it *gotest.T) {
-			analysistest.Run(it.T(), testdata, lint.Analyzer, "withnolint")
-		})
-	})
-
-	t.When("foreign lookalikes", func(w *gotest.T) {
-		w.It("ignores assertion and polling names from other packages", func(it *gotest.T) {
-			analysistest.Run(it.T(), testdata, lint.Analyzer, "withforeign")
-		})
-	})
-
-	t.When("poll scope", func(w *gotest.T) {
-		w.It("detects poll scope violations", func(it *gotest.T) {
-			analysistest.Run(it.T(), testdata, lint.Analyzer, "withpollscope")
-		})
-	})
-
-	t.When("assertion simplify", func(w *gotest.T) {
-		w.It("detects sub-optimal assertion patterns", func(it *gotest.T) {
-			analysistest.RunWithSuggestedFixes(it.T(), testdata, lint.Analyzer, "withsimplify")
-		})
-	})
-
-	t.When("fail guard", func(w *gotest.T) {
-		w.It("detects if+Fail guards that assertions express directly", func(it *gotest.T) {
-			analysistest.RunWithSuggestedFixes(it.T(), testdata, lint.Analyzer, "withfailguard", "withfailguard_noimport")
-		})
-	})
-
-	t.When("assertion redundant", func(w *gotest.T) {
-		w.It("detects redundant guard assertions before stronger ones", func(it *gotest.T) {
-			analysistest.RunWithSuggestedFixes(it.T(), testdata, lint.Analyzer, "withredundant")
-		})
-	})
-
-	t.When("suite cleanup", func(w *gotest.T) {
-		w.It("detects .T().Cleanup in suite methods", func(it *gotest.T) {
-			analysistest.Run(it.T(), testdata, lint.Analyzer, "withcleanup")
-		})
-	})
-
-	t.When("suite direct calls", func(w *gotest.T) {
-		w.It("detects T.Parallel and T.Run in suite methods", func(it *gotest.T) {
-			analysistest.Run(it.T(), testdata, lint.Analyzer, "withdirectcalls")
-		})
-	})
-
-	t.When("t escape", func(w *gotest.T) {
-		w.It("detects unnecessary .T() escape and applies fixes", func(it *gotest.T) {
-			analysistest.RunWithSuggestedFixes(it.T(), testdata, lint.Analyzer, "withtescape")
-		})
-	})
-
-	t.When("file-level nolint", func(w *gotest.T) {
-		w.It("respects file-level nolint", func(it *gotest.T) {
-			analysistest.Run(it.T(), testdata, lint.Analyzer, "withnolint_file")
-		})
-	})
-
-	t.When("shared fixture declarations", func(w *gotest.T) {
-		w.It("flags undeclared shared fixture reads and exempts local construction", func(it *gotest.T) {
-			analysistest.Run(it.T(), testdata, lint.Analyzer, "withsharedfixture")
+func (s *LintTestSuite) TestSuggestedFixes(t *gotest.T) {
+	t.When("a rule that offers a rewrite", func(w *gotest.T) {
+		w.It("produces the fix recorded in the golden file", func(it *gotest.T) {
+			analysistest.RunWithSuggestedFixes(it.T(), analysistest.TestData(), lint.Analyzer, rewriteFixtures...)
 		})
 	})
 }

--- a/skills/writing-gotest-tests/SKILL.md
+++ b/skills/writing-gotest-tests/SKILL.md
@@ -33,22 +33,33 @@ applies EXCEPT these four, which fail there:
    `-test.timeout` kills it with no teardown, and so does any entry after
    a `-failfast` trip. Filter whole suites or methods only there.
 
-Sections tagged **v1.27+** below need v1.27.0 or newer and fail hard on
-v1.26.x rather than degrading: `SuiteConfig.Exclusive` is an unknown
-field there (compile error) and the `shared-fixture-undeclared` lint rule
-does not exist (its findings are simply never reported — do not rely on
-the linter for fixture-window mistakes on v1.26.x). Skip those sections
-on v1.26.x and earlier.
+Sections tagged **v1.27+** below need v1.27.0 or newer; skip them on
+v1.26.x and earlier. What v1.27 adds:
 
-Also v1.27+: `gotest spec --static` renders the specification from source
-without running anything, so you can read what a package promises before
-(or instead of) executing it. It reports on stderr any method whose
-behaviors it could not enumerate — a `When`/`It` inside a condition or a
-loop, a non-literal description, an `Each` over a non-literal table — so
-treat "incomplete:" lines as a prompt to write the behavior literally if
-you want it visible in tooling. `spec --input --render-only` exits 0 on a
-failing stream, for callers that render results rather than gate on them;
-without it `--input` exits 1 whenever the stream carries a failure.
+1. **`SuiteConfig.Exclusive`** — an unknown field on v1.26.x, so a suite
+   declaring it does not compile there.
+2. **The `shared-fixture-undeclared` lint rule** — absent on v1.26.x, and
+   absent silently: its findings are simply never reported, so do not
+   rely on the linter for fixture-window mistakes there.
+3. **`gotest spec --static`** — renders the specification from source
+   without running anything, so you can read what a package promises
+   before (or instead of) executing it. It reports on stderr any method
+   whose behaviors it could not enumerate — a `When`/`It` inside a
+   condition or a loop, a non-literal description, an `Each` over a
+   non-literal table — so treat "incomplete:" lines as a prompt to write
+   the behavior literally if you want it visible in tooling.
+4. **`spec --input --render-only`** — exits 0 on a failing stream, for
+   callers that render results rather than gate on them; without it
+   `--input` exits 1 whenever the stream carries a failure.
+5. **A duration on every `spec` row** — each row carries the wall clock
+   it occupied, never the sum of the rows beneath it. To find what is
+   slow, read top-down and stop where the children stop explaining the
+   parent; never add sibling durations up, because they overlap whenever
+   anything ran in parallel and their total can exceed the clock that
+   passed. A row larger than everything under it held that time itself:
+   a subprocess started in a `When` body, or a `BeforeAll`. On v1.26.x
+   only leaf rows carry a duration at all, so there the expensive test
+   can be the one showing nothing.
 
 Exit codes on v1.25.x are weaker than they look — never treat a green
 gotest exit alone as proof there: a package failing to compile mid-run, a

--- a/vscode-gotest/src/reporting.test.ts
+++ b/vscode-gotest/src/reporting.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("vscode", () => ({
+  workspace: {},
+  window: {},
+  env: {},
+}));
+
+import { buildTestResultsTable } from "./reporting.js";
+import type { TestResultStore, TestResult } from "./testResultStore.js";
+
+interface FakeItem {
+  id: string;
+  label: string;
+  tags: { id: string }[];
+  kids: FakeItem[];
+}
+
+function node(
+  id: string,
+  label: string,
+  kids: FakeItem[] = [],
+  tags: string[] = [],
+): FakeItem {
+  return { id, label, kids, tags: tags.map((t) => ({ id: t })) };
+}
+
+// asItem shapes a FakeItem like the slice of vscode.TestItem the walk touches:
+// an id, a label, tags, and a children collection with size and forEach.
+function asItem(n: FakeItem): never {
+  return {
+    id: n.id,
+    label: n.label,
+    tags: n.tags,
+    children: {
+      size: n.kids.length,
+      forEach: (fn: (child: unknown) => void) =>
+        n.kids.forEach((k) => fn(asItem(k))),
+    },
+  } as never;
+}
+
+function store(results: Record<string, TestResult>): TestResultStore {
+  return { get: (id: string) => results[id] } as never;
+}
+
+function rootsOf(items: FakeItem[]): never {
+  return {
+    forEach: (fn: (i: unknown) => void) => items.forEach((i) => fn(asItem(i))),
+  } as never;
+}
+
+const BASE = Date.parse("2026-08-16T10:00:00.000Z");
+
+/** A pass bracketed from +offset to +offset+span, measuring `measured`. */
+function at(offset: number, span: number, measured = span): TestResult {
+  return {
+    status: "pass",
+    duration: measured,
+    startedAt: BASE + offset,
+    endedAt: BASE + offset + span,
+  };
+}
+
+/** Marks a result as one that called t.Parallel, so it was parked before it ran. */
+function parked(r: TestResult): TestResult {
+  return { ...r, paused: true };
+}
+
+/** The cell in the Time column of the row whose label contains `label`. */
+function timeOf(table: string, label: string): string {
+  const line = table.split("\n").find((l) => l.includes(label));
+  return line ? (line.trim().split(/\s{2,}/)[1] ?? "") : "";
+}
+
+describe("buildTestResultsTable", () => {
+  it("reports what a container held when its children report nothing", () => {
+    // The shape of every When that drives a subprocess: the work happens in the
+    // container body and the leaves only assert on what it produced.
+    const tree = node("suite:Hangs", "Hangs", [
+      node("when:setup", "the setup never returns", [
+        node("it:budget", "names the budget"),
+        node("it:fails", "fails the run"),
+      ]),
+    ]);
+
+    const table = buildTestResultsTable(
+      rootsOf([tree]),
+      store({
+        "suite:Hangs": at(0, 60290),
+        "when:setup": at(0, 60290),
+        "it:budget": at(60290, 0),
+        "it:fails": at(60290, 0),
+      }),
+      () => undefined,
+    );
+
+    expect(table).toBeDefined();
+    expect(timeOf(table!, "the setup never returns")).toBe("60.290s");
+    expect(timeOf(table!, "Hangs")).toBe("60.290s");
+    expect(table).toContain("Total: 2 passed (60.290s)");
+  });
+
+  it("reports the interval a parallel suite occupied, not the sum", () => {
+    // go test stops a parent's clock when it returns, so the suite measures
+    // nothing while its methods together claim more than the clock passed.
+    const tree = node("suite:Parallel", "Parallel", [
+      node("m:first", "first"),
+      node("m:second", "second"),
+      node("m:third", "third"),
+    ]);
+
+    const table = buildTestResultsTable(
+      rootsOf([tree]),
+      store({
+        "suite:Parallel": at(0, 58, 0),
+        "m:first": parked(at(0, 58)),
+        "m:second": parked(at(0, 50)),
+        "m:third": parked(at(0, 52)),
+      }),
+      () => undefined,
+    );
+
+    expect(timeOf(table!, "Parallel")).toBe("0.058s");
+    expect(table).toContain("Total: 3 passed (0.058s)");
+  });
+
+  it("charges a leaf only for what it executed, not for queueing", () => {
+    // Registered at once, resumed 50ms later, then done in a millisecond. The
+    // wait belongs to whatever set the concurrency, not to the test.
+    const tree = node("suite:S", "S", [node("m:regexp", "matches correctly")]);
+
+    const table = buildTestResultsTable(
+      rootsOf([tree]),
+      store({ "suite:S": at(0, 51), "m:regexp": parked(at(0, 51, 1)) }),
+      () => undefined,
+    );
+
+    expect(timeOf(table!, "matches correctly")).toBe("0.001s");
+    expect(timeOf(table!, "S")).toBe("0.051s");
+  });
+
+  it("ignores the bracket of a method whose report was flushed late", () => {
+    // Measured against a real stream: the method resumed at 5.1s, ran 300ms,
+    // and had its terminal event held behind a 60s sibling. Its children keep
+    // clean timestamps; only the parked node's own end is delayed.
+    const tree = node("suite:Panic", "Panic", [
+      node("m:each", "PanicInEachAfterRecordedFailure", [
+        node("w:each", "an Each entry records a failure and then panics"),
+      ]),
+      node("m:hang", "SetupThatNeverReturns"),
+    ]);
+
+    const table = buildTestResultsTable(
+      rootsOf([tree]),
+      store({
+        "suite:Panic": at(0, 60784),
+        "m:each": parked(at(0, 60783, 300)),
+        "w:each": at(5107, 300),
+        "m:hang": parked(at(0, 60784, 60400)),
+      }),
+      () => undefined,
+    );
+
+    expect(timeOf(table!, "PanicInEachAfterRecordedFailure")).toBe("0.300s");
+    expect(timeOf(table!, "an Each entry")).toBe("0.300s");
+    expect(timeOf(table!, "SetupThatNeverReturns")).toBe("60.400s");
+    // The minute is not lost: it stays on the suite, which really did span it.
+    expect(timeOf(table!, "Panic ")).toBe("60.784s");
+  });
+
+  it("never lets a row read shorter than what it contains", () => {
+    // go test reports a parked node's measure to 10ms while a child's bracket
+    // is exact, so a 15ms method can read 10ms beside its own 15ms child — and
+    // a parked child can round above the exact bracket of the suite holding it.
+    const tree = node("suite:Spec", "Spec", [
+      node("m:grace", "GraceKill", [
+        node("w:grace", "using GraceKill strategy"),
+      ]),
+    ]);
+
+    const table = buildTestResultsTable(
+      rootsOf([tree]),
+      store({
+        "suite:Spec": at(0, 229),
+        "m:grace": parked(at(0, 9000, 10)),
+        "w:grace": at(0, 15),
+      }),
+      () => undefined,
+    );
+
+    expect(timeOf(table!, "GraceKill")).toBe("0.015s");
+    expect(timeOf(table!, "Spec")).toBe("0.229s");
+  });
+
+  it("counts overlap once when a grouping row assembles several suites", () => {
+    // A directory is not something that executes, so it is worth the clock
+    // during which something under it was running — no more.
+    const tree = node("dir:internal", "internal", [
+      node("suite:Alpha", "Alpha", [node("m:one", "one")], []),
+      node("suite:Beta", "Beta", [node("m:two", "two")], []),
+    ]);
+
+    const table = buildTestResultsTable(
+      rootsOf([tree]),
+      store({
+        "suite:Alpha": at(0, 100),
+        "m:one": at(0, 100),
+        "suite:Beta": at(50, 100),
+        "m:two": at(50, 100),
+      }),
+      () => undefined,
+    );
+
+    // Two 100ms suites overlapping by 50ms occupied 150ms, not 200ms.
+    expect(timeOf(table!, "internal")).toBe("0.150s");
+  });
+
+  it("skips the gap between results recorded hours apart", () => {
+    // The store keeps results for a week, so a tree can hold one package from
+    // this morning beside another from just now. The interval between two runs
+    // is nobody's cost.
+    const morning = node("dir:a", "a", [
+      node("suite:Alpha", "Alpha", [node("m:one", "one")]),
+    ]);
+    const afternoon = node("dir:b", "b", [
+      node("suite:Beta", "Beta", [node("m:two", "two")]),
+    ]);
+    const fourHours = 4 * 60 * 60 * 1000;
+
+    const table = buildTestResultsTable(
+      rootsOf([morning, afternoon]),
+      store({
+        "suite:Alpha": at(0, 1000),
+        "m:one": at(0, 1000),
+        "suite:Beta": at(fourHours, 2000),
+        "m:two": at(fourHours, 2000),
+      }),
+      () => undefined,
+    );
+
+    expect(table).toContain("Total: 2 passed (3.000s)");
+  });
+
+  it("bounds a subtree by both measures when no timestamps were recorded", () => {
+    const tree = node("suite:Held", "Held", [node("m:one", "one")]);
+
+    const table = buildTestResultsTable(
+      rootsOf([tree]),
+      store({
+        "suite:Held": { status: "pass", duration: 5000 },
+        "m:one": { status: "pass", duration: 0 },
+      }),
+      () => undefined,
+    );
+
+    expect(timeOf(table!, "Held")).toBe("5.000s");
+  });
+
+  it("reports no results rather than a zero total when nothing ran", () => {
+    const tree = node("suite:A", "A", [node("m:one", "one")]);
+
+    const table = buildTestResultsTable(
+      rootsOf([tree]),
+      store({}),
+      () => undefined,
+    );
+
+    expect(table).toContain("Total: no results");
+  });
+
+  it("returns undefined when there is nothing to render", () => {
+    expect(
+      buildTestResultsTable(rootsOf([]), store({}), () => undefined),
+    ).toBeUndefined();
+  });
+});

--- a/vscode-gotest/src/reporting.ts
+++ b/vscode-gotest/src/reporting.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import type { CoverageStore } from "./coverageStore.js";
 import type { DiscoveryCache } from "./discovery.js";
-import type { TestResultStore } from "./testResultStore.js";
+import type { TestResult, TestResultStore } from "./testResultStore.js";
 
 export async function copyCoverageSummary(
   store: CoverageStore,
@@ -194,17 +194,86 @@ export async function copyCoverageSummary(
   vscode.window.showInformationMessage("Coverage summary copied to clipboard.");
 }
 
-export async function copyTestResults(
+/** Every duration in the table is printed in seconds, to three decimals. */
+function fmtSeconds(ms: number): string {
+  return `${(ms / 1000).toFixed(3)}s`;
+}
+
+interface Window {
+  start: number;
+  end: number;
+}
+
+/**
+ * Where a node sat on the clock. A parked node declines: its measure says how
+ * long it ran but neither endpoint says when, so placing it would put a window
+ * in the wrong part of the timeline.
+ */
+function windowOf(result: TestResult | undefined): Window | undefined {
+  if (!result || result.paused) return undefined;
+  if (result.startedAt === undefined || result.endedAt === undefined) {
+    return undefined;
+  }
+  if (result.endedAt < result.startedAt) return undefined;
+  return { start: result.startedAt, end: result.endedAt };
+}
+
+/**
+ * What a node cost. Which of its two measures to believe follows from why each
+ * one lies. A node that called t.Parallel reports what go test measured, because
+ * its bracket carries both the wait for a slot and go test's habit of flushing a
+ * parked test's report through its parent — which can delay the end by however
+ * long a slower sibling runs. Everything else reports its bracket, because a
+ * measure that stops when the function returns cannot see parallel children,
+ * while the bracket encloses the whole subtree.
+ */
+function effectiveOf(result: TestResult | undefined): number | undefined {
+  if (!result) return undefined;
+  if (result.paused) return result.duration;
+  const own = windowOf(result);
+  return own ? own.end - own.start : result.duration;
+}
+
+/**
+ * Total clock covered by the windows, counting overlap once. This is what makes
+ * a row assembled out of several nodes honest: two suites that ran side by side
+ * for a second cost a second, not two. It also drops the gap between windows,
+ * so a tree still holding results from an earlier run reports the time that run
+ * spent rather than the hours since.
+ */
+function occupied(windows: Window[]): number {
+  if (windows.length === 0) return 0;
+  const sorted = [...windows].sort((a, b) => a.start - b.start);
+  let total = 0;
+  let cur = { ...sorted[0] };
+  for (const w of sorted.slice(1)) {
+    if (w.start > cur.end) {
+      total += cur.end - cur.start;
+      cur = { ...w };
+      continue;
+    }
+    if (w.end > cur.end) cur.end = w.end;
+  }
+  return total + (cur.end - cur.start);
+}
+
+// Exported for tests; copyTestResults is the thin clipboard wrapper.
+export function buildTestResultsTable(
   controllerItems: vscode.TestItemCollection,
   resultStore: TestResultStore,
   findItem: (id: string) => vscode.TestItem | undefined,
   rootItem?: vscode.TestItem,
-): Promise<void> {
+): string | undefined {
   type Agg = {
     passed: number;
     failed: number;
     skipped: number;
+    // What this row displayed, so a parent without timestamps can still fall
+    // back to summing; the longest single child, and the windows this row
+    // contributes upward.
     duration: number;
+    maxChild: number;
+    windows: Window[];
   };
   type Row = {
     label: string;
@@ -224,44 +293,102 @@ export async function copyTestResults(
     const rowIdx = rows.length;
     rows.push({
       label: "  ".repeat(indent) + item.label,
-      duration: result?.duration,
+      duration: effectiveOf(result),
       status: result?.status,
     });
 
-    const childAgg: Agg = { passed: 0, failed: 0, skipped: 0, duration: 0 };
+    const childAgg: Agg = {
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      duration: 0,
+      maxChild: 0,
+      windows: [],
+    };
     item.children.forEach((child) => {
       const ca = walkItem(child, indent + 1);
       childAgg.passed += ca.passed;
       childAgg.failed += ca.failed;
       childAgg.skipped += ca.skipped;
       childAgg.duration += ca.duration;
+      childAgg.maxChild = Math.max(childAgg.maxChild, ca.duration);
+      childAgg.windows.push(...ca.windows);
     });
 
-    if (item.children.size > 0) {
+    const isLeaf = item.children.size === 0;
+    const own = windowOf(result);
+
+    if (!isLeaf) {
+      // A directory or a package is not something that executes and has no
+      // bracket of its own, so it is worth the clock during which something
+      // under it was running. A node that does execute reports what it cost,
+      // including any idle it spent waiting — that idle is its cost.
+      let displayed = effectiveOf(result);
+      if (displayed === undefined) {
+        if (childAgg.windows.length > 0) {
+          displayed = occupied(childAgg.windows);
+        } else {
+          // No timestamps anywhere: a hand-built tree, or results recorded from
+          // a stream without them. Bound the subtree by both measures.
+          const bound = Math.max(result?.duration ?? 0, childAgg.duration);
+          displayed = bound > 0 ? bound : undefined;
+        }
+      }
+
+      // A child runs inside its parent, so the parent is at least as long as
+      // any single one of them and as the clock they occupied between them.
+      // Flooring by that repairs the rounding go test applies to a parked
+      // node's measure — it reports to 10ms, while a child's bracket is exact
+      // — and can never invent time, since neither bound can exceed what the
+      // parent actually ran for.
+      const floor = Math.max(childAgg.maxChild, occupied(childAgg.windows));
+      if (displayed !== undefined && floor > displayed) displayed = floor;
+
       rows[rowIdx].agg = childAgg;
-      return childAgg;
+      rows[rowIdx].duration = displayed;
+      return {
+        ...childAgg,
+        duration: displayed ?? 0,
+        // Pass the real nodes' brackets up rather than this row's total: a
+        // union can have holes, and an ancestor has to union the pieces itself.
+        // A parked node has no window to pass, so its children's stand in.
+        windows: own ? [own] : childAgg.windows,
+      };
     }
 
-    const leafAgg: Agg = { passed: 0, failed: 0, skipped: 0, duration: 0 };
+    const leafAgg: Agg = {
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      duration: effectiveOf(result) ?? 0,
+      maxChild: 0,
+      windows: own ? [own] : [],
+    };
     if (result?.status === "pass") leafAgg.passed = 1;
     else if (result?.status === "fail") leafAgg.failed = 1;
     else if (result?.status === "skip") leafAgg.skipped = 1;
-    if (result?.duration) leafAgg.duration = result.duration;
     return leafAgg;
   };
 
+  const roots: Agg[] = [];
   const resolved = rootItem ? findItem(rootItem.id) : undefined;
   if (resolved) {
-    walkItem(resolved, 0);
+    roots.push(walkItem(resolved, 0));
   } else {
-    controllerItems.forEach((item) => walkItem(item, 0));
+    controllerItems.forEach((item) => roots.push(walkItem(item, 0)));
   }
 
+  // The total is the clock the run occupied, not the sum of the rows: rows
+  // overlap whenever anything ran in parallel, and summing them would report
+  // more time than passed.
+  const rootWindows = roots.flatMap((r) => r.windows);
+  const rootDuration =
+    rootWindows.length > 0
+      ? occupied(rootWindows)
+      : roots.reduce((a, r) => a + r.duration, 0);
+
   if (rows.length === 0) {
-    vscode.window.showInformationMessage(
-      "No test items available. Run discovery first.",
-    );
-    return;
+    return undefined;
   }
 
   const maxLabelLen = Math.max(4, ...rows.map((r) => r.label.length));
@@ -272,26 +399,23 @@ export async function copyTestResults(
   let totalPassed = 0;
   let totalFailed = 0;
   let totalSkipped = 0;
-  let totalDuration = 0;
 
   for (const row of rows) {
+    const time = row.duration !== undefined ? fmtSeconds(row.duration) : "-";
+
     if (row.agg) {
       const a = row.agg;
-      const aggTime =
-        a.duration > 0 ? (a.duration / 1000).toFixed(3) + "s" : "-";
       const parts: string[] = [];
       if (a.passed > 0) parts.push(`${a.passed} passed`);
       if (a.failed > 0) parts.push(`${a.failed} failed`);
       if (a.skipped > 0) parts.push(`${a.skipped} skipped`);
       const aggSummary = parts.length > 0 ? parts.join(", ") : "-";
       lines.push(
-        `${row.label.padEnd(maxLabelLen)}  ${aggTime.padEnd(9)}  ${aggSummary}`,
+        `${row.label.padEnd(maxLabelLen)}  ${time.padEnd(9)}  ${aggSummary}`,
       );
       continue;
     }
 
-    const time =
-      row.duration !== undefined ? (row.duration / 1000).toFixed(3) + "s" : "-";
     const status = row.status ?? "-";
     lines.push(
       `${row.label.padEnd(maxLabelLen)}  ${time.padEnd(9)}  ${status}`,
@@ -300,7 +424,6 @@ export async function copyTestResults(
     if (row.status === "pass") totalPassed++;
     else if (row.status === "fail") totalFailed++;
     else if (row.status === "skip") totalSkipped++;
-    if (row.duration) totalDuration += row.duration;
   }
 
   lines.push(separator);
@@ -310,14 +433,33 @@ export async function copyTestResults(
     if (totalPassed > 0) parts.push(`${totalPassed} passed`);
     if (totalFailed > 0) parts.push(`${totalFailed} failed`);
     if (totalSkipped > 0) parts.push(`${totalSkipped} skipped`);
-    lines.push(
-      `Total: ${parts.join(", ")} (${(totalDuration / 1000).toFixed(3)}s)`,
-    );
+    lines.push(`Total: ${parts.join(", ")} (${fmtSeconds(rootDuration)})`);
   } else {
     lines.push("Total: no results");
   }
 
-  const text = lines.join("\n");
+  return lines.join("\n");
+}
+
+export async function copyTestResults(
+  controllerItems: vscode.TestItemCollection,
+  resultStore: TestResultStore,
+  findItem: (id: string) => vscode.TestItem | undefined,
+  rootItem?: vscode.TestItem,
+): Promise<void> {
+  const text = buildTestResultsTable(
+    controllerItems,
+    resultStore,
+    findItem,
+    rootItem,
+  );
+  if (text === undefined) {
+    vscode.window.showInformationMessage(
+      "No test items available. Run discovery first.",
+    );
+    return;
+  }
+
   await vscode.env.clipboard.writeText(text);
   vscode.window.showInformationMessage("Test results copied to clipboard.");
 }

--- a/vscode-gotest/src/runnerUtils.test.ts
+++ b/vscode-gotest/src/runnerUtils.test.ts
@@ -458,6 +458,7 @@ describe("applyResults", () => {
     const controller = {
       findItem: vi.fn((id: string) => itemMap.get(id) ?? undefined),
       recordResult: vi.fn(),
+      noteStart: vi.fn(),
       createDynamicSubtest: vi.fn(),
     };
 
@@ -548,15 +549,18 @@ describe("applyResults", () => {
       passItem.id,
       "pass",
       100,
+      undefined,
     );
     expect(controller.recordResult).toHaveBeenCalledWith(
       failItem.id,
       "fail",
       200,
+      undefined,
     );
     expect(controller.recordResult).toHaveBeenCalledWith(
       skipItem.id,
       "skip",
+      undefined,
       undefined,
     );
 
@@ -722,6 +726,7 @@ describe("applyEvent", () => {
       recordResult: vi.fn((id: string, status: string, duration?: number) => {
         results.set(id, { status, duration });
       }),
+      noteStart: vi.fn(),
       getResult: vi.fn((id: string) => results.get(id)),
       createDynamicSubtest: vi.fn(),
     };
@@ -744,6 +749,31 @@ describe("applyEvent", () => {
       skipItem,
     };
   }
+
+  // Real streams always carry Time; it is what brackets a node against every
+  // other node, including ones from suites running in other processes.
+  const STAMP = "2026-08-16T10:00:00.000Z";
+  const STAMP_MS = Date.parse(STAMP);
+
+  it("processes 'run' event — calls run.started, notes the bracket start", () => {
+    const { controller, run, passItem } = makeApplyEventFixture();
+
+    applyEvent(
+      controller as any,
+      run as any,
+      {
+        Action: "run",
+        Test: "TestMySuite/TestPass",
+        Package: "example.com/pkg",
+        Time: STAMP,
+      } as any,
+      new Map<string, string>(),
+      "example.com/pkg",
+      "/some/dir",
+    );
+
+    expect(controller.noteStart).toHaveBeenCalledWith(passItem.id, STAMP_MS);
+  });
 
   it("processes 'run' event — calls run.started, returns undefined", () => {
     const { controller, run, passItem } = makeApplyEventFixture();
@@ -778,6 +808,7 @@ describe("applyEvent", () => {
         Test: "TestMySuite/TestPass",
         Package: "example.com/pkg",
         Elapsed: 0.1,
+        Time: STAMP,
       } as any,
       outputMap,
       "example.com/pkg",
@@ -794,6 +825,7 @@ describe("applyEvent", () => {
       passItem.id,
       "pass",
       100,
+      STAMP_MS,
     );
   });
 
@@ -808,6 +840,7 @@ describe("applyEvent", () => {
         Action: "skip",
         Test: "TestMySuite/TestSkip",
         Package: "example.com/pkg",
+        Time: STAMP,
       } as any,
       outputMap,
       "example.com/pkg",
@@ -824,6 +857,7 @@ describe("applyEvent", () => {
       skipItem.id,
       "skip",
       undefined,
+      STAMP_MS,
     );
   });
 
@@ -868,6 +902,7 @@ describe("applyEvent", () => {
         Test: "TestMySuite/TestFail",
         Package: "example.com/pkg",
         Elapsed: 0.2,
+        Time: STAMP,
       } as any,
       outputMap,
       "example.com/pkg",
@@ -884,6 +919,7 @@ describe("applyEvent", () => {
       failItem.id,
       "fail",
       200,
+      STAMP_MS,
     );
   });
 

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -313,11 +313,15 @@ export function applyEvent(
 
   const duration =
     event.Elapsed !== undefined ? event.Elapsed * 1000 : undefined;
+  // The event's own clock, not ours: it brackets the node against every other
+  // node in the stream, including ones from suites running in other processes.
+  const stamp = Date.parse(event.Time);
+  const at = Number.isNaN(stamp) ? undefined : stamp;
 
   switch (event.Action) {
     case "pass":
       run.passed(item, duration);
-      controller.recordResult(item.id, "pass", duration);
+      controller.recordResult(item.id, "pass", duration, at);
       return { itemId: item.id, status: "pass", duration };
     case "fail": {
       const output = outputMap.get(event.Test) ?? "";
@@ -351,15 +355,24 @@ export function applyEvent(
         vscodeMessages.push(fallback);
       }
       run.failed(item, vscodeMessages, duration);
-      controller.recordResult(item.id, "fail", duration);
+      controller.recordResult(item.id, "fail", duration, at);
       return { itemId: item.id, status: "fail", duration };
     }
     case "skip":
       run.skipped(item);
-      controller.recordResult(item.id, "skip", undefined);
+      controller.recordResult(item.id, "skip", undefined, at);
       return { itemId: item.id, status: "skip", duration: undefined };
     case "run":
       run.started(item);
+      if (at !== undefined) {
+        controller.noteStart(item.id, at);
+      }
+      return undefined;
+    case "pause":
+    case "cont":
+      // The node called t.Parallel. That is the one fact its own timestamps
+      // cannot survive, so it has to be carried alongside them.
+      controller.notePaused(item.id);
       return undefined;
   }
 

--- a/vscode-gotest/src/testController.ts
+++ b/vscode-gotest/src/testController.ts
@@ -16,6 +16,10 @@ export class GoTestController implements vscode.Disposable {
   // longer carry a marker segment — they are the go test path — so membership
   // is tracked instead of inferred from the string.
   private dynamicIds = new Set<string>();
+  // Open brackets: nodes go test has started and not yet reported on, and
+  // which of them parked themselves with t.Parallel.
+  private pendingStarts = new Map<string, number>();
+  private pendingPaused = new Set<string>();
 
   constructor(
     private readonly cache: DiscoveryCache,
@@ -557,6 +561,11 @@ export class GoTestController implements vscode.Disposable {
   }
 
   createTestRun(request: vscode.TestRunRequest, name: string): vscode.TestRun {
+    // A run that died mid-way leaves brackets open on nodes that never
+    // reported. They are worthless to the next run and would otherwise sit in
+    // the map for the rest of the session.
+    this.pendingStarts.clear();
+    this.pendingPaused.clear();
     return this.controller.createTestRun(request, name);
   }
 
@@ -564,12 +573,35 @@ export class GoTestController implements vscode.Disposable {
     return this.findItemRecursive(this.controller.items, id);
   }
 
+  // noteStart remembers when go test registered a node, so the terminal event
+  // can close the bracket. It is kept off the result store on purpose: an
+  // in-flight node has no verdict, and a run that dies mid-way must not leave
+  // half a result behind to be restored on the next reload.
+  noteStart(itemId: string, at: number): void {
+    this.pendingStarts.set(itemId, at);
+  }
+
+  // notePaused records that the node called t.Parallel. What that costs its
+  // bracket is described on TestResult.paused.
+  notePaused(itemId: string): void {
+    this.pendingPaused.add(itemId);
+  }
+
   recordResult(
     itemId: string,
     status: "pass" | "fail" | "skip",
     duration?: number,
+    endedAt?: number,
   ): void {
-    this.resultStore.record(itemId, status, duration);
+    const startedAt = this.pendingStarts.get(itemId);
+    const paused = this.pendingPaused.has(itemId);
+    this.pendingStarts.delete(itemId);
+    this.pendingPaused.delete(itemId);
+    this.resultStore.record(itemId, status, duration, {
+      startedAt,
+      endedAt,
+      paused,
+    });
   }
 
   getResult(itemId: string): TestResult | undefined {
@@ -591,6 +623,8 @@ export class GoTestController implements vscode.Disposable {
       d.dispose();
     }
     this.disposables = [];
+    this.pendingStarts.clear();
+    this.pendingPaused.clear();
     this.controller.dispose();
   }
 

--- a/vscode-gotest/src/testResultStore.ts
+++ b/vscode-gotest/src/testResultStore.ts
@@ -3,15 +3,46 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 
 export interface TestResult {
   status: "pass" | "fail" | "skip";
+  /**
+   * What go test measured for this node alone. For a leaf that is its execution
+   * time; for a node with children it is close to useless, because go test
+   * stops a parent's clock when the parent function returns.
+   */
   duration?: number;
+  /**
+   * The node's bracket in the event stream — when go test registered it and
+   * when it reported. It encloses every descendant, so for a node that was not
+   * parked it is what that node cost.
+   */
+  startedAt?: number;
+  endedAt?: number;
+  /**
+   * The node called t.Parallel, so it was parked before it ran. Its bracket is
+   * then worthless in both halves: it opens at registration rather than at the
+   * start of work, and go test flushes a parked test's report through its
+   * parent, which can delay the close by however long a slower sibling runs.
+   * Its duration stays exact, because go test does not count parked time.
+   */
+  paused?: boolean;
 }
 
 interface StoredTestResult extends TestResult {
   timestamp: number;
 }
 
+// Version 2 is the shape v1.27 ships: a verdict, the wall-clock bracket, and
+// whether the node was parked. Version 1 — every release through v1.26 —
+// carries none of the last three and cannot be migrated: an upgraded row would
+// keep reporting the old number, unlabelled, in a table that claims to show
+// intervals. This is a cache of a run that repeats in one command and expires
+// in a week regardless, so a mismatch drops it and starts clean. The number
+// cannot catch a store left by an unreleased v1.27 build, which predates these
+// fields without saying so; that one falls back to the pre-bracket numbers
+// until the next run replaces it.
+const STORE_VERSION = 2;
+
 interface StoredData {
-  version: 2;
+  version: number;
   results: Record<string, StoredTestResult>;
 }
 
@@ -42,8 +73,16 @@ export class TestResultStore {
     itemId: string,
     status: TestResult["status"],
     duration?: number,
+    bracket?: { startedAt?: number; endedAt?: number; paused?: boolean },
   ): void {
-    this.results.set(itemId, { status, duration, timestamp: Date.now() });
+    this.results.set(itemId, {
+      status,
+      duration,
+      startedAt: bracket?.startedAt,
+      endedAt: bracket?.endedAt,
+      paused: bracket?.paused,
+      timestamp: Date.now(),
+    });
   }
 
   get(itemId: string): TestResult | undefined {
@@ -72,7 +111,7 @@ export class TestResultStore {
     try {
       const content = await readFile(this.storagePath, "utf-8");
       const data = JSON.parse(content) as StoredData;
-      if (data.version !== 2) return;
+      if (data.version !== STORE_VERSION) return;
       this.results.clear();
       for (const [id, result] of Object.entries(data.results)) {
         this.results.set(id, result);
@@ -110,7 +149,7 @@ export class TestResultStore {
     if (!this.storagePath) return;
     this.evictStale();
     const data: StoredData = {
-      version: 2,
+      version: STORE_VERSION,
       results: Object.fromEntries(this.results),
     };
     await mkdir(path.dirname(this.storagePath), { recursive: true });


### PR DESCRIPTION
Durations in the spec view and the VS Code results table were unreliable.
Rows that group other rows reported the sum of their children, which
double-counts work that ran in parallel, and rows whose work occurred
outside a nested step reported nothing at all.

In this repository a test that runs for a full minute was displayed as
0.000s, while several tests with negligible work were displayed as
multiple seconds. The column pointed away from the tests that actually
cost time.

Each row now reports the time it occupied, consistently across both
surfaces. Test execution itself is unchanged. The README, the
specification document and the agent skill have been updated accordingly,
including guidance not to sum rows.