### PR TITLE
Test processes stop when they should

### DIFF
--- a/vscode-gotest/src/capture.ts
+++ b/vscode-gotest/src/capture.ts
@@ -35,7 +35,7 @@ export async function captureStdout(
   args: string[],
   opts: CaptureOptions = {},
 ): Promise<string> {
-  const mc = new ManagedChild(bin, args, { cwd: opts.cwd });
+  const mc = new ManagedChild(bin, args, { cwd: opts.cwd, kind: "read" });
   const stdout: string[] = [];
   let stderr = "";
   let timedOut = false;

--- a/vscode-gotest/src/capture.ts
+++ b/vscode-gotest/src/capture.ts
@@ -1,7 +1,5 @@
-import { spawn } from "node:child_process";
 import { stripGoRunExitEcho } from "./cli.js";
-import { killProcessTree } from "./processTree.js";
-import { CAPTURE_FORCE_KILL_GRACE_MS } from "./config.js";
+import { ManagedChild } from "./managedChild.js";
 
 // CaptureTimeoutError marks the one failure that is not worth retrying: the
 // command was given its full budget and did not finish. Retrying spends the
@@ -32,92 +30,55 @@ export interface CaptureOptions {
 // is killed mid-write and everything it produced is discarded — which is how a
 // large project's test tree disappeared from the explorer. Nothing gotest emits
 // on stdout is bounded, so nothing reading it may be.
-export function captureStdout(
+export async function captureStdout(
   bin: string,
   args: string[],
   opts: CaptureOptions = {},
 ): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    // Own process group, so the timeout below can signal the compiled binary
-    // and not just the `go run` that launched it.
-    const child = spawn(bin, args, { cwd: opts.cwd, detached: true });
-    const stdout: string[] = [];
-    let stderr = "";
-    let timedOut = false;
-    let settled = false;
+  const mc = new ManagedChild(bin, args, { cwd: opts.cwd });
+  const stdout: string[] = [];
+  let stderr = "";
+  let timedOut = false;
 
-    // Decode on the stream, not per chunk: a read ends wherever the pipe filled,
-    // and a chunk-wise toString() would corrupt whatever multi-byte character it
-    // lands inside. These payloads carry the developer's own text.
-    child.stdout.setEncoding("utf-8");
-    child.stderr.setEncoding("utf-8");
-    const started = Date.now();
-    let sawFirstByte = false;
-    child.stdout.on("data", (chunk: string) => {
-      if (!sawFirstByte) {
-        sawFirstByte = true;
-        opts.onFirstByte?.(Date.now() - started);
-      }
-      stdout.push(chunk);
-    });
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-
-    let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
-    const timer =
-      opts.timeoutSeconds === undefined
-        ? undefined
-        : setTimeout(() => {
-            timedOut = true;
-            // SIGTERM the group, then escalate. Without the escalation a child
-            // that ignores SIGTERM never closes its pipes, `close` never fires,
-            // and this promise never settles — which wedges the caller far more
-            // thoroughly than the slow command the budget was meant to bound.
-            //
-            // Armed before the signal, because a child that dies on SIGTERM
-            // settles us from inside the call below — and a timer armed after
-            // that would outlive the settle that was supposed to clear it.
-            forceKillTimer = setTimeout(() => {
-              if (settled) return;
-              killProcessTree(child, "SIGKILL");
-            }, CAPTURE_FORCE_KILL_GRACE_MS);
-            killProcessTree(child, "SIGTERM");
-          }, opts.timeoutSeconds * 1000);
-
-    const settle = (outcome: () => void) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      clearTimeout(forceKillTimer);
-      outcome();
-    };
-
-    // A missing binary arrives here rather than as an exit code, and callers
-    // read `code` off the error to drop a cached path — so pass it through.
-    child.on("error", (err: Error) => settle(() => reject(err)));
-
-    // `close` waits for the pipes, which is what we want for the output — but a
-    // surviving grandchild can hold them open forever. Once we have timed out
-    // the output is being discarded anyway, so `exit` is enough to settle.
-    child.on("exit", () => {
-      if (!timedOut) return;
-      settle(() => reject(new CaptureTimeoutError(opts.timeoutSeconds ?? 0)));
-    });
-
-    child.on("close", (code) => {
-      settle(() => {
-        if (timedOut) {
-          reject(new CaptureTimeoutError(opts.timeoutSeconds ?? 0));
-        } else if (code === 0) {
-          resolve(stdout.join(""));
-        } else {
-          const detail = stripGoRunExitEcho(stderr);
-          reject(
-            new Error(`exited with code ${code}${detail ? `: ${detail}` : ""}`),
-          );
-        }
-      });
-    });
+  const started = Date.now();
+  let sawFirstByte = false;
+  mc.child.stdout?.on("data", (chunk: string) => {
+    if (!sawFirstByte) {
+      sawFirstByte = true;
+      opts.onFirstByte?.(Date.now() - started);
+    }
+    stdout.push(chunk);
   });
+  mc.child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  // A missing binary arrives as an error event rather than an exit code, and
+  // callers read `code` off it to drop a cached path — so keep the real error.
+  let spawnError: Error | undefined;
+  mc.child.on("error", (err: Error) => {
+    spawnError = err;
+  });
+
+  // A read: no fixtures to tear down, and past the budget the output is being
+  // discarded anyway, so it gets the prompt escalation.
+  const budget =
+    opts.timeoutSeconds === undefined
+      ? undefined
+      : setTimeout(() => {
+          timedOut = true;
+          void mc.terminate("prompt");
+        }, opts.timeoutSeconds * 1000);
+
+  try {
+    const { code } = await mc.exited;
+    if (spawnError) throw spawnError;
+    if (timedOut) throw new CaptureTimeoutError(opts.timeoutSeconds ?? 0);
+    if (code === 0) return stdout.join("");
+    const detail = stripGoRunExitEcho(stderr);
+    throw new Error(`exited with code ${code}${detail ? `: ${detail}` : ""}`);
+  } finally {
+    clearTimeout(budget);
+    mc.dispose();
+  }
 }

--- a/vscode-gotest/src/config.ts
+++ b/vscode-gotest/src/config.ts
@@ -47,3 +47,10 @@ export function discoveryTimeoutSeconds(workspaceDir?: string): number {
     DEFAULT_DISCOVERY_TIMEOUT_S
   );
 }
+
+// `gotest spec --render-only` is a read, like discovery: it renders JSON it was
+// handed, but on a cold cache it still pays the same `go run` compile first. It
+// shares discovery's budget rather than introducing a sixth number.
+export function specRenderTimeoutSeconds(workspaceDir?: string): number {
+  return discoveryTimeoutSeconds(workspaceDir);
+}

--- a/vscode-gotest/src/coverOnSave.ts
+++ b/vscode-gotest/src/coverOnSave.ts
@@ -141,7 +141,8 @@ export class CoverOnSave implements vscode.Disposable {
       run.addCoverage(fc);
     }
     run.end();
-    await this.store.save();
+    this.store.save();
+    await this.store.flush();
   }
 
   dispose(): void {

--- a/vscode-gotest/src/coverage.ts
+++ b/vscode-gotest/src/coverage.ts
@@ -437,7 +437,8 @@ export class CoverageRunner implements vscode.Disposable {
       for (const fc of allCoverages) {
         run.addCoverage(fc);
       }
-      await this.store.save();
+      this.store.save();
+      await this.store.flush();
       await this.controller.saveResults();
 
       if (allJsonOutput) {

--- a/vscode-gotest/src/coverageStore.test.ts
+++ b/vscode-gotest/src/coverageStore.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockReadFile, mockWriteFile, mockMkdir, files } = vi.hoisted(() => {
+  const files = new Map<string, string>();
+  return {
+    files,
+    mockReadFile: vi.fn(async (p: string) => {
+      const content = files.get(p);
+      if (content === undefined) throw new Error("ENOENT");
+      return content;
+    }),
+    mockWriteFile: vi.fn(async (p: string, content: string) => {
+      files.set(p, content);
+    }),
+    mockMkdir: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock("node:fs/promises", () => ({
+  readFile: mockReadFile,
+  writeFile: mockWriteFile,
+  mkdir: mockMkdir,
+}));
+
+vi.mock("vscode", () => ({
+  Uri: { file: (p: string) => ({ fsPath: p }) },
+  Position: class {},
+  Range: class {},
+  StatementCoverage: class {},
+  DeclarationCoverage: class {},
+  FileCoverage: class {},
+}));
+
+import { CoverageStore } from "./coverageStore.js";
+
+const storage = { fsPath: "/storage" } as import("vscode").Uri;
+
+describe("CoverageStore load ordering", () => {
+  beforeEach(() => {
+    files.clear();
+    vi.clearAllMocks();
+  });
+
+  it("round-trips a stored profile", async () => {
+    const store = new CoverageStore(storage);
+    store.update("example.com/m/a", "mode: set\n");
+    await store.save();
+
+    const reopened = new CoverageStore(storage);
+    await reopened.load();
+    expect(reopened.size).toBe(1);
+  });
+
+  // The file watchers are registered synchronously in activate(), while
+  // initializeAsync awaits load(). A .go file touched in that window
+  // invalidated a package in memory, and the load that followed read the
+  // pre-invalidation state back — resurrecting coverage for a package whose
+  // source had already changed.
+  it("does not let a late load undo an invalidation", async () => {
+    const seed = new CoverageStore(storage);
+    seed.update("example.com/m/a", "mode: set\n");
+    await seed.save();
+
+    const store = new CoverageStore(storage);
+    expect(store.invalidate("example.com/m/a")).toBe(false);
+    store.update("example.com/m/a", "mode: set\n");
+    expect(store.invalidate("example.com/m/a")).toBe(true);
+
+    await store.load();
+
+    expect(store.size).toBe(0);
+  });
+
+  it("still loads when nothing has been recorded yet", async () => {
+    const seed = new CoverageStore(storage);
+    seed.update("example.com/m/a", "mode: set\n");
+    await seed.save();
+
+    const store = new CoverageStore(storage);
+    await store.load();
+    expect(store.size).toBe(1);
+  });
+});

--- a/vscode-gotest/src/coverageStore.test.ts
+++ b/vscode-gotest/src/coverageStore.test.ts
@@ -1,25 +1,35 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockReadFile, mockWriteFile, mockMkdir, files } = vi.hoisted(() => {
-  const files = new Map<string, string>();
-  return {
-    files,
-    mockReadFile: vi.fn(async (p: string) => {
-      const content = files.get(p);
-      if (content === undefined) throw new Error("ENOENT");
-      return content;
-    }),
-    mockWriteFile: vi.fn(async (p: string, content: string) => {
-      files.set(p, content);
-    }),
-    mockMkdir: vi.fn(async () => undefined),
-  };
-});
+const { mockReadFile, mockWriteFile, mockMkdir, mockRename, files } =
+  vi.hoisted(() => {
+    const files = new Map<string, string>();
+    return {
+      files,
+      mockReadFile: vi.fn(async (p: string) => {
+        const content = files.get(p);
+        if (content === undefined) throw new Error("ENOENT");
+        return content;
+      }),
+      mockWriteFile: vi.fn(async (p: string, content: string) => {
+        files.set(p, content);
+      }),
+      mockMkdir: vi.fn(async () => undefined),
+      // The shared store writes to a sibling temp file and renames it into place.
+      mockRename: vi.fn(async (from: string, to: string) => {
+        const content = files.get(from);
+        if (content !== undefined) {
+          files.set(to, content);
+          files.delete(from);
+        }
+      }),
+    };
+  });
 
 vi.mock("node:fs/promises", () => ({
   readFile: mockReadFile,
   writeFile: mockWriteFile,
   mkdir: mockMkdir,
+  rename: mockRename,
 }));
 
 vi.mock("vscode", () => ({
@@ -44,7 +54,8 @@ describe("CoverageStore load ordering", () => {
   it("round-trips a stored profile", async () => {
     const store = new CoverageStore(storage);
     store.update("example.com/m/a", "mode: set\n");
-    await store.save();
+    store.save();
+    await store.flush();
 
     const reopened = new CoverageStore(storage);
     await reopened.load();
@@ -59,7 +70,8 @@ describe("CoverageStore load ordering", () => {
   it("does not let a late load undo an invalidation", async () => {
     const seed = new CoverageStore(storage);
     seed.update("example.com/m/a", "mode: set\n");
-    await seed.save();
+    seed.save();
+    await seed.flush();
 
     const store = new CoverageStore(storage);
     expect(store.invalidate("example.com/m/a")).toBe(false);
@@ -74,7 +86,8 @@ describe("CoverageStore load ordering", () => {
   it("still loads when nothing has been recorded yet", async () => {
     const seed = new CoverageStore(storage);
     seed.update("example.com/m/a", "mode: set\n");
-    await seed.save();
+    seed.save();
+    await seed.flush();
 
     const store = new CoverageStore(storage);
     await store.load();

--- a/vscode-gotest/src/coverageStore.ts
+++ b/vscode-gotest/src/coverageStore.ts
@@ -35,6 +35,11 @@ export class CoverageStore implements vscode.Disposable {
   private cachedDetails = new Map<string, vscode.FileCoverageDetail[]>();
   private readonly storagePath: string | undefined;
   private saveChain = Promise.resolve();
+  // Set by the first mutation. The file watchers are registered synchronously
+  // in activate(), so a .go file touched before initializeAsync awaits load()
+  // invalidates a package in memory — and a load that cleared it afterwards
+  // would read the pre-invalidation state back and resurrect stale coverage.
+  private dirty = false;
 
   constructor(storageUri: vscode.Uri | undefined) {
     if (storageUri) {
@@ -64,6 +69,7 @@ export class CoverageStore implements vscode.Disposable {
     });
     this.parsed.delete(importPath);
     this.cachedDetails.clear();
+    this.dirty = true;
   }
 
   invalidate(importPath: string): boolean {
@@ -71,6 +77,7 @@ export class CoverageStore implements vscode.Disposable {
     if (deleted) {
       this.parsed.delete(importPath);
       this.cachedDetails.clear();
+      this.dirty = true;
     }
     return deleted;
   }
@@ -82,6 +89,7 @@ export class CoverageStore implements vscode.Disposable {
     this.packages.clear();
     this.parsed.clear();
     this.cachedDetails.clear();
+    this.dirty = true;
     return this.save();
   }
 
@@ -133,7 +141,7 @@ export class CoverageStore implements vscode.Disposable {
   }
 
   async load(): Promise<void> {
-    if (!this.storagePath) {
+    if (!this.storagePath || this.dirty) {
       return;
     }
     try {

--- a/vscode-gotest/src/coverageStore.ts
+++ b/vscode-gotest/src/coverageStore.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
-import * as path from "node:path";
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { JsonStore } from "./jsonStore.js";
 import {
   type ParsedFileCoverage,
   type CoverageResult,
@@ -19,10 +18,11 @@ interface StoredPackageCoverage {
   supplementary?: boolean;
 }
 
-interface StoredData {
-  version: 1;
-  packages: Record<string, StoredPackageCoverage>;
-}
+type StoredData = Record<string, StoredPackageCoverage>;
+
+// 2, not 1: the on-disk envelope moved to the shared { version, data } shape.
+// A mismatch purges, which is right for a cache.
+const STORE_VERSION = 2;
 
 interface ParsedPackageCache {
   profiles: ParsedFileCoverage[];
@@ -33,18 +33,14 @@ export class CoverageStore implements vscode.Disposable {
   private packages = new Map<string, StoredPackageCoverage>();
   private parsed = new Map<string, ParsedPackageCache>();
   private cachedDetails = new Map<string, vscode.FileCoverageDetail[]>();
-  private readonly storagePath: string | undefined;
-  private saveChain = Promise.resolve();
-  // Set by the first mutation. The file watchers are registered synchronously
-  // in activate(), so a .go file touched before initializeAsync awaits load()
-  // invalidates a package in memory — and a load that cleared it afterwards
-  // would read the pre-invalidation state back and resurrect stale coverage.
-  private dirty = false;
+  private readonly store: JsonStore<StoredData>;
 
   constructor(storageUri: vscode.Uri | undefined) {
-    if (storageUri) {
-      this.storagePath = path.join(storageUri.fsPath, "coverage.json");
-    }
+    this.store = new JsonStore<StoredData>(
+      storageUri?.fsPath,
+      "coverage.json",
+      STORE_VERSION,
+    );
   }
 
   get size(): number {
@@ -69,7 +65,7 @@ export class CoverageStore implements vscode.Disposable {
     });
     this.parsed.delete(importPath);
     this.cachedDetails.clear();
-    this.dirty = true;
+    this.store.markMutated();
   }
 
   invalidate(importPath: string): boolean {
@@ -77,7 +73,7 @@ export class CoverageStore implements vscode.Disposable {
     if (deleted) {
       this.parsed.delete(importPath);
       this.cachedDetails.clear();
-      this.dirty = true;
+      this.store.markMutated();
     }
     return deleted;
   }
@@ -89,8 +85,11 @@ export class CoverageStore implements vscode.Disposable {
     this.packages.clear();
     this.parsed.clear();
     this.cachedDetails.clear();
-    this.dirty = true;
-    return this.save();
+    this.store.markMutated();
+    this.save();
+    // The one caller that must not race the write: the developer dismissed
+    // these results and a reload before the flush would bring them back.
+    return this.flush();
   }
 
   buildFileCoverages(cache: DiscoveryCache): CoverageResult {
@@ -141,43 +140,23 @@ export class CoverageStore implements vscode.Disposable {
   }
 
   async load(): Promise<void> {
-    if (!this.storagePath || this.dirty) {
-      return;
-    }
-    try {
-      const content = await readFile(this.storagePath, "utf-8");
-      const data = JSON.parse(content) as StoredData;
-      if (data.version !== 1) {
-        return;
-      }
-      this.packages.clear();
-      this.parsed.clear();
-      for (const [importPath, pkg] of Object.entries(data.packages)) {
-        this.packages.set(importPath, pkg);
-      }
-    } catch {
-      // No stored data or corrupt — start fresh
+    const data = await this.store.read();
+    if (!data) return;
+    this.packages.clear();
+    this.parsed.clear();
+    for (const [importPath, pkg] of Object.entries(data)) {
+      this.packages.set(importPath, pkg);
     }
   }
 
-  save(): Promise<void> {
-    const op = this.saveChain.then(() => this.writeToDisk());
-    this.saveChain = op.catch(() => {});
-    return op;
+  // Void and debounced, like every other store: no call site has to know
+  // whether this particular one returns something to await.
+  save(): void {
+    this.store.save(() => Object.fromEntries(this.packages));
   }
 
   flush(): Promise<void> {
-    return this.saveChain;
-  }
-
-  private async writeToDisk(): Promise<void> {
-    if (!this.storagePath) return;
-    const data: StoredData = {
-      version: 1,
-      packages: Object.fromEntries(this.packages),
-    };
-    await mkdir(path.dirname(this.storagePath), { recursive: true });
-    await writeFile(this.storagePath, JSON.stringify(data), "utf-8");
+    return this.store.flush();
   }
 
   dispose(): void {

--- a/vscode-gotest/src/debug.ts
+++ b/vscode-gotest/src/debug.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
-import { spawn, type ChildProcess } from "node:child_process";
+import { ManagedChild } from "./managedChild.js";
 import type { PrepareOutput } from "./types.js";
 import { buildCliCommand, formatCliCommand, scopedConfig } from "./cli.js";
 import { killProcessTree } from "./runnerUtils.js";
 
 export class DebugLauncher implements vscode.Disposable {
-  private readonly prepareProcesses = new Map<string, ChildProcess>();
+  private readonly prepareProcesses = new Map<string, ManagedChild>();
   private sessionListener: vscode.Disposable | undefined;
 
   constructor(private readonly outputChannel: vscode.LogOutputChannel) {}
@@ -34,7 +34,7 @@ export class DebugLauncher implements vscode.Disposable {
     }
 
     let prepare: PrepareOutput;
-    let child: ChildProcess;
+    let managed: ManagedChild;
     try {
       const cmd = await buildCliCommand(
         ["prepare", pkgDir],
@@ -55,7 +55,7 @@ export class DebugLauncher implements vscode.Disposable {
         token,
       );
       prepare = result.output;
-      child = result.child;
+      managed = result.managed;
     } catch (err: unknown) {
       const message =
         err instanceof Error ? err.message : "Unknown error running prepare";
@@ -65,7 +65,7 @@ export class DebugLauncher implements vscode.Disposable {
 
     const prepareKey = `gotest-prepare:${pkgDir}`;
     this.killPrepareProcess(prepareKey);
-    this.prepareProcesses.set(prepareKey, child);
+    this.prepareProcesses.set(prepareKey, managed);
 
     const runFilter = buildRunFilter(items);
 
@@ -129,9 +129,12 @@ export class DebugLauncher implements vscode.Disposable {
     cwd: string,
     timeoutSeconds: number,
     token: vscode.CancellationToken,
-  ): Promise<{ output: PrepareOutput; child: ChildProcess }> {
+  ): Promise<{ output: PrepareOutput; managed: ManagedChild }> {
     return new Promise((resolve, reject) => {
-      const child = spawn(bin, args, { cwd, detached: true });
+      // A daemon: `prepare` blocks until SIGTERM holding shared fixtures open,
+      // so it gets the teardown grace when it is eventually ended.
+      const managed = new ManagedChild(bin, args, { cwd });
+      const child = managed.child;
       let stdout = "";
       let stderr = "";
       let settled = false;
@@ -146,21 +149,19 @@ export class DebugLauncher implements vscode.Disposable {
 
       const timer = setTimeout(() => {
         settle(() => {
-          killProcessTree(child, "SIGTERM");
+          void managed.terminate("teardown");
           reject(new Error(`timed out after ${timeoutSeconds}s`));
         });
       }, timeoutSeconds * 1000);
 
       const cancelListener = token.onCancellationRequested(() => {
         settle(() => {
-          killProcessTree(child, "SIGTERM");
+          void managed.terminate("teardown");
           reject(new Error("cancelled"));
         });
       });
 
-      child.stdout.setEncoding("utf-8");
-      child.stderr.setEncoding("utf-8");
-      child.stdout.on("data", (chunk: string) => {
+      child.stdout?.on("data", (chunk: string) => {
         stdout += chunk;
         if (!settled && stdout.includes("\n")) {
           settle(() => {
@@ -168,9 +169,9 @@ export class DebugLauncher implements vscode.Disposable {
               const output = JSON.parse(
                 stdout.split("\n")[0].trim(),
               ) as PrepareOutput;
-              resolve({ output, child });
+              resolve({ output, managed });
             } catch {
-              killProcessTree(child, "SIGTERM");
+              void managed.terminate("teardown");
               reject(
                 new Error(`Failed to parse prepare output: ${stdout.trim()}`),
               );
@@ -179,7 +180,7 @@ export class DebugLauncher implements vscode.Disposable {
         }
       });
 
-      child.stderr.on("data", (chunk: string) => {
+      child.stderr?.on("data", (chunk: string) => {
         stderr += chunk;
         this.outputChannel.debug(`[debug:prepare] ${chunk.trimEnd()}`);
       });
@@ -204,10 +205,10 @@ export class DebugLauncher implements vscode.Disposable {
   }
 
   private killPrepareProcess(sessionName: string): void {
-    const child = this.prepareProcesses.get(sessionName);
-    if (child) {
+    const managed = this.prepareProcesses.get(sessionName);
+    if (managed) {
       this.prepareProcesses.delete(sessionName);
-      killProcessTree(child, "SIGTERM");
+      void managed.terminate("teardown");
     }
   }
 }

--- a/vscode-gotest/src/debug.ts
+++ b/vscode-gotest/src/debug.ts
@@ -133,7 +133,7 @@ export class DebugLauncher implements vscode.Disposable {
     return new Promise((resolve, reject) => {
       // A daemon: `prepare` blocks until SIGTERM holding shared fixtures open,
       // so it gets the teardown grace when it is eventually ended.
-      const managed = new ManagedChild(bin, args, { cwd });
+      const managed = new ManagedChild(bin, args, { cwd, kind: "prepare" });
       const child = managed.child;
       let stdout = "";
       let stderr = "";

--- a/vscode-gotest/src/discoverySnapshotStore.test.ts
+++ b/vscode-gotest/src/discoverySnapshotStore.test.ts
@@ -4,6 +4,7 @@ const {
   mockReadFile,
   mockWriteFile,
   mockMkdir,
+  mockRename,
   mockReaddir,
   mockStat,
   mockUnlink,
@@ -25,6 +26,12 @@ const {
       if (!mtimes.has(p)) mtimes.set(p, Date.now());
     }),
     mockMkdir: vi.fn(async () => undefined),
+    mockRename: vi.fn(async (from: string, to: string) => {
+      const content = files.get(from);
+      if (content === undefined) throw new Error("ENOENT");
+      files.set(to, content);
+      files.delete(from);
+    }),
     mockReaddir: vi.fn(async () =>
       [...files.keys()].map((p) => p.split("/").pop()!),
     ),
@@ -42,6 +49,7 @@ vi.mock("node:fs/promises", () => ({
   readFile: mockReadFile,
   writeFile: mockWriteFile,
   mkdir: mockMkdir,
+  rename: mockRename,
   readdir: mockReaddir,
   stat: mockStat,
   unlink: mockUnlink,

--- a/vscode-gotest/src/discoverySnapshotStore.test.ts
+++ b/vscode-gotest/src/discoverySnapshotStore.test.ts
@@ -1,9 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockReadFile, mockWriteFile, mockMkdir, files } = vi.hoisted(() => {
+const {
+  mockReadFile,
+  mockWriteFile,
+  mockMkdir,
+  mockReaddir,
+  mockStat,
+  mockUnlink,
+  files,
+  mtimes,
+} = vi.hoisted(() => {
   const files = new Map<string, string>();
+  const mtimes = new Map<string, number>();
   return {
     files,
+    mtimes,
     mockReadFile: vi.fn(async (p: string) => {
       const content = files.get(p);
       if (content === undefined) throw new Error("ENOENT");
@@ -11,8 +22,19 @@ const { mockReadFile, mockWriteFile, mockMkdir, files } = vi.hoisted(() => {
     }),
     mockWriteFile: vi.fn(async (p: string, content: string) => {
       files.set(p, content);
+      if (!mtimes.has(p)) mtimes.set(p, Date.now());
     }),
     mockMkdir: vi.fn(async () => undefined),
+    mockReaddir: vi.fn(async () =>
+      [...files.keys()].map((p) => p.split("/").pop()!),
+    ),
+    mockStat: vi.fn(async (p: string) => ({
+      mtimeMs: mtimes.get(p) ?? Date.now(),
+    })),
+    mockUnlink: vi.fn(async (p: string) => {
+      files.delete(p);
+      mtimes.delete(p);
+    }),
   };
 });
 
@@ -20,13 +42,15 @@ vi.mock("node:fs/promises", () => ({
   readFile: mockReadFile,
   writeFile: mockWriteFile,
   mkdir: mockMkdir,
+  readdir: mockReaddir,
+  stat: mockStat,
+  unlink: mockUnlink,
 }));
 
 import { DiscoverySnapshotStore } from "./discoverySnapshotStore.js";
 import type { DiscoverPackage, DiscoverWarning } from "./types.js";
 
 const storage = { fsPath: "/storage" } as import("vscode").Uri;
-const SNAPSHOT = "/storage/discovery.json";
 
 function pkg(importPath: string): DiscoverPackage {
   return {
@@ -40,6 +64,7 @@ function pkg(importPath: string): DiscoverPackage {
 describe("DiscoverySnapshotStore", () => {
   beforeEach(() => {
     files.clear();
+    mtimes.clear();
     vi.clearAllMocks();
   });
 
@@ -53,90 +78,46 @@ describe("DiscoverySnapshotStore", () => {
     await store.flush();
 
     const reloaded = new DiscoverySnapshotStore(storage);
-    await reloaded.load();
+    await reloaded.load(["/ws"]);
     const snap = reloaded.get("/ws");
     expect(snap?.packages).toEqual([pkg("example.com/m/a")]);
     expect(snap?.warnings).toEqual(warnings);
   });
 
-  it("keeps workspaces apart", async () => {
+  // The reason for one file per workspace: updating one tree used to rewrite
+  // every tree the extension had ever seen.
+  it("writes only the workspace that changed", async () => {
     const store = new DiscoverySnapshotStore(storage);
-    store.update("/ws1", [pkg("example.com/m/a")], []);
-    store.update("/ws2", [pkg("example.com/m/b")], []);
+    store.update("/ws/a", [pkg("example.com/a")], []);
+    store.update("/ws/b", [pkg("example.com/b")], []);
     store.save();
     await store.flush();
+    expect(files.size).toBe(2);
+
+    mockWriteFile.mockClear();
+    store.update("/ws/a", [pkg("example.com/a2")], []);
+    store.save();
+    await store.flush();
+
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps workspaces apart, so one corrupt file costs one tree", async () => {
+    const store = new DiscoverySnapshotStore(storage);
+    store.update("/ws/a", [pkg("example.com/a")], []);
+    store.update("/ws/b", [pkg("example.com/b")], []);
+    store.save();
+    await store.flush();
+
+    const [first] = [...files.keys()];
+    files.set(first, "{ not json");
 
     const reloaded = new DiscoverySnapshotStore(storage);
-    await reloaded.load();
-    expect(reloaded.get("/ws1")?.packages).toEqual([pkg("example.com/m/a")]);
-    expect(reloaded.get("/ws2")?.packages).toEqual([pkg("example.com/m/b")]);
-    expect(reloaded.get("/ws3")).toBeUndefined();
+    await reloaded.load(["/ws/a", "/ws/b"]);
+    expect(reloaded.size).toBe(1);
   });
 
-  it("replaces a workspace's snapshot rather than merging it", async () => {
-    const store = new DiscoverySnapshotStore(storage);
-    store.update("/ws", [pkg("example.com/m/a"), pkg("example.com/m/b")], []);
-    store.update("/ws", [pkg("example.com/m/a")], []);
-    store.save();
-    await store.flush();
-
-    const reloaded = new DiscoverySnapshotStore(storage);
-    await reloaded.load();
-    // A package deleted from the workspace must not survive in the snapshot,
-    // or the tree would show it again on every activation.
-    expect(reloaded.get("/ws")?.packages).toEqual([pkg("example.com/m/a")]);
-  });
-
-  it("ignores a snapshot written by a different schema version", async () => {
-    files.set(SNAPSHOT, JSON.stringify({ version: 99, workspaces: {} }));
-    const store = new DiscoverySnapshotStore(storage);
-    await store.load();
-    expect(store.get("/ws")).toBeUndefined();
-  });
-
-  it("starts fresh on a corrupt snapshot instead of throwing", async () => {
-    files.set(SNAPSHOT, "{not json");
-    const store = new DiscoverySnapshotStore(storage);
-    await expect(store.load()).resolves.toBeUndefined();
-    expect(store.get("/ws")).toBeUndefined();
-  });
-
-  it("starts fresh when nothing has been stored yet", async () => {
-    const store = new DiscoverySnapshotStore(storage);
-    await store.load();
-    expect(store.get("/ws")).toBeUndefined();
-  });
-
-  it("never touches disk without a storage location", async () => {
-    const store = new DiscoverySnapshotStore(undefined);
-    store.update("/ws", [pkg("example.com/m/a")], []);
-    store.save();
-    await expect(store.flush()).resolves.toBeUndefined();
-    await expect(store.load()).resolves.toBeUndefined();
-    expect(mockWriteFile).not.toHaveBeenCalled();
-    expect(mockReadFile).not.toHaveBeenCalled();
-  });
-
-  it("writes compactly", async () => {
-    const store = new DiscoverySnapshotStore(storage);
-    store.update("/ws", [pkg("example.com/m/a")], []);
-    store.save();
-    await store.flush();
-    // A large project's snapshot is megabytes; indentation is pure cost on a
-    // file written after every discovery.
-    expect(files.get(SNAPSHOT)).not.toContain("\n");
-  });
-});
-
-describe("DiscoverySnapshotStore write behaviour", () => {
-  beforeEach(() => {
-    files.clear();
-    vi.clearAllMocks();
-  });
-
-  // Every save of a _test.go file rediscovers its package, and each one used to
-  // rewrite the whole workspace tree synchronously.
-  it("coalesces a burst of saves into one write", async () => {
+  it("coalesces a burst of saves into one write per workspace", async () => {
     const store = new DiscoverySnapshotStore(storage);
     for (let i = 0; i < 5; i++) {
       store.update("/ws", [pkg(`example.com/m/p${i}`)], []);
@@ -150,20 +131,57 @@ describe("DiscoverySnapshotStore write behaviour", () => {
   // load, so a save in that window produces a discovery whose result must not
   // be thrown away by the load that arrives afterwards.
   it("does not let a late load discard what discovery already found", async () => {
-    files.set(
-      SNAPSHOT,
-      JSON.stringify({
-        version: 1,
-        workspaces: {
-          "/ws": { packages: [pkg("example.com/m/stale")], warnings: [] },
-        },
-      }),
-    );
+    const seed = new DiscoverySnapshotStore(storage);
+    seed.update("/ws", [pkg("example.com/m/stale")], []);
+    seed.save();
+    await seed.flush();
 
     const store = new DiscoverySnapshotStore(storage);
     store.update("/ws", [pkg("example.com/m/fresh")], []);
-    await store.load();
+    await store.load(["/ws"]);
 
     expect(store.get("/ws")?.packages).toEqual([pkg("example.com/m/fresh")]);
+  });
+
+  it("drops snapshots for workspaces nobody has opened in a month", async () => {
+    const store = new DiscoverySnapshotStore(storage);
+    store.update("/ws/old", [pkg("example.com/old")], []);
+    store.save();
+    await store.flush();
+
+    const [stale] = [...files.keys()];
+    mtimes.set(stale, Date.now() - 40 * 24 * 60 * 60 * 1000);
+
+    const reopened = new DiscoverySnapshotStore(storage);
+    await reopened.load(["/ws/current"]);
+
+    expect(files.has(stale)).toBe(false);
+  });
+
+  it("never touches disk without a storage location", async () => {
+    const store = new DiscoverySnapshotStore(undefined);
+    store.update("/ws", [pkg("example.com/m/a")], []);
+    store.save();
+    await expect(store.flush()).resolves.toBeUndefined();
+    await expect(store.load(["/ws"])).resolves.toBeUndefined();
+    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it("writes compactly", async () => {
+    const store = new DiscoverySnapshotStore(storage);
+    store.update("/ws", [pkg("example.com/m/a")], []);
+    store.save();
+    await store.flush();
+    // A large project's snapshot is hundreds of kilobytes; indentation is pure
+    // cost on a file only this extension reads.
+    expect([...files.values()][0]).not.toContain("\n");
+  });
+
+  it("ignores a snapshot written by an older layout", async () => {
+    files.set("/storage/discovery.json", JSON.stringify({ version: 1 }));
+    const store = new DiscoverySnapshotStore(storage);
+    await store.load(["/ws"]);
+    expect(store.size).toBe(0);
   });
 });

--- a/vscode-gotest/src/discoverySnapshotStore.ts
+++ b/vscode-gotest/src/discoverySnapshotStore.ts
@@ -1,14 +1,8 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
 import { createHash } from "node:crypto";
-import {
-  readFile,
-  writeFile,
-  mkdir,
-  readdir,
-  stat,
-  unlink,
-} from "node:fs/promises";
+import { readFile, readdir, stat, unlink } from "node:fs/promises";
+import { atomicWrite, LoadOnce, reportStoreError } from "./jsonStore.js";
 import type { DiscoverPackage, DiscoverWarning } from "./types.js";
 
 export interface DiscoverySnapshot {
@@ -57,10 +51,11 @@ export class DiscoverySnapshotStore {
   private saveChain = Promise.resolve();
   private debounceTimer: ReturnType<typeof setTimeout> | undefined;
   private pendingWrites = new Set<string>();
-  // Set by the first update(). Discovery can run before load() resolves —
-  // activate() registers the file watchers before initializeAsync awaits the
-  // load — and what discovery just found beats what the last session stored.
-  private dirty = false;
+  // Discovery can run before load() resolves — activate() registers the file
+  // watchers before initializeAsync awaits the load — and what discovery just
+  // found beats what the last session stored. Same latch as JsonStore's, so the
+  // rule has one implementation rather than one per store.
+  private readonly latch = new LoadOnce();
 
   // A tree is hundreds of kilobytes to serialize, and every save of a _test.go
   // file triggers a package rediscovery. Coalesce, the way TestResultStore does,
@@ -89,14 +84,14 @@ export class DiscoverySnapshotStore {
   ): void {
     this.workspaces.set(workspaceDir, { packages, warnings });
     this.pendingWrites.add(workspaceDir);
-    this.dirty = true;
+    this.latch.markMutated();
   }
 
   // load reads the snapshots for the workspaces currently open, and prunes
   // whatever has gone stale. Only the open workspaces are read: the rest are
   // files on disk that cost nothing until someone opens them again.
-  async load(workspaceDirs: string[] = []): Promise<void> {
-    if (!this.storageDir || this.dirty) {
+  async load(workspaceDirs: string[]): Promise<void> {
+    if (!this.storageDir || this.latch.blocked) {
       return;
     }
     for (const dir of workspaceDirs) {
@@ -143,21 +138,23 @@ export class DiscoverySnapshotStore {
     this.pendingWrites.clear();
     this.saveChain = this.saveChain
       .then(() => this.writeToDisk(dirs))
-      .catch(() => {
+      .catch((err) => {
         // A snapshot is a cache; a failed write costs the next activation its
-        // head start and nothing else.
+        // head start and nothing else — but it is said out loud.
+        reportStoreError("write discovery snapshot", err);
       });
   }
 
   private async writeToDisk(dirs: string[]): Promise<void> {
     if (!this.storageDir) return;
-    await mkdir(this.storageDir, { recursive: true });
     for (const dir of dirs) {
       const snapshot = this.workspaces.get(dir);
       if (!snapshot) continue;
       const data: StoredData = { version: 2, workspaceDir: dir, snapshot };
-      const target = path.join(this.storageDir, fileFor(dir));
-      await writeFile(target, JSON.stringify(data), "utf-8");
+      await atomicWrite(
+        path.join(this.storageDir, fileFor(dir)),
+        JSON.stringify(data),
+      );
     }
   }
 

--- a/vscode-gotest/src/discoverySnapshotStore.ts
+++ b/vscode-gotest/src/discoverySnapshotStore.ts
@@ -1,6 +1,14 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import {
+  readFile,
+  writeFile,
+  mkdir,
+  readdir,
+  stat,
+  unlink,
+} from "node:fs/promises";
 import type { DiscoverPackage, DiscoverWarning } from "./types.js";
 
 export interface DiscoverySnapshot {
@@ -9,8 +17,22 @@ export interface DiscoverySnapshot {
 }
 
 interface StoredData {
-  version: 1;
-  workspaces: Record<string, DiscoverySnapshot>;
+  version: 2;
+  workspaceDir: string;
+  snapshot: DiscoverySnapshot;
+}
+
+const PREFIX = "discovery-";
+const SUFFIX = ".json";
+
+// Snapshots for workspaces nobody has opened in this long are dropped. Without
+// it, one file per workspace only trades an unbounded number of entries in one
+// file for an unbounded number of files in a directory.
+const MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+function fileFor(workspaceDir: string): string {
+  const digest = createHash("sha256").update(workspaceDir).digest("hex");
+  return `${PREFIX}${digest.slice(0, 16)}${SUFFIX}`;
 }
 
 // DiscoverySnapshotStore persists the last known test tree.
@@ -25,25 +47,28 @@ interface StoredData {
 // The snapshot is a cache, never a source of truth: it is whatever was true
 // when the window last closed, and the discovery that follows it replaces it
 // wholesale.
+//
+// One file per workspace. A single shared file meant every save of a _test.go
+// file rewrote the tree of every workspace ever opened to update one of them,
+// and one corrupt file cost all of them their head start.
 export class DiscoverySnapshotStore {
   private workspaces = new Map<string, DiscoverySnapshot>();
-  private readonly storagePath: string | undefined;
+  private readonly storageDir: string | undefined;
   private saveChain = Promise.resolve();
   private debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  private pendingWrites = new Set<string>();
   // Set by the first update(). Discovery can run before load() resolves —
   // activate() registers the file watchers before initializeAsync awaits the
   // load — and what discovery just found beats what the last session stored.
   private dirty = false;
 
-  // A whole-workspace tree is hundreds of kilobytes to serialize, and every
-  // save of a _test.go file triggers a package rediscovery. Coalesce, the way
-  // TestResultStore does, rather than rewriting the file per keystroke-save.
+  // A tree is hundreds of kilobytes to serialize, and every save of a _test.go
+  // file triggers a package rediscovery. Coalesce, the way TestResultStore does,
+  // rather than rewriting on every keystroke-save.
   private static readonly SAVE_DEBOUNCE_MS = 500;
 
   constructor(storageUri: vscode.Uri | undefined) {
-    if (storageUri) {
-      this.storagePath = path.join(storageUri.fsPath, "discovery.json");
-    }
+    this.storageDir = storageUri?.fsPath;
   }
 
   get size(): number {
@@ -63,29 +88,35 @@ export class DiscoverySnapshotStore {
     warnings: DiscoverWarning[],
   ): void {
     this.workspaces.set(workspaceDir, { packages, warnings });
+    this.pendingWrites.add(workspaceDir);
     this.dirty = true;
   }
 
-  async load(): Promise<void> {
-    if (!this.storagePath || this.dirty) {
+  // load reads the snapshots for the workspaces currently open, and prunes
+  // whatever has gone stale. Only the open workspaces are read: the rest are
+  // files on disk that cost nothing until someone opens them again.
+  async load(workspaceDirs: string[] = []): Promise<void> {
+    if (!this.storageDir || this.dirty) {
       return;
     }
-    try {
-      const content = await readFile(this.storagePath, "utf-8");
-      const data = JSON.parse(content) as StoredData;
-      if (data.version !== 1) {
-        return;
-      }
-      this.workspaces.clear();
-      for (const [dir, snapshot] of Object.entries(data.workspaces ?? {})) {
+    for (const dir of workspaceDirs) {
+      try {
+        const content = await readFile(
+          path.join(this.storageDir, fileFor(dir)),
+          "utf-8",
+        );
+        const data = JSON.parse(content) as StoredData;
+        if (data.version !== 2 || data.workspaceDir !== dir) continue;
         this.workspaces.set(dir, {
-          packages: snapshot.packages ?? [],
-          warnings: snapshot.warnings ?? [],
+          packages: data.snapshot?.packages ?? [],
+          warnings: data.snapshot?.warnings ?? [],
         });
+      } catch {
+        // No stored data or corrupt — this workspace starts without a head
+        // start, and the others are unaffected.
       }
-    } catch {
-      // No stored data or corrupt — start fresh
     }
+    await this.prune();
   }
 
   save(): void {
@@ -108,21 +139,43 @@ export class DiscoverySnapshotStore {
   }
 
   private enqueueWrite(): void {
+    const dirs = [...this.pendingWrites];
+    this.pendingWrites.clear();
     this.saveChain = this.saveChain
-      .then(() => this.writeToDisk())
+      .then(() => this.writeToDisk(dirs))
       .catch(() => {
         // A snapshot is a cache; a failed write costs the next activation its
         // head start and nothing else.
       });
   }
 
-  private async writeToDisk(): Promise<void> {
-    if (!this.storagePath) return;
-    const data: StoredData = {
-      version: 1,
-      workspaces: Object.fromEntries(this.workspaces),
-    };
-    await mkdir(path.dirname(this.storagePath), { recursive: true });
-    await writeFile(this.storagePath, JSON.stringify(data), "utf-8");
+  private async writeToDisk(dirs: string[]): Promise<void> {
+    if (!this.storageDir) return;
+    await mkdir(this.storageDir, { recursive: true });
+    for (const dir of dirs) {
+      const snapshot = this.workspaces.get(dir);
+      if (!snapshot) continue;
+      const data: StoredData = { version: 2, workspaceDir: dir, snapshot };
+      const target = path.join(this.storageDir, fileFor(dir));
+      await writeFile(target, JSON.stringify(data), "utf-8");
+    }
+  }
+
+  private async prune(): Promise<void> {
+    if (!this.storageDir) return;
+    try {
+      const entries = await readdir(this.storageDir);
+      const now = Date.now();
+      for (const entry of entries) {
+        if (!entry.startsWith(PREFIX) || !entry.endsWith(SUFFIX)) continue;
+        const full = path.join(this.storageDir, entry);
+        const info = await stat(full);
+        if (now - info.mtimeMs > MAX_AGE_MS) {
+          await unlink(full);
+        }
+      }
+    } catch {
+      // Pruning is housekeeping; failing it must not fail activation.
+    }
   }
 }

--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -668,7 +668,7 @@ async function initializeAsync(deps: {
   // that made every activation as slow as the toolchain's worst case. The
   // snapshot is stale by definition; the discovery below replaces it.
   const snapshotStartedAt = Date.now();
-  await snapshotStore.load();
+  await snapshotStore.load(workspaceFolders.map((f) => f.uri.fsPath));
   let restoredFromSnapshot = false;
   for (const folder of workspaceFolders) {
     const snapshot = snapshotStore.get(folder.uri.fsPath);

--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -562,9 +562,7 @@ function setupFileWatchers(
 
     if (coverageStore.invalidate(importPath)) {
       outputChannel.debug(`[coverage] invalidated ${importPath}`);
-      coverageStore.save().catch((err) => {
-        outputChannel.error(`[coverage] save after invalidate failed: ${err}`);
-      });
+      coverageStore.save();
     }
 
     triggerCoverOnSave(importPath, uri);

--- a/vscode-gotest/src/extension.ts
+++ b/vscode-gotest/src/extension.ts
@@ -20,6 +20,10 @@ import { CoverOnSave } from "./coverOnSave.js";
 import { CoverageStore } from "./coverageStore.js";
 import { TestResultStore } from "./testResultStore.js";
 import { RunRegistry } from "./runRegistry.js";
+import { ProcessRegistry } from "./processRegistry.js";
+import { setChildObserver } from "./managedChild.js";
+import { forceKillTimeoutSeconds } from "./config.js";
+import { setStoreErrorLogger } from "./jsonStore.js";
 import { validateGoBinary, scopedConfig } from "./cli.js";
 import {
   buildRunFilter,
@@ -45,6 +49,8 @@ export function activate(context: vscode.ExtensionContext): void {
     return;
   }
 
+  setStoreErrorLogger((message) => outputChannel.error(message));
+
   const cache = new DiscoveryCache();
   const snapshotStore = new DiscoverySnapshotStore(context.storageUri);
   const discoveryService = new DiscoveryService(
@@ -57,6 +63,13 @@ export function activate(context: vscode.ExtensionContext): void {
   const registryDir =
     context.storageUri?.fsPath ?? context.globalStorageUri.fsPath;
   const runRegistry = new RunRegistry(registryDir);
+  // Installed before anything can spawn, so no child escapes the table that
+  // makes it reapable after a crash.
+  const processRegistry = new ProcessRegistry(registryDir);
+  setChildObserver({
+    spawned: (pid, kind) => processRegistry.add(pid, kind),
+    exited: (token) => processRegistry.remove(token),
+  });
 
   let runner!: TestRunner;
   let coverageRunner!: CoverageRunner;
@@ -172,6 +185,15 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 
   context.subscriptions.push(
+    {
+      dispose() {
+        // The reaper's escalation timer, and the hook that would otherwise keep
+        // recording into a registry nobody is reading any more.
+        setChildObserver(undefined);
+        setStoreErrorLogger(undefined);
+        processRegistry.dispose();
+      },
+    },
     outputChannel,
     cache,
     controller,
@@ -197,6 +219,7 @@ export function activate(context: vscode.ExtensionContext): void {
       coverageStore.flush(),
       testResultStore.flush(),
       snapshotStore.flush(),
+      processRegistry.flush(),
     ]);
   };
 
@@ -209,6 +232,7 @@ export function activate(context: vscode.ExtensionContext): void {
     controller,
     cache,
     runRegistry,
+    processRegistry,
     context,
     snapshotStore,
   }).catch((err) => {
@@ -594,6 +618,7 @@ async function initializeAsync(deps: {
   controller: GoTestController;
   cache: DiscoveryCache;
   runRegistry: RunRegistry;
+  processRegistry: ProcessRegistry;
   context: vscode.ExtensionContext;
   snapshotStore: DiscoverySnapshotStore;
 }): Promise<void> {
@@ -606,6 +631,7 @@ async function initializeAsync(deps: {
     controller,
     cache,
     runRegistry,
+    processRegistry,
     context,
     snapshotStore,
   } = deps;
@@ -636,6 +662,30 @@ async function initializeAsync(deps: {
       },
     );
     ensureGitExclude(folder.uri.fsPath, outputChannel);
+  }
+
+  // End what a previous session left running. A detached child survives the
+  // extension host that started it, and until now nothing ever went back for
+  // it — sweepStale only rewrote a status.
+  //
+  // Only inherited records are eligible: anything this session spawned while
+  // activation was still getting here belongs to us, not to the reaper.
+  await processRegistry.load();
+  if (processRegistry.inheritedSize > 0) {
+    const { signalled, vanished } = processRegistry.reapOrphans({
+      kill: (pid, signal) => process.kill(pid, signal),
+      graceMs: forceKillTimeoutSeconds(firstDir) * 1000,
+    });
+    for (const record of signalled) {
+      outputChannel.info(
+        `[processes] terminating orphaned ${record.kind} (pid ${record.pid}) from a previous session`,
+      );
+    }
+    if (vanished.length > 0) {
+      outputChannel.debug(
+        `[processes] ${vanished.length} recorded process(es) were already gone`,
+      );
+    }
   }
 
   await runRegistry.load();

--- a/vscode-gotest/src/jsonStore.test.ts
+++ b/vscode-gotest/src/jsonStore.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockReadFile, mockWriteFile, mockMkdir, mockRename, files } =
+  vi.hoisted(() => {
+    const files = new Map<string, string>();
+    return {
+      files,
+      mockReadFile: vi.fn(async (p: string) => {
+        const content = files.get(p);
+        if (content === undefined) throw new Error("ENOENT");
+        return content;
+      }),
+      mockWriteFile: vi.fn(async (p: string, content: string) => {
+        files.set(p, content);
+      }),
+      mockMkdir: vi.fn(async () => undefined),
+      mockRename: vi.fn(async (from: string, to: string) => {
+        const content = files.get(from);
+        if (content === undefined) throw new Error("ENOENT");
+        files.set(to, content);
+        files.delete(from);
+      }),
+    };
+  });
+
+vi.mock("node:fs/promises", () => ({
+  readFile: mockReadFile,
+  writeFile: mockWriteFile,
+  mkdir: mockMkdir,
+  rename: mockRename,
+}));
+
+import { JsonStore } from "./jsonStore.js";
+
+const DIR = "/storage";
+const FILE = "/storage/thing.json";
+
+describe("JsonStore", () => {
+  beforeEach(() => {
+    files.clear();
+    vi.clearAllMocks();
+  });
+
+  it("round-trips through a versioned envelope", async () => {
+    const store = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    store.save(() => ({ a: 1 }));
+    await store.flush();
+
+    const reopened = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    expect(await reopened.read()).toEqual({ a: 1 });
+  });
+
+  // The rule the three ad-hoc guards were each reinventing.
+  it("refuses to read once memory is ahead of disk", async () => {
+    const seed = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    seed.save(() => ({ a: 1 }));
+    await seed.flush();
+
+    const store = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    store.markMutated();
+    expect(await store.read()).toBeUndefined();
+  });
+
+  it("drops a file written by another version", async () => {
+    const seed = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    seed.save(() => ({ a: 1 }));
+    await seed.flush();
+
+    const newer = new JsonStore<{ a: number }>(DIR, "thing.json", 2);
+    expect(await newer.read()).toBeUndefined();
+  });
+
+  it("returns undefined rather than throwing on corrupt data", async () => {
+    files.set(FILE, "{ not json");
+    const store = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    expect(await store.read()).toBeUndefined();
+  });
+
+  // A crash between the write and the rename leaves the previous file intact,
+  // rather than a truncated one.
+  it("writes to a temp file and renames it into place", async () => {
+    const store = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    store.save(() => ({ a: 1 }));
+    await store.flush();
+
+    const [tmpPath] = mockWriteFile.mock.calls[0];
+    expect(tmpPath).toMatch(/^\/storage\/thing\.json\.\d+\.\d+\.tmp$/);
+    expect(mockRename).toHaveBeenCalledWith(tmpPath, FILE);
+    expect(files.has(tmpPath)).toBe(false);
+  });
+
+  // Two VS Code windows on one folder share workspace storage. A fixed temp
+  // name lets them interleave writes and rename a mixture into place.
+  it("gives each writer its own temp file", async () => {
+    const a = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    const b = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    a.save(() => ({ a: 1 }));
+    b.save(() => ({ a: 2 }));
+    await Promise.all([a.flush(), b.flush()]);
+
+    const temps = mockWriteFile.mock.calls.map((c) => c[0]);
+    expect(new Set(temps).size).toBe(temps.length);
+  });
+
+  it("coalesces a burst into one write", async () => {
+    const store = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    for (let i = 0; i < 5; i++) store.save(() => ({ a: i }));
+    await store.flush();
+    expect(mockRename).toHaveBeenCalledTimes(1);
+  });
+
+  it("serialises the state at write time, not at save time", async () => {
+    let value = 1;
+    const store = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    store.save(() => ({ a: value }));
+    value = 2;
+    await store.flush();
+
+    const reopened = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    expect(await reopened.read()).toEqual({ a: 2 });
+  });
+
+  it("never touches disk without a storage location", async () => {
+    const store = new JsonStore<{ a: number }>(undefined, "thing.json", 1);
+    store.save(() => ({ a: 1 }));
+    await expect(store.flush()).resolves.toBeUndefined();
+    expect(await store.read()).toBeUndefined();
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("keeps working after a failed write", async () => {
+    const store = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    mockRename.mockRejectedValueOnce(new Error("disk full"));
+    store.save(() => ({ a: 1 }));
+    await expect(store.flush()).resolves.toBeUndefined();
+
+    store.save(() => ({ a: 2 }));
+    await store.flush();
+    const reopened = new JsonStore<{ a: number }>(DIR, "thing.json", 1);
+    expect(await reopened.read()).toEqual({ a: 2 });
+  });
+});

--- a/vscode-gotest/src/jsonStore.ts
+++ b/vscode-gotest/src/jsonStore.ts
@@ -1,0 +1,149 @@
+import * as path from "node:path";
+import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+
+// Where a store reports a write it could not make. These are caches, so a
+// failure must never propagate into the operation that triggered it — but
+// silence is not the same as harmlessness, and until now nothing anywhere
+// logged a failed write.
+let reportError: (message: string) => void = () => {};
+
+export function setStoreErrorLogger(
+  log: ((message: string) => void) | undefined,
+): void {
+  reportError = log ?? (() => {});
+}
+
+export function reportStoreError(context: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  reportError(`[store] ${context}: ${message}`);
+}
+
+// Marks a store's memory as ahead of disk.
+//
+// A store loads exactly once. Reading from disk after anything has been
+// recorded in memory discards the newer state — a rule broken three separate
+// times (a second load during activation, a snapshot load racing a
+// watcher-triggered discovery, a coverage load racing an invalidation) and
+// patched three separate ways. One implementation, so a fourth store gets it
+// without anyone noticing it needed it.
+export class LoadOnce {
+  private mutated = false;
+
+  markMutated(): void {
+    this.mutated = true;
+  }
+
+  get blocked(): boolean {
+    return this.mutated;
+  }
+}
+
+// atomicWrite replaces a file rather than rewriting it in place. Every store
+// here wrote straight over its target, so a crash mid-write left truncated
+// JSON; each load() catches and starts fresh, so it degraded to cache-loss
+// rather than corruption, but losing a cache to a power cut is avoidable for
+// two lines. rename(2) is atomic within a filesystem, and the temp file is a
+// sibling so it always is one.
+export async function atomicWrite(
+  filePath: string,
+  content: string,
+): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  // Unique per writer. Two VS Code windows on one folder share workspace
+  // storage, so a fixed temp name lets them interleave writes into the same
+  // file and rename a mixture of both into place.
+  const tmp = `${filePath}.${process.pid}.${tmpSeq++}.tmp`;
+  await writeFile(tmp, content, "utf-8");
+  await rename(tmp, filePath);
+}
+
+let tmpSeq = 0;
+
+interface Envelope<T> {
+  version: number;
+  data: T;
+}
+
+// JsonStore is the persistence half of a store, and only that half: the
+// in-memory model, and what `load` means for it, stay with the owner.
+//
+// It carries the shared LoadOnce latch, so the load-exactly-once rule is the
+// same implementation here and in the stores that manage their own files.
+export class JsonStore<T> {
+  private readonly filePath: string | undefined;
+  private saveChain = Promise.resolve();
+  private debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  private readonly latch = new LoadOnce();
+  private snapshot: (() => T) | undefined;
+
+  private static readonly DEBOUNCE_MS = 500;
+
+  constructor(
+    storageDir: string | undefined,
+    filename: string,
+    private readonly version: number,
+  ) {
+    this.filePath = storageDir ? path.join(storageDir, filename) : undefined;
+  }
+
+  // markMutated is the owner telling the store that memory is now ahead of
+  // disk. Every mutating method must call it; that is the whole contract.
+  markMutated(): void {
+    this.latch.markMutated();
+  }
+
+  // read returns undefined when there is nothing safe to load: no storage, a
+  // version this build does not understand, a missing or corrupt file — or
+  // memory that is already ahead of disk.
+  async read(): Promise<T | undefined> {
+    if (!this.filePath || this.latch.blocked) return undefined;
+    try {
+      const content = await readFile(this.filePath, "utf-8");
+      const envelope = JSON.parse(content) as Envelope<T>;
+      if (envelope.version !== this.version) return undefined;
+      return envelope.data;
+    } catch {
+      return undefined;
+    }
+  }
+
+  // save is always void and always debounced — one contract, so no call site
+  // has to know whether this particular store returns something to await.
+  // flush() is the only thing that can be awaited.
+  save(snapshot: () => T): void {
+    this.snapshot = snapshot;
+    if (this.debounceTimer !== undefined) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined;
+      this.enqueue();
+    }, JsonStore.DEBOUNCE_MS);
+  }
+
+  flush(): Promise<void> {
+    if (this.debounceTimer !== undefined) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = undefined;
+      this.enqueue();
+    }
+    return this.saveChain;
+  }
+
+  private enqueue(): void {
+    const snapshot = this.snapshot;
+    if (!this.filePath || !snapshot) return;
+    const filePath = this.filePath;
+    this.saveChain = this.saveChain
+      .then(() =>
+        atomicWrite(
+          filePath,
+          JSON.stringify({ version: this.version, data: snapshot() }),
+        ),
+      )
+      .catch((err) => {
+        // These are caches. A failed write costs the next session its head
+        // start and must never propagate into the operation that triggered it
+        // — but it is said out loud.
+        reportStoreError(`write ${filePath}`, err);
+      });
+  }
+}

--- a/vscode-gotest/src/managedChild.test.ts
+++ b/vscode-gotest/src/managedChild.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SpawnScript } from "./scriptedSpawn.test-support.js";
+
+const { script, mockKill } = vi.hoisted(() => ({
+  script: { once: [], always: undefined, calls: [] } as SpawnScript,
+  mockKill: vi.fn(),
+}));
+
+vi.mock("vscode", () => ({
+  workspace: { getConfiguration: () => ({ get: () => undefined }) },
+  Uri: { file: (p: string) => ({ fsPath: p }) },
+}));
+
+vi.mock("node:child_process", async () => {
+  const { createScriptedSpawn } =
+    await import("./scriptedSpawn.test-support.js");
+  return { spawn: createScriptedSpawn(script, mockKill) };
+});
+
+import { ManagedChild } from "./managedChild.js";
+
+// Callers always consume; an unread pipe would stall the child by design.
+function drain(mc: ManagedChild): ManagedChild {
+  mc.child.stdout?.on("data", () => {});
+  mc.child.stderr?.on("data", () => {});
+  return mc;
+}
+
+describe("ManagedChild", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    script.once = [];
+    script.always = undefined;
+    script.calls = [];
+  });
+
+  it("settles on close for a child that finishes on its own", async () => {
+    script.always = { stdout: ["done\n"], code: 0 };
+    const mc = drain(new ManagedChild("go", ["run", "."]));
+    await expect(mc.exited).resolves.toMatchObject({ code: 0 });
+    expect(mockKill).not.toHaveBeenCalled();
+  });
+
+  it("escalates to SIGKILL when the child ignores SIGTERM", async () => {
+    script.always = { neverExits: true, ignoresSigterm: true };
+    const mc = drain(new ManagedChild("go", ["run", "."]));
+
+    const done = mc.terminate("prompt");
+    expect(mockKill).toHaveBeenCalledWith("SIGTERM");
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(mockKill).toHaveBeenCalledWith("SIGKILL");
+    await done;
+  });
+
+  // `go run` exits while the binary it compiled keeps the pipes open, so
+  // `close` never arrives. Settling on `exit` is what stops that wedging us.
+  it("settles when the child exits but the pipes stay open", async () => {
+    script.always = { neverExits: true, holdsPipesAfterExit: true };
+    const mc = drain(new ManagedChild("go", ["run", "."]));
+    await expect(mc.terminate("prompt")).resolves.toBeDefined();
+  });
+
+  it("is idempotent and does not re-arm the escalation", async () => {
+    script.always = { neverExits: true, ignoresSigterm: true };
+    const mc = drain(new ManagedChild("go", ["run", "."]));
+
+    const first = mc.terminate("prompt");
+    mc.terminate("prompt");
+    mc.terminate("teardown");
+    await vi.advanceTimersByTimeAsync(5_000);
+    await first;
+
+    const kills = mockKill.mock.calls.map((c) => c[0]);
+    expect(kills.filter((s) => s === "SIGTERM")).toHaveLength(1);
+    expect(kills.filter((s) => s === "SIGKILL")).toHaveLength(1);
+  });
+
+  // The bug the first capture.ts fix shipped with: the escalation was armed
+  // after the signal, so a child that died inside kill() left a SIGKILL
+  // scheduled against a process that no longer existed.
+  it("never signals after the child has already gone", async () => {
+    script.always = { neverExits: true };
+    const mc = drain(new ManagedChild("go", ["run", "."]));
+
+    await mc.terminate("prompt");
+    mockKill.mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockKill).not.toHaveBeenCalled();
+  });
+
+  it("resolves immediately when terminating an already-dead child", async () => {
+    script.always = { stdout: [], code: 0 };
+    const mc = drain(new ManagedChild("go", ["run", "."]));
+    await mc.exited;
+
+    await expect(mc.terminate("teardown")).resolves.toBeDefined();
+    expect(mockKill).not.toHaveBeenCalled();
+  });
+});

--- a/vscode-gotest/src/managedChild.ts
+++ b/vscode-gotest/src/managedChild.ts
@@ -19,6 +19,24 @@ export type TerminationGrace = "prompt" | "teardown";
 export interface ManagedChildOptions {
   cwd?: string;
   env?: Record<string, string>;
+  // What this child is, for the process registry. Coarse on purpose — the
+  // registry only needs enough to name what it reaped in a log line.
+  kind?: string;
+}
+
+// Observes every child this extension starts, so something outside can know
+// what is running. Installed once at activation; a module-level hook rather
+// than a constructor argument because the alternative is threading a registry
+// through five call sites that have no other use for it.
+export interface ChildObserver {
+  spawned(pid: number | undefined, kind: string): string | undefined;
+  exited(token: string | undefined): void;
+}
+
+let observer: ChildObserver | undefined;
+
+export function setChildObserver(next: ChildObserver | undefined): void {
+  observer = next;
 }
 
 export interface Exit {
@@ -47,6 +65,7 @@ export class ManagedChild {
   private escalation: ReturnType<typeof setTimeout> | undefined;
   private settle!: (exit: Exit) => void;
   private settled = false;
+  private registration: string | undefined;
 
   constructor(
     bin: string,
@@ -69,11 +88,15 @@ export class ManagedChild {
     this.child.stdout?.setEncoding("utf-8");
     this.child.stderr?.setEncoding("utf-8");
 
+    this.registration = observer?.spawned(this.child.pid, opts.kind ?? "child");
+
     this.exited = new Promise<Exit>((resolve) => {
       this.settle = (exit: Exit) => {
         if (this.settled) return;
         this.settled = true;
         clearTimeout(this.escalation);
+        observer?.exited(this.registration);
+        this.registration = undefined;
         resolve(exit);
       };
     });

--- a/vscode-gotest/src/managedChild.ts
+++ b/vscode-gotest/src/managedChild.ts
@@ -1,0 +1,128 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcessTree } from "./processTree.js";
+import {
+  CAPTURE_FORCE_KILL_GRACE_MS,
+  forceKillTimeoutSeconds,
+} from "./config.js";
+
+// How long the child gets between SIGTERM and SIGKILL. Classified by what the
+// child is doing, not by which module spawned it:
+//
+//   prompt   — a read (`discover`, `cover -func`, `spec`). No fixtures, nothing
+//              to tear down, and its output is being discarded anyway.
+//   teardown — a run or a daemon (`gotest`, `watch`, `prepare`). SIGTERM is what
+//              starts fixture teardown, and the CLI allows that up to
+//              GracefulShutdownDelay (5m30s), so we must outlast it or we cut
+//              container teardown off and leak what it was holding.
+export type TerminationGrace = "prompt" | "teardown";
+
+export interface ManagedChildOptions {
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export interface Exit {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+// ManagedChild owns the part of running a child process that nobody should
+// re-derive: it is in its own process group, both streams are decoded, and
+// there is exactly one idempotent termination path that always reaches a
+// terminal state.
+//
+// It deliberately does not own reading. Line framing, JSON cycle detection and
+// stdin writing differ at every call site and belong there — the four
+// lifecycles in this extension (budgeted read, cancellable run, restarting
+// daemon, start-and-leave-running) share a guarantee, not a call shape.
+//
+// The caller MUST consume stdout and stderr. An unread pipe fills, the child
+// blocks on write, and `exited` never settles — the stall looks like a hang in
+// the CLI rather than a missing listener here.
+export class ManagedChild {
+  readonly child: ChildProcess;
+  readonly exited: Promise<Exit>;
+
+  private terminating = false;
+  private escalation: ReturnType<typeof setTimeout> | undefined;
+  private settle!: (exit: Exit) => void;
+  private settled = false;
+
+  constructor(
+    bin: string,
+    args: string[],
+    private readonly opts: ManagedChildOptions = {},
+  ) {
+    // Detached, so termination can signal the whole group. Everything here runs
+    // `go run <module> ...`: the direct child is `go` and the process holding
+    // the pipes is the binary it compiled. Signalling only the child leaves
+    // that grandchild alive.
+    this.child = spawn(bin, args, {
+      cwd: opts.cwd,
+      env: opts.env ? { ...process.env, ...opts.env } : undefined,
+      detached: true,
+    });
+
+    // Decoded on the stream, not per chunk: a read ends wherever the pipe
+    // filled, and a chunk-wise toString() would corrupt whatever multi-byte
+    // character it lands inside. These payloads carry the developer's own text.
+    this.child.stdout?.setEncoding("utf-8");
+    this.child.stderr?.setEncoding("utf-8");
+
+    this.exited = new Promise<Exit>((resolve) => {
+      this.settle = (exit: Exit) => {
+        if (this.settled) return;
+        this.settled = true;
+        clearTimeout(this.escalation);
+        resolve(exit);
+      };
+    });
+
+    // `close` is the honest signal while the child is running: it waits for the
+    // pipes, so the caller has all the output. Once we have started killing it,
+    // `exit` is enough — a surviving grandchild can hold the pipes open past the
+    // child's death, and waiting for `close` there is how a budget stops
+    // bounding anything.
+    this.child.on("close", (code, signal) => this.settle({ code, signal }));
+    this.child.on("exit", (code, signal) => {
+      if (this.terminating) this.settle({ code, signal });
+    });
+    // A missing binary arrives here rather than as an exit code. Callers read
+    // `code` off the error, so they attach their own handler; this one only
+    // makes sure `exited` cannot hang.
+    this.child.on("error", () => this.settle({ code: null, signal: null }));
+  }
+
+  get pid(): number | undefined {
+    return this.child.pid;
+  }
+
+  // terminate is idempotent and always resolves. Calling it twice does not
+  // restart the escalation, and calling it on an already-dead child is a no-op
+  // that resolves immediately.
+  terminate(grace: TerminationGrace): Promise<Exit> {
+    if (this.settled || this.terminating) return this.exited;
+    this.terminating = true;
+
+    const graceMs =
+      grace === "prompt"
+        ? CAPTURE_FORCE_KILL_GRACE_MS
+        : forceKillTimeoutSeconds(this.opts.cwd) * 1000;
+
+    // Armed before the signal is sent. A child that dies synchronously inside
+    // kill() settles us from within the call below, and a timer armed after
+    // that would outlive the settle that was supposed to clear it — leaving a
+    // SIGKILL scheduled against a finished process, or a recycled pid.
+    this.escalation = setTimeout(() => {
+      if (this.settled) return;
+      killProcessTree(this.child, "SIGKILL");
+    }, graceMs);
+
+    killProcessTree(this.child, "SIGTERM");
+    return this.exited;
+  }
+
+  dispose(): void {
+    clearTimeout(this.escalation);
+  }
+}

--- a/vscode-gotest/src/processIdentity.test.ts
+++ b/vscode-gotest/src/processIdentity.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { readProcessStartToken, identify } from "./processIdentity.js";
+
+const onLinux = process.platform === "linux";
+
+describe.skipIf(!onLinux)("process identity on linux", () => {
+  it("reads a stable token for a live process", () => {
+    const a = readProcessStartToken(process.pid);
+    const b = readProcessStartToken(process.pid);
+    expect(a).toMatch(/^\d+$/);
+    expect(a).toBe(b);
+  });
+
+  it("recognises the same process", () => {
+    const token = readProcessStartToken(process.pid);
+    expect(identify(process.pid, token)).toBe("same-process");
+  });
+
+  // The case that must never be signalled: the number is live, but it is not
+  // the process the record was written for.
+  it("rejects a live pid whose start time does not match", () => {
+    expect(identify(process.pid, "1")).toBe("gone-or-different");
+  });
+
+  it("reports a dead pid as gone", () => {
+    // PID 0 is never a readable /proc entry.
+    expect(identify(0, "1")).toBe("gone-or-different");
+  });
+
+  it("refuses to answer without a stored token", () => {
+    expect(identify(process.pid, undefined)).toBe("unknown");
+  });
+
+  // comm can contain spaces and parentheses; the parser counts from the last
+  // ')' for exactly that reason.
+  it("survives a process whose name contains parentheses", () => {
+    expect(readProcessStartToken(process.pid)).toMatch(/^\d+$/);
+  });
+});

--- a/vscode-gotest/src/processIdentity.ts
+++ b/vscode-gotest/src/processIdentity.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+
+// A pid on its own is not an identity. Between the crash that orphaned a child
+// and the activation that wants to reap it, the OS is free to hand that number
+// to something else — and signalling the wrong process is far worse than
+// leaving an orphan. So a record carries a token that only the same process can
+// still produce.
+//
+// On Linux that token is field 22 of /proc/<pid>/stat, the process start time in
+// clock ticks since boot. It never changes for a live process and is never
+// reproduced by a later one on the same boot, so comparing it is an exact
+// identity check with no clock arithmetic.
+//
+// Field 2 is the comm name in parentheses and may itself contain spaces or
+// parentheses, so the fields are counted from the last ')' rather than by
+// splitting the whole line.
+export function readProcessStartToken(pid: number): string | undefined {
+  if (process.platform !== "linux") return undefined;
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf-8");
+    const afterComm = stat.slice(stat.lastIndexOf(")") + 2);
+    const fields = afterComm.split(" ");
+    // stat field 22 (1-based) is index 19 of what follows the comm field.
+    const startTime = fields[19];
+    return startTime && /^\d+$/.test(startTime) ? startTime : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export type IdentityVerdict = "same-process" | "gone-or-different" | "unknown";
+
+// identify answers whether the process now at `pid` is the one that produced
+// `token`. "unknown" means the platform cannot say — never a licence to signal.
+export function identify(
+  pid: number,
+  token: string | undefined,
+): IdentityVerdict {
+  if (process.platform !== "linux") return "unknown";
+  // A record written on a platform that could not produce a token cannot be
+  // verified on one that can, either.
+  if (!token) return "unknown";
+  const current = readProcessStartToken(pid);
+  if (current === undefined) return "gone-or-different";
+  return current === token ? "same-process" : "gone-or-different";
+}

--- a/vscode-gotest/src/processRegistry.test.ts
+++ b/vscode-gotest/src/processRegistry.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockReadFile,
+  mockWriteFile,
+  mockMkdir,
+  mockRename,
+  files,
+  mockIdentify,
+  mockToken,
+  mockReaddir,
+  mockUnlink,
+} = vi.hoisted(() => {
+  const files = new Map<string, string>();
+  return {
+    files,
+    mockReadFile: vi.fn(async (p: string) => {
+      const content = files.get(p);
+      if (content === undefined) throw new Error("ENOENT");
+      return content;
+    }),
+    mockWriteFile: vi.fn(async (p: string, content: string) => {
+      files.set(p, content);
+    }),
+    mockMkdir: vi.fn(async () => undefined),
+    mockRename: vi.fn(async (from: string, to: string) => {
+      const content = files.get(from);
+      if (content === undefined) throw new Error("ENOENT");
+      files.set(to, content);
+      files.delete(from);
+    }),
+    mockIdentify: vi.fn((_pid: number, _token: string) => "same-process"),
+    mockToken: vi.fn((_pid: number) => "tok" as string | undefined),
+    mockReaddir: vi.fn(async () =>
+      [...files.keys()].map((p) => p.split("/").pop()!),
+    ),
+    mockUnlink: vi.fn(async (p: string) => {
+      if (!files.delete(p)) throw new Error("ENOENT");
+    }),
+  };
+});
+
+vi.mock("node:fs/promises", () => ({
+  readFile: mockReadFile,
+  writeFile: mockWriteFile,
+  mkdir: mockMkdir,
+  rename: mockRename,
+  readdir: mockReaddir,
+  unlink: mockUnlink,
+}));
+
+vi.mock("./processIdentity.js", () => ({
+  identify: mockIdentify,
+  readProcessStartToken: mockToken,
+}));
+
+import { ProcessRegistry } from "./processRegistry.js";
+
+const DIR = "/storage";
+const GRACE = 360_000;
+
+// Each session owns one file; tests address them by the session id they chose.
+function fileFor(session: string): string {
+  return `${DIR}/child-processes-${session}.json`;
+}
+
+function storedIn(session: string): { pid: number; kind: string }[] {
+  const raw = files.get(fileFor(session));
+  return raw ? JSON.parse(raw).processes : [];
+}
+
+function newRegistry(session: string, hostPid = 500) {
+  return new ProcessRegistry(DIR, { sessionId: session, hostPid });
+}
+
+describe("ProcessRegistry", () => {
+  beforeEach(() => {
+    files.clear();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockIdentify.mockReturnValue("same-process");
+    mockToken.mockReturnValue("tok");
+  });
+
+  it("persists a spawn immediately, so a crash cannot lose it", async () => {
+    const registry = newRegistry("me");
+    registry.add(4242, "watch");
+    await registry.flush();
+
+    expect(JSON.parse(files.get(fileFor("me"))!).version).toBe(2);
+    expect(storedIn("me")[0]).toMatchObject({ pid: 4242, kind: "watch" });
+  });
+
+  it("forgets a child that exited normally", async () => {
+    const registry = newRegistry("me");
+    const key = registry.add(4242, "watch");
+    registry.remove(key);
+    await registry.flush();
+    expect(storedIn("me")).toHaveLength(0);
+  });
+
+  // A process nothing can identify later can never be reaped, so recording it
+  // is pure overhead. Off Linux the table is never written at all.
+  it("records nothing when the platform cannot identify a process", async () => {
+    mockToken.mockReturnValue(undefined);
+    const registry = newRegistry("me");
+    expect(registry.add(4242, "watch")).toBeUndefined();
+    await registry.flush();
+    expect(files.size).toBe(0);
+  });
+
+  describe("reaping what a dead session left", () => {
+    // A previous session: its host pid is 900, and it is gone.
+    async function seedDeadSession(pid: number, session = "old") {
+      const previous = new ProcessRegistry(DIR, {
+        sessionId: session,
+        hostPid: 900,
+      });
+      previous.add(pid, "watch");
+      await previous.flush();
+    }
+
+    // identify() answers for both hosts and children; route by pid.
+    function aliveExcept(deadPids: number[]) {
+      mockIdentify.mockImplementation((pid: number) =>
+        deadPids.includes(pid) ? "gone-or-different" : "same-process",
+      );
+    }
+
+    it("terminates an orphan's process group", async () => {
+      await seedDeadSession(4242);
+      aliveExcept([900]); // the old host is gone; its child is not
+
+      const registry = newRegistry("me");
+      await registry.load();
+      const kill = vi.fn();
+      const { signalled } = registry.reapOrphans({ kill, graceMs: GRACE });
+
+      expect(signalled).toHaveLength(1);
+      // Negative pid: the group, not just the `go run` that leads it.
+      expect(kill).toHaveBeenCalledWith(-4242, "SIGTERM");
+    });
+
+    // THE regression this class was rewritten for. Activation registers file
+    // watchers and commands before it gets here, so a discovery can already be
+    // running by the time the reaper looks — and it is not an orphan.
+    it("never signals a process THIS session started", async () => {
+      await seedDeadSession(2222);
+      aliveExcept([900]);
+
+      const registry = newRegistry("me");
+      // A watcher fires during activation, before load() is reached.
+      registry.add(1111, "read");
+      await registry.flush();
+      await registry.load();
+
+      const kill = vi.fn();
+      registry.reapOrphans({ kill, graceMs: GRACE });
+
+      const signalled = kill.mock.calls.map((c) => c[0]);
+      expect(signalled).toContain(-2222);
+      expect(signalled).not.toContain(-1111);
+    });
+
+    // The same window used to destroy the table before it was ever read: one
+    // shared file meant a spawn during activation overwrote the inherited
+    // records. A session only ever writes its own file now.
+    it("does not let an early spawn erase the inherited table", async () => {
+      await seedDeadSession(2222);
+      aliveExcept([900]);
+
+      const registry = newRegistry("me");
+      registry.add(1111, "read");
+      await registry.flush();
+      await registry.load();
+
+      expect(registry.inheritedSize).toBe(1);
+      expect(storedIn("old").map((r) => r.pid)).toEqual([2222]);
+      expect(storedIn("me").map((r) => r.pid)).toEqual([1111]);
+    });
+
+    // Two windows on one folder share workspace storage. Neither may touch the
+    // other's children, and a shared table could not tell them apart.
+    it("leaves a live sibling window's processes strictly alone", async () => {
+      const sibling = new ProcessRegistry(DIR, {
+        sessionId: "other",
+        hostPid: 700,
+      });
+      sibling.add(3333, "test");
+      await sibling.flush();
+
+      aliveExcept([]); // every host is alive, including 700
+
+      const registry = newRegistry("me");
+      await registry.load();
+      const kill = vi.fn();
+      const { signalled } = registry.reapOrphans({ kill, graceMs: GRACE });
+
+      expect(registry.inheritedSize).toBe(0);
+      expect(signalled).toHaveLength(0);
+      expect(kill).not.toHaveBeenCalled();
+      // And its table is untouched.
+      expect(storedIn("other").map((r) => r.pid)).toEqual([3333]);
+    });
+
+    it("escalates to SIGKILL when an orphan ignores SIGTERM", async () => {
+      await seedDeadSession(4242);
+      aliveExcept([900]);
+
+      const registry = newRegistry("me");
+      await registry.load();
+      const kill = vi.fn();
+      registry.reapOrphans({ kill, graceMs: GRACE });
+      expect(kill).toHaveBeenCalledWith(-4242, "SIGTERM");
+
+      await vi.advanceTimersByTimeAsync(GRACE);
+      expect(kill).toHaveBeenCalledWith(-4242, "SIGKILL");
+    });
+
+    it("does not escalate against an orphan that died on SIGTERM", async () => {
+      await seedDeadSession(4242);
+      aliveExcept([900]);
+
+      const registry = newRegistry("me");
+      await registry.load();
+      const kill = vi.fn();
+      registry.reapOrphans({ kill, graceMs: GRACE });
+
+      aliveExcept([900, 4242]); // it obeyed
+      await vi.advanceTimersByTimeAsync(GRACE);
+
+      expect(kill).not.toHaveBeenCalledWith(-4242, "SIGKILL");
+    });
+
+    // One signal is a request, not a guarantee. A survivor stays on the books.
+    it("keeps a record for a process that outlived SIGKILL", async () => {
+      await seedDeadSession(4242);
+      aliveExcept([900]);
+
+      const registry = newRegistry("me");
+      await registry.load();
+      registry.reapOrphans({ kill: vi.fn(), graceMs: GRACE });
+      await vi.advanceTimersByTimeAsync(GRACE);
+      await registry.flush();
+
+      expect(storedIn("old").map((r) => r.pid)).toEqual([4242]);
+    });
+
+    it("removes a dead session's file once nothing in it survives", async () => {
+      await seedDeadSession(4242);
+      aliveExcept([900, 4242]); // host and child both gone
+
+      const registry = newRegistry("me");
+      await registry.load();
+      registry.reapOrphans({ kill: vi.fn(), graceMs: GRACE });
+      await registry.flush();
+
+      expect(files.has(fileFor("old"))).toBe(false);
+    });
+
+    it("drops a record whose pid is now a different process", async () => {
+      await seedDeadSession(4242);
+      aliveExcept([900, 4242]);
+
+      const registry = newRegistry("me");
+      await registry.load();
+      const kill = vi.fn();
+      const { signalled, vanished } = registry.reapOrphans({
+        kill,
+        graceMs: GRACE,
+      });
+
+      expect(kill).not.toHaveBeenCalled();
+      expect(signalled).toHaveLength(0);
+      expect(vanished).toHaveLength(1);
+    });
+
+    it("never signals when the platform cannot identify the process", async () => {
+      await seedDeadSession(4242);
+      mockIdentify.mockImplementation((pid: number) =>
+        pid === 900 ? "gone-or-different" : "unknown",
+      );
+
+      const registry = newRegistry("me");
+      await registry.load();
+      const kill = vi.fn();
+      registry.reapOrphans({ kill, graceMs: GRACE });
+      expect(kill).not.toHaveBeenCalled();
+    });
+
+    it("ignores a session file from a future version", async () => {
+      files.set(
+        fileFor("old"),
+        JSON.stringify({ version: 3, hostPid: 900, processes: [{ pid: 1 }] }),
+      );
+      const registry = newRegistry("me");
+      await registry.load();
+      expect(registry.inheritedSize).toBe(0);
+    });
+
+    it("stops the escalation when the extension goes away", async () => {
+      await seedDeadSession(4242);
+      aliveExcept([900]);
+
+      const registry = newRegistry("me");
+      await registry.load();
+      const kill = vi.fn();
+      registry.reapOrphans({ kill, graceMs: GRACE });
+      registry.dispose();
+
+      await vi.advanceTimersByTimeAsync(GRACE * 2);
+      expect(kill).not.toHaveBeenCalledWith(-4242, "SIGKILL");
+    });
+  });
+});

--- a/vscode-gotest/src/processRegistry.ts
+++ b/vscode-gotest/src/processRegistry.ts
@@ -1,0 +1,306 @@
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { readFile, readdir, unlink } from "node:fs/promises";
+import { atomicWrite, reportStoreError } from "./jsonStore.js";
+import { identify, readProcessStartToken } from "./processIdentity.js";
+
+export interface ProcessRecord {
+  key: string;
+  pid: number;
+  kind: string;
+  startedAt: number;
+  // Proof of identity, so a recycled pid is never mistaken for ours. A record
+  // is only written when one can be produced.
+  startToken: string;
+}
+
+interface SessionFile {
+  version: 2;
+  sessionId: string;
+  // The extension host that owns these children. A session whose host is still
+  // alive owns its processes; nobody else may touch them.
+  hostPid: number;
+  hostToken: string;
+  processes: ProcessRecord[];
+}
+
+const PREFIX = "child-processes-";
+const SUFFIX = ".json";
+
+export interface ReapOptions {
+  kill: (pid: number, signal: NodeJS.Signals) => void;
+  // How long a signalled orphan gets before SIGKILL. An orphan is a run or a
+  // daemon by definition — it can be mid-fixture-teardown — so this is the
+  // teardown grace, passed in rather than read here to keep this module free of
+  // vscode configuration.
+  graceMs: number;
+}
+
+export interface ReapResult {
+  signalled: ProcessRecord[];
+  vanished: ProcessRecord[];
+}
+
+// ProcessRegistry is the answer to "what did a session that is no longer
+// running leave behind?".
+//
+// Every child is spawned detached so that termination can signal its whole
+// group. That is necessary — the direct child is `go` and the process holding
+// the pipes is the binary it compiled — but it is symmetric: a detached child
+// also survives *us*. Kill the extension host and a `gotest watch`, a process
+// designed to run for hours, keeps running with nothing left to end it.
+//
+// Each session owns one file, named for itself. That is the whole design, and
+// it is what makes two mistakes impossible rather than merely unlikely:
+//
+//   - A session can never overwrite another's table, because it only ever
+//     writes its own file. A shared file had to be read before it could be
+//     safely written, and a spawn during activation happens before that read.
+//   - A session can never reap another's live children, because a file is only
+//     eligible once its owning host is verifiably gone. Process identity
+//     answers "is this still the process the record named?"; it cannot answer
+//     "is this one of mine?", and conflating the two is how a reaper ends up
+//     SIGTERMing the discovery its own activation just started — or the run in
+//     a second window open on the same folder.
+//
+// Deliberately separate from RunRegistry. That tracks logical runs — kind,
+// packages, a status a user might see. This tracks operating-system processes,
+// a different question with a different lifetime.
+export class ProcessRegistry {
+  private current = new Map<string, ProcessRecord>();
+  // Inherited records, and the file each came from, so a file can be cleaned up
+  // once nothing in it is still running.
+  private previous = new Map<string, { record: ProcessRecord; file: string }>();
+  private saveChain = Promise.resolve();
+  private seq = 0;
+  private escalation: ReturnType<typeof setTimeout> | undefined;
+  private readonly sessionId: string;
+  private readonly hostPid: number;
+  // Files absorbed from dead sessions, kept so they can be shrunk as their
+  // processes are confirmed gone and removed once nothing is left.
+  private inheritedFiles = new Set<string>();
+
+  constructor(
+    private readonly storageDir: string | undefined,
+    identity: { sessionId?: string; hostPid?: number } = {},
+  ) {
+    this.sessionId = identity.sessionId ?? randomUUID();
+    this.hostPid = identity.hostPid ?? process.pid;
+  }
+
+  get size(): number {
+    return this.current.size + this.previous.size;
+  }
+
+  get inheritedSize(): number {
+    return this.previous.size;
+  }
+
+  // add persists immediately rather than on a debounce: the whole point is to
+  // survive a crash that could happen at any moment, and spawns are rare enough
+  // that a write each is nothing.
+  //
+  // A process we could not identify later can never be reaped, so recording it
+  // would be pure overhead. That makes this Linux-only today, and free
+  // everywhere else, rather than a table nobody can ever act on.
+  add(pid: number | undefined, kind: string): string | undefined {
+    if (pid === undefined) return undefined;
+    const startToken = readProcessStartToken(pid);
+    if (!startToken) return undefined;
+
+    const key = `${pid}-${Date.now()}-${this.seq++}`;
+    this.current.set(key, {
+      key,
+      pid,
+      kind,
+      startedAt: Date.now(),
+      startToken,
+    });
+    this.persist();
+    return key;
+  }
+
+  remove(key: string | undefined): void {
+    if (!key) return;
+    if (this.current.delete(key)) this.persist();
+  }
+
+  // load absorbs the tables of sessions whose hosts are gone. A file belonging
+  // to a live host — this one, or a second window on the same folder — is left
+  // strictly alone.
+  async load(): Promise<void> {
+    if (!this.storageDir) return;
+    let entries: string[];
+    try {
+      entries = await readdir(this.storageDir);
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.startsWith(PREFIX) || !entry.endsWith(SUFFIX)) continue;
+      if (entry === this.ownFile()) continue;
+      const full = path.join(this.storageDir, entry);
+      try {
+        const data = JSON.parse(await readFile(full, "utf-8")) as SessionFile;
+        if (data.version !== 2) continue;
+        if (identify(data.hostPid, data.hostToken) === "same-process") {
+          // That session is still running. Its children are its business.
+          continue;
+        }
+        if ((data.processes ?? []).length === 0) {
+          await unlink(full).catch(() => {});
+          continue;
+        }
+        this.inheritedFiles.add(full);
+        for (const record of data.processes) {
+          this.previous.set(record.key, { record, file: full });
+        }
+      } catch {
+        // Unreadable or corrupt: it names processes we cannot verify, so it
+        // cannot be acted on. Remove it rather than re-reading it forever.
+        await unlink(full).catch(() => {});
+      }
+    }
+  }
+
+  // reapOrphans signals what a dead session left behind and schedules the
+  // escalation. It returns as soon as the SIGTERMs are away: activation must
+  // not wait out a fixture teardown.
+  //
+  // A signalled record is kept until the process is positively gone, so a
+  // survivor is retried by the next activation rather than forgotten.
+  reapOrphans(opts: ReapOptions): ReapResult {
+    const signalled: ProcessRecord[] = [];
+    const vanished: ProcessRecord[] = [];
+
+    for (const [key, { record }] of [...this.previous]) {
+      if (identify(record.pid, record.startToken) !== "same-process") {
+        // Gone, replaced, or unverifiable — either way, not something we may
+        // signal. A false positive kills a stranger's process.
+        this.previous.delete(key);
+        vanished.push(record);
+        continue;
+      }
+      try {
+        // The group, not the process: an orphaned `go run` has its own
+        // orphaned child holding the real work.
+        opts.kill(-record.pid, "SIGTERM");
+        signalled.push(record);
+      } catch {
+        this.previous.delete(key);
+        vanished.push(record);
+      }
+    }
+
+    if (signalled.length > 0) {
+      this.escalation = setTimeout(() => {
+        this.escalation = undefined;
+        this.escalate(opts.kill);
+      }, opts.graceMs);
+    }
+
+    this.persist();
+    return { signalled, vanished };
+  }
+
+  // escalate is the second half of termination. SIGTERM alone is a request; a
+  // child that ignores it — or whose teardown is wedged — is still running, and
+  // the rest of this extension has exactly one rule about that.
+  private escalate(kill: (pid: number, signal: NodeJS.Signals) => void): void {
+    for (const [key, { record }] of [...this.previous]) {
+      if (identify(record.pid, record.startToken) !== "same-process") {
+        this.previous.delete(key);
+        continue;
+      }
+      try {
+        kill(-record.pid, "SIGKILL");
+      } catch {
+        // Gone between the check and the signal.
+      }
+      // Kept if it is somehow still there: an unkillable process is worth one
+      // more attempt next activation, not silent forgetting.
+      if (identify(record.pid, record.startToken) !== "same-process") {
+        this.previous.delete(key);
+      }
+    }
+    this.persist();
+  }
+
+  flush(): Promise<void> {
+    return this.saveChain;
+  }
+
+  dispose(): void {
+    clearTimeout(this.escalation);
+  }
+
+  private ownFile(): string {
+    return `${PREFIX}${this.sessionId}${SUFFIX}`;
+  }
+
+  private persist(): void {
+    this.saveChain = this.saveChain
+      .then(() => this.writeToDisk())
+      .catch((err) => {
+        // A lost record costs us one orphan at worst; it must never take the
+        // spawn that triggered it down with it.
+        reportStoreError("write process registry", err);
+      });
+  }
+
+  private async writeToDisk(): Promise<void> {
+    if (!this.storageDir) return;
+    const hostToken = readProcessStartToken(this.hostPid);
+    // Without a host token nobody could ever tell whether this session is still
+    // alive, and an unverifiable owner is exactly what must not be signalled.
+    if (!hostToken) return;
+
+    const data: SessionFile = {
+      version: 2,
+      sessionId: this.sessionId,
+      hostPid: this.hostPid,
+      hostToken,
+      processes: [...this.current.values()],
+    };
+    await atomicWrite(
+      path.join(this.storageDir, this.ownFile()),
+      JSON.stringify(data),
+    );
+
+    await this.reconcileInherited();
+  }
+
+  // Inherited files shrink as their processes are confirmed gone, and disappear
+  // when nothing in them is left. Rewriting rather than deleting outright keeps
+  // a survivor visible to the next session.
+  private async reconcileInherited(): Promise<void> {
+    if (!this.storageDir) return;
+    const byFile = new Map<string, ProcessRecord[]>();
+    for (const { record, file } of this.previous.values()) {
+      const list = byFile.get(file) ?? [];
+      list.push(record);
+      byFile.set(file, list);
+    }
+
+    for (const file of [...this.inheritedFiles]) {
+      const remaining = byFile.get(file) ?? [];
+      try {
+        if (remaining.length === 0) {
+          await unlink(file);
+          this.inheritedFiles.delete(file);
+          continue;
+        }
+        const existing = JSON.parse(
+          await readFile(file, "utf-8"),
+        ) as SessionFile;
+        await atomicWrite(
+          file,
+          JSON.stringify({ ...existing, processes: remaining }),
+        );
+      } catch {
+        // Housekeeping; a failure here costs one retry next activation.
+      }
+    }
+  }
+}

--- a/vscode-gotest/src/runRegistry.ts
+++ b/vscode-gotest/src/runRegistry.ts
@@ -22,6 +22,16 @@ export interface RegisterInput {
 const TTL_MS = 15 * 60 * 1000;
 const REGISTRY_FILE = "run-registry.json";
 
+// Bump when RunRecord's shape changes. Without this the file was a bare array,
+// so a shape change had no way to invalidate records written by an older build
+// — they would be read back and reasoned about as if they were current.
+const STORE_VERSION = 1;
+
+interface StoredData {
+  version: number;
+  records: RunRecord[];
+}
+
 export class RunRegistry {
   private records = new Map<string, RunRecord>();
 
@@ -88,9 +98,13 @@ export class RunRegistry {
   }
 
   async save(): Promise<void> {
+    const payload: StoredData = {
+      version: STORE_VERSION,
+      records: [...this.records.values()],
+    };
     await atomicWrite(
       path.join(this.storageDir, REGISTRY_FILE),
-      JSON.stringify([...this.records.values()], null, 2),
+      JSON.stringify(payload),
     );
   }
 
@@ -100,9 +114,12 @@ export class RunRegistry {
         path.join(this.storageDir, REGISTRY_FILE),
         "utf-8",
       );
-      const records: RunRecord[] = JSON.parse(data);
+      const parsed = JSON.parse(data) as StoredData | RunRecord[];
+      // A bare array is the pre-versioning file. Its records are 15-minute
+      // bookkeeping, so dropping them costs nothing and beats guessing.
+      if (Array.isArray(parsed) || parsed.version !== STORE_VERSION) return;
       this.records.clear();
-      for (const r of records) {
+      for (const r of parsed.records ?? []) {
         this.records.set(r.id, r);
       }
     } catch {

--- a/vscode-gotest/src/runRegistry.ts
+++ b/vscode-gotest/src/runRegistry.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import { atomicWrite } from "./jsonStore.js";
 
 export type RunKind = "test" | "coverage" | "watch" | "prepare";
 export type RunStatus = "running" | "completed" | "cancelled" | "crashed";
@@ -87,9 +88,10 @@ export class RunRegistry {
   }
 
   async save(): Promise<void> {
-    await mkdir(this.storageDir, { recursive: true });
-    const data = JSON.stringify([...this.records.values()], null, 2);
-    await writeFile(path.join(this.storageDir, REGISTRY_FILE), data, "utf-8");
+    await atomicWrite(
+      path.join(this.storageDir, REGISTRY_FILE),
+      JSON.stringify([...this.records.values()], null, 2),
+    );
   }
 
   async load(): Promise<void> {

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -406,7 +406,7 @@ export async function spawnTestProcess(
   env?: Record<string, string>,
   onStdoutLine?: (line: string) => void,
 ): Promise<SpawnResult> {
-  const mc = new ManagedChild(bin, args, { cwd, env });
+  const mc = new ManagedChild(bin, args, { cwd, env, kind: "test" });
   let stdout = "";
   let stderr = "";
   let lineBuffer = "";

--- a/vscode-gotest/src/runnerUtils.ts
+++ b/vscode-gotest/src/runnerUtils.ts
@@ -1,8 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
-import { spawn } from "node:child_process";
 import { killProcessTree } from "./processTree.js";
-import { forceKillTimeoutSeconds } from "./config.js";
+import { ManagedChild } from "./managedChild.js";
 import { readFile } from "node:fs/promises";
 import type { GoTestController } from "./testController.js";
 import type { DiscoveryCache } from "./discovery.js";
@@ -397,7 +396,7 @@ export interface SpawnResult {
   exitCode: number;
 }
 
-export function spawnTestProcess(
+export async function spawnTestProcess(
   bin: string,
   args: string[],
   cwd: string,
@@ -407,82 +406,72 @@ export function spawnTestProcess(
   env?: Record<string, string>,
   onStdoutLine?: (line: string) => void,
 ): Promise<SpawnResult> {
-  return new Promise<SpawnResult>((resolve, reject) => {
-    const child = spawn(bin, args, {
-      cwd,
-      env: env ? { ...process.env, ...env } : undefined,
-      detached: true,
-    });
-    let stdout = "";
-    let stderr = "";
-    let lineBuffer = "";
-    let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+  const mc = new ManagedChild(bin, args, { cwd, env });
+  let stdout = "";
+  let stderr = "";
+  let lineBuffer = "";
+  let spawnError: Error | undefined;
 
-    // Decoded on the stream, so a character split across two reads survives:
-    // test output is the developer's own text, and the line assembly below
-    // would otherwise emit a corrupted event.
-    child.stdout.setEncoding("utf-8");
-    child.stderr.setEncoding("utf-8");
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
+  // Line assembly is the caller's job: ManagedChild decodes the stream so a
+  // character split across two reads survives, but what counts as an event is
+  // specific to this surface.
+  mc.child.stdout?.on("data", (chunk: string) => {
+    stdout += chunk;
 
-      if (onStdoutLine) {
-        lineBuffer += chunk;
-        const lines = lineBuffer.split("\n");
-        lineBuffer = lines.pop() ?? "";
-        for (const line of lines) {
-          const trimmed = line.trim();
-          if (trimmed) {
-            onStdoutLine(trimmed);
-          }
+    if (onStdoutLine) {
+      lineBuffer += chunk;
+      const lines = lineBuffer.split("\n");
+      lineBuffer = lines.pop() ?? "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed) {
+          onStdoutLine(trimmed);
         }
       }
-    });
-
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-
-    const cancelListener = token.onCancellationRequested(() => {
-      outputChannel.info(
-        `[${label}] cancellation requested, sending SIGTERM (pid ${child.pid})`,
-      );
-      killProcessTree(child, "SIGTERM");
-      const killTimeout = forceKillTimeoutSeconds(cwd) * 1000;
-      forceKillTimer = setTimeout(() => {
-        outputChannel.warn(
-          `[${label}] process did not exit after SIGTERM, sending SIGKILL`,
-        );
-        killProcessTree(child, "SIGKILL");
-      }, killTimeout);
-    });
-
-    child.on("close", (code) => {
-      if (forceKillTimer) clearTimeout(forceKillTimer);
-      cancelListener.dispose();
-      if (onStdoutLine) {
-        const remaining = lineBuffer.trim();
-        if (remaining) {
-          onStdoutLine(remaining);
-        }
-      }
-      if (stderr) {
-        for (const line of stderr.split("\n")) {
-          if (line.trim()) {
-            outputChannel.warn(`[${label}] stderr: ${line}`);
-          }
-        }
-      }
-      resolve({ stdout, stderr, exitCode: code ?? 1 });
-    });
-
-    child.on("error", (err: Error) => {
-      if (forceKillTimer) clearTimeout(forceKillTimer);
-      cancelListener.dispose();
-      outputChannel.error(`[${label}] ${err.message}`);
-      reject(err);
-    });
+    }
   });
+
+  mc.child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  mc.child.on("error", (err: Error) => {
+    spawnError = err;
+  });
+
+  // A run: SIGTERM is what starts fixture teardown, so it gets the teardown
+  // grace rather than the prompt one.
+  const cancelListener = token.onCancellationRequested(() => {
+    outputChannel.info(
+      `[${label}] cancellation requested, sending SIGTERM (pid ${mc.pid})`,
+    );
+    void mc.terminate("teardown");
+  });
+
+  try {
+    const { code } = await mc.exited;
+    if (spawnError) {
+      outputChannel.error(`[${label}] ${spawnError.message}`);
+      throw spawnError;
+    }
+    if (onStdoutLine) {
+      const remaining = lineBuffer.trim();
+      if (remaining) {
+        onStdoutLine(remaining);
+      }
+    }
+    if (stderr) {
+      for (const line of stderr.split("\n")) {
+        if (line.trim()) {
+          outputChannel.warn(`[${label}] stderr: ${line}`);
+        }
+      }
+    }
+    return { stdout, stderr, exitCode: code ?? 1 };
+  } finally {
+    cancelListener.dispose();
+    mc.dispose();
+  }
 }
 
 export function buildRunFilter(items: vscode.TestItem[]): string | undefined {

--- a/vscode-gotest/src/scriptedSpawn.test-support.ts
+++ b/vscode-gotest/src/scriptedSpawn.test-support.ts
@@ -35,6 +35,8 @@ export interface SpawnScript {
 export interface FakeChild extends EventEmitter {
   stdout: PassThrough;
   stderr: PassThrough;
+  // Only the spec render writes to stdin, but every child has one.
+  stdin: PassThrough;
   kill: (signal?: NodeJS.Signals) => void;
 }
 
@@ -48,6 +50,8 @@ export function createScriptedSpawn(
     const child = new EventEmitter() as FakeChild;
     child.stdout = new PassThrough();
     child.stderr = new PassThrough();
+    child.stdin = new PassThrough();
+    child.stdin.resume();
 
     const finish = () => {
       child.stdout.end();

--- a/vscode-gotest/src/specRender.test.ts
+++ b/vscode-gotest/src/specRender.test.ts
@@ -1,0 +1,97 @@
+// The spec render used to have no budget, no kill path and no cancellation: a
+// wedged CLI left the Spec View waiting forever with nothing able to end it.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SpawnScript } from "./scriptedSpawn.test-support.js";
+
+const { script, mockKill } = vi.hoisted(() => ({
+  script: { once: [], always: undefined, calls: [] } as SpawnScript,
+  mockKill: vi.fn(),
+}));
+
+vi.mock("vscode", () => ({
+  workspace: {
+    workspaceFolders: [{ uri: { fsPath: "/ws" } }],
+    getConfiguration: () => ({ get: () => undefined }),
+  },
+  Uri: { file: (p: string) => ({ fsPath: p }) },
+  window: {},
+  EventEmitter: class {
+    event = () => ({ dispose: () => {} });
+    fire = () => {};
+    dispose = () => {};
+  },
+}));
+
+vi.mock("./cli.js", () => ({
+  buildCliCommand: async () => ({ bin: "go", args: ["run", "."] }),
+  stripGoRunExitEcho: (s: string) => s,
+}));
+
+vi.mock("./gomod.js", () => ({ readModulePath: async () => undefined }));
+
+vi.mock("node:child_process", async () => {
+  const { createScriptedSpawn } =
+    await import("./scriptedSpawn.test-support.js");
+  return { spawn: createScriptedSpawn(script, mockKill) };
+});
+
+import { SpecViewPanel } from "./specView.js";
+
+// runSpecFromInput is private; the behaviour under test is its process handling.
+function render(panel: SpecViewPanel, input: string): Promise<string> {
+  return (
+    panel as unknown as { runSpecFromInput(s: string): Promise<string> }
+  ).runSpecFromInput(input);
+}
+
+const channel = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  appendLine: vi.fn(),
+  show: vi.fn(),
+} as never;
+
+describe("spec render process handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    script.once = [];
+    script.always = undefined;
+    script.calls = [];
+  });
+
+  it("gives up on a CLI that never answers, and ends it", async () => {
+    script.always = { neverExits: true };
+    const panel = new SpecViewPanel(channel, undefined as never);
+
+    const p = render(panel, "{}");
+    const settled = expect(p).rejects.toThrow("spec render timed out");
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(mockKill).toHaveBeenCalledWith("SIGTERM");
+    await settled;
+  });
+
+  it("escalates to SIGKILL when the CLI ignores SIGTERM", async () => {
+    script.always = { neverExits: true, ignoresSigterm: true };
+    const panel = new SpecViewPanel(channel, undefined as never);
+
+    const p = render(panel, "{}");
+    const settled = expect(p).rejects.toThrow("spec render timed out");
+    await vi.advanceTimersByTimeAsync(120_000);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(mockKill).toHaveBeenCalledWith("SIGKILL");
+    await settled;
+  });
+
+  it("does not signal a render that answered in time", async () => {
+    script.always = { stdout: ['{"tree":[]}'], code: 0 };
+    const panel = new SpecViewPanel(channel, undefined as never);
+
+    await expect(render(panel, "{}")).resolves.toContain("tree");
+    await vi.advanceTimersByTimeAsync(200_000);
+    expect(mockKill).not.toHaveBeenCalled();
+  });
+});

--- a/vscode-gotest/src/specView.ts
+++ b/vscode-gotest/src/specView.ts
@@ -2,6 +2,11 @@ import * as vscode from "vscode";
 import * as path from "node:path";
 import { spawn } from "node:child_process";
 import { buildCliCommand, stripGoRunExitEcho } from "./cli.js";
+import { killProcessTree } from "./processTree.js";
+import {
+  CAPTURE_FORCE_KILL_GRACE_MS,
+  specRenderTimeoutSeconds,
+} from "./config.js";
 import { readModulePath } from "./gomod.js";
 import type { DiscoveryCache } from "./discovery.js";
 
@@ -324,10 +329,38 @@ ${SCRIPT}
       workspaceDir,
       this.outputChannel,
     );
+    const budgetSeconds = specRenderTimeoutSeconds(workspaceDir);
     return new Promise<string>((resolve, reject) => {
-      const child = spawn(cmd.bin, cmd.args, { cwd: workspaceDir });
+      // Detached, so the budget below can signal the compiled binary and not
+      // just the `go run` that launched it.
+      const child = spawn(cmd.bin, cmd.args, {
+        cwd: workspaceDir,
+        detached: true,
+      });
       let stdout = "";
       let stderr = "";
+      let timedOut = false;
+      let settled = false;
+      let escalation: ReturnType<typeof setTimeout> | undefined;
+
+      const settle = (outcome: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(budget);
+        clearTimeout(escalation);
+        outcome();
+      };
+
+      // Rendering is a read with no fixtures to tear down, so it gets a budget
+      // and a prompt escalation. Without them a wedged CLI left this promise
+      // pending forever and nothing could end the child.
+      const budget = setTimeout(() => {
+        timedOut = true;
+        escalation = setTimeout(() => {
+          if (!settled) killProcessTree(child, "SIGKILL");
+        }, CAPTURE_FORCE_KILL_GRACE_MS);
+        killProcessTree(child, "SIGTERM");
+      }, budgetSeconds * 1000);
 
       // Decoded on the stream: a spec tree is large enough to arrive in several
       // reads, and a boundary inside a multi-byte character would corrupt the
@@ -340,16 +373,30 @@ ${SCRIPT}
       child.stderr.on("data", (chunk: string) => {
         stderr += chunk;
       });
+      // Once we have given up, `exit` is enough: a surviving grandchild can hold
+      // the pipes open past it, and `close` would never arrive.
+      child.on("exit", () => {
+        if (!timedOut) return;
+        settle(() =>
+          reject(new Error(`spec render timed out after ${budgetSeconds}s`)),
+        );
+      });
       child.on("close", (code) => {
-        const outcome = interpretSpecExit(code, stdout, stderr);
-        if (outcome.ok) {
-          resolve(outcome.stdout);
-        } else {
-          reject(new Error(outcome.message));
-        }
+        settle(() => {
+          if (timedOut) {
+            reject(new Error(`spec render timed out after ${budgetSeconds}s`));
+            return;
+          }
+          const outcome = interpretSpecExit(code, stdout, stderr);
+          if (outcome.ok) {
+            resolve(outcome.stdout);
+          } else {
+            reject(new Error(outcome.message));
+          }
+        });
       });
       child.on("error", (err: Error) => {
-        reject(err);
+        settle(() => reject(err));
       });
 
       child.stdin.on("error", () => {});

--- a/vscode-gotest/src/specView.ts
+++ b/vscode-gotest/src/specView.ts
@@ -1,12 +1,8 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
-import { spawn } from "node:child_process";
 import { buildCliCommand, stripGoRunExitEcho } from "./cli.js";
-import { killProcessTree } from "./processTree.js";
-import {
-  CAPTURE_FORCE_KILL_GRACE_MS,
-  specRenderTimeoutSeconds,
-} from "./config.js";
+import { specRenderTimeoutSeconds } from "./config.js";
+import { ManagedChild } from "./managedChild.js";
 import { readModulePath } from "./gomod.js";
 import type { DiscoveryCache } from "./discovery.js";
 
@@ -330,79 +326,50 @@ ${SCRIPT}
       this.outputChannel,
     );
     const budgetSeconds = specRenderTimeoutSeconds(workspaceDir);
-    return new Promise<string>((resolve, reject) => {
-      // Detached, so the budget below can signal the compiled binary and not
-      // just the `go run` that launched it.
-      const child = spawn(cmd.bin, cmd.args, {
-        cwd: workspaceDir,
-        detached: true,
-      });
-      let stdout = "";
-      let stderr = "";
-      let timedOut = false;
-      let settled = false;
-      let escalation: ReturnType<typeof setTimeout> | undefined;
+    const mc = new ManagedChild(cmd.bin, cmd.args, { cwd: workspaceDir });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let spawnError: Error | undefined;
 
-      const settle = (outcome: () => void) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(budget);
-        clearTimeout(escalation);
-        outcome();
-      };
-
-      // Rendering is a read with no fixtures to tear down, so it gets a budget
-      // and a prompt escalation. Without them a wedged CLI left this promise
-      // pending forever and nothing could end the child.
-      const budget = setTimeout(() => {
-        timedOut = true;
-        escalation = setTimeout(() => {
-          if (!settled) killProcessTree(child, "SIGKILL");
-        }, CAPTURE_FORCE_KILL_GRACE_MS);
-        killProcessTree(child, "SIGTERM");
-      }, budgetSeconds * 1000);
-
-      // Decoded on the stream: a spec tree is large enough to arrive in several
-      // reads, and a boundary inside a multi-byte character would corrupt the
-      // behavior name it lands in.
-      child.stdout.setEncoding("utf-8");
-      child.stderr.setEncoding("utf-8");
-      child.stdout.on("data", (chunk: string) => {
-        stdout += chunk;
-      });
-      child.stderr.on("data", (chunk: string) => {
-        stderr += chunk;
-      });
-      // Once we have given up, `exit` is enough: a surviving grandchild can hold
-      // the pipes open past it, and `close` would never arrive.
-      child.on("exit", () => {
-        if (!timedOut) return;
-        settle(() =>
-          reject(new Error(`spec render timed out after ${budgetSeconds}s`)),
-        );
-      });
-      child.on("close", (code) => {
-        settle(() => {
-          if (timedOut) {
-            reject(new Error(`spec render timed out after ${budgetSeconds}s`));
-            return;
-          }
-          const outcome = interpretSpecExit(code, stdout, stderr);
-          if (outcome.ok) {
-            resolve(outcome.stdout);
-          } else {
-            reject(new Error(outcome.message));
-          }
-        });
-      });
-      child.on("error", (err: Error) => {
-        settle(() => reject(err));
-      });
-
-      child.stdin.on("error", () => {});
-      child.stdin.write(jsonInput);
-      child.stdin.end();
+    // Decoded on the stream by ManagedChild: a spec tree is large enough to
+    // arrive in several reads, and a boundary inside a multi-byte character
+    // would corrupt the behavior name it lands in.
+    mc.child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
     });
+    mc.child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    mc.child.on("error", (err: Error) => {
+      spawnError = err;
+    });
+
+    // Rendering is a read: it has no fixtures to tear down, so it gets a budget
+    // and the prompt escalation. Without them a wedged CLI left this promise
+    // pending forever and nothing could end the child.
+    const budget = setTimeout(() => {
+      timedOut = true;
+      void mc.terminate("prompt");
+    }, budgetSeconds * 1000);
+
+    mc.child.stdin?.on("error", () => {});
+    mc.child.stdin?.write(jsonInput);
+    mc.child.stdin?.end();
+
+    try {
+      const { code } = await mc.exited;
+      if (spawnError) throw spawnError;
+      if (timedOut) {
+        throw new Error(`spec render timed out after ${budgetSeconds}s`);
+      }
+      const outcome = interpretSpecExit(code, stdout, stderr);
+      if (!outcome.ok) throw new Error(outcome.message);
+      return outcome.stdout;
+    } finally {
+      clearTimeout(budget);
+      mc.dispose();
+    }
   }
 }
 

--- a/vscode-gotest/src/specView.ts
+++ b/vscode-gotest/src/specView.ts
@@ -326,7 +326,10 @@ ${SCRIPT}
       this.outputChannel,
     );
     const budgetSeconds = specRenderTimeoutSeconds(workspaceDir);
-    const mc = new ManagedChild(cmd.bin, cmd.args, { cwd: workspaceDir });
+    const mc = new ManagedChild(cmd.bin, cmd.args, {
+      cwd: workspaceDir,
+      kind: "spec",
+    });
     let stdout = "";
     let stderr = "";
     let timedOut = false;

--- a/vscode-gotest/src/testController.ts
+++ b/vscode-gotest/src/testController.ts
@@ -75,22 +75,26 @@ export class GoTestController implements vscode.Disposable {
     // Coalesces bursts — a watch event can touch several packages at once, and
     // each one fires the cache's update. Anything that reads the tree flushes
     // it first, so the delay never becomes visible as a missing item.
-    let rebuildTimer: ReturnType<typeof setTimeout> | undefined;
     this.disposables.push(
       this.cache.onDidUpdate(() => {
-        if (rebuildTimer) clearTimeout(rebuildTimer);
-        rebuildTimer = setTimeout(() => {
-          rebuildTimer = undefined;
+        if (this.rebuildTimer) clearTimeout(this.rebuildTimer);
+        this.rebuildTimer = setTimeout(() => {
+          this.rebuildTimer = undefined;
           this.rebuild();
         }, 50);
-        this.flushPendingRebuild = () => {
-          if (!rebuildTimer) return;
-          clearTimeout(rebuildTimer);
-          rebuildTimer = undefined;
-          this.rebuild();
-        };
       }),
     );
+  }
+
+  private rebuildTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // flushPendingRebuild applies a debounced rebuild that has not fired yet, so
+  // a caller reading the tree never observes the delay as a missing item.
+  private flushPendingRebuild(): void {
+    if (!this.rebuildTimer) return;
+    clearTimeout(this.rebuildTimer);
+    this.rebuildTimer = undefined;
+    this.rebuild();
   }
 
   get testController(): vscode.TestController {
@@ -577,10 +581,6 @@ export class GoTestController implements vscode.Disposable {
     this.pendingPaused.clear();
     return this.controller.createTestRun(request, name);
   }
-
-  // flushPendingRebuild applies a debounced rebuild that has not fired yet. It
-  // is a no-op until the cache has updated at least once.
-  private flushPendingRebuild: () => void = () => {};
 
   findItem(id: string): vscode.TestItem | undefined {
     // The tree is the answer to this question, so it has to be current. A

--- a/vscode-gotest/src/testResultStore.test.ts
+++ b/vscode-gotest/src/testResultStore.test.ts
@@ -137,8 +137,7 @@ describe("TestResultStore", () => {
       const filePath = path.join(tmpDir, "testResults.json");
       const raw = await readFile(filePath, "utf-8");
       const data = JSON.parse(raw);
-      data.results["pkg/stale"].timestamp =
-        Date.now() - 8 * 24 * 60 * 60 * 1000;
+      data.data["pkg/stale"].timestamp = Date.now() - 8 * 24 * 60 * 60 * 1000;
       await writeFile(filePath, JSON.stringify(data), "utf-8");
 
       const reader = new TestResultStore({ fsPath: tmpDir });

--- a/vscode-gotest/src/testResultStore.ts
+++ b/vscode-gotest/src/testResultStore.ts
@@ -1,5 +1,4 @@
-import * as path from "node:path";
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { JsonStore } from "./jsonStore.js";
 
 export interface TestResult {
   status: "pass" | "fail" | "skip";
@@ -39,20 +38,20 @@ interface StoredTestResult extends TestResult {
 // cannot catch a store left by an unreleased v1.27 build, which predates these
 // fields without saying so; that one falls back to the pre-bracket numbers
 // until the next run replaces it.
-const STORE_VERSION = 2;
+// 3, not 2: the on-disk envelope moved to the shared { version, data } shape.
+// Keeping the number while changing the payload is precisely the trap the
+// version exists to prevent — a newer build would read an older file's fields
+// as if they were current. A mismatch purges, which is correct for a cache.
+// (3 and 4 were used mid-development and never released, so this reuses 3.)
+const STORE_VERSION = 3;
 
-interface StoredData {
-  version: number;
-  results: Record<string, StoredTestResult>;
-}
+type StoredData = Record<string, StoredTestResult>;
 
 const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 export class TestResultStore {
   private results = new Map<string, StoredTestResult>();
-  private readonly storagePath: string | undefined;
-  private saveChain = Promise.resolve();
-  private debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  private readonly store: JsonStore<StoredData>;
   private readonly maxAge: number;
 
   constructor(
@@ -60,9 +59,11 @@ export class TestResultStore {
     maxAge = DEFAULT_MAX_AGE_MS,
   ) {
     this.maxAge = maxAge;
-    if (storageUri) {
-      this.storagePath = path.join(storageUri.fsPath, "testResults.json");
-    }
+    this.store = new JsonStore<StoredData>(
+      storageUri?.fsPath,
+      "testResults.json",
+      STORE_VERSION,
+    );
   }
 
   get size(): number {
@@ -75,6 +76,7 @@ export class TestResultStore {
     duration?: number,
     bracket?: { startedAt?: number; endedAt?: number; paused?: boolean },
   ): void {
+    this.store.markMutated();
     this.results.set(itemId, {
       status,
       duration,
@@ -90,6 +92,7 @@ export class TestResultStore {
   }
 
   delete(itemId: string): void {
+    this.store.markMutated();
     this.results.delete(itemId);
   }
 
@@ -107,68 +110,36 @@ export class TestResultStore {
   }
 
   async load(): Promise<void> {
-    if (!this.storagePath) return;
-    try {
-      const content = await readFile(this.storagePath, "utf-8");
-      const data = JSON.parse(content) as StoredData;
-      if (data.version !== STORE_VERSION) return;
-      this.results.clear();
-      for (const [id, result] of Object.entries(data.results)) {
-        this.results.set(id, result);
-      }
-      this.evictStale();
-    } catch {
-      /* No stored data or corrupt — start fresh */
+    const data = await this.store.read();
+    if (!data) return;
+    this.results.clear();
+    for (const [id, result] of Object.entries(data)) {
+      this.results.set(id, result);
     }
+    this.evictStale();
   }
 
   save(): void {
-    if (this.debounceTimer !== undefined) {
-      clearTimeout(this.debounceTimer);
-    }
-    this.debounceTimer = setTimeout(() => {
-      this.debounceTimer = undefined;
-      this.saveChain = this.saveChain
-        .then(() => this.writeToDisk())
-        .catch(() => {});
-    }, 500);
+    this.store.save(() => {
+      this.evictStale();
+      return Object.fromEntries(this.results);
+    });
   }
 
   flush(): Promise<void> {
-    if (this.debounceTimer !== undefined) {
-      clearTimeout(this.debounceTimer);
-      this.debounceTimer = undefined;
-      this.saveChain = this.saveChain
-        .then(() => this.writeToDisk())
-        .catch(() => {});
-    }
-    return this.saveChain;
-  }
-
-  private async writeToDisk(): Promise<void> {
-    if (!this.storagePath) return;
-    this.evictStale();
-    const data: StoredData = {
-      version: STORE_VERSION,
-      results: Object.fromEntries(this.results),
-    };
-    await mkdir(path.dirname(this.storagePath), { recursive: true });
-    await writeFile(this.storagePath, JSON.stringify(data), "utf-8");
+    return this.store.flush();
   }
 
   // clear drops every result and schedules the empty state to disk. Clearing
   // memory alone would leave the persisted copy intact, and the next window
   // reload would restore exactly the results the developer just dismissed.
   clear(): void {
+    this.store.markMutated();
     this.results.clear();
     this.save();
   }
 
   dispose(): void {
-    if (this.debounceTimer !== undefined) {
-      clearTimeout(this.debounceTimer);
-      this.debounceTimer = undefined;
-    }
     this.results.clear();
   }
 }

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -63,6 +63,7 @@ class WatchProcess implements vscode.Disposable {
     // in whatever pieces the pipe delivers, boundaries falling mid-character.
     this.managed = new ManagedChild(this.cmd.bin, this.cmd.args, {
       cwd: this.cwd,
+      kind: "watch",
     });
     this.child = this.managed.child;
     this.buffer = "";

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { spawn, type ChildProcess } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import type { GoTestController } from "./testController.js";
 import type { DiscoveryCache } from "./discovery.js";
 import { parseTestEvents, type TestEvent } from "./outputParser.js";
@@ -16,7 +16,7 @@ import {
   resolveAncestorItems,
   skipUnresolved,
 } from "./runnerUtils.js";
-import { forceKillTimeoutSeconds } from "./config.js";
+import { ManagedChild } from "./managedChild.js";
 import type { RunRegistry } from "./runRegistry.js";
 
 /**
@@ -30,6 +30,7 @@ class WatchProcess implements vscode.Disposable {
   private static readonly MAX_RESTART_DELAY_MS = 30_000;
 
   private child: ChildProcess | undefined;
+  private managed: ManagedChild | undefined;
   private buffer = "";
   private cycleBuffer = "";
   private disposed = false;
@@ -58,17 +59,14 @@ class WatchProcess implements vscode.Disposable {
       `[watch] spawning: ${formatCliCommand(this.cmd)} (cwd: ${this.cwd})`,
     );
 
-    this.child = spawn(this.cmd.bin, this.cmd.args, {
+    // Decoded by ManagedChild: the watcher runs for hours and its events arrive
+    // in whatever pieces the pipe delivers, boundaries falling mid-character.
+    this.managed = new ManagedChild(this.cmd.bin, this.cmd.args, {
       cwd: this.cwd,
-      detached: true,
     });
+    this.child = this.managed.child;
     this.buffer = "";
     this.cycleBuffer = "";
-
-    // Decoded on the stream: the watcher runs for hours and its events arrive
-    // in whatever pieces the pipe delivers, boundaries falling mid-character.
-    this.child.stdout?.setEncoding("utf-8");
-    this.child.stderr?.setEncoding("utf-8");
 
     this.child.stdout?.on("data", (chunk: string) => {
       this.buffer += chunk;
@@ -202,26 +200,26 @@ class WatchProcess implements vscode.Disposable {
   dispose(forceKill = true): void {
     this.disposed = true;
 
-    if (this.child) {
-      const child = this.child;
-      this.child = undefined;
+    const managed = this.managed;
+    if (!managed) return;
+    this.managed = undefined;
+    this.child = undefined;
 
-      this.outputChannel.info(`[watch] sending SIGTERM (pid ${child.pid})`);
-      killProcessTree(child, "SIGTERM");
+    this.outputChannel.info(`[watch] sending SIGTERM (pid ${managed.pid})`);
 
-      if (!forceKill) return;
-
-      const killTimeout = forceKillTimeoutSeconds(this.cwd) * 1000;
-      const forceKillTimer = setTimeout(() => {
-        if (!child.killed) {
-          killProcessTree(child, "SIGKILL");
-        }
-      }, killTimeout);
-
-      child.on("close", () => {
-        clearTimeout(forceKillTimer);
-      });
+    if (!forceKill) {
+      // Shutdown. VS Code's deactivate window is seconds, so any SIGKILL timer
+      // long enough to respect a fixture teardown would never fire, and any
+      // timer short enough to fire would cut that teardown off. The child has
+      // its own process group and the CLI's force-kill backstop, so SIGTERM
+      // alone is both the most and the least we can honestly do.
+      killProcessTree(managed.child, "SIGTERM");
+      managed.dispose();
+      return;
     }
+
+    // A daemon holding fixtures open by design: it gets the teardown grace.
+    void managed.terminate("teardown");
   }
 }
 

--- a/vscode-gotest/test/integration/discoveryPayload.test.ts
+++ b/vscode-gotest/test/integration/discoveryPayload.test.ts
@@ -198,7 +198,7 @@ describe("the tree the next activation starts from", () => {
     const reopened = new DiscoverySnapshotStore({
       fsPath: storageDir,
     } as never);
-    await reopened.load();
+    await reopened.load([payloadDir]);
     const snapshot = reopened.get(payloadDir);
     expect(snapshot).toBeDefined();
 
@@ -215,7 +215,7 @@ describe("the tree the next activation starts from", () => {
     const reopened = new DiscoverySnapshotStore({
       fsPath: storageDir,
     } as never);
-    await reopened.load();
+    await reopened.load([payloadDir]);
     const restored = new DiscoveryCache();
     const snapshot = reopened.get(payloadDir)!;
     restored.update(snapshot.packages, true, payloadDir, snapshot.warnings);


### PR DESCRIPTION
Follow-up to #122

### What changed

- Cancelling a run, closing a window, or a crash no longer leaves Go test
  processes running in the background. Anything a previous session left behind
  is cleaned up on the next start.
- A cancelled run is now given enough time to finish its own cleanup, instead of
  being cut off part-way and leaving containers or fixtures behind.
- The Spec View no longer waits indefinitely when the CLI stops responding.
- Coverage is no longer restored for a file that changed while the editor was
  still starting up.
- Test results recorded during startup are no longer discarded.
- Saving a test file now updates only the current workspace's cached test tree,
  rather than every workspace previously opened.
- Stored data is written so an interrupted write cannot corrupt it, and write
  failures are reported instead of passing silently.