### PR TITLE
Test the extension on Windows, and stop detaching where it has no effect

### DIFF
--- a/.github/actions/extension-check/action.yml
+++ b/.github/actions/extension-check/action.yml
@@ -1,6 +1,16 @@
 name: "Extension Check"
 description: "Lint, typecheck, test, and compile the VS Code extension"
 
+inputs:
+  format:
+    description: >-
+      Run the formatting check. Off outside Linux: only *.snap is pinned to LF
+      in .gitattributes, so a Windows checkout is CRLF and prettier would flag
+      every file. Formatting does not vary by platform, so checking it once is
+      enough.
+    required: false
+    default: "true"
+
 runs:
   using: "composite"
   steps:
@@ -13,6 +23,7 @@ runs:
       shell: bash
       working-directory: vscode-gotest
     - run: npm run format:check
+      if: inputs.format == 'true'
       shell: bash
       working-directory: vscode-gotest
     - run: npm run typecheck

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -63,3 +63,30 @@ jobs:
         run: npm run contract:verify
       - name: Cross the process boundary for real
         run: npm run test:integration
+
+  # The unit suite mocks node:child_process, so nothing in it crosses a real
+  # process boundary. This job is the only place the extension spawns the actual
+  # CLI on Windows — where the child-process APIs differ most from a developer's
+  # machine, and where killProcessTree has no process-group path at all.
+  #
+  # Integration only: contract:record/verify is a `git diff` against a recorded
+  # file, and a Windows checkout is CRLF (.gitattributes pins only *.snap to
+  # LF), so the diff would fail for line endings rather than for drift.
+  contract-windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: vscode-gotest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.27"
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: vscode-gotest/package-lock.json
+      - run: npm ci
+      - name: Cross the process boundary for real
+        run: npm run test:integration

--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -17,12 +17,19 @@ defaults:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/extension-check
+        with:
+          format: ${{ matrix.os == 'ubuntu-latest' }}
 
   package:
+    # One artifact, and it is platform-independent.
     runs-on: ubuntu-latest
     needs: check
     steps:

--- a/vscode-gotest/src/buildCliCommand.test.ts
+++ b/vscode-gotest/src/buildCliCommand.test.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const {
@@ -59,7 +60,7 @@ import { buildCliCommand } from "./cli.js";
 
 function setGoMod(dir: string, content: string) {
   mockReadFile.mockImplementation(async (filePath: unknown) => {
-    if (filePath === `${dir}/go.mod`) return content;
+    if (filePath === path.join(dir, "go.mod")) return content;
     throw new Error("ENOENT");
   });
 }
@@ -150,7 +151,7 @@ describe("buildCliCommand", () => {
 
       const cmd = await buildCliCommand(["spec"], "/workspace");
 
-      expect(cmd.bin).toBe("/workspace/bin/gotest");
+      expect(cmd.bin).toBe(path.resolve("/workspace", "bin/gotest"));
     });
   });
 

--- a/vscode-gotest/src/coverage.test.ts
+++ b/vscode-gotest/src/coverage.test.ts
@@ -112,7 +112,7 @@ describe("parseCoverProfile", () => {
 
     const result = parseCoverProfile(content, moduleToDir);
     expect(result).toHaveLength(1);
-    expect(result[0].absPath).toBe("/abs/pkg/main.go");
+    expect(result[0].absPath).toBe(path.join("/abs/pkg", "main.go"));
     expect(result[0].statements).toHaveLength(2);
   });
 
@@ -139,7 +139,9 @@ describe("parseCoverProfile", () => {
     const result = parseCoverProfile(content, moduleToDir);
     expect(result).toHaveLength(2);
 
-    const aFile = result.find((r) => r.absPath === "/abs/pkg/a.go");
+    const aFile = result.find(
+      (r) => r.absPath === path.join("/abs/pkg", "a.go"),
+    );
     expect(aFile).toBeDefined();
     expect(aFile!.statements).toHaveLength(2);
   });
@@ -184,7 +186,10 @@ describe("parseCoverProfile", () => {
     const result = parseCoverProfile(content, moduleToDir);
     expect(result).toHaveLength(2);
     const paths = result.map((r) => r.absPath).sort();
-    expect(paths).toEqual(["/abs/other/util.go", "/abs/pkg/main.go"]);
+    expect(paths).toEqual([
+      path.join("/abs/other", "util.go"),
+      path.join("/abs/pkg", "main.go"),
+    ]);
   });
 });
 
@@ -203,7 +208,7 @@ describe("parseFuncCoverage", () => {
 
     const result = parseFuncCoverage(content, moduleToDir);
     expect(result.size).toBe(1);
-    const decls = result.get("/abs/pkg/main.go")!;
+    const decls = result.get(path.join("/abs/pkg", "main.go"))!;
     expect(decls).toHaveLength(2);
     expect(decls[0].name).toBe("Login");
     expect(decls[0].executed).toBeCloseTo(0.857);
@@ -214,7 +219,7 @@ describe("parseFuncCoverage", () => {
   it("marks 0% functions as not executed", () => {
     const content = "example.com/pkg/main.go:5:\tUnused\t\t0.0%\n";
     const result = parseFuncCoverage(content, moduleToDir);
-    const decls = result.get("/abs/pkg/main.go")!;
+    const decls = result.get(path.join("/abs/pkg", "main.go"))!;
     expect(decls[0].executed).toBe(false);
   });
 
@@ -245,10 +250,10 @@ describe("buildFileCoverages", () => {
     );
     const { coverages, details } = buildFileCoverages(parsed);
     expect(coverages).toHaveLength(1);
-    expect(coverages[0].uri.fsPath).toBe("/abs/pkg/main.go");
+    expect(coverages[0].uri.fsPath).toBe(path.join("/abs/pkg", "main.go"));
     expect(coverages[0].statementCoverage.covered).toBe(5);
     expect(coverages[0].statementCoverage.total).toBe(8);
-    expect(details.get("/abs/pkg/main.go")).toHaveLength(2);
+    expect(details.get(path.join("/abs/pkg", "main.go"))).toHaveLength(2);
   });
 
   it("includes declarations in details but not in sidebar metric", () => {
@@ -264,7 +269,7 @@ describe("buildFileCoverages", () => {
     const { coverages, details } = buildFileCoverages(parsed, declarations);
     expect(coverages).toHaveLength(1);
     expect(coverages[0].declarationCoverage).toBeUndefined();
-    expect(details.get("/abs/pkg/main.go")).toHaveLength(3);
+    expect(details.get(path.join("/abs/pkg", "main.go"))).toHaveLength(3);
   });
 
   it("has no declarationCoverage regardless of input", () => {
@@ -282,7 +287,7 @@ describe("buildFileCoverages", () => {
       moduleToDir,
     );
     const { details } = buildFileCoverages(parsed);
-    const d = details.get("/abs/pkg/main.go")!;
+    const d = details.get(path.join("/abs/pkg", "main.go"))!;
     expect(d).toHaveLength(2);
   });
 });
@@ -304,8 +309,8 @@ describe("deduplicateProfiles", () => {
     );
     const result = deduplicateProfiles(parsed);
     expect(result).toHaveLength(2);
-    const a = result.find((r) => r.absPath === "/abs/pkg/a.go")!;
-    const b = result.find((r) => r.absPath === "/abs/pkg/b.go")!;
+    const a = result.find((r) => r.absPath === path.join("/abs/pkg", "a.go"))!;
+    const b = result.find((r) => r.absPath === path.join("/abs/pkg", "b.go"))!;
     expect(a.statements).toHaveLength(1);
     expect(b.statements).toHaveLength(1);
   });
@@ -323,7 +328,7 @@ describe("deduplicateProfiles", () => {
     const result = deduplicateProfiles(combined);
 
     expect(result).toHaveLength(1);
-    expect(result[0].absPath).toBe("/abs/pkg/main.go");
+    expect(result[0].absPath).toBe(path.join("/abs/pkg", "main.go"));
     expect(result[0].statements).toHaveLength(1);
     expect(result[0].statements[0].executed).toBe(5);
     expect(result[0].numStatements).toEqual([4]);
@@ -422,7 +427,7 @@ describe("filterSupplementaryProfiles", () => {
     );
     const result = filterSupplementaryProfiles(primary, supplementary);
     expect(result).toHaveLength(1);
-    expect(result[0].absPath).toBe("/abs/pkg/a.go");
+    expect(result[0].absPath).toBe(path.join("/abs/pkg", "a.go"));
   });
 
   it("returns empty when no supplementary files match primary scope", () => {
@@ -500,7 +505,7 @@ describe("CoverageStore.getDetails", () => {
         ip === "example.com/pkg" ? "/abs/pkg" : undefined,
     };
     store.buildFileCoverages(mockCache as any);
-    const details = store.getDetails("/abs/pkg/main.go");
+    const details = store.getDetails(path.join("/abs/pkg", "main.go"));
     expect(details.length).toBeGreaterThan(0);
   });
 
@@ -520,9 +525,11 @@ describe("CoverageStore.getDetails", () => {
         ip === "example.com/pkg" ? "/abs/pkg" : undefined,
     };
     store.buildFileCoverages(mockCache as any);
-    expect(store.getDetails("/abs/pkg/main.go").length).toBeGreaterThan(0);
+    expect(
+      store.getDetails(path.join("/abs/pkg", "main.go")).length,
+    ).toBeGreaterThan(0);
     store.invalidate("example.com/pkg");
-    expect(store.getDetails("/abs/pkg/main.go")).toEqual([]);
+    expect(store.getDetails(path.join("/abs/pkg", "main.go"))).toEqual([]);
   });
 
   it("clears cached details on clear", () => {
@@ -536,8 +543,10 @@ describe("CoverageStore.getDetails", () => {
         ip === "example.com/pkg" ? "/abs/pkg" : undefined,
     };
     store.buildFileCoverages(mockCache as any);
-    expect(store.getDetails("/abs/pkg/main.go").length).toBeGreaterThan(0);
+    expect(
+      store.getDetails(path.join("/abs/pkg", "main.go")).length,
+    ).toBeGreaterThan(0);
     store.clear();
-    expect(store.getDetails("/abs/pkg/main.go")).toEqual([]);
+    expect(store.getDetails(path.join("/abs/pkg", "main.go"))).toEqual([]);
   });
 });

--- a/vscode-gotest/src/coverageUtils.test.ts
+++ b/vscode-gotest/src/coverageUtils.test.ts
@@ -47,7 +47,9 @@ describe("runGoToolCoverFunc", () => {
     const out = await runGoToolCoverFunc("/tmp/cover.out", "/ws");
 
     expect(out).toHaveLength(report.length);
-    expect(script.calls?.[0]).toEqual({
+    // toMatchObject, not toEqual: the fake also records spawn options, which
+    // this test has no opinion about.
+    expect(script.calls?.[0]).toMatchObject({
       bin: "/usr/bin/go",
       args: ["tool", "cover", "-func=/tmp/cover.out"],
     });

--- a/vscode-gotest/src/discoverySnapshotStore.test.ts
+++ b/vscode-gotest/src/discoverySnapshotStore.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as nodePath from "node:path";
 
 const {
   mockReadFile,
@@ -33,7 +34,7 @@ const {
       files.delete(from);
     }),
     mockReaddir: vi.fn(async () =>
-      [...files.keys()].map((p) => p.split(/[\\/]/).pop()!),
+      [...files.keys()].map((p) => nodePath.basename(p)),
     ),
     mockStat: vi.fn(async (p: string) => ({
       mtimeMs: mtimes.get(p) ?? Date.now(),

--- a/vscode-gotest/src/discoverySnapshotStore.test.ts
+++ b/vscode-gotest/src/discoverySnapshotStore.test.ts
@@ -33,7 +33,7 @@ const {
       files.delete(from);
     }),
     mockReaddir: vi.fn(async () =>
-      [...files.keys()].map((p) => p.split("/").pop()!),
+      [...files.keys()].map((p) => p.split(/[\\/]/).pop()!),
     ),
     mockStat: vi.fn(async (p: string) => ({
       mtimeMs: mtimes.get(p) ?? Date.now(),
@@ -55,10 +55,13 @@ vi.mock("node:fs/promises", () => ({
   unlink: mockUnlink,
 }));
 
+import * as path from "node:path";
 import { DiscoverySnapshotStore } from "./discoverySnapshotStore.js";
 import type { DiscoverPackage, DiscoverWarning } from "./types.js";
 
-const storage = { fsPath: "/storage" } as import("vscode").Uri;
+const storage = {
+  fsPath: path.join(path.sep, "storage"),
+} as import("vscode").Uri;
 
 function pkg(importPath: string): DiscoverPackage {
   return {

--- a/vscode-gotest/src/jsonStore.test.ts
+++ b/vscode-gotest/src/jsonStore.test.ts
@@ -30,10 +30,11 @@ vi.mock("node:fs/promises", () => ({
   rename: mockRename,
 }));
 
+import * as path from "node:path";
 import { JsonStore } from "./jsonStore.js";
 
-const DIR = "/storage";
-const FILE = "/storage/thing.json";
+const DIR = path.join(path.sep, "storage");
+const FILE = path.join(DIR, "thing.json");
 
 describe("JsonStore", () => {
   beforeEach(() => {
@@ -84,7 +85,12 @@ describe("JsonStore", () => {
     await store.flush();
 
     const [tmpPath] = mockWriteFile.mock.calls[0];
-    expect(tmpPath).toMatch(/^\/storage\/thing\.json\.\d+\.\d+\.tmp$/);
+    // Built from FILE, not a literal: the separator is the platform's.
+    expect(tmpPath).toMatch(
+      new RegExp(
+        `^${FILE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\.\\d+\\.\\d+\\.tmp$`,
+      ),
+    );
     expect(mockRename).toHaveBeenCalledWith(tmpPath, FILE);
     expect(files.has(tmpPath)).toBe(false);
   });

--- a/vscode-gotest/src/managedChild.test.ts
+++ b/vscode-gotest/src/managedChild.test.ts
@@ -89,6 +89,15 @@ describe("ManagedChild", () => {
     expect(mockKill).not.toHaveBeenCalled();
   });
 
+  // Detaching is what makes group signalling possible — and on Windows there is
+  // no group path (killProcessTree falls back to child.kill) and no registry to
+  // reap with, so it would only buy a child that outlives the extension host.
+  it("detaches only where the group can actually be signalled", async () => {
+    script.always = { stdout: [], code: 0 };
+    drain(new ManagedChild("go", ["run", "."]));
+    expect(script.calls?.[0].opts?.detached).toBe(process.platform !== "win32");
+  });
+
   it("resolves immediately when terminating an already-dead child", async () => {
     script.always = { stdout: [], code: 0 };
     const mc = drain(new ManagedChild("go", ["run", "."]));

--- a/vscode-gotest/src/managedChild.ts
+++ b/vscode-gotest/src/managedChild.ts
@@ -76,10 +76,17 @@ export class ManagedChild {
     // `go run <module> ...`: the direct child is `go` and the process holding
     // the pipes is the binary it compiled. Signalling only the child leaves
     // that grandchild alive.
+    //
+    // Not on Windows, where detaching is all cost and no benefit:
+    // killProcessTree has no group path there and falls back to child.kill(),
+    // and the process registry records nothing because identity is unavailable.
+    // What detaching *would* buy is a child that outlives the extension host —
+    // the exact orphan this class exists to prevent, on the one platform with
+    // no reaper to clean it up.
     this.child = spawn(bin, args, {
       cwd: opts.cwd,
       env: opts.env ? { ...process.env, ...opts.env } : undefined,
-      detached: true,
+      detached: process.platform !== "win32",
     });
 
     // Decoded on the stream, not per chunk: a read ends wherever the pipe

--- a/vscode-gotest/src/outputParser.test.ts
+++ b/vscode-gotest/src/outputParser.test.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { describe, it, expect } from "vitest";
 import {
   parseTestEvents,
@@ -56,7 +57,7 @@ describe("extractTestMessages", () => {
 
     expect(messages).toHaveLength(1);
     expect(messages[0]).toEqual({
-      file: "/abs/pkg/foo_test.go",
+      file: path.join("/abs/pkg", "foo_test.go"),
       line: 42,
       message: "expected 1, got 2",
     });
@@ -209,7 +210,7 @@ describe("extractDiagnosticLocation", () => {
   it("prepends pkgDir to relative paths", () => {
     const output = "      foo.go:10 +0x1a4\n";
     const loc = extractDiagnosticLocation(output, "/abs/pkg");
-    expect(loc).toEqual({ file: "/abs/pkg/foo.go", line: 10 });
+    expect(loc).toEqual({ file: path.join("/abs/pkg", "foo.go"), line: 10 });
   });
 
   it("returns undefined when no .go file references", () => {

--- a/vscode-gotest/src/processRegistry.test.ts
+++ b/vscode-gotest/src/processRegistry.test.ts
@@ -54,14 +54,15 @@ vi.mock("./processIdentity.js", () => ({
   readProcessStartToken: mockToken,
 }));
 
+import * as path from "node:path";
 import { ProcessRegistry } from "./processRegistry.js";
 
-const DIR = "/storage";
+const DIR = path.join(path.sep, "storage");
 const GRACE = 360_000;
 
 // Each session owns one file; tests address them by the session id they chose.
 function fileFor(session: string): string {
-  return `${DIR}/child-processes-${session}.json`;
+  return path.join(DIR, `child-processes-${session}.json`);
 }
 
 function storedIn(session: string): { pid: number; kind: string }[] {

--- a/vscode-gotest/src/processRegistry.test.ts
+++ b/vscode-gotest/src/processRegistry.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as nodePath from "node:path";
 
 const {
   mockReadFile,
@@ -32,7 +33,9 @@ const {
     mockIdentify: vi.fn((_pid: number, _token: string) => "same-process"),
     mockToken: vi.fn((_pid: number) => "tok" as string | undefined),
     mockReaddir: vi.fn(async () =>
-      [...files.keys()].map((p) => p.split("/").pop()!),
+      // readdir yields basenames, and only path.basename knows which separator
+      // this platform used to build the key.
+      [...files.keys()].map((p) => nodePath.basename(p)),
     ),
     mockUnlink: vi.fn(async (p: string) => {
       if (!files.delete(p)) throw new Error("ENOENT");
@@ -183,6 +186,12 @@ describe("ProcessRegistry", () => {
     // Two windows on one folder share workspace storage. Neither may touch the
     // other's children, and a shared table could not tell them apart.
     it("leaves a live sibling window's processes strictly alone", async () => {
+      // A dead session is seeded alongside the live one on purpose. Asserting
+      // only that the sibling was spared cannot tell "correctly skipped" from
+      // "read nothing at all" — a Windows run passed this test while load()
+      // was absorbing no files whatsoever. The dead session is the control.
+      await seedDeadSession(2222);
+
       const sibling = new ProcessRegistry(DIR, {
         sessionId: "other",
         hostPid: 700,
@@ -190,17 +199,18 @@ describe("ProcessRegistry", () => {
       sibling.add(3333, "test");
       await sibling.flush();
 
-      aliveExcept([]); // every host is alive, including 700
+      aliveExcept([900]); // the old host is gone; the sibling's host is not
 
       const registry = newRegistry("me");
       await registry.load();
       const kill = vi.fn();
       const { signalled } = registry.reapOrphans({ kill, graceMs: GRACE });
 
-      expect(registry.inheritedSize).toBe(0);
-      expect(signalled).toHaveLength(0);
-      expect(kill).not.toHaveBeenCalled();
-      // And its table is untouched.
+      // The dead session's child is reaped...
+      expect(signalled.map((r) => r.pid)).toEqual([2222]);
+      expect(kill).toHaveBeenCalledWith(-2222, "SIGTERM");
+      // ...and the live sibling's is not, nor is its table touched.
+      expect(kill).not.toHaveBeenCalledWith(-3333, "SIGTERM");
       expect(storedIn("other").map((r) => r.pid)).toEqual([3333]);
     });
 

--- a/vscode-gotest/src/scriptedSpawn.test-support.ts
+++ b/vscode-gotest/src/scriptedSpawn.test-support.ts
@@ -28,8 +28,13 @@ export interface SpawnScript {
   // front of a standing failure.
   once: ScriptedRun[];
   always?: ScriptedRun;
-  // What was spawned, in order, for tests that care about the command itself.
-  calls?: Array<{ bin: string; args: string[] }>;
+  // What was spawned, in order, for tests that care about the command itself
+  // or the options it was given.
+  calls?: Array<{
+    bin: string;
+    args: string[];
+    opts?: Record<string, unknown>;
+  }>;
 }
 
 export interface FakeChild extends EventEmitter {
@@ -43,9 +48,9 @@ export interface FakeChild extends EventEmitter {
 export function createScriptedSpawn(
   script: SpawnScript,
   onKill: (signal?: NodeJS.Signals) => void = () => {},
-): (bin: string, args: string[]) => FakeChild {
-  return (bin: string, args: string[]) => {
-    script.calls?.push({ bin, args });
+): (bin: string, args: string[], opts?: Record<string, unknown>) => FakeChild {
+  return (bin: string, args: string[], opts?: Record<string, unknown>) => {
+    script.calls?.push({ bin, args, opts });
     const run = script.once.shift() ?? script.always ?? { stdout: [] };
     const child = new EventEmitter() as FakeChild;
     child.stdout = new PassThrough();

--- a/vscode-gotest/test/integration/specSync.test.ts
+++ b/vscode-gotest/test/integration/specSync.test.ts
@@ -206,7 +206,10 @@ describe("CLI resolution is the mode the test intends", () => {
     await panel.show();
     await panel.refresh(stream("mixed"), "run");
 
-    expect(debug.some((m) => m.includes("go run"))).toBe(true);
+    // Every go-run branch logs "<goBin> run <target>", and goBin carries the
+    // executable's own name — `go` on POSIX, `go.exe` on Windows. Match the
+    // invocation, not the filename.
+    expect(debug.some((m) => / run /.test(m))).toBe(true);
     expect(debug.some((m) => m.includes("cliPath override"))).toBe(false);
   });
 


### PR DESCRIPTION
Follow-up to #123

### What changed

- The extension's checks now run on Windows as well as Linux. Formatting is
  still checked once on Linux only, since a Windows checkout uses different
  line endings and the result would not be meaningful.
- A new job runs the integration suite on Windows — the only place the
  extension starts the real CLI on that platform.
- Child processes are no longer detached on Windows. Detaching there had no
  effect on how processes are stopped, and only made them able to outlive the
  editor.