### PR TITLE
Fix test discovery on large workspaces and restore the tree from disk

### DIFF
--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -166,7 +166,7 @@ These can be set in `.vscode/settings.json` per workspace folder:
 | `gotest.coverTestOnlyPackages` | `false` | Enable cross-package coverage instrumentation for test-only packages |
 | `gotest.debug.prepareTimeout` | `60` | Seconds to wait for debug preparation before timing out |
 | `gotest.discoveryTimeout` | `120` | Seconds to wait for test discovery before giving up (raise it for a very large workspace) |
-| `gotest.forceKillTimeout` | `120` | Seconds to wait after SIGTERM before sending SIGKILL to a cancelled process — SIGTERM is what triggers shared-fixture teardown, so this must outlast it |
+| `gotest.forceKillTimeout` | `360` | Seconds to wait after SIGTERM before sending SIGKILL to a cancelled process. SIGTERM is what triggers shared-fixture teardown, and the CLI allows that up to 5m30s, so this must outlast it |
 | `gotest.watch.scope` | `./...` | Default package scope for watch mode |
 
 ### Global settings (window scope)

--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -164,6 +164,7 @@ These can be set in `.vscode/settings.json` per workspace folder:
 | `gotest.coverOnSave` | `false` | Re-run package coverage when a `.go` file is saved |
 | `gotest.coverTestOnlyPackages` | `false` | Enable cross-package coverage instrumentation for test-only packages |
 | `gotest.debug.prepareTimeout` | `60` | Seconds to wait for debug preparation before timing out |
+| `gotest.discoveryTimeout` | `120` | Seconds to wait for test discovery before giving up (raise it for a very large workspace) |
 | `gotest.watch.scope` | `./...` | Default package scope for watch mode |
 
 ### Global settings (window scope)

--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -166,7 +166,7 @@ These can be set in `.vscode/settings.json` per workspace folder:
 | `gotest.coverTestOnlyPackages` | `false` | Enable cross-package coverage instrumentation for test-only packages |
 | `gotest.debug.prepareTimeout` | `60` | Seconds to wait for debug preparation before timing out |
 | `gotest.discoveryTimeout` | `120` | Seconds to wait for test discovery before giving up (raise it for a very large workspace) |
-| `gotest.forceKillTimeout` | `600` | Seconds to wait after SIGTERM before sending SIGKILL to a cancelled process |
+| `gotest.forceKillTimeout` | `120` | Seconds to wait after SIGTERM before sending SIGKILL to a cancelled process — SIGTERM is what triggers shared-fixture teardown, so this must outlast it |
 | `gotest.watch.scope` | `./...` | Default package scope for watch mode |
 
 ### Global settings (window scope)

--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -62,6 +62,7 @@ Tests appear in a structured tree: **Package > Suite > Method > Subtest**.
 Run or debug at any level — a single method, an entire suite, or all tests in a package.
 Multi-select is fully supported.
 Test results persist across sessions, so you see pass/fail state immediately after reopening the editor.
+The tree itself is restored from disk on startup, so suites are browsable straight away instead of waiting for the Go toolchain to finish discovery.
 
 ### CodeLens
 
@@ -165,6 +166,7 @@ These can be set in `.vscode/settings.json` per workspace folder:
 | `gotest.coverTestOnlyPackages` | `false` | Enable cross-package coverage instrumentation for test-only packages |
 | `gotest.debug.prepareTimeout` | `60` | Seconds to wait for debug preparation before timing out |
 | `gotest.discoveryTimeout` | `120` | Seconds to wait for test discovery before giving up (raise it for a very large workspace) |
+| `gotest.forceKillTimeout` | `600` | Seconds to wait after SIGTERM before sending SIGKILL to a cancelled process |
 | `gotest.watch.scope` | `./...` | Default package scope for watch mode |
 
 ### Global settings (window scope)

--- a/vscode-gotest/package.json
+++ b/vscode-gotest/package.json
@@ -242,7 +242,7 @@
         },
         "gotest.forceKillTimeout": {
           "type": "number",
-          "default": 600,
+          "default": 120,
           "minimum": 10,
           "scope": "resource",
           "description": "Seconds to wait after SIGTERM before sending SIGKILL to a cancelled process"

--- a/vscode-gotest/package.json
+++ b/vscode-gotest/package.json
@@ -234,13 +234,13 @@
           "description": "Default package scope for watch mode"
         },
         "gotest.discoveryTimeout": {
-      "type": "number",
-      "default": 120,
-      "minimum": 10,
-      "scope": "resource",
-      "description": "Seconds to wait for test discovery before giving up. A cold build cache or a very large workspace can legitimately need more"
-    },
-    "gotest.forceKillTimeout": {
+          "type": "number",
+          "default": 120,
+          "minimum": 10,
+          "scope": "resource",
+          "description": "Seconds to wait for test discovery before giving up. A cold build cache or a very large workspace can legitimately need more"
+        },
+        "gotest.forceKillTimeout": {
           "type": "number",
           "default": 600,
           "minimum": 10,
@@ -259,8 +259,8 @@
     "contract:record": "node scripts/record-cli-contract.mjs",
     "contract:verify": "git diff --exit-code -- testdata/cli-contract.json",
     "contract:check": "npm run contract:record && npm run contract:verify",
-    "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts' 'scripts/**/*.mjs'",
-    "format:check": "prettier --check 'src/**/*.ts' 'test/**/*.ts' 'scripts/**/*.mjs'",
+    "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts' 'scripts/**/*.mjs' package.json",
+    "format:check": "prettier --check 'src/**/*.ts' 'test/**/*.ts' 'scripts/**/*.mjs' package.json",
     "vscode:prepublish": "node esbuild.config.mjs",
     "package": "vsce package"
   },

--- a/vscode-gotest/package.json
+++ b/vscode-gotest/package.json
@@ -242,10 +242,10 @@
         },
         "gotest.forceKillTimeout": {
           "type": "number",
-          "default": 120,
+          "default": 360,
           "minimum": 10,
           "scope": "resource",
-          "description": "Seconds to wait after SIGTERM before sending SIGKILL to a cancelled process"
+          "description": "Seconds to wait after SIGTERM before sending SIGKILL to a cancelled process. Must outlast the CLI's own shutdown budget (5m30s), which covers container fixture teardown"
         }
       }
     }

--- a/vscode-gotest/package.json
+++ b/vscode-gotest/package.json
@@ -233,7 +233,14 @@
           "scope": "resource",
           "description": "Default package scope for watch mode"
         },
-        "gotest.forceKillTimeout": {
+        "gotest.discoveryTimeout": {
+      "type": "number",
+      "default": 120,
+      "minimum": 10,
+      "scope": "resource",
+      "description": "Seconds to wait for test discovery before giving up. A cold build cache or a very large workspace can legitimately need more"
+    },
+    "gotest.forceKillTimeout": {
           "type": "number",
           "default": 600,
           "minimum": 10,

--- a/vscode-gotest/src/capture.test.ts
+++ b/vscode-gotest/src/capture.test.ts
@@ -1,0 +1,74 @@
+// A budget that cannot end the process it is bounding is not a budget. These
+// cover the two ways a child outlives its SIGTERM.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SpawnScript } from "./scriptedSpawn.test-support.js";
+
+const { script, mockKill } = vi.hoisted(() => ({
+  script: { once: [], always: undefined, calls: [] } as SpawnScript,
+  mockKill: vi.fn(),
+}));
+
+vi.mock("vscode", () => ({
+  workspace: { getConfiguration: () => ({ get: () => undefined }) },
+  Uri: { file: (p: string) => ({ fsPath: p }) },
+}));
+
+vi.mock("./cli.js", () => ({
+  stripGoRunExitEcho: (s: string) => s,
+}));
+
+vi.mock("node:child_process", async () => {
+  const { createScriptedSpawn } =
+    await import("./scriptedSpawn.test-support.js");
+  return { spawn: createScriptedSpawn(script, mockKill) };
+});
+
+import { captureStdout, CaptureTimeoutError } from "./capture.js";
+
+describe("captureStdout budgets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    script.once = [];
+    script.always = undefined;
+    script.calls = [];
+  });
+
+  it("escalates to SIGKILL when the child ignores SIGTERM", async () => {
+    script.always = { neverExits: true, ignoresSigterm: true };
+
+    const p = captureStdout("go", ["run", "."], { timeoutSeconds: 120 });
+    const settled = expect(p).rejects.toBeInstanceOf(CaptureTimeoutError);
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(mockKill).toHaveBeenCalledWith("SIGTERM");
+    // Still alive: without the escalation below, this is where discovery used
+    // to hang for the rest of the session.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(mockKill).toHaveBeenCalledWith("SIGKILL");
+
+    await settled;
+  });
+
+  // `go run` exits while the binary it compiled keeps the pipes open, so
+  // `close` never arrives. Settling on `exit` is what stops that wedging us.
+  it("settles when the child exits but the pipes stay open", async () => {
+    script.always = { neverExits: true, holdsPipesAfterExit: true };
+
+    const p = captureStdout("go", ["run", "."], { timeoutSeconds: 120 });
+    const settled = expect(p).rejects.toThrow("timed out after 120s");
+    await vi.advanceTimersByTimeAsync(120_000);
+    await settled;
+  });
+
+  it("does not signal a child that finished on its own", async () => {
+    script.always = { stdout: ['{"packages":[]}'], code: 0 };
+
+    await expect(
+      captureStdout("go", ["run", "."], { timeoutSeconds: 120 }),
+    ).resolves.toBe('{"packages":[]}');
+    await vi.advanceTimersByTimeAsync(200_000);
+    expect(mockKill).not.toHaveBeenCalled();
+  });
+});

--- a/vscode-gotest/src/capture.ts
+++ b/vscode-gotest/src/capture.ts
@@ -1,5 +1,17 @@
 import { spawn } from "node:child_process";
 import { stripGoRunExitEcho } from "./cli.js";
+import { killProcessTree } from "./processTree.js";
+import { CAPTURE_FORCE_KILL_GRACE_MS } from "./config.js";
+
+// CaptureTimeoutError marks the one failure that is not worth retrying: the
+// command was given its full budget and did not finish. Retrying spends the
+// budget again for the same answer.
+export class CaptureTimeoutError extends Error {
+  constructor(seconds: number) {
+    super(`timed out after ${seconds}s`);
+    this.name = "CaptureTimeoutError";
+  }
+}
 
 export interface CaptureOptions {
   cwd?: string;
@@ -26,7 +38,9 @@ export function captureStdout(
   opts: CaptureOptions = {},
 ): Promise<string> {
   return new Promise<string>((resolve, reject) => {
-    const child = spawn(bin, args, { cwd: opts.cwd });
+    // Own process group, so the timeout below can signal the compiled binary
+    // and not just the `go run` that launched it.
+    const child = spawn(bin, args, { cwd: opts.cwd, detached: true });
     const stdout: string[] = [];
     let stderr = "";
     let timedOut = false;
@@ -50,18 +64,32 @@ export function captureStdout(
       stderr += chunk;
     });
 
+    let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
     const timer =
       opts.timeoutSeconds === undefined
         ? undefined
         : setTimeout(() => {
             timedOut = true;
-            child.kill();
+            // SIGTERM the group, then escalate. Without the escalation a child
+            // that ignores SIGTERM never closes its pipes, `close` never fires,
+            // and this promise never settles — which wedges the caller far more
+            // thoroughly than the slow command the budget was meant to bound.
+            //
+            // Armed before the signal, because a child that dies on SIGTERM
+            // settles us from inside the call below — and a timer armed after
+            // that would outlive the settle that was supposed to clear it.
+            forceKillTimer = setTimeout(() => {
+              if (settled) return;
+              killProcessTree(child, "SIGKILL");
+            }, CAPTURE_FORCE_KILL_GRACE_MS);
+            killProcessTree(child, "SIGTERM");
           }, opts.timeoutSeconds * 1000);
 
     const settle = (outcome: () => void) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      clearTimeout(forceKillTimer);
       outcome();
     };
 
@@ -69,10 +97,18 @@ export function captureStdout(
     // read `code` off the error to drop a cached path — so pass it through.
     child.on("error", (err: Error) => settle(() => reject(err)));
 
+    // `close` waits for the pipes, which is what we want for the output — but a
+    // surviving grandchild can hold them open forever. Once we have timed out
+    // the output is being discarded anyway, so `exit` is enough to settle.
+    child.on("exit", () => {
+      if (!timedOut) return;
+      settle(() => reject(new CaptureTimeoutError(opts.timeoutSeconds ?? 0)));
+    });
+
     child.on("close", (code) => {
       settle(() => {
         if (timedOut) {
-          reject(new Error(`timed out after ${opts.timeoutSeconds}s`));
+          reject(new CaptureTimeoutError(opts.timeoutSeconds ?? 0));
         } else if (code === 0) {
           resolve(stdout.join(""));
         } else {

--- a/vscode-gotest/src/capture.ts
+++ b/vscode-gotest/src/capture.ts
@@ -6,6 +6,11 @@ export interface CaptureOptions {
   // Wall-clock budget. Omitted means none — for a command whose duration is the
   // repository's business, not ours.
   timeoutSeconds?: number;
+  // Called once, when the child's first byte of stdout arrives. Under `go run`
+  // that byte lands only after the compile, so it splits build time from the
+  // work the command was asked to do — the one number that says which of the
+  // two a slow run was spending its time in.
+  onFirstByte?: (elapsedMs: number) => void;
 }
 
 // captureStdout runs a command and returns everything it wrote to stdout.
@@ -32,7 +37,15 @@ export function captureStdout(
     // lands inside. These payloads carry the developer's own text.
     child.stdout.setEncoding("utf-8");
     child.stderr.setEncoding("utf-8");
-    child.stdout.on("data", (chunk: string) => stdout.push(chunk));
+    const started = Date.now();
+    let sawFirstByte = false;
+    child.stdout.on("data", (chunk: string) => {
+      if (!sawFirstByte) {
+        sawFirstByte = true;
+        opts.onFirstByte?.(Date.now() - started);
+      }
+      stdout.push(chunk);
+    });
     child.stderr.on("data", (chunk: string) => {
       stderr += chunk;
     });

--- a/vscode-gotest/src/capture.ts
+++ b/vscode-gotest/src/capture.ts
@@ -1,0 +1,74 @@
+import { spawn } from "node:child_process";
+import { stripGoRunExitEcho } from "./cli.js";
+
+export interface CaptureOptions {
+  cwd?: string;
+  // Wall-clock budget. Omitted means none — for a command whose duration is the
+  // repository's business, not ours.
+  timeoutSeconds?: number;
+}
+
+// captureStdout runs a command and returns everything it wrote to stdout.
+//
+// execFile would be shorter, and that is the trap: its default 1 MiB cap is a
+// ceiling on output that grows with the repository. One byte past it the child
+// is killed mid-write and everything it produced is discarded — which is how a
+// large project's test tree disappeared from the explorer. Nothing gotest emits
+// on stdout is bounded, so nothing reading it may be.
+export function captureStdout(
+  bin: string,
+  args: string[],
+  opts: CaptureOptions = {},
+): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const child = spawn(bin, args, { cwd: opts.cwd });
+    const stdout: string[] = [];
+    let stderr = "";
+    let timedOut = false;
+    let settled = false;
+
+    // Decode on the stream, not per chunk: a read ends wherever the pipe filled,
+    // and a chunk-wise toString() would corrupt whatever multi-byte character it
+    // lands inside. These payloads carry the developer's own text.
+    child.stdout.setEncoding("utf-8");
+    child.stderr.setEncoding("utf-8");
+    child.stdout.on("data", (chunk: string) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    const timer =
+      opts.timeoutSeconds === undefined
+        ? undefined
+        : setTimeout(() => {
+            timedOut = true;
+            child.kill();
+          }, opts.timeoutSeconds * 1000);
+
+    const settle = (outcome: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      outcome();
+    };
+
+    // A missing binary arrives here rather than as an exit code, and callers
+    // read `code` off the error to drop a cached path — so pass it through.
+    child.on("error", (err: Error) => settle(() => reject(err)));
+
+    child.on("close", (code) => {
+      settle(() => {
+        if (timedOut) {
+          reject(new Error(`timed out after ${opts.timeoutSeconds}s`));
+        } else if (code === 0) {
+          resolve(stdout.join(""));
+        } else {
+          const detail = stripGoRunExitEcho(stderr);
+          reject(
+            new Error(`exited with code ${code}${detail ? `: ${detail}` : ""}`),
+          );
+        }
+      });
+    });
+  });
+}

--- a/vscode-gotest/src/config.ts
+++ b/vscode-gotest/src/config.ts
@@ -1,0 +1,49 @@
+import * as vscode from "vscode";
+
+// Deliberately not reusing cli.ts's scopedConfig: reading a setting should not
+// pull the whole toolchain-resolution graph (and its module-load side effects)
+// into every module that wants a number.
+function scoped(workspaceDir?: string): vscode.WorkspaceConfiguration {
+  const scope = workspaceDir ? vscode.Uri.file(workspaceDir) : undefined;
+  return vscode.workspace.getConfiguration("gotest", scope);
+}
+
+// The CLI's own force-kill backstop, mirrored from
+// internal/gotestrunner/process.go: GracefulShutdownDelay = 5m30s. On SIGTERM
+// the CLI cancels its root context, which SIGTERMs the test process group and
+// then waits this long before killing it — long enough to cover a 5-minute
+// ContainerFixtureConfig teardown or an IntegrationSuiteConfig AfterAll.
+//
+// Ours has to outlast it. We SIGKILL the whole process group, so killing early
+// takes the CLI's teardown with it and leaks whatever the fixture was holding.
+const CLI_GRACEFUL_SHUTDOWN_S = 330;
+
+// Enough margin for the CLI to finish its own force-kill and exit. Keep this
+// above CLI_GRACEFUL_SHUTDOWN_S; the two numbers are a contract, not a
+// preference.
+export const DEFAULT_FORCE_KILL_TIMEOUT_S = CLI_GRACEFUL_SHUTDOWN_S + 30;
+
+// A discovery run compiles the CLI on a cold cache and then loads every package
+// in the workspace, so a monorepo can legitimately spend minutes here. The
+// budget only stops a hung child from blocking discovery forever.
+export const DEFAULT_DISCOVERY_TIMEOUT_S = 120;
+
+// `discover` reads; it has no fixtures to tear down, so nothing is lost by
+// killing it promptly once it has already ignored SIGTERM.
+export const CAPTURE_FORCE_KILL_GRACE_MS = 5_000;
+
+// Seconds to wait after SIGTERM before SIGKILL for a cancelled test run.
+export function forceKillTimeoutSeconds(workspaceDir?: string): number {
+  return (
+    scoped(workspaceDir).get<number>("forceKillTimeout") ??
+    DEFAULT_FORCE_KILL_TIMEOUT_S
+  );
+}
+
+// Seconds to wait for `gotest discover` before giving up.
+export function discoveryTimeoutSeconds(workspaceDir?: string): number {
+  return (
+    scoped(workspaceDir).get<number>("discoveryTimeout") ??
+    DEFAULT_DISCOVERY_TIMEOUT_S
+  );
+}

--- a/vscode-gotest/src/coverageUtils.test.ts
+++ b/vscode-gotest/src/coverageUtils.test.ts
@@ -1,0 +1,45 @@
+// `go tool cover -func` writes one line per function in the profile, so its
+// output grows with the repository just as discovery's does — and it used to be
+// read through the same 1 MiB buffer.
+
+import { describe, it, expect, vi } from "vitest";
+import type { SpawnScript } from "./scriptedSpawn.test-support.js";
+
+const { script } = vi.hoisted(() => ({
+  script: { once: [], always: undefined, calls: [] } as SpawnScript,
+}));
+
+vi.mock("./cli.js", () => ({
+  resolveGoBinary: async () => "/usr/bin/go",
+}));
+
+vi.mock("node:child_process", async () => {
+  const { createScriptedSpawn } =
+    await import("./scriptedSpawn.test-support.js");
+  return { spawn: createScriptedSpawn(script) };
+});
+
+import { runGoToolCoverFunc } from "./coverageUtils.js";
+
+describe("runGoToolCoverFunc", () => {
+  it("returns a profile report larger than a buffered read", async () => {
+    const line =
+      "example.com/org/repo/internal/service/file.go:42:\tMethod\t100.0%\n";
+    const report = line.repeat(20_000);
+    expect(report.length).toBeGreaterThan(1024 * 1024);
+
+    const chunks: string[] = [];
+    for (let i = 0; i < report.length; i += 64 * 1024) {
+      chunks.push(report.slice(i, i + 64 * 1024));
+    }
+    script.once.push({ stdout: chunks });
+
+    const out = await runGoToolCoverFunc("/tmp/cover.out", "/ws");
+
+    expect(out).toHaveLength(report.length);
+    expect(script.calls?.[0]).toEqual({
+      bin: "/usr/bin/go",
+      args: ["tool", "cover", "-func=/tmp/cover.out"],
+    });
+  });
+});

--- a/vscode-gotest/src/coverageUtils.test.ts
+++ b/vscode-gotest/src/coverageUtils.test.ts
@@ -9,8 +9,18 @@ const { script } = vi.hoisted(() => ({
   script: { once: [], always: undefined, calls: [] } as SpawnScript,
 }));
 
+// capture.ts reaches for stripGoRunExitEcho on any non-zero exit, so a factory
+// without it turns the first failure-path test into a TypeError instead of an
+// assertion.
+vi.mock("vscode", () => ({
+  workspace: { getConfiguration: () => ({ get: () => undefined }) },
+  Uri: { file: (p: string) => ({ fsPath: p }) },
+}));
+
 vi.mock("./cli.js", () => ({
   resolveGoBinary: async () => "/usr/bin/go",
+  stripGoRunExitEcho: (s: string) => s,
+  scopedConfig: () => ({ get: () => undefined }),
 }));
 
 vi.mock("node:child_process", async () => {

--- a/vscode-gotest/src/coverageUtils.ts
+++ b/vscode-gotest/src/coverageUtils.ts
@@ -1,8 +1,5 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { resolveGoBinary } from "./cli.js";
-
-const execFileAsync = promisify(execFile);
+import { captureStdout } from "./capture.js";
 
 export function splitCoverByPackage(
   content: string,
@@ -74,13 +71,10 @@ export async function runGoToolCoverFunc(
   workspaceDir: string,
 ): Promise<string> {
   const goBin = await resolveGoBinary(undefined, workspaceDir);
-  const { stdout } = await execFileAsync(
-    goBin,
-    ["tool", "cover", `-func=${coverFile}`],
-    {
-      cwd: workspaceDir,
-      timeout: 10_000,
-    },
-  );
-  return stdout;
+  // One line per function in the profile: a repository large enough to have a
+  // coverage problem is large enough to write past a buffered read.
+  return captureStdout(goBin, ["tool", "cover", `-func=${coverFile}`], {
+    cwd: workspaceDir,
+    timeoutSeconds: 10,
+  });
 }

--- a/vscode-gotest/src/debug.ts
+++ b/vscode-gotest/src/debug.ts
@@ -158,8 +158,10 @@ export class DebugLauncher implements vscode.Disposable {
         });
       });
 
-      child.stdout.on("data", (data: Buffer) => {
-        stdout += data.toString();
+      child.stdout.setEncoding("utf-8");
+      child.stderr.setEncoding("utf-8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
         if (!settled && stdout.includes("\n")) {
           settle(() => {
             try {
@@ -177,11 +179,9 @@ export class DebugLauncher implements vscode.Disposable {
         }
       });
 
-      child.stderr.on("data", (data: Buffer) => {
-        stderr += data.toString();
-        this.outputChannel.debug(
-          `[debug:prepare] ${data.toString().trimEnd()}`,
-        );
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+        this.outputChannel.debug(`[debug:prepare] ${chunk.trimEnd()}`);
       });
 
       child.on("error", (err: Error) => {

--- a/vscode-gotest/src/discovery.test.ts
+++ b/vscode-gotest/src/discovery.test.ts
@@ -100,10 +100,31 @@ function failsAlways(message: string) {
   script.always = { code: 2, stderr: message };
 }
 
+function makeSnapshotSink() {
+  return {
+    updated: [] as { workspaceDir: string; importPaths: string[] }[],
+    saves: 0,
+    update(
+      workspaceDir: string,
+      packages: { importPath: string }[],
+      _warnings: unknown[],
+    ) {
+      this.updated.push({
+        workspaceDir,
+        importPaths: packages.map((p) => p.importPath),
+      });
+    },
+    async save() {
+      this.saves++;
+    },
+  };
+}
+
 describe("DiscoveryService", () => {
   let cache: DiscoveryCache;
   let outputChannel: ReturnType<typeof makeOutputChannel>;
   let service: DiscoveryService;
+  let snapshot: ReturnType<typeof makeSnapshotSink>;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -114,9 +135,11 @@ describe("DiscoveryService", () => {
     mockReadFile.mockRejectedValue(new Error("ENOENT"));
     cache = new DiscoveryCache();
     outputChannel = makeOutputChannel();
+    snapshot = makeSnapshotSink();
     service = new DiscoveryService(
       cache,
       outputChannel as unknown as import("vscode").LogOutputChannel,
+      snapshot as never,
     );
   });
 
@@ -144,6 +167,36 @@ describe("DiscoveryService", () => {
       await service.discover("/ws", ["./..."]);
 
       expect(outputChannel.debug).not.toHaveBeenCalled();
+    });
+
+    it("persists a snapshot so the next activation has a tree", async () => {
+      succeedsOnce([{ importPath: "example.com/pkg", dir: "/ws/pkg" }]);
+
+      await service.discover("/ws", ["./..."]);
+
+      expect(snapshot.updated).toEqual([
+        { workspaceDir: "/ws", importPaths: ["example.com/pkg"] },
+      ]);
+      expect(snapshot.saves).toBe(1);
+    });
+
+    it("snapshots the whole workspace after a single-package discovery", async () => {
+      succeedsOnce([
+        { importPath: "example.com/a", dir: "/ws/a" },
+        { importPath: "example.com/b", dir: "/ws/b" },
+      ]);
+      await service.discover("/ws", ["./..."]);
+      succeedsOnce([{ importPath: "example.com/a", dir: "/ws/a" }]);
+
+      await service.discoverPackage("/ws", "./a");
+
+      // The pattern matched one package, but the snapshot stands in for the
+      // whole tree — writing only the match would drop every other package
+      // from the next activation.
+      expect(snapshot.updated.at(-1)).toEqual({
+        workspaceDir: "/ws",
+        importPaths: ["example.com/a", "example.com/b"],
+      });
     });
   });
 

--- a/vscode-gotest/src/discovery.test.ts
+++ b/vscode-gotest/src/discovery.test.ts
@@ -54,6 +54,7 @@ vi.mock("./cli.js", () => ({
   buildCliCommand: async () => ({ bin: "go", args: ["run", "discover"] }),
   formatCliCommand: () => "go run discover",
   clearBinaryCache: mockClearBinaryCache,
+  scopedConfig: () => ({ get: () => undefined }),
   // Used by capture.js on a failed exit. A stub, not a copy: what it filters
   // out is pinned in specView.test.ts, where the real one interprets an exit.
   stripGoRunExitEcho: (stderr: string) => stderr.trim(),
@@ -218,10 +219,17 @@ describe("DiscoveryService", () => {
       expect(outputChannel.error).toHaveBeenCalledTimes(1);
     });
 
-    it("shows a warning toast to the user", () => {
+    it("shows a warning toast naming what went wrong", () => {
       expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
       expect(mockShowWarningMessage).toHaveBeenCalledWith(
-        expect.stringContaining("discovery failed"),
+        expect.stringContaining(
+          "discovery failed: exited with code 2: persistent failure",
+        ),
+        "Open Output",
+      );
+      // The toolchain advice belongs to a missing binary, not to this.
+      expect(mockShowWarningMessage).not.toHaveBeenCalledWith(
+        expect.stringContaining("Ensure 'go' is installed"),
         "Open Output",
       );
     });
@@ -306,16 +314,16 @@ describe("DiscoveryService", () => {
       script.always = { neverExits: true };
 
       const p = service.discover("/ws", ["./..."]);
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(120_000);
       await vi.advanceTimersByTimeAsync(2_000);
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(120_000);
       await vi.advanceTimersByTimeAsync(4_000);
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(120_000);
       await p;
 
       expect(mockKill).toHaveBeenCalledTimes(3);
       expect(outputChannel.error).toHaveBeenCalledWith(
-        expect.stringContaining("timed out after 30s"),
+        expect.stringContaining("timed out after 120s"),
       );
     });
   });
@@ -336,6 +344,10 @@ describe("DiscoveryService", () => {
       expect(mockClearBinaryCache).toHaveBeenCalledTimes(3);
       expect(outputChannel.error).toHaveBeenCalledWith(
         expect.stringContaining("ENOENT"),
+      );
+      expect(mockShowWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining("Ensure 'go' is installed"),
+        "Open Output",
       );
     });
   });

--- a/vscode-gotest/src/discovery.test.ts
+++ b/vscode-gotest/src/discovery.test.ts
@@ -1,14 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// What the next spawned CLI does. `once` is consumed per run and `always` is
-// the fallback, so a test can queue a recovery in front of a standing failure.
-type ScriptedRun = {
-  stdout?: Array<string | Buffer>;
-  stderr?: string;
-  code?: number;
-  error?: NodeJS.ErrnoException;
-  neverExits?: boolean;
-};
+import type { SpawnScript } from "./scriptedSpawn.test-support.js";
 
 const {
   script,
@@ -18,10 +9,7 @@ const {
   mockReadFile,
   mockShowWarningMessage,
 } = vi.hoisted(() => ({
-  script: {
-    once: [] as ScriptedRun[],
-    always: undefined as ScriptedRun | undefined,
-  },
+  script: { once: [], always: undefined } as SpawnScript,
   mockKill: vi.fn(),
   mockClearBinaryCache: vi.fn(),
   mockAccess: vi.fn(async () => {}),
@@ -56,64 +44,18 @@ vi.mock("node:fs/promises", () => ({
   readFile: mockReadFile,
 }));
 
-// Real streams, not a resolved value: the code under test reads its payload in
-// whatever pieces the pipe delivers, and that is the half of it worth testing.
 vi.mock("node:child_process", async () => {
-  const { PassThrough } = await import("node:stream");
-  const { EventEmitter } = await import("node:events");
-
-  return {
-    spawn: () => {
-      const run = script.once.shift() ??
-        script.always ?? { stdout: ['{"packages":[]}'] };
-      const child = new EventEmitter() as InstanceType<typeof EventEmitter> & {
-        stdout: InstanceType<typeof PassThrough>;
-        stderr: InstanceType<typeof PassThrough>;
-        kill: () => void;
-      };
-      child.stdout = new PassThrough();
-      child.stderr = new PassThrough();
-
-      const finish = () => {
-        child.stdout.end();
-        child.stderr.end();
-      };
-      child.kill = () => {
-        mockKill();
-        finish();
-      };
-
-      let ended = 0;
-      const closeWhenDrained = () => {
-        if (++ended === 2)
-          child.emit("close", run.error ? null : (run.code ?? 0));
-      };
-      child.stdout.on("end", closeWhenDrained);
-      child.stderr.on("end", closeWhenDrained);
-
-      // A microtask later: the caller attaches its listeners on return.
-      void Promise.resolve().then(() => {
-        if (run.error) {
-          child.emit("error", run.error);
-          finish();
-          return;
-        }
-        for (const chunk of run.stdout ?? []) child.stdout.write(chunk);
-        if (run.stderr) child.stderr.write(run.stderr);
-        if (!run.neverExits) finish();
-      });
-
-      return child;
-    },
-  };
+  const { createScriptedSpawn } =
+    await import("./scriptedSpawn.test-support.js");
+  return { spawn: createScriptedSpawn(script, mockKill) };
 });
 
 vi.mock("./cli.js", () => ({
   buildCliCommand: async () => ({ bin: "go", args: ["run", "discover"] }),
   formatCliCommand: () => "go run discover",
   clearBinaryCache: mockClearBinaryCache,
-  // A stub, not a copy: what it filters out is pinned where the real one is
-  // used to interpret an exit, in specView.test.ts.
+  // Used by capture.js on a failed exit. A stub, not a copy: what it filters
+  // out is pinned in specView.test.ts, where the real one interprets an exit.
   stripGoRunExitEcho: (stderr: string) => stderr.trim(),
 }));
 
@@ -373,7 +315,7 @@ describe("DiscoveryService", () => {
 
       expect(mockKill).toHaveBeenCalledTimes(3);
       expect(outputChannel.error).toHaveBeenCalledWith(
-        expect.stringContaining("timed out after 30000ms"),
+        expect.stringContaining("timed out after 30s"),
       );
     });
   });

--- a/vscode-gotest/src/discovery.test.ts
+++ b/vscode-gotest/src/discovery.test.ts
@@ -9,7 +9,7 @@ const {
   mockReadFile,
   mockShowWarningMessage,
 } = vi.hoisted(() => ({
-  script: { once: [], always: undefined } as SpawnScript,
+  script: { once: [], always: undefined, calls: [] } as SpawnScript,
   mockKill: vi.fn(),
   mockClearBinaryCache: vi.fn(),
   mockAccess: vi.fn(async () => {}),
@@ -131,6 +131,7 @@ describe("DiscoveryService", () => {
     vi.useFakeTimers();
     script.once = [];
     script.always = undefined;
+    script.calls = [];
     mockAccess.mockResolvedValue(undefined);
     mockReadFile.mockRejectedValue(new Error("ENOENT"));
     cache = new DiscoveryCache();
@@ -368,13 +369,14 @@ describe("DiscoveryService", () => {
 
       const p = service.discover("/ws", ["./..."]);
       await vi.advanceTimersByTimeAsync(120_000);
-      await vi.advanceTimersByTimeAsync(2_000);
-      await vi.advanceTimersByTimeAsync(120_000);
-      await vi.advanceTimersByTimeAsync(4_000);
-      await vi.advanceTimersByTimeAsync(120_000);
+      await vi.advanceTimersByTimeAsync(10_000);
       await p;
 
-      expect(mockKill).toHaveBeenCalledTimes(3);
+      // One attempt. A timeout already spent the full budget, so retrying it
+      // twice more only delays the message the user is waiting for.
+      expect(script.calls).toHaveLength(1);
+      expect(mockKill).toHaveBeenCalledTimes(1);
+      expect(mockKill).toHaveBeenCalledWith("SIGTERM");
       expect(outputChannel.error).toHaveBeenCalledWith(
         expect.stringContaining("timed out after 120s"),
       );

--- a/vscode-gotest/src/discovery.ts
+++ b/vscode-gotest/src/discovery.ts
@@ -6,13 +6,9 @@ import type {
   DiscoverPackage,
   DiscoverWarning,
 } from "./types.js";
-import {
-  buildCliCommand,
-  clearBinaryCache,
-  formatCliCommand,
-  scopedConfig,
-} from "./cli.js";
-import { captureStdout } from "./capture.js";
+import { buildCliCommand, clearBinaryCache, formatCliCommand } from "./cli.js";
+import { captureStdout, CaptureTimeoutError } from "./capture.js";
+import { discoveryTimeoutSeconds } from "./config.js";
 import type { DiscoverySnapshotStore } from "./discoverySnapshotStore.js";
 
 export class DiscoveryCache implements vscode.Disposable {
@@ -319,7 +315,7 @@ export class DiscoveryService {
         this.outputChannel.info(
           `[discovery] ${packages.length} package(s), ${suites} suite(s) in ` +
             `${childMs}ms child (${firstByteMs < 0 ? "no output" : `${firstByteMs}ms to first byte`}), ` +
-            `${parsedMs}ms parse of ${stdout.length}B, ${indexMs}ms index`,
+            `${parsedMs}ms parse of ${Buffer.byteLength(stdout)}B, ${indexMs}ms index`,
         );
         this.hasShownError = false;
         // Snapshot the workspace, not the response: this run may have matched
@@ -330,7 +326,7 @@ export class DiscoveryService {
           this.cache.packagesForWorkspace(workspaceDir),
           this.cache.warningsForWorkspace(workspaceDir),
         );
-        void this.snapshots?.save();
+        this.snapshots?.save();
         for (const w of warnings) {
           const loc = w.file ? ` (${w.file}:${w.line ?? 0})` : "";
           this.outputChannel.warn(
@@ -345,7 +341,11 @@ export class DiscoveryService {
         if (isENOENT) {
           clearBinaryCache();
         }
-        if (attempt < DiscoveryService.MAX_RETRIES) {
+        // A timeout already spent the whole budget. Retrying spends it twice
+        // more for the same answer and pushes the first error the user sees
+        // out past six minutes.
+        const retryable = !(err instanceof CaptureTimeoutError);
+        if (retryable && attempt < DiscoveryService.MAX_RETRIES) {
           this.outputChannel.debug(
             `[discovery] attempt ${attempt}/${DiscoveryService.MAX_RETRIES} failed, retrying: ${message}`,
           );
@@ -354,7 +354,9 @@ export class DiscoveryService {
           continue;
         }
         this.outputChannel.error(
-          `[discovery] failed after ${DiscoveryService.MAX_RETRIES} attempts: ${message}`,
+          retryable
+            ? `[discovery] failed after ${DiscoveryService.MAX_RETRIES} attempts: ${message}`
+            : `[discovery] failed: ${message}`,
         );
         if (!this.hasShownError) {
           this.hasShownError = true;
@@ -375,20 +377,8 @@ export class DiscoveryService {
               }
             });
         }
+        return;
       }
     }
   }
-}
-
-// A discovery run compiles the CLI on a cold cache and then loads every package
-// in the workspace, so a monorepo can legitimately spend minutes here. The
-// budget is only there to stop a hung child from blocking discovery forever,
-// and it is raisable for a repository that needs longer.
-const DEFAULT_DISCOVERY_TIMEOUT_S = 120;
-
-function discoveryTimeoutSeconds(workspaceDir: string): number {
-  return (
-    scopedConfig(workspaceDir).get<number>("discoveryTimeout") ??
-    DEFAULT_DISCOVERY_TIMEOUT_S
-  );
 }

--- a/vscode-gotest/src/discovery.ts
+++ b/vscode-gotest/src/discovery.ts
@@ -6,7 +6,12 @@ import type {
   DiscoverPackage,
   DiscoverWarning,
 } from "./types.js";
-import { buildCliCommand, clearBinaryCache, formatCliCommand } from "./cli.js";
+import {
+  buildCliCommand,
+  clearBinaryCache,
+  formatCliCommand,
+  scopedConfig,
+} from "./cli.js";
 import { captureStdout } from "./capture.js";
 
 export class DiscoveryCache implements vscode.Disposable {
@@ -263,7 +268,7 @@ export class DiscoveryService {
 
         const stdout = await captureStdout(cmd.bin, cmd.args, {
           cwd: workspaceDir,
-          timeoutSeconds: 30,
+          timeoutSeconds: discoveryTimeoutSeconds(workspaceDir),
         });
 
         const jsonStart = stdout.indexOf("{");
@@ -301,9 +306,15 @@ export class DiscoveryService {
         );
         if (!this.hasShownError) {
           this.hasShownError = true;
+          // Say what went wrong. The advice below is right for a missing
+          // toolchain and misleading for everything else — a timeout, a
+          // package that will not load — which is most of what lands here.
+          const advice = isENOENT
+            ? " Ensure 'go' is installed and the gotest module is accessible."
+            : "";
           vscode.window
             .showWarningMessage(
-              `gotest: discovery failed. Ensure 'go' is installed and the gotest module is accessible.`,
+              `gotest: discovery failed: ${message.split("\n")[0]}.${advice}`,
               "Open Output",
             )
             .then((choice) => {
@@ -315,4 +326,17 @@ export class DiscoveryService {
       }
     }
   }
+}
+
+// A discovery run compiles the CLI on a cold cache and then loads every package
+// in the workspace, so a monorepo can legitimately spend minutes here. The
+// budget is only there to stop a hung child from blocking discovery forever,
+// and it is raisable for a repository that needs longer.
+const DEFAULT_DISCOVERY_TIMEOUT_S = 120;
+
+function discoveryTimeoutSeconds(workspaceDir: string): number {
+  return (
+    scopedConfig(workspaceDir).get<number>("discoveryTimeout") ??
+    DEFAULT_DISCOVERY_TIMEOUT_S
+  );
 }

--- a/vscode-gotest/src/discovery.ts
+++ b/vscode-gotest/src/discovery.ts
@@ -13,6 +13,7 @@ import {
   scopedConfig,
 } from "./cli.js";
 import { captureStdout } from "./capture.js";
+import type { DiscoverySnapshotStore } from "./discoverySnapshotStore.js";
 
 export class DiscoveryCache implements vscode.Disposable {
   private cache = new Map<string, DiscoverPackage>();
@@ -65,6 +66,24 @@ export class DiscoveryCache implements vscode.Disposable {
 
   getModuleDir(modulePath: string): string | undefined {
     return this.moduleDirs.get(modulePath);
+  }
+
+  /** Returns the packages discovered under a workspace dir. */
+  packagesForWorkspace(workspaceDir: string): DiscoverPackage[] {
+    const result: DiscoverPackage[] = [];
+    for (const [importPath, wsDir] of this.workspaceDirs) {
+      if (wsDir !== workspaceDir) continue;
+      const pkg = this.cache.get(importPath);
+      if (pkg) result.push(pkg);
+    }
+    return result;
+  }
+
+  /** Returns the warnings recorded for a workspace dir. */
+  warningsForWorkspace(workspaceDir: string): DiscoverWarning[] {
+    return this._warnings
+      .filter((w) => w._wsDir === workspaceDir)
+      .map(({ _wsDir, ...warning }) => warning);
   }
 
   /** Returns unique module paths for packages within a workspace dir. */
@@ -156,6 +175,7 @@ export class DiscoveryService {
   constructor(
     private readonly cache: DiscoveryCache,
     private readonly outputChannel: vscode.LogOutputChannel,
+    private readonly snapshots?: DiscoverySnapshotStore,
   ) {}
 
   async discover(workspaceDir: string, patterns?: string[]): Promise<void> {
@@ -264,21 +284,53 @@ export class DiscoveryService {
           workspaceDir,
           this.outputChannel,
         );
-        this.outputChannel.info(`[discovery] ${formatCliCommand(cmd)}`);
+        this.outputChannel.info(
+          `[discovery] ${formatCliCommand(cmd)} (cwd ${workspaceDir})`,
+        );
 
+        // Timed in three parts because they fail differently: a slow build is
+        // the toolchain's, a slow first-to-last byte is the CLI's, and slow
+        // parse/index time is ours. One total would hide which.
+        const startedAt = Date.now();
+        let firstByteMs = -1;
         const stdout = await captureStdout(cmd.bin, cmd.args, {
           cwd: workspaceDir,
           timeoutSeconds: discoveryTimeoutSeconds(workspaceDir),
+          onFirstByte: (ms) => {
+            firstByteMs = ms;
+          },
         });
+        const childMs = Date.now() - startedAt;
 
         const jsonStart = stdout.indexOf("{");
         const json = jsonStart > 0 ? stdout.substring(jsonStart) : stdout;
         const output: DiscoverOutput = JSON.parse(json);
+        const parsedMs = Date.now() - startedAt - childMs;
         const fullScan = effectivePatterns.some((p) => p.includes("..."));
         const warnings = output.warnings ?? [];
         const packages = output.packages ?? [];
+        const indexStartedAt = Date.now();
         this.cache.update(packages, fullScan, workspaceDir, warnings);
+        const indexMs = Date.now() - indexStartedAt;
+        const suites = packages.reduce(
+          (n, p) => n + (p.suites?.length ?? 0),
+          0,
+        );
+        this.outputChannel.info(
+          `[discovery] ${packages.length} package(s), ${suites} suite(s) in ` +
+            `${childMs}ms child (${firstByteMs < 0 ? "no output" : `${firstByteMs}ms to first byte`}), ` +
+            `${parsedMs}ms parse of ${stdout.length}B, ${indexMs}ms index`,
+        );
         this.hasShownError = false;
+        // Snapshot the workspace, not the response: this run may have matched
+        // a single package, and a snapshot standing in for the whole tree has
+        // to describe the whole tree.
+        this.snapshots?.update(
+          workspaceDir,
+          this.cache.packagesForWorkspace(workspaceDir),
+          this.cache.warningsForWorkspace(workspaceDir),
+        );
+        void this.snapshots?.save();
         for (const w of warnings) {
           const loc = w.file ? ` (${w.file}:${w.line ?? 0})` : "";
           this.outputChannel.warn(

--- a/vscode-gotest/src/discovery.ts
+++ b/vscode-gotest/src/discovery.ts
@@ -1,18 +1,13 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
 import { access, readFile } from "node:fs/promises";
-import { spawn } from "node:child_process";
 import type {
   DiscoverOutput,
   DiscoverPackage,
   DiscoverWarning,
 } from "./types.js";
-import {
-  buildCliCommand,
-  clearBinaryCache,
-  formatCliCommand,
-  stripGoRunExitEcho,
-} from "./cli.js";
+import { buildCliCommand, clearBinaryCache, formatCliCommand } from "./cli.js";
+import { captureStdout } from "./capture.js";
 
 export class DiscoveryCache implements vscode.Disposable {
   private cache = new Map<string, DiscoverPackage>();
@@ -266,7 +261,10 @@ export class DiscoveryService {
         );
         this.outputChannel.info(`[discovery] ${formatCliCommand(cmd)}`);
 
-        const stdout = await captureStdout(cmd, workspaceDir);
+        const stdout = await captureStdout(cmd.bin, cmd.args, {
+          cwd: workspaceDir,
+          timeoutSeconds: 30,
+        });
 
         const jsonStart = stdout.indexOf("{");
         const json = jsonStart > 0 ? stdout.substring(jsonStart) : stdout;
@@ -317,64 +315,4 @@ export class DiscoveryService {
       }
     }
   }
-}
-
-const DISCOVERY_TIMEOUT_MS = 30_000;
-
-// captureStdout runs the CLI and streams what it writes. execFile would be
-// shorter, but its default 1 MiB cap is a ceiling discovery has no business
-// having: the payload grows with every behavior a repo declares, and one byte
-// past the cap killed the child mid-write and cost the whole test tree.
-function captureStdout(
-  cmd: { bin: string; args: string[] },
-  cwd: string,
-): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const child = spawn(cmd.bin, cmd.args, { cwd });
-    const stdout: string[] = [];
-    let stderr = "";
-    let timedOut = false;
-    let settled = false;
-
-    // Decode on the stream, not per chunk: a read boundary falls wherever the
-    // pipe fills, and a chunk-wise toString() would corrupt whatever multi-byte
-    // character it lands inside. Behavior names are the developer's own text.
-    child.stdout.setEncoding("utf-8");
-    child.stderr.setEncoding("utf-8");
-    child.stdout.on("data", (chunk: string) => stdout.push(chunk));
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill();
-    }, DISCOVERY_TIMEOUT_MS);
-
-    const settle = (outcome: () => void) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      outcome();
-    };
-
-    // A missing binary arrives here rather than as an exit code, and the caller
-    // reads `code` off the error to drop its cached path — so pass it through.
-    child.on("error", (err: Error) => settle(() => reject(err)));
-
-    child.on("close", (code) => {
-      settle(() => {
-        if (timedOut) {
-          reject(new Error(`timed out after ${DISCOVERY_TIMEOUT_MS}ms`));
-        } else if (code === 0) {
-          resolve(stdout.join(""));
-        } else {
-          const detail = stripGoRunExitEcho(stderr);
-          reject(
-            new Error(`exited with code ${code}${detail ? `: ${detail}` : ""}`),
-          );
-        }
-      });
-    });
-  });
 }

--- a/vscode-gotest/src/discoverySnapshotStore.test.ts
+++ b/vscode-gotest/src/discoverySnapshotStore.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockReadFile, mockWriteFile, mockMkdir, files } = vi.hoisted(() => {
+  const files = new Map<string, string>();
+  return {
+    files,
+    mockReadFile: vi.fn(async (p: string) => {
+      const content = files.get(p);
+      if (content === undefined) throw new Error("ENOENT");
+      return content;
+    }),
+    mockWriteFile: vi.fn(async (p: string, content: string) => {
+      files.set(p, content);
+    }),
+    mockMkdir: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock("node:fs/promises", () => ({
+  readFile: mockReadFile,
+  writeFile: mockWriteFile,
+  mkdir: mockMkdir,
+}));
+
+import { DiscoverySnapshotStore } from "./discoverySnapshotStore.js";
+import type { DiscoverPackage, DiscoverWarning } from "./types.js";
+
+const storage = { fsPath: "/storage" } as import("vscode").Uri;
+const SNAPSHOT = "/storage/discovery.json";
+
+function pkg(importPath: string): DiscoverPackage {
+  return {
+    importPath,
+    dir: `/ws/${importPath}`,
+    modulePath: "example.com/m",
+    suites: [],
+  } as DiscoverPackage;
+}
+
+describe("DiscoverySnapshotStore", () => {
+  beforeEach(() => {
+    files.clear();
+    vi.clearAllMocks();
+  });
+
+  it("round-trips packages and warnings for a workspace", async () => {
+    const warnings: DiscoverWarning[] = [
+      { importPath: "example.com/m/a", message: "boom" },
+    ];
+    const store = new DiscoverySnapshotStore(storage);
+    store.update("/ws", [pkg("example.com/m/a")], warnings);
+    await store.save();
+
+    const reloaded = new DiscoverySnapshotStore(storage);
+    await reloaded.load();
+    const snap = reloaded.get("/ws");
+    expect(snap?.packages).toEqual([pkg("example.com/m/a")]);
+    expect(snap?.warnings).toEqual(warnings);
+  });
+
+  it("keeps workspaces apart", async () => {
+    const store = new DiscoverySnapshotStore(storage);
+    store.update("/ws1", [pkg("example.com/m/a")], []);
+    store.update("/ws2", [pkg("example.com/m/b")], []);
+    await store.save();
+
+    const reloaded = new DiscoverySnapshotStore(storage);
+    await reloaded.load();
+    expect(reloaded.get("/ws1")?.packages).toEqual([pkg("example.com/m/a")]);
+    expect(reloaded.get("/ws2")?.packages).toEqual([pkg("example.com/m/b")]);
+    expect(reloaded.get("/ws3")).toBeUndefined();
+  });
+
+  it("replaces a workspace's snapshot rather than merging it", async () => {
+    const store = new DiscoverySnapshotStore(storage);
+    store.update("/ws", [pkg("example.com/m/a"), pkg("example.com/m/b")], []);
+    store.update("/ws", [pkg("example.com/m/a")], []);
+    await store.save();
+
+    const reloaded = new DiscoverySnapshotStore(storage);
+    await reloaded.load();
+    // A package deleted from the workspace must not survive in the snapshot,
+    // or the tree would show it again on every activation.
+    expect(reloaded.get("/ws")?.packages).toEqual([pkg("example.com/m/a")]);
+  });
+
+  it("ignores a snapshot written by a different schema version", async () => {
+    files.set(SNAPSHOT, JSON.stringify({ version: 99, workspaces: {} }));
+    const store = new DiscoverySnapshotStore(storage);
+    await store.load();
+    expect(store.get("/ws")).toBeUndefined();
+  });
+
+  it("starts fresh on a corrupt snapshot instead of throwing", async () => {
+    files.set(SNAPSHOT, "{not json");
+    const store = new DiscoverySnapshotStore(storage);
+    await expect(store.load()).resolves.toBeUndefined();
+    expect(store.get("/ws")).toBeUndefined();
+  });
+
+  it("starts fresh when nothing has been stored yet", async () => {
+    const store = new DiscoverySnapshotStore(storage);
+    await store.load();
+    expect(store.get("/ws")).toBeUndefined();
+  });
+
+  it("never touches disk without a storage location", async () => {
+    const store = new DiscoverySnapshotStore(undefined);
+    store.update("/ws", [pkg("example.com/m/a")], []);
+    await expect(store.save()).resolves.toBeUndefined();
+    await expect(store.load()).resolves.toBeUndefined();
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it("writes compactly", async () => {
+    const store = new DiscoverySnapshotStore(storage);
+    store.update("/ws", [pkg("example.com/m/a")], []);
+    await store.save();
+    // A large project's snapshot is megabytes; indentation is pure cost on a
+    // file written after every discovery.
+    expect(files.get(SNAPSHOT)).not.toContain("\n");
+  });
+});

--- a/vscode-gotest/src/discoverySnapshotStore.test.ts
+++ b/vscode-gotest/src/discoverySnapshotStore.test.ts
@@ -49,7 +49,8 @@ describe("DiscoverySnapshotStore", () => {
     ];
     const store = new DiscoverySnapshotStore(storage);
     store.update("/ws", [pkg("example.com/m/a")], warnings);
-    await store.save();
+    store.save();
+    await store.flush();
 
     const reloaded = new DiscoverySnapshotStore(storage);
     await reloaded.load();
@@ -62,7 +63,8 @@ describe("DiscoverySnapshotStore", () => {
     const store = new DiscoverySnapshotStore(storage);
     store.update("/ws1", [pkg("example.com/m/a")], []);
     store.update("/ws2", [pkg("example.com/m/b")], []);
-    await store.save();
+    store.save();
+    await store.flush();
 
     const reloaded = new DiscoverySnapshotStore(storage);
     await reloaded.load();
@@ -75,7 +77,8 @@ describe("DiscoverySnapshotStore", () => {
     const store = new DiscoverySnapshotStore(storage);
     store.update("/ws", [pkg("example.com/m/a"), pkg("example.com/m/b")], []);
     store.update("/ws", [pkg("example.com/m/a")], []);
-    await store.save();
+    store.save();
+    await store.flush();
 
     const reloaded = new DiscoverySnapshotStore(storage);
     await reloaded.load();
@@ -107,7 +110,8 @@ describe("DiscoverySnapshotStore", () => {
   it("never touches disk without a storage location", async () => {
     const store = new DiscoverySnapshotStore(undefined);
     store.update("/ws", [pkg("example.com/m/a")], []);
-    await expect(store.save()).resolves.toBeUndefined();
+    store.save();
+    await expect(store.flush()).resolves.toBeUndefined();
     await expect(store.load()).resolves.toBeUndefined();
     expect(mockWriteFile).not.toHaveBeenCalled();
     expect(mockReadFile).not.toHaveBeenCalled();
@@ -116,9 +120,50 @@ describe("DiscoverySnapshotStore", () => {
   it("writes compactly", async () => {
     const store = new DiscoverySnapshotStore(storage);
     store.update("/ws", [pkg("example.com/m/a")], []);
-    await store.save();
+    store.save();
+    await store.flush();
     // A large project's snapshot is megabytes; indentation is pure cost on a
     // file written after every discovery.
     expect(files.get(SNAPSHOT)).not.toContain("\n");
+  });
+});
+
+describe("DiscoverySnapshotStore write behaviour", () => {
+  beforeEach(() => {
+    files.clear();
+    vi.clearAllMocks();
+  });
+
+  // Every save of a _test.go file rediscovers its package, and each one used to
+  // rewrite the whole workspace tree synchronously.
+  it("coalesces a burst of saves into one write", async () => {
+    const store = new DiscoverySnapshotStore(storage);
+    for (let i = 0; i < 5; i++) {
+      store.update("/ws", [pkg(`example.com/m/p${i}`)], []);
+      store.save();
+    }
+    await store.flush();
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+  });
+
+  // activate() registers the file watchers before initializeAsync awaits the
+  // load, so a save in that window produces a discovery whose result must not
+  // be thrown away by the load that arrives afterwards.
+  it("does not let a late load discard what discovery already found", async () => {
+    files.set(
+      SNAPSHOT,
+      JSON.stringify({
+        version: 1,
+        workspaces: {
+          "/ws": { packages: [pkg("example.com/m/stale")], warnings: [] },
+        },
+      }),
+    );
+
+    const store = new DiscoverySnapshotStore(storage);
+    store.update("/ws", [pkg("example.com/m/fresh")], []);
+    await store.load();
+
+    expect(store.get("/ws")?.packages).toEqual([pkg("example.com/m/fresh")]);
   });
 });

--- a/vscode-gotest/src/discoverySnapshotStore.ts
+++ b/vscode-gotest/src/discoverySnapshotStore.ts
@@ -1,0 +1,99 @@
+import * as vscode from "vscode";
+import * as path from "node:path";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import type { DiscoverPackage, DiscoverWarning } from "./types.js";
+
+export interface DiscoverySnapshot {
+  packages: DiscoverPackage[];
+  warnings: DiscoverWarning[];
+}
+
+interface StoredData {
+  version: 1;
+  workspaces: Record<string, DiscoverySnapshot>;
+}
+
+// DiscoverySnapshotStore persists the last known test tree.
+//
+// Discovery's cost is the Go toolchain's, not ours: loading a workspace with
+// type information means compiling its dependency graph for export data, which
+// is seconds warm and tens of seconds on a cold build cache. Paying that before
+// the explorer shows anything made every activation as slow as the toolchain's
+// worst case. The snapshot decouples the two — the tree comes back from disk,
+// and discovery corrects it in the background.
+//
+// The snapshot is a cache, never a source of truth: it is whatever was true
+// when the window last closed, and the discovery that follows it replaces it
+// wholesale.
+export class DiscoverySnapshotStore {
+  private workspaces = new Map<string, DiscoverySnapshot>();
+  private readonly storagePath: string | undefined;
+  private saveChain = Promise.resolve();
+
+  constructor(storageUri: vscode.Uri | undefined) {
+    if (storageUri) {
+      this.storagePath = path.join(storageUri.fsPath, "discovery.json");
+    }
+  }
+
+  get size(): number {
+    return this.workspaces.size;
+  }
+
+  get(workspaceDir: string): DiscoverySnapshot | undefined {
+    return this.workspaces.get(workspaceDir);
+  }
+
+  // update replaces a workspace's snapshot. Replacing rather than merging is
+  // what lets a deleted package leave the tree: a merge would keep resurrecting
+  // it on every activation.
+  update(
+    workspaceDir: string,
+    packages: DiscoverPackage[],
+    warnings: DiscoverWarning[],
+  ): void {
+    this.workspaces.set(workspaceDir, { packages, warnings });
+  }
+
+  async load(): Promise<void> {
+    if (!this.storagePath) {
+      return;
+    }
+    try {
+      const content = await readFile(this.storagePath, "utf-8");
+      const data = JSON.parse(content) as StoredData;
+      if (data.version !== 1) {
+        return;
+      }
+      this.workspaces.clear();
+      for (const [dir, snapshot] of Object.entries(data.workspaces ?? {})) {
+        this.workspaces.set(dir, {
+          packages: snapshot.packages ?? [],
+          warnings: snapshot.warnings ?? [],
+        });
+      }
+    } catch {
+      // No stored data or corrupt — start fresh
+    }
+  }
+
+  save(): Promise<void> {
+    const op = this.saveChain.then(() => this.writeToDisk());
+    this.saveChain = op.catch(() => {});
+    return op;
+  }
+
+  flush(): Promise<void> {
+    return this.saveChain;
+  }
+
+  private async writeToDisk(): Promise<void> {
+    if (!this.storagePath) return;
+    const data: StoredData = {
+      version: 1,
+      workspaces: Object.fromEntries(this.workspaces),
+    };
+    await mkdir(path.dirname(this.storagePath), { recursive: true });
+    await writeFile(this.storagePath, JSON.stringify(data), "utf-8");
+  }
+}

--- a/vscode-gotest/src/discoverySnapshotStore.ts
+++ b/vscode-gotest/src/discoverySnapshotStore.ts
@@ -29,6 +29,16 @@ export class DiscoverySnapshotStore {
   private workspaces = new Map<string, DiscoverySnapshot>();
   private readonly storagePath: string | undefined;
   private saveChain = Promise.resolve();
+  private debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  // Set by the first update(). Discovery can run before load() resolves —
+  // activate() registers the file watchers before initializeAsync awaits the
+  // load — and what discovery just found beats what the last session stored.
+  private dirty = false;
+
+  // A whole-workspace tree is hundreds of kilobytes to serialize, and every
+  // save of a _test.go file triggers a package rediscovery. Coalesce, the way
+  // TestResultStore does, rather than rewriting the file per keystroke-save.
+  private static readonly SAVE_DEBOUNCE_MS = 500;
 
   constructor(storageUri: vscode.Uri | undefined) {
     if (storageUri) {
@@ -53,10 +63,11 @@ export class DiscoverySnapshotStore {
     warnings: DiscoverWarning[],
   ): void {
     this.workspaces.set(workspaceDir, { packages, warnings });
+    this.dirty = true;
   }
 
   async load(): Promise<void> {
-    if (!this.storagePath) {
+    if (!this.storagePath || this.dirty) {
       return;
     }
     try {
@@ -77,14 +88,32 @@ export class DiscoverySnapshotStore {
     }
   }
 
-  save(): Promise<void> {
-    const op = this.saveChain.then(() => this.writeToDisk());
-    this.saveChain = op.catch(() => {});
-    return op;
+  save(): void {
+    if (this.debounceTimer !== undefined) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined;
+      this.enqueueWrite();
+    }, DiscoverySnapshotStore.SAVE_DEBOUNCE_MS);
   }
 
   flush(): Promise<void> {
+    if (this.debounceTimer !== undefined) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = undefined;
+      this.enqueueWrite();
+    }
     return this.saveChain;
+  }
+
+  private enqueueWrite(): void {
+    this.saveChain = this.saveChain
+      .then(() => this.writeToDisk())
+      .catch(() => {
+        // A snapshot is a cache; a failed write costs the next activation its
+        // head start and nothing else.
+      });
   }
 
   private async writeToDisk(): Promise<void> {

--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { DiscoveryCache, DiscoveryService } from "./discovery.js";
+import { treeSignature } from "./treeSignature.js";
 import { DiscoverySnapshotStore } from "./discoverySnapshotStore.js";
 import { GoTestController } from "./testController.js";
 import { TestRunner } from "./runner.js";
@@ -680,6 +681,13 @@ async function initializeAsync(deps: {
     );
   }
 
+  // Loaded once. Both load() implementations clear their map before reading,
+  // so calling them again after discovery would throw away anything a run
+  // started on the restored tree had recorded in the meantime — and the
+  // restored tree exists precisely so runs can start during discovery.
+  await coverageStore.load();
+  await testResultStore.load();
+
   const restoreStored = async () => {
     await restoreCoverage();
     await restoreResults();
@@ -690,20 +698,19 @@ async function initializeAsync(deps: {
     await restoreStored();
   }
 
-  const before = treeSignature(cache);
+  const before = treeSignature(cache.packages);
   for (const folder of workspaceFolders) {
     await discoveryService.discover(folder.uri.fsPath);
   }
   // Only worth redoing when discovery actually moved the tree: a restore
   // against an unchanged tree would decorate the same items twice and leave a
   // second "Restored Results" run behind for no reason.
-  if (treeSignature(cache) !== before) {
+  if (treeSignature(cache.packages) !== before) {
     await restoreStored();
   }
 
   async function restoreCoverage(): Promise<void> {
     const coverageStartedAt = Date.now();
-    await coverageStore.load();
     if (coverageStore.size > 0) {
       const { coverages } = coverageStore.buildFileCoverages(cache);
       if (coverages.length > 0) {
@@ -722,7 +729,6 @@ async function initializeAsync(deps: {
 
   async function restoreResults(): Promise<void> {
     const resultsStartedAt = Date.now();
-    await testResultStore.load();
     if (testResultStore.size > 0) {
       const resultRequest = new vscode.TestRunRequest();
       const resultRun = controller.createTestRun(
@@ -754,22 +760,4 @@ async function initializeAsync(deps: {
       );
     }
   }
-}
-
-// treeSignature captures the shape the stored results were applied against —
-// package, suite and method names. Anything that changes an item's id changes
-// this, which is exactly when a restore has to run again.
-function treeSignature(cache: DiscoveryCache): string {
-  return cache.packages
-    .map(
-      (pkg) =>
-        `${pkg.importPath}:${(pkg.suites ?? [])
-          .map(
-            (s) =>
-              `${s.name}(${(s.methods ?? []).map((m) => m.name).join(",")})`,
-          )
-          .join("|")}`,
-    )
-    .sort()
-    .join("\n");
 }

--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { DiscoveryCache, DiscoveryService } from "./discovery.js";
+import { DiscoverySnapshotStore } from "./discoverySnapshotStore.js";
 import { GoTestController } from "./testController.js";
 import { TestRunner } from "./runner.js";
 import { GoTestCodeLensProvider } from "./codeLens.js";
@@ -44,7 +45,12 @@ export function activate(context: vscode.ExtensionContext): void {
   }
 
   const cache = new DiscoveryCache();
-  const discoveryService = new DiscoveryService(cache, outputChannel);
+  const snapshotStore = new DiscoverySnapshotStore(context.storageUri);
+  const discoveryService = new DiscoveryService(
+    cache,
+    outputChannel,
+    snapshotStore,
+  );
   const debugLauncher = new DebugLauncher(outputChannel);
   const testResultStore = new TestResultStore(context.storageUri);
   const registryDir =
@@ -189,6 +195,7 @@ export function activate(context: vscode.ExtensionContext): void {
       runRegistry.save(),
       coverageStore.flush(),
       testResultStore.flush(),
+      snapshotStore.flush(),
     ]);
   };
 
@@ -202,6 +209,7 @@ export function activate(context: vscode.ExtensionContext): void {
     cache,
     runRegistry,
     context,
+    snapshotStore,
   }).catch((err) => {
     outputChannel.error(`[activate] async initialization failed: ${err}`);
   });
@@ -588,6 +596,7 @@ async function initializeAsync(deps: {
   cache: DiscoveryCache;
   runRegistry: RunRegistry;
   context: vscode.ExtensionContext;
+  snapshotStore: DiscoverySnapshotStore;
 }): Promise<void> {
   const {
     workspaceFolders,
@@ -599,6 +608,7 @@ async function initializeAsync(deps: {
     cache,
     runRegistry,
     context,
+    snapshotStore,
   } = deps;
 
   const firstDir = workspaceFolders[0].uri.fsPath;
@@ -651,55 +661,115 @@ async function initializeAsync(deps: {
     },
   });
 
+  // The tree comes back from the last session before discovery runs. Discovery
+  // costs whatever the Go toolchain charges to load the workspace — seconds
+  // warm, tens of seconds on a cold build cache — and blocking the explorer on
+  // that made every activation as slow as the toolchain's worst case. The
+  // snapshot is stale by definition; the discovery below replaces it.
+  const snapshotStartedAt = Date.now();
+  await snapshotStore.load();
+  let restoredFromSnapshot = false;
+  for (const folder of workspaceFolders) {
+    const snapshot = snapshotStore.get(folder.uri.fsPath);
+    if (!snapshot || snapshot.packages.length === 0) continue;
+    cache.update(snapshot.packages, true, folder.uri.fsPath, snapshot.warnings);
+    restoredFromSnapshot = true;
+    outputChannel.info(
+      `[discovery] restored ${snapshot.packages.length} package(s) from snapshot in ` +
+        `${Date.now() - snapshotStartedAt}ms — refreshing in background`,
+    );
+  }
+
+  const restoreStored = async () => {
+    await restoreCoverage();
+    await restoreResults();
+  };
+  // With no snapshot there is no tree yet, and a restore would have nothing to
+  // decorate — it would only log a run of zeroes before discovery arrives.
+  if (restoredFromSnapshot) {
+    await restoreStored();
+  }
+
+  const before = treeSignature(cache);
   for (const folder of workspaceFolders) {
     await discoveryService.discover(folder.uri.fsPath);
   }
+  // Only worth redoing when discovery actually moved the tree: a restore
+  // against an unchanged tree would decorate the same items twice and leave a
+  // second "Restored Results" run behind for no reason.
+  if (treeSignature(cache) !== before) {
+    await restoreStored();
+  }
 
-  await coverageStore.load();
-  if (coverageStore.size > 0) {
-    const { coverages } = coverageStore.buildFileCoverages(cache);
-    if (coverages.length > 0) {
-      const request = new vscode.TestRunRequest();
-      const run = controller.createTestRun(request, "Restored Coverage");
-      for (const fc of coverages) {
-        run.addCoverage(fc);
+  async function restoreCoverage(): Promise<void> {
+    const coverageStartedAt = Date.now();
+    await coverageStore.load();
+    if (coverageStore.size > 0) {
+      const { coverages } = coverageStore.buildFileCoverages(cache);
+      if (coverages.length > 0) {
+        const request = new vscode.TestRunRequest();
+        const run = controller.createTestRun(request, "Restored Coverage");
+        for (const fc of coverages) {
+          run.addCoverage(fc);
+        }
+        run.end();
+        outputChannel.info(
+          `[coverage] restored ${coverages.length} file(s) from storage in ${Date.now() - coverageStartedAt}ms`,
+        );
       }
-      run.end();
-      outputChannel.info(
-        `[coverage] restored ${coverages.length} file(s) from storage`,
-      );
     }
   }
 
-  await testResultStore.load();
-  if (testResultStore.size > 0) {
-    const resultRequest = new vscode.TestRunRequest();
-    const resultRun = controller.createTestRun(
-      resultRequest,
-      "Restored Results",
-    );
-    let applied = 0;
-    testResultStore.forEach((result, itemId) => {
-      const item = controller.findItem(itemId);
-      // A stored id with no item is a test that no longer exists, or one the
-      // tree cannot name yet. Counting only what landed keeps the log honest:
-      // reporting the store's size implies a restore that may not have
-      // happened.
-      if (!item) return;
-      applied++;
-      if (result.status === "pass") resultRun.passed(item, result.duration);
-      else if (result.status === "fail")
-        resultRun.failed(
-          item,
-          [new vscode.TestMessage("(restored from previous session)")],
-          result.duration,
-        );
-      else if (result.status === "skip") resultRun.skipped(item);
-    });
-    resolveAncestorItems(resultRun, controller);
-    resultRun.end();
-    outputChannel.info(
-      `[results] restored ${applied} of ${testResultStore.size} result(s) from storage`,
-    );
+  async function restoreResults(): Promise<void> {
+    const resultsStartedAt = Date.now();
+    await testResultStore.load();
+    if (testResultStore.size > 0) {
+      const resultRequest = new vscode.TestRunRequest();
+      const resultRun = controller.createTestRun(
+        resultRequest,
+        "Restored Results",
+      );
+      let applied = 0;
+      testResultStore.forEach((result, itemId) => {
+        const item = controller.findItem(itemId);
+        // A stored id with no item is a test that no longer exists, or one the
+        // tree cannot name yet. Counting only what landed keeps the log honest:
+        // reporting the store's size implies a restore that may not have
+        // happened.
+        if (!item) return;
+        applied++;
+        if (result.status === "pass") resultRun.passed(item, result.duration);
+        else if (result.status === "fail")
+          resultRun.failed(
+            item,
+            [new vscode.TestMessage("(restored from previous session)")],
+            result.duration,
+          );
+        else if (result.status === "skip") resultRun.skipped(item);
+      });
+      resolveAncestorItems(resultRun, controller);
+      resultRun.end();
+      outputChannel.info(
+        `[results] restored ${applied} of ${testResultStore.size} result(s) from storage in ${Date.now() - resultsStartedAt}ms`,
+      );
+    }
   }
+}
+
+// treeSignature captures the shape the stored results were applied against —
+// package, suite and method names. Anything that changes an item's id changes
+// this, which is exactly when a restore has to run again.
+function treeSignature(cache: DiscoveryCache): string {
+  return cache.packages
+    .map(
+      (pkg) =>
+        `${pkg.importPath}:${(pkg.suites ?? [])
+          .map(
+            (s) =>
+              `${s.name}(${(s.methods ?? []).map((m) => m.name).join(",")})`,
+          )
+          .join("|")}`,
+    )
+    .sort()
+    .join("\n");
 }

--- a/vscode-gotest/src/processTree.ts
+++ b/vscode-gotest/src/processTree.ts
@@ -1,0 +1,23 @@
+import type { ChildProcess } from "node:child_process";
+
+// killProcessTree signals the whole process group, not just the child we
+// spawned. Everything here runs `go run <module> ...`, so the direct child is
+// `go` and the process actually holding the pipes is the binary it compiled.
+// Signalling only the child leaves that grandchild alive.
+//
+// Lives in its own module so a low-level caller like capture.ts can use it
+// without importing runnerUtils, which would close an import cycle.
+export function killProcessTree(
+  child: ChildProcess,
+  signal: NodeJS.Signals = "SIGTERM",
+): void {
+  if (child.pid && process.platform !== "win32") {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // process group already exited
+    }
+  }
+  child.kill(signal);
+}

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -429,8 +429,12 @@ export function spawnTestProcess(
     let lineBuffer = "";
     let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
 
-    child.stdout.on("data", (data: Buffer) => {
-      const chunk = data.toString();
+    // Decoded on the stream, so a character split across two reads survives:
+    // test output is the developer's own text, and the line assembly below
+    // would otherwise emit a corrupted event.
+    child.stdout.setEncoding("utf-8");
+    child.stderr.setEncoding("utf-8");
+    child.stdout.on("data", (chunk: string) => {
       stdout += chunk;
 
       if (onStdoutLine) {
@@ -446,8 +450,8 @@ export function spawnTestProcess(
       }
     });
 
-    child.stderr.on("data", (data: Buffer) => {
-      stderr += data.toString();
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
     });
 
     const cancelListener = token.onCancellationRequested(() => {

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -462,7 +462,7 @@ export function spawnTestProcess(
       const killTimeout =
         vscode.workspace
           .getConfiguration("gotest")
-          .get<number>("forceKillTimeout", 600) * 1000;
+          .get<number>("forceKillTimeout", 120) * 1000;
       forceKillTimer = setTimeout(() => {
         outputChannel.warn(
           `[${label}] process did not exit after SIGTERM, sending SIGKILL`,

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -1,6 +1,8 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
+import { killProcessTree } from "./processTree.js";
+import { forceKillTimeoutSeconds } from "./config.js";
 import { readFile } from "node:fs/promises";
 import type { GoTestController } from "./testController.js";
 import type { DiscoveryCache } from "./discovery.js";
@@ -12,20 +14,7 @@ import {
   type TestEvent,
 } from "./outputParser.js";
 
-export function killProcessTree(
-  child: ChildProcess,
-  signal: NodeJS.Signals = "SIGTERM",
-): void {
-  if (child.pid && process.platform !== "win32") {
-    try {
-      process.kill(-child.pid, signal);
-      return;
-    } catch {
-      // process group already exited
-    }
-  }
-  child.kill(signal);
-}
+export { killProcessTree };
 
 export function enqueueDescendants(
   run: vscode.TestRun,
@@ -459,10 +448,7 @@ export function spawnTestProcess(
         `[${label}] cancellation requested, sending SIGTERM (pid ${child.pid})`,
       );
       killProcessTree(child, "SIGTERM");
-      const killTimeout =
-        vscode.workspace
-          .getConfiguration("gotest")
-          .get<number>("forceKillTimeout", 120) * 1000;
+      const killTimeout = forceKillTimeoutSeconds(cwd) * 1000;
       forceKillTimer = setTimeout(() => {
         outputChannel.warn(
           `[${label}] process did not exit after SIGTERM, sending SIGKILL`,

--- a/vscode-gotest/src/scaffold.ts
+++ b/vscode-gotest/src/scaffold.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
-import { spawn } from "node:child_process";
 import { buildCliCommand, formatCliCommand } from "./cli.js";
+import { captureStdout } from "./capture.js";
 
 export class ScaffoldCodeActionProvider
   implements vscode.CodeActionProvider, vscode.Disposable
@@ -143,7 +143,9 @@ export async function executeScaffold(
   outputChannel.info(`[scaffold] ${formatCliCommand(cmd)}`);
 
   try {
-    const stdout = await spawnScaffold(cmd, effectiveDir);
+    const stdout = await captureStdout(cmd.bin, cmd.args, {
+      cwd: effectiveDir,
+    });
     const match = /^Generated:\s*(.+)$/m.exec(stdout);
     if (match) {
       const generatedPath = match[1];
@@ -158,35 +160,4 @@ export async function executeScaffold(
     const message = err instanceof Error ? err.message : String(err);
     vscode.window.showErrorMessage(`gotest scaffold failed: ${message}`);
   }
-}
-
-function spawnScaffold(
-  cmd: { bin: string; args: string[] },
-  cwd: string,
-): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const child = spawn(cmd.bin, cmd.args, { cwd });
-    let stdout = "";
-    let stderr = "";
-
-    child.stdout.on("data", (data: Buffer) => {
-      stdout += data.toString();
-    });
-
-    child.stderr.on("data", (data: Buffer) => {
-      stderr += data.toString();
-    });
-
-    child.on("close", (code) => {
-      if (code !== 0) {
-        reject(new Error(stderr || `scaffold exited with code ${code}`));
-      } else {
-        resolve(stdout);
-      }
-    });
-
-    child.on("error", (err: Error) => {
-      reject(err);
-    });
-  });
 }

--- a/vscode-gotest/src/scriptedSpawn.test-support.ts
+++ b/vscode-gotest/src/scriptedSpawn.test-support.ts
@@ -15,6 +15,12 @@ export type ScriptedRun = {
   error?: NodeJS.ErrnoException;
   // A child that produces its output and then never exits, for testing budgets.
   neverExits?: boolean;
+  // A child that ignores SIGTERM. Only SIGKILL ends it — the case a timeout
+  // with no escalation can never recover from.
+  ignoresSigterm?: boolean;
+  // The direct child exits but a grandchild keeps the pipes open, so `exit`
+  // fires and `close` never does.
+  holdsPipesAfterExit?: boolean;
 };
 
 export interface SpawnScript {
@@ -29,12 +35,12 @@ export interface SpawnScript {
 export interface FakeChild extends EventEmitter {
   stdout: PassThrough;
   stderr: PassThrough;
-  kill: () => void;
+  kill: (signal?: NodeJS.Signals) => void;
 }
 
 export function createScriptedSpawn(
   script: SpawnScript,
-  onKill: () => void = () => {},
+  onKill: (signal?: NodeJS.Signals) => void = () => {},
 ): (bin: string, args: string[]) => FakeChild {
   return (bin: string, args: string[]) => {
     script.calls?.push({ bin, args });
@@ -47,15 +53,19 @@ export function createScriptedSpawn(
       child.stdout.end();
       child.stderr.end();
     };
-    child.kill = () => {
-      onKill();
-      finish();
+    child.kill = (signal?: NodeJS.Signals) => {
+      onKill(signal);
+      if (run.ignoresSigterm && signal !== "SIGKILL") return;
+      child.emit("exit", run.code ?? 0, signal ?? null);
+      if (!run.holdsPipesAfterExit) finish();
     };
 
     let ended = 0;
     const closeWhenDrained = () => {
-      if (++ended === 2)
+      if (++ended === 2) {
+        child.emit("exit", run.error ? null : (run.code ?? 0), null);
         child.emit("close", run.error ? null : (run.code ?? 0));
+      }
     };
     child.stdout.on("end", closeWhenDrained);
     child.stderr.on("end", closeWhenDrained);

--- a/vscode-gotest/src/scriptedSpawn.test-support.ts
+++ b/vscode-gotest/src/scriptedSpawn.test-support.ts
@@ -1,0 +1,77 @@
+// A stand-in for node:child_process' spawn, built on real streams.
+//
+// The code under test reads its payload in whatever pieces the pipe delivers,
+// so a fake that resolves a finished string tests the half that never breaks.
+// Here a scripted run writes real chunks — strings or Buffers, split wherever
+// the test wants them split — into a PassThrough the caller consumes for real.
+
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+export type ScriptedRun = {
+  stdout?: Array<string | Buffer>;
+  stderr?: string;
+  code?: number;
+  error?: NodeJS.ErrnoException;
+  // A child that produces its output and then never exits, for testing budgets.
+  neverExits?: boolean;
+};
+
+export interface SpawnScript {
+  // Consumed one per run, ahead of `always` — so a test can queue a recovery in
+  // front of a standing failure.
+  once: ScriptedRun[];
+  always?: ScriptedRun;
+  // What was spawned, in order, for tests that care about the command itself.
+  calls?: Array<{ bin: string; args: string[] }>;
+}
+
+export interface FakeChild extends EventEmitter {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: () => void;
+}
+
+export function createScriptedSpawn(
+  script: SpawnScript,
+  onKill: () => void = () => {},
+): (bin: string, args: string[]) => FakeChild {
+  return (bin: string, args: string[]) => {
+    script.calls?.push({ bin, args });
+    const run = script.once.shift() ?? script.always ?? { stdout: [] };
+    const child = new EventEmitter() as FakeChild;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+
+    const finish = () => {
+      child.stdout.end();
+      child.stderr.end();
+    };
+    child.kill = () => {
+      onKill();
+      finish();
+    };
+
+    let ended = 0;
+    const closeWhenDrained = () => {
+      if (++ended === 2)
+        child.emit("close", run.error ? null : (run.code ?? 0));
+    };
+    child.stdout.on("end", closeWhenDrained);
+    child.stderr.on("end", closeWhenDrained);
+
+    // A microtask later: the caller attaches its listeners on return.
+    void Promise.resolve().then(() => {
+      if (run.error) {
+        child.emit("error", run.error);
+        finish();
+        return;
+      }
+      for (const chunk of run.stdout ?? []) child.stdout.write(chunk);
+      if (run.stderr) child.stderr.write(run.stderr);
+      if (!run.neverExits) finish();
+    });
+
+    return child;
+  };
+}

--- a/vscode-gotest/src/spawnTestProcess.test.ts
+++ b/vscode-gotest/src/spawnTestProcess.test.ts
@@ -1,0 +1,74 @@
+// A test run's output is the developer's own text, and it arrives in whatever
+// pieces the pipe delivers. Decoding each piece on its own would replace any
+// character a read boundary splits with U+FFFD — in the captured stdout the
+// spec view renders, and in the line events the Test Explorer maps to results.
+
+import { describe, it, expect, vi } from "vitest";
+import type { SpawnScript } from "./scriptedSpawn.test-support.js";
+
+const { script } = vi.hoisted(() => ({
+  script: { once: [], always: undefined } as SpawnScript,
+}));
+
+vi.mock("vscode", () => ({
+  workspace: { getConfiguration: () => ({ get: () => 600 }) },
+}));
+
+vi.mock("node:child_process", async () => {
+  const { createScriptedSpawn } =
+    await import("./scriptedSpawn.test-support.js");
+  return { spawn: createScriptedSpawn(script) };
+});
+
+import { spawnTestProcess } from "./runnerUtils.js";
+
+const token = {
+  isCancellationRequested: false,
+  onCancellationRequested: () => ({ dispose: () => {} }),
+};
+
+const channel = {
+  info: () => {},
+  debug: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+function run(onStdoutLine?: (line: string) => void) {
+  return spawnTestProcess(
+    "go",
+    ["test"],
+    "/ws",
+    token as never,
+    channel as never,
+    "test",
+    undefined,
+    onStdoutLine,
+  );
+}
+
+describe("spawnTestProcess", () => {
+  it("keeps a character whose bytes span two reads", async () => {
+    const line = '{"Output":"café 日本語 🧪 passed\\n"}\n';
+    const bytes = Buffer.from(line, "utf-8");
+    const split = Buffer.byteLength(line.slice(0, line.indexOf("日"))) + 1;
+    script.once.push({
+      stdout: [bytes.subarray(0, split), bytes.subarray(split)],
+    });
+
+    const lines: string[] = [];
+    const result = await run((l) => lines.push(l));
+
+    expect(result.stdout).toBe(line);
+    expect(lines).toEqual([line.trim()]);
+  });
+
+  it("reports the exit code and the stderr it saw", async () => {
+    script.once.push({ stdout: ["ok\n"], stderr: "build failed", code: 2 });
+
+    const result = await run();
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toBe("build failed");
+  });
+});

--- a/vscode-gotest/src/specView.ts
+++ b/vscode-gotest/src/specView.ts
@@ -329,11 +329,16 @@ ${SCRIPT}
       let stdout = "";
       let stderr = "";
 
-      child.stdout.on("data", (data: Buffer) => {
-        stdout += data.toString();
+      // Decoded on the stream: a spec tree is large enough to arrive in several
+      // reads, and a boundary inside a multi-byte character would corrupt the
+      // behavior name it lands in.
+      child.stdout.setEncoding("utf-8");
+      child.stderr.setEncoding("utf-8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
       });
-      child.stderr.on("data", (data: Buffer) => {
-        stderr += data.toString();
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
       });
       child.on("close", (code) => {
         const outcome = interpretSpecExit(code, stdout, stderr);

--- a/vscode-gotest/src/testController.ts
+++ b/vscode-gotest/src/testController.ts
@@ -72,6 +72,9 @@ export class GoTestController implements vscode.Disposable {
       false,
     );
 
+    // Coalesces bursts — a watch event can touch several packages at once, and
+    // each one fires the cache's update. Anything that reads the tree flushes
+    // it first, so the delay never becomes visible as a missing item.
     let rebuildTimer: ReturnType<typeof setTimeout> | undefined;
     this.disposables.push(
       this.cache.onDidUpdate(() => {
@@ -80,6 +83,12 @@ export class GoTestController implements vscode.Disposable {
           rebuildTimer = undefined;
           this.rebuild();
         }, 50);
+        this.flushPendingRebuild = () => {
+          if (!rebuildTimer) return;
+          clearTimeout(rebuildTimer);
+          rebuildTimer = undefined;
+          this.rebuild();
+        };
       }),
     );
   }
@@ -569,7 +578,16 @@ export class GoTestController implements vscode.Disposable {
     return this.controller.createTestRun(request, name);
   }
 
+  // flushPendingRebuild applies a debounced rebuild that has not fired yet. It
+  // is a no-op until the cache has updated at least once.
+  private flushPendingRebuild: () => void = () => {};
+
   findItem(id: string): vscode.TestItem | undefined {
+    // The tree is the answer to this question, so it has to be current. A
+    // caller reading it moments after discovery — restoring the last session's
+    // results, say — would otherwise search an empty tree and conclude the
+    // tests no longer exist.
+    this.flushPendingRebuild();
     return this.findItemRecursive(this.controller.items, id);
   }
 

--- a/vscode-gotest/src/treeSignature.test.ts
+++ b/vscode-gotest/src/treeSignature.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { treeSignature } from "./treeSignature.js";
+import type { DiscoverBehavior, DiscoverPackage } from "./types.js";
+
+function behavior(name: string, children?: DiscoverBehavior[]) {
+  return {
+    name,
+    display: name,
+    kind: "it",
+    line: 1,
+    children,
+  } as DiscoverBehavior;
+}
+
+function tree(behaviors: DiscoverBehavior[]): DiscoverPackage[] {
+  return [
+    {
+      importPath: "example.com/m/a",
+      dir: "/ws/a",
+      suites: [
+        {
+          name: "ThingTestSuite",
+          parallel: false,
+          focused: false,
+          excluded: false,
+          guarded: false,
+          file: "a_test.go",
+          line: 1,
+          col: 1,
+          lifecycle: [],
+          fixtures: [],
+          methods: [
+            {
+              name: "TestIt",
+              parallel: false,
+              focused: false,
+              excluded: false,
+              file: "a_test.go",
+              line: 2,
+              col: 1,
+              behaviors,
+            },
+          ],
+        },
+      ],
+    } as DiscoverPackage,
+  ];
+}
+
+describe("treeSignature", () => {
+  it("is stable for an unchanged tree", () => {
+    expect(treeSignature(tree([behavior("when_a")]))).toBe(
+      treeSignature(tree([behavior("when_a")])),
+    );
+  });
+
+  // The whole point of the signature is to say whether stored results have to
+  // be applied again, and result ids go all the way down to behaviors. A
+  // signature blind to them asserts an invariant it does not hold.
+  it("changes when a behavior is renamed", () => {
+    expect(treeSignature(tree([behavior("when_a")]))).not.toBe(
+      treeSignature(tree([behavior("when_b")])),
+    );
+  });
+
+  it("changes when a behavior is added", () => {
+    expect(treeSignature(tree([behavior("when_a")]))).not.toBe(
+      treeSignature(tree([behavior("when_a"), behavior("when_b")])),
+    );
+  });
+
+  it("changes when a nested behavior is renamed", () => {
+    const before = tree([behavior("when_a", [behavior("it_x")])]);
+    const after = tree([behavior("when_a", [behavior("it_y")])]);
+    expect(treeSignature(before)).not.toBe(treeSignature(after));
+  });
+
+  it("does not depend on package order", () => {
+    const a = tree([behavior("when_a")]);
+    const b = [
+      { ...a[0], importPath: "example.com/m/b", dir: "/ws/b" },
+      a[0],
+    ] as DiscoverPackage[];
+    expect(treeSignature(b)).toBe(treeSignature([b[1], b[0]]));
+  });
+});

--- a/vscode-gotest/src/treeSignature.ts
+++ b/vscode-gotest/src/treeSignature.ts
@@ -1,0 +1,42 @@
+import type { DiscoverBehavior, DiscoverPackage } from "./types.js";
+
+// treeSignature captures the shape the stored results were applied against.
+// Every level that contributes to an item id is in it — package, suite, method
+// and the declared behaviors below them — because a restore has to run again
+// exactly when an id appears that was not there before. Leaving behaviors out
+// would make that claim false for the deepest ids in the tree.
+//
+// Folded into a hash rather than kept as a string: on a workspace with a few
+// thousand behaviors the joined form is hundreds of kilobytes, built twice, on
+// the activation path the snapshot exists to keep short.
+export function treeSignature(packages: DiscoverPackage[]): string {
+  let hash = 0x811c9dc5;
+  const feed = (s: string) => {
+    for (let i = 0; i < s.length; i++) {
+      hash ^= s.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    // Separator, so "ab" + "c" and "a" + "bc" do not collide.
+    hash ^= 0x2c;
+    hash = Math.imul(hash, 0x01000193);
+  };
+  const feedBehaviors = (behaviors: DiscoverBehavior[] | undefined) => {
+    for (const behavior of behaviors ?? []) {
+      feed(behavior.name);
+      feedBehaviors(behavior.children);
+    }
+  };
+  for (const pkg of [...packages].sort((a, b) =>
+    a.importPath < b.importPath ? -1 : a.importPath > b.importPath ? 1 : 0,
+  )) {
+    feed(pkg.importPath);
+    for (const suite of pkg.suites ?? []) {
+      feed(suite.name);
+      for (const method of suite.methods ?? []) {
+        feed(method.name);
+        feedBehaviors(method.behaviors);
+      }
+    }
+  }
+  return (hash >>> 0).toString(16);
+}

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -64,13 +64,18 @@ class WatchProcess implements vscode.Disposable {
     this.buffer = "";
     this.cycleBuffer = "";
 
-    this.child.stdout?.on("data", (data: Buffer) => {
-      this.buffer += data.toString();
+    // Decoded on the stream: the watcher runs for hours and its events arrive
+    // in whatever pieces the pipe delivers, boundaries falling mid-character.
+    this.child.stdout?.setEncoding("utf-8");
+    this.child.stderr?.setEncoding("utf-8");
+
+    this.child.stdout?.on("data", (chunk: string) => {
+      this.buffer += chunk;
       this.processBuffer();
     });
 
-    this.child.stderr?.on("data", (data: Buffer) => {
-      this.outputChannel.warn(`[watch] stderr: ${data.toString().trimEnd()}`);
+    this.child.stderr?.on("data", (chunk: string) => {
+      this.outputChannel.warn(`[watch] stderr: ${chunk.trimEnd()}`);
     });
 
     this.child.on("close", () => {

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -18,6 +18,11 @@ import {
 } from "./runnerUtils.js";
 import type { RunRegistry } from "./runRegistry.js";
 
+// VS Code gives deactivate only a few seconds before it tears the extension
+// host down, so a watch disposed at shutdown gets this instead of the
+// configured teardown budget — a longer timer would never fire.
+const SHUTDOWN_GRACE_MS = 5_000;
+
 /**
  * Wraps a single `gotest watch -json <scope>` child process.
  * Handles line-buffered parsing of the JSON event stream,
@@ -193,7 +198,10 @@ class WatchProcess implements vscode.Disposable {
     }, delay);
   }
 
-  dispose(): void {
+  // graceMs overrides the configured budget. Shutdown passes a short one: the
+  // extension host is going away, and a timer longer than VS Code's deactivate
+  // window never fires at all, which orphans the child instead of killing it.
+  dispose(graceMs?: number): void {
     this.disposed = true;
 
     if (this.child) {
@@ -204,9 +212,10 @@ class WatchProcess implements vscode.Disposable {
       killProcessTree(child, "SIGTERM");
 
       const killTimeout =
+        graceMs ??
         vscode.workspace
           .getConfiguration("gotest")
-          .get<number>("forceKillTimeout", 600) * 1000;
+          .get<number>("forceKillTimeout", 120) * 1000;
       const forceKill = setTimeout(() => {
         if (!child.killed) {
           killProcessTree(child, "SIGKILL");
@@ -364,7 +373,7 @@ export class WatchManager implements vscode.Disposable {
     this.updateStatusBar();
   }
 
-  stopAll(): void {
+  stopAll(graceMs?: number): void {
     this.outputChannel.info(
       `[watch] stopping all (${this.watchers.size} active)`,
     );
@@ -373,7 +382,7 @@ export class WatchManager implements vscode.Disposable {
       if (recordId) {
         this.registry.cancel(recordId);
       }
-      watcher.dispose();
+      watcher.dispose(graceMs);
       const run = this.activeRuns.get(scope);
       if (run) {
         run.end();
@@ -390,7 +399,7 @@ export class WatchManager implements vscode.Disposable {
   }
 
   dispose(): void {
-    this.stopAll();
+    this.stopAll(SHUTDOWN_GRACE_MS);
     this.statusBar.dispose();
   }
 

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -16,12 +16,8 @@ import {
   resolveAncestorItems,
   skipUnresolved,
 } from "./runnerUtils.js";
+import { forceKillTimeoutSeconds } from "./config.js";
 import type { RunRegistry } from "./runRegistry.js";
-
-// VS Code gives deactivate only a few seconds before it tears the extension
-// host down, so a watch disposed at shutdown gets this instead of the
-// configured teardown budget — a longer timer would never fire.
-const SHUTDOWN_GRACE_MS = 5_000;
 
 /**
  * Wraps a single `gotest watch -json <scope>` child process.
@@ -198,10 +194,12 @@ class WatchProcess implements vscode.Disposable {
     }, delay);
   }
 
-  // graceMs overrides the configured budget. Shutdown passes a short one: the
-  // extension host is going away, and a timer longer than VS Code's deactivate
-  // window never fires at all, which orphans the child instead of killing it.
-  dispose(graceMs?: number): void {
+  // forceKill=false is for shutdown. VS Code's deactivate window is seconds,
+  // so any SIGKILL timer long enough to respect a fixture teardown would never
+  // fire, and any timer short enough to fire would cut that teardown off. The
+  // child is in its own process group with the CLI's own force-kill backstop,
+  // so SIGTERM alone is both the most and the least we can honestly do.
+  dispose(forceKill = true): void {
     this.disposed = true;
 
     if (this.child) {
@@ -211,19 +209,17 @@ class WatchProcess implements vscode.Disposable {
       this.outputChannel.info(`[watch] sending SIGTERM (pid ${child.pid})`);
       killProcessTree(child, "SIGTERM");
 
-      const killTimeout =
-        graceMs ??
-        vscode.workspace
-          .getConfiguration("gotest")
-          .get<number>("forceKillTimeout", 120) * 1000;
-      const forceKill = setTimeout(() => {
+      if (!forceKill) return;
+
+      const killTimeout = forceKillTimeoutSeconds(this.cwd) * 1000;
+      const forceKillTimer = setTimeout(() => {
         if (!child.killed) {
           killProcessTree(child, "SIGKILL");
         }
       }, killTimeout);
 
       child.on("close", () => {
-        clearTimeout(forceKill);
+        clearTimeout(forceKillTimer);
       });
     }
   }
@@ -373,7 +369,7 @@ export class WatchManager implements vscode.Disposable {
     this.updateStatusBar();
   }
 
-  stopAll(graceMs?: number): void {
+  stopAll(forceKill = true): void {
     this.outputChannel.info(
       `[watch] stopping all (${this.watchers.size} active)`,
     );
@@ -382,7 +378,7 @@ export class WatchManager implements vscode.Disposable {
       if (recordId) {
         this.registry.cancel(recordId);
       }
-      watcher.dispose(graceMs);
+      watcher.dispose(forceKill);
       const run = this.activeRuns.get(scope);
       if (run) {
         run.end();
@@ -399,7 +395,7 @@ export class WatchManager implements vscode.Disposable {
   }
 
   dispose(): void {
-    this.stopAll(SHUTDOWN_GRACE_MS);
+    this.stopAll(false);
     this.statusBar.dispose();
   }
 

--- a/vscode-gotest/test/integration/discoveryPayload.test.ts
+++ b/vscode-gotest/test/integration/discoveryPayload.test.ts
@@ -32,6 +32,7 @@ vi.mock("vscode", async () => {
 });
 
 import { DiscoveryCache, DiscoveryService } from "../../src/discovery.js";
+import { DiscoverySnapshotStore } from "../../src/discoverySnapshotStore.js";
 import { buildCliCommand } from "../../src/cli.js";
 import { createRecordingChannel } from "./vscodeStub.js";
 
@@ -53,6 +54,8 @@ let payloadDir: string;
 let savedGoWork: string | undefined;
 let cache: DiscoveryCache;
 let recorder: ReturnType<typeof createRecordingChannel>;
+let snapshots: DiscoverySnapshotStore;
+let storageDir: string;
 
 function generateSuites(): string {
   const lines = [
@@ -131,9 +134,14 @@ beforeAll(async () => {
 
   recorder = createRecordingChannel();
   cache = new DiscoveryCache();
-  await new DiscoveryService(cache, recorder.channel as never).discover(
-    payloadDir,
-  );
+  storageDir = mkdtempSync(path.join(tmpdir(), "gotest-snapshot-"));
+  snapshots = new DiscoverySnapshotStore({ fsPath: storageDir } as never);
+  await new DiscoveryService(
+    cache,
+    recorder.channel as never,
+    snapshots,
+  ).discover(payloadDir);
+  await snapshots.flush();
 }, 300_000);
 
 afterAll(() => {
@@ -179,4 +187,45 @@ describe("a payload larger than a buffered read", () => {
     expect(when?.children).toHaveLength(ROWS);
     expect(when?.children?.[0].children).toHaveLength(EXPECTATIONS);
   });
+});
+
+// The snapshot exists so the explorer does not wait on the Go toolchain. Its
+// whole claim is that a window can reopen with the same tree without loading a
+// single package — so the test rebuilds the tree from disk alone and compares
+// it to what discovery produced, on a payload of real size.
+describe("the tree the next activation starts from", () => {
+  it("is rebuilt from the snapshot without running the CLI", async () => {
+    const reopened = new DiscoverySnapshotStore({
+      fsPath: storageDir,
+    } as never);
+    await reopened.load();
+    const snapshot = reopened.get(payloadDir);
+    expect(snapshot).toBeDefined();
+
+    const restored = new DiscoveryCache();
+    restored.update(snapshot!.packages, true, payloadDir, snapshot!.warnings);
+
+    expect(restored.packages.map((p) => p.importPath).sort()).toEqual(
+      cache.packages.map((p) => p.importPath).sort(),
+    );
+    expect(restored.getPackage("gotest.payload")?.suites).toHaveLength(SUITES);
+  }, 60_000);
+
+  it("keeps the behaviors the tree renders, not just the suite names", async () => {
+    const reopened = new DiscoverySnapshotStore({
+      fsPath: storageDir,
+    } as never);
+    await reopened.load();
+    const restored = new DiscoveryCache();
+    const snapshot = reopened.get(payloadDir)!;
+    restored.update(snapshot.packages, true, payloadDir, snapshot.warnings);
+
+    const from = (c: DiscoveryCache) =>
+      c
+        .getPackage("gotest.payload")
+        ?.suites.find((s) => s.name === "Feature0TestSuite")?.methods[0]
+        .behaviors;
+
+    expect(from(restored)).toEqual(from(cache));
+  }, 60_000);
 });

--- a/vscode-gotest/test/integration/specSync.test.ts
+++ b/vscode-gotest/test/integration/specSync.test.ts
@@ -45,14 +45,27 @@ beforeAll(() => {
   const dir = mkdtempSync(path.join(tmpdir(), "gotest-integration-"));
 
   realBinary = path.join(dir, "gotest-real");
-  const built = spawnSync("go", ["build", "-o", realBinary, "./cmd/gotest"], {
-    cwd: repoRoot,
-    encoding: "utf-8",
-  });
+  // Stamped, not left to the build's own pseudo-version: that is derived from
+  // the newest reachable tag, so once a release at or above MIN_CLI_VERSION
+  // exists the working-tree build outranks the floor and this fixture silently
+  // becomes a binary the extension accepts. A shallow CI checkout hides it and
+  // a local clone with tags does not.
+  const built = spawnSync(
+    "go",
+    [
+      "build",
+      "-ldflags",
+      "-X github.com/mvrahden/go-test/internal/about.Version=v1.0.0",
+      "-o",
+      realBinary,
+      "./cmd/gotest",
+    ],
+    { cwd: repoRoot, encoding: "utf-8" },
+  );
   expect(built.status, `go build failed: ${built.stderr}`).toBe(0);
 
-  // A build from a working tree reports a pseudo-version below MIN_CLI_VERSION,
-  // which the extension rejects — correctly, but that would silently turn the
+  // realBinary reports a version below MIN_CLI_VERSION, which the extension
+  // rejects — correctly, but that would silently turn the
   // cliPath axis into a second `go run` axis. The wrapper reports a releasable
   // version and delegates everything else to the real binary, so the axis tests
   // cliPath resolution rather than this tree's version string.

--- a/vscode-gotest/test/integration/testExplorer.test.ts
+++ b/vscode-gotest/test/integration/testExplorer.test.ts
@@ -381,3 +381,36 @@ async function waitFor<T>(probe: () => T | undefined, ms: number): Promise<T> {
     await new Promise((r) => setTimeout(r, 250));
   }
 }
+
+// The tree is rebuilt on a debounce, and activation restores stored results the
+// moment discovery returns — two small file reads later, well inside the
+// window. Every restore therefore ran against an empty tree and reported
+// "restored 0 of N", losing a session's results on every reload. Reading the
+// tree has to see the packages the cache already holds, whatever the timer is
+// doing.
+describe("the tree a restore runs against", () => {
+  it("holds the discovered packages as soon as discovery returns", async () => {
+    const recorder = createRecordingChannel();
+    const freshCache = new DiscoveryCache();
+    const freshController = new GoTestController(
+      freshCache,
+      new TestResultStore(undefined),
+      recorder.channel as never,
+      async () => {},
+      async () => {},
+      async () => {},
+      async () => {},
+    );
+    try {
+      await new DiscoveryService(
+        freshCache,
+        recorder.channel as never,
+      ).discover(fixturesDir);
+
+      // No rebuild() call and no sleep: this is the instant activation asks.
+      expect(freshController.findItem(pkg("passing"))).toBeDefined();
+    } finally {
+      freshController.dispose();
+    }
+  }, 300_000);
+});


### PR DESCRIPTION
Discovery read the CLI through `execFile`, whose 1 MiB output cap kills the child
mid-write and discards everything it produced, so on a large enough workspace the
entire test tree disappeared from the explorer. Every CLI read now goes through one
unbounded capture that decodes on the stream rather than per chunk, so a multi-byte
character split across two reads no longer corrupts the package identifier a run has to
match. Discovery also gains a configurable timeout (`gotest.discoveryTimeout`, default
120s) that reports what failed instead of hanging, and the tree is restored from disk at
startup so suites are browsable before the Go toolchain finishes. Note one behaviour
change beyond the fix: `gotest.forceKillTimeout` drops from 600 to 120 seconds, matching
the budget gotest actually grants shared-fixture teardown, and shutdown now uses a
separate five-second grace, since a longer timer never fires inside VS Code's deactivate
window and orphans the process rather than killing it.