### PR TITLE
Docs correctness sweep

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -425,6 +425,27 @@ The system has **four levels of parallelism**, each with distinct mechanisms:
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
+### Dispatch Phases and Sanitizer Awareness
+
+Level 3 dispatch runs in **two phases**. The parallel bulk dispatches every
+non-exclusive suite through the semaphore. Suites with
+`SuiteConfig{Exclusive: true}` are held back and run strictly after the bulk
+drains — one at a time, in deterministic order — because their verdicts
+measure wall-clock behavior (timing budgets, contended resources) that
+concurrently running suites would corrupt. At the bulk→tail barrier the
+runner re-windows shared fixtures for the exclusive tail: fixtures only the
+tail needs are started there (`StartKeys`), fixtures nothing in the tail
+needs are torn down (`TeardownKeys`).
+
+The Level 1 and Level 3 semaphore defaults (`NumCPU`, `2×GOMAXPROCS`) apply
+to uninstrumented builds; under `-race`/`-msan`/`-asan` both halve, since
+instrumentation at least doubles the CPU cost per instruction stream. An
+explicit `--compile-parallel`/`--parallel` always wins. Two aids keep
+wall-clock verdicts diagnosable: builds running past 15s log a slow-build
+notice (a log line, never a verdict), and scheduling context (`schedinfo`)
+is appended to fixture-setup deadline failures — a starved build looks
+exactly like a broken one.
+
 ### Streaming Execution (Compile-Execute Overlap)
 
 `RunPipeline` with `Streaming: true` is the primary execution path. It overlaps
@@ -456,12 +477,13 @@ and dispatches suites as soon as their specific dependencies are all ready:
 ```
 Suite goroutine:
   │
-  ├─ needsFixture? ──yes──▶ waitForFixtureKeys(suite.SharedFixtureKeys)
+  ├─ needsFixture? ──yes──▶ wait on SharedFixtureProcess.Ready(key)
+  │                          for each declared key
   │                              │
   │                              ├─ Blocks until all keys in the suite's
   │                              │   dependency set have emitted state
-  │                              ├─ Writes per-suite state file (only
-  │                              │   the entries this suite needs)
+  │                              ├─ WriteStateFileForKeys writes a per-suite
+  │                              │   state file (only the entries it needs)
   │                              ├─ Returns env with GOTEST_SHARED_STATE_FILE
   │                              └─ Error? → streamCancel(), return
   │
@@ -472,6 +494,13 @@ Suites that only need `PostgresSharedFixture` start as soon as Postgres
 is ready — they don't wait for `SchemaSharedFixture` or other unrelated
 fixtures. This reduces wall-clock time when fixtures have different
 startup durations.
+
+Fixture *lifetimes* are window-scheduled: `planFixtureWindows` computes,
+from the actual runnable suites, when each shared fixture is first needed
+and when its last consumer finishes. The setup subprocess starts and tears
+fixtures down on command (`StartKeys`/`TeardownKeys` verbs over its stdin),
+so a fixture is resident only while a scheduled suite that declared it can
+still run — never speculatively.
 
 ---
 
@@ -584,7 +613,7 @@ to the entire group, not just the leader process.
 ```
 ┌─ RunBatchText (default) ────────────────────────────────────────────┐
 │                                                                      │
-│  PackageBatcher collects results per package.                        │
+│  OutputCollector collects results per package.                       │
 │  When ALL suites for a package complete → flush in deterministic     │
 │  order (by registration index, not completion time).                 │
 │                                                                      │
@@ -610,7 +639,7 @@ to the entire group, not just the leader process.
 ## 7. Suite Target Construction
 
 ```
-BuildSuiteTargets(compiled, suitesByPkg, dirsByPkg, runFlags, userRunFilter)
+BuildSuiteTargets(compiled, suitesByPkg, dirsByPkg, exclusiveByPkg, runFlags, userRunFilter)
   │
   for each package:
     for each suite struct name (e.g., "FooTestSuite"):
@@ -657,26 +686,26 @@ t=0s    CLI starts
         │
 t=0.5s  RunPipeline begins (Streaming: true)
         ├─ Start goroutine: CompilePackagesStream → compileCh
-        ├─ Start goroutine: startSharedFixtures (if any)
+        ├─ Start goroutine: StartSharedFixtures (if any)
         │
 t=1s    pkg/auth compiles first → CompileResult on compileCh
         ├─ BuildSuiteTargets → [AuthTestSuite, TokenTestSuite]
-        ├─ AuthTestSuite needs shared fixtures → blocks on resolveFixtureEnv()
+        ├─ AuthTestSuite needs shared fixtures → blocks on Ready(key)
         └─ TokenTestSuite doesn't → acquires sem slot, starts subprocess
            └─ ./auth_hash.test -test.run=^TestTokenTestSuite$ -test.v=test2json
         │
 t=2s    pkg/cart compiles → 2 more suites start
         │
 t=3s    Shared fixture setup completes → JSON state written
-        ├─ resolveFixtureEnv() unblocks
+        ├─ Ready(key) unblocks; WriteStateFileForKeys → per-suite state file
         └─ AuthTestSuite now starts (had been waiting)
         │
 t=4s    TokenTestSuite finishes (exit 0)
-        ├─ batcher.Record("pkg/auth", 1, result) → not all done yet
+        ├─ collector.RecordResult("pkg/auth", 1, result) → not all done yet
         │
 t=5s    AuthTestSuite finishes (exit 0)
-        ├─ batcher.Record("pkg/auth", 0, result) → all done!
-        └─ batcher.Flush("pkg/auth") → print both suites, package summary
+        ├─ collector.RecordResult("pkg/auth", 0, result) → all done!
+        └─ collector flushes pkg/auth → print both suites, package summary
         │
 t=8s    All suites done, wg.Wait() returns
         ├─ setupProc.Teardown()

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ func (s *UserServiceTestSuite) TestCreate(t *gotest.T) {
         gotest.NoError(it, err)
     })
 
-    t.When("email already exists", func(w *gotest.T) {
+    t.When("when email already exists", func(w *gotest.T) {
         w.It("returns ErrDuplicate", func(it *gotest.T) {
             err := s.svc.Create("alice@example.com")
             gotest.NoError(it, err)
@@ -72,8 +72,8 @@ Standard `go test` output:
 === RUN   TestUserServiceTestSuite
 === RUN   TestUserServiceTestSuite/TestCreate
 === RUN   TestUserServiceTestSuite/TestCreate/creates_a_user_with_valid_input
-=== RUN   TestUserServiceTestSuite/TestCreate/email_already_exists
-=== RUN   TestUserServiceTestSuite/TestCreate/email_already_exists/returns_ErrDuplicate
+=== RUN   TestUserServiceTestSuite/TestCreate/when_email_already_exists
+=== RUN   TestUserServiceTestSuite/TestCreate/when_email_already_exists/returns_ErrDuplicate
 --- PASS: TestUserServiceTestSuite (0.01s)
 ```
 
@@ -138,7 +138,7 @@ Tests are structured as behavioral specifications using BDD vocabulary.
 
 ```go
 func (s *Suite) TestCreate(t *gotest.T) {
-    t.When("input is valid", func(w *gotest.T) {
+    t.When("when input is valid", func(w *gotest.T) {
         w.It("creates the record", func(it *gotest.T) {
             // ...
         })
@@ -170,7 +170,7 @@ UserService (133ms)
     ✓ soft-deletes the user (5ms)
     ~ hard-deletes after 30 days — SKIPPED (<1ms)
 
-2 suites, 5 behaviors: 4 passed, 1 skipped
+1 suites, 5 behaviors: 4 passed, 1 skipped
 ```
 
 Every row shows the wall clock it occupied, never the sum of the rows beneath it — so a row that exceeds its children is time it held itself, and one that falls short of their total is children that overlapped.
@@ -439,6 +439,7 @@ gotest ./... -parallel 8            # explicit per-suite, no budget management
 | `--parallel N -parallel M` | `min(S, GOMAXPROCS, N/M)` | `M` | `~N` |
 
 Where *S* is the number of suites and *inter* is the computed process count.
+Under `-race`/`-msan`/`-asan` the default budget halves (as does compile concurrency) — instrumentation at least doubles the CPU cost per instruction stream, and keeping the uninstrumented defaults would oversubscribe the machine. An explicit `--parallel`/`--compile-parallel` always wins over this heuristic.
 
 ## Testing Toolkit
 
@@ -458,6 +459,8 @@ gotest.False(t, condition)
 // Zero / nil
 gotest.Zero(t, value)                        // [V comparable] — value == zero value for type
 gotest.NotZero(t, value)                     // [V comparable] — also covers pointer/interface nil
+gotest.Nil(t, object)                        // non-comparable nilables (slices, maps, funcs); type-guarded
+gotest.NotNil(t, object)
 
 // Errors
 gotest.NoError(t, err)
@@ -503,6 +506,9 @@ gotest.Fail(t, "unreachable")                // immediate unconditional failure
 // Async polling
 gotest.Eventually(t, 5*time.Second, 100*time.Millisecond, func(poll *gotest.R) { ... })
 gotest.Consistently(t, 500*time.Millisecond, 50*time.Millisecond, func(poll *gotest.R) { ... })
+
+// Panic-safe goroutines
+wait := gotest.Go(t, func() { ... })         // captures a goroutine panic and re-raises it on the test's goroutine
 ```
 
 Unwrap `(T, error)` or `(T, bool)` pairs in test setup:
@@ -610,6 +616,10 @@ func (s *BatchTestSuite) SuiteConfig() gotest.SuiteConfig {
 
 The returned config is used as-is — a zero (or omitted) duration means no timeout, and without a `SuiteConfig()`/`FixtureConfig()` method the defaults apply.
 Start from a preset to combine defaults with overrides (`cfg := gotest.DefaultSuiteConfig(); cfg.Parallel = true; return cfg`).
+
+`Exclusive: true` schedules the suite's process strictly alone: after every non-exclusive suite has finished, one exclusive suite at a time, in deterministic order.
+Use it for suites whose verdicts depend on wall-clock behavior or contended resources (timing budgets, containers, ports, heavy child builds) — a budget verdict taken on a saturated machine is not a verdict you can act on.
+Like `Parallel`, it is resolved statically by the generator and affects scheduling only.
 
 Preset constructors for common scenarios:
 
@@ -727,9 +737,9 @@ Catch common mistakes in test suites with static analysis:
 gotest lint ./...
 ```
 
-Sixteen rules in three tiers:
+Seventeen rules in three tiers:
 
-- **Integrity** — violations can make test outcomes unreliable or leak resources: committed `F_` prefixes, value receivers on suite methods, lifecycle hook typos, `BeforeAll` without `AfterAll`, `X_` prefixes on lifecycle hooks, wrong test signatures, suite-lifecycle bypasses via `t.T()` (`Cleanup`/`Parallel`/`Run`), outer `t` inside `Eventually`/`Consistently` callbacks, `Nil`/`Empty` assertions on types their runtime guards reject, and generated files checked into version control.
+- **Integrity** — violations can make test outcomes unreliable or leak resources: committed `F_` prefixes, value receivers on suite methods, lifecycle hook typos, `BeforeAll` without `AfterAll`, `X_` prefixes on lifecycle hooks, wrong test signatures, suite-lifecycle bypasses via `t.T()` (`Cleanup`/`Parallel`/`Run`), outer `t` inside `Eventually`/`Consistently` callbacks, `Nil`/`Empty` assertions on types their runtime guards reject, reads of shared fixtures a suite never declared (window scheduling only starts what is declared), and generated files checked into version control.
 - **Expressiveness** — the test is correct but its syntax can be improved: simplifiable assertions (`True(t, a == b)` → `Equal`, `Len(t, x, 0)` → `Empty`, …), redundant assertions, `if cond { Fail(...) }` guards that an assertion expresses directly, and unnecessary `t.T()` escapes. `-fix` applies the safe rewrites.
 - **Migration** — adoption aids for codebases moving to gotest: stdlib test functions and testify imports; coexistence is legitimate.
 

--- a/docs/design/fixtures.md
+++ b/docs/design/fixtures.md
@@ -392,7 +392,7 @@ The default `gotest` run streams: each shared fixture's state is emitted as its 
 ### Failure semantics
 
 - A panic inside a fixture *setup* hook is recovered and converted to an error — it fails setup, it does not crash the process.
-  Teardown-side panics (`AfterAll`/`Dehydrate`) are not recovered and crash the test process.
+  Teardown-side panics are contained the same way: a panicking `AfterAll` is recovered and reported as `<fixture>.AfterAll panicked`, a panicking `Dehydrate` as `dehydrate panicked` — both become teardown failures, and teardown of the remaining fixtures continues.
 - Shared-fixture setup failure aborts the run: exit code 2 in batch modes (`watch`/`spec`/`summary`/`prepare`); in the default streaming run the affected suites are reported as failures (exit 1).
   In-test-process package-fixture setup failure is a `t.Fatalf` (exit 1).
 - Fixture teardown failure flips an otherwise passing run to a failure (`fixture teardown failed`).

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -93,10 +93,10 @@ This is deliberate: `go test` stays fully usable with its caching and ecosystem,
 A complete run is both commands; the canonical CI shape is two steps — `go test ./...` followed by `gotest`.
 
 `gotest` reports the half it does not run:
-packages with stdlib tests but no suites print `?   <pkg>  [no suites]` (never the false `[no test files]`), and a run that skipped stdlib tests ends with a note on stderr:
+packages with stdlib tests but no suites print `?   <pkg>  [no suites]` (never the false `[no test files]`), and a run that skipped stdlib tests ends with a note on stderr naming the affected packages (sorted, truncated after three with `… N more`):
 
 ```
-note: 8 stdlib test(s) in 1 package(s) not run — gotest runs suites; use 'go test' for stdlib tests
+note: 8 stdlib test(s) in pkg/legacy, pkg/util not run — gotest runs suites; use 'go test' for stdlib tests
 ```
 
 ---
@@ -175,7 +175,7 @@ gotest ./... --debug                     # keep generated files for inspection
 Registered `go test` flags pass through to the underlying run; unknown single-dash flags are rejected rather than forwarded (guard against typos) — use a bare `--` or `-args` to forward unvalidated flags verbatim.
 `-json` is intercepted and re-emitted by the runner, and `-ldflags=-checklinkname=0` is injected into every `go test` invocation (required for the assertion tracer on Go 1.23+).
 Each subcommand accepts its own subset of the `--gotest` flags; out-of-scope flags error with "not valid for this subcommand".
-`--github` is `summary`-only; `--no-color` applies to `spec`/`summary`.
+`--github` applies to `summary` and `lint`; `--no-color` applies to `spec`/`summary`.
 
 ---
 
@@ -1173,7 +1173,7 @@ No tests are executed.
 
 ```
 { "packages": [ {
-    "importPath": …, "dir": …, "modulePath": …, "testOnly": bool,
+    "importPath": …, "dir": …, "modulePath": …, "testOnly": bool, "broken": bool,
     "suites": [ {
       "name": …, "file": …, "line": …, "col": …,
       "parallel": bool, "focused": bool, "excluded": bool, "guarded": bool,
@@ -1394,7 +1394,7 @@ Manual setup works without the action:
 - run: gotest spec ./... --format=md --output=behavior-spec.md
 ```
 
-Exit codes: 0 = pass, 1 = test failure, 2 = usage, generation, or build error (stricter than `go test`, which exits 1 on build errors).
+Exit codes: 0 = pass, 1 = test failure, 2 = usage, generation, or build error (stricter than `go test`, which exits 1 on build errors), 130 = run interrupted (SIGINT/SIGTERM).
 
 The exit code of `spec --input` and `summary --input` answers two questions at once: whether the stream carried failures (1) and whether the command itself failed (2). A client that renders a stream rather than gating on it needs only the second, and passes `--render-only` to drop the first; 2 is never suppressed, so an unreadable input or an unparseable stream still fails. Consumers that treat any non-zero exit as "the command broke" — rather than reading the rendered document on stdout — will misread a failing test run as a broken tool.
 

--- a/site/content/blog/advanced-fixture-patterns.md
+++ b/site/content/blog/advanced-fixture-patterns.md
@@ -43,7 +43,7 @@ CacheFixture ─────┘        │
                       └── WorkerTestSuite
 ```
 
-Multiple suites can reference the same fixture. It is initialized once per package, shared across suites. `APITestSuite` and `WorkerTestSuite` both get the same `ServiceFixture` instance, which in turn shares the same `DatabaseFixture` and `CacheFixture`. No duplication, no coordination code.
+Multiple suites can reference the same fixture graph. Each suite runs in its own test process, so each suite constructs its own instances and pays its own `BeforeAll` — `APITestSuite` and `WorkerTestSuite` each get a `ServiceFixture` wired to its own `DatabaseFixture` and `CacheFixture`. The wiring is declared once and there is no coordination code; when the setup cost must be paid once for the whole run, promote the fixture to a `SharedFixture`.
 
 ## Embedding vs. referencing
 
@@ -149,23 +149,26 @@ func (f *PostgresFixture) AfterAll(ctx context.Context) error {
 
 ## Per-test isolation with BeforeEach/AfterEach
 
-Fixture-level `BeforeEach`/`AfterEach` wraps the suite's own hooks. This is perfect for transaction-per-test isolation:
+Fixture-level `BeforeEach`/`AfterEach` wraps the suite's own hooks. This is perfect for transaction-per-test isolation. Give the fixture a `Tx pgx.Tx` field and manage it per test:
 
 ```go {title="postgres_fixture_test.go"}
 func (f *PostgresFixture) BeforeEach(ctx context.Context) error {
-    _, err := f.Pool.Exec(ctx, "BEGIN")
-    return err
+    tx, err := f.Pool.Begin(ctx)
+    if err != nil {
+        return err
+    }
+    f.Tx = tx
+    return nil
 }
 
 func (f *PostgresFixture) AfterEach(ctx context.Context) error {
-    _, err := f.Pool.Exec(ctx, "ROLLBACK")
-    return err
+    return f.Tx.Rollback(ctx)
 }
 ```
 
-Every test in every suite that uses this fixture automatically runs in a transaction that rolls back after the test. The suite does not need to know. Isolation is a fixture concern, not a test concern.
+Note that the transaction has to be held as a `pgx.Tx`, not issued as a bare `BEGIN` through the pool — each `Pool.Exec` call can land on a different pooled connection, so a `BEGIN` on one would not enclose the statements that follow. Tests and suite hooks run their queries through `f.Tx`, and every statement lands inside a transaction that rolls back after the test. The suite does not need to manage any of it. Isolation is a fixture concern, not a test concern.
 
-This pattern separates two lifecycle scopes cleanly. The container lifecycle (`BeforeAll`/`AfterAll`) runs once per package. The transaction lifecycle (`BeforeEach`/`AfterEach`) runs once per test. A suite that references `PostgresFixture` gets both: the container is already running when the suite starts, and each test gets a fresh transaction.
+This pattern separates two lifecycle scopes cleanly. The container lifecycle (`BeforeAll`/`AfterAll`) runs once per suite process — two suites referencing the fixture start two containers; use a `SharedFixture` to pay for one. The transaction lifecycle (`BeforeEach`/`AfterEach`) runs once per test. A suite that references `PostgresFixture` gets both: the container is already running when the suite starts, and each test gets a fresh transaction.
 
 ## Custom configuration and presets
 
@@ -224,7 +227,7 @@ func (f *InMemoryStoreFixture) Get(key string) (any, bool) {
 
 Tests interact with the fixture through its methods, never touching internal state directly. The fixture owns its synchronization. A `RWMutex` allows concurrent reads while serializing writes, which is the common pattern for test state that is read-heavy.
 
-This matters when a suite declares `SuiteConfig{Parallel: true}`. The suite's tests run concurrently, and any shared fixture must handle that. The fixture's API boundary is where thread safety lives.
+This matters when a suite declares `SuiteConfig{Parallel: true}`. The suite's tests run concurrently, and any shared fixture must handle that. (Parallel suites also require a *returning* `BeforeEach` — per-test state lives in the returned context struct, not on the shared suite struct.) The fixture's API boundary is where thread safety lives.
 
 ## Binding shared fixtures to local resources
 
@@ -238,7 +241,8 @@ type InfraFixture struct {
 
 func (f *InfraFixture) BeforeAll(ctx context.Context) error {
     // Alpha is already hydrated with cross-package state
-    conn, err := grpc.Dial(f.Alpha.ServiceAddr)
+    conn, err := grpc.NewClient(f.Alpha.ServiceAddr,
+        grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         return err
     }

--- a/site/content/blog/code-generation-not-reflection.md
+++ b/site/content/blog/code-generation-not-reflection.md
@@ -47,7 +47,7 @@ AST discovery → code generation → overlay injection
 
 ### Stage 1: AST discovery
 
-gotest uses Go's `go/parser` and `go/ast` packages to walk your source files. It looks for naming conventions:
+gotest loads your packages with `golang.org/x/tools/go/packages` and walks the syntax trees using Go's `go/ast` and `go/types` packages. It looks for naming conventions:
 
 - **Structs ending in `TestSuite`**: recognized as test suites
 - **Methods starting with `Test`** on suite types: recognized as test cases
@@ -81,13 +81,15 @@ func TestUserServiceTestSuite(t *testing.T) {
     s := &UserServiceTestSuite{}
 
     t.Run("TestCreate", func(t *testing.T) {
-        s.BeforeEach(gotest.NewT(t))
-        s.TestCreate(gotest.NewT(t))
+        it := gotest.NewT(t)
+        s.BeforeEach(it)
+        s.TestCreate(it)
     })
 
     t.Run("TestDelete", func(t *testing.T) {
-        s.BeforeEach(gotest.NewT(t))
-        s.TestDelete(gotest.NewT(t))
+        it := gotest.NewT(t)
+        s.BeforeEach(it)
+        s.TestDelete(it)
     })
 }
 ```
@@ -100,20 +102,20 @@ For suites with fixtures, the generated code also includes fixture initializatio
 
 Here's the part that makes code generation practical: the generated files never touch your source tree.
 
-Go 1.16 introduced the `-overlay` flag for the `go` toolchain. It takes a JSON file that maps virtual file paths to actual file paths on disk. When the compiler encounters a file reference, it checks the overlay map first. This means a file can appear to exist at `pkg/user/gotest_psuite_test.go` while actually living in a temp directory.
+Go 1.16 introduced the `-overlay` flag for the `go` toolchain. It takes a JSON file that maps virtual file paths to actual file paths on disk. When the compiler encounters a file reference, it checks the overlay map first. This means a file can appear to exist at `pkg/user/gotest_psuite_test.go` while actually living in gotest's cache directory.
 
-```go {title="overlay.json"}
+```json {title="overlay.json"}
 {
   "Replace": {
-    "pkg/user/gotest_psuite_test.go": "/tmp/gotest-overlay/0/gotest_psuite_test.go",
-    "pkg/order/gotest_psuite_test.go": "/tmp/gotest-overlay/1/gotest_psuite_test.go"
+    "/home/you/project/pkg/user/gotest_psuite_test.go": "/home/you/.cache/gotest/overlays/3f2a…/0/gotest_psuite_test.go",
+    "/home/you/project/pkg/order/gotest_psuite_test.go": "/home/you/.cache/gotest/overlays/3f2a…/1/gotest_psuite_test.go"
   }
 }
 ```
 
-gotest writes the generated files to a content-addressable cache directory, creates the overlay JSON, and passes it to `go test -overlay=overlay.json`. After the run, nothing is left behind. Your source directory stays clean, your git status stays unchanged, and pull requests don't include generated code.
+gotest writes the generated files to a content-addressable cache directory, creates the overlay JSON, and passes it to `go test -overlay=...`. Nothing is ever written into your project. Your source directory stays clean, your git status stays unchanged, and pull requests don't include generated code.
 
-The cache uses SHA-256 hashing of the generated content. If you run tests twice without changing any suite code, the second run reuses the cached overlay; no regeneration needed.
+The cache is keyed by a SHA-256 hash of the generated content. If you run tests twice without changing any suite code, the second run hashes to the same entry and reuses the existing overlay files — and because the overlay path stays stable, Go's own build cache can reuse the compiled test packages.
 
 ## What code generation gains over reflection
 
@@ -123,8 +125,8 @@ The code generation approach has several concrete advantages over reflection:
 
 If your `BeforeEach` method takes `(ctx context.Context)` instead of `(t *gotest.T)`, gotest tells you at generation time:
 
-```go
-user_test.go:12: BeforeEach: expected signature func(t *gotest.T), got func(ctx context.Context)
+```text
+user_test.go:12: unsupported param type for signature of "UserServiceTestSuite.BeforeEach": must be *gotest.T or *testing.T
 ```
 
 With reflection, this would either panic at runtime or, worse, silently skip the hook because the framework doesn't recognize the method signature.
@@ -149,7 +151,7 @@ func TestUserSuite(t *testing.T) {
 
 ### Zero runtime overhead
 
-The generated code compiles to direct function calls. No `reflect.ValueOf`, no `reflect.Method`, no interface dispatch. At test execution time, there's no framework code in the call stack: just your suite methods being called directly.
+The generated code compiles to direct function calls. No `reflect.ValueOf`, no `reflect.Method`. At test execution time, your suite methods are called directly — there is no reflective dispatch between the test runner and your code.
 
 ## The pipeline in practice
 
@@ -163,7 +165,7 @@ When you run `gotest ./...`, the full pipeline executes automatically:
 1. **Overlay**: create the overlay JSON mapping
 1. **Compile & run**: invoke `go test -overlay=...`
 
-Steps 1--6 are fast; they operate on parse trees, not compiled code. And with caching, steps 4--6 are skipped entirely on repeat runs if the source hasn't changed.
+Steps 1--6 are fast; they operate on parse trees, not compiled code. And caching keeps repeat runs cheap: unchanged sources hash to the same overlay entry, so nothing is rewritten and the compile step hits Go's build cache.
 
 For large projects, gotest also uses streaming compilation: test packages start running as soon as they're compiled, without waiting for all packages to finish compiling. This overlaps compilation time with execution time, reducing wall-clock duration for multi-package test runs — the place this matters most is CI, as covered in [Go Tests in GitHub Actions]({{< ref "/blog/gotest-in-ci" >}}).
 
@@ -186,10 +188,10 @@ The generated files are standard Go test files. They import your package, refere
 
 ## The trade-off
 
-Code generation isn't free. It adds a build step: the AST discovery and generation that runs before `go test`. If you run `go test` directly without `gotest`, you'll get a compilation error because the generated bridge file doesn't exist.
+Code generation isn't free. It adds a build step: the AST discovery and generation that runs before `go test`. And plain `go test` has no idea your suites exist — without the generated bridge, the package compiles cleanly and simply reports no tests. Your suites are structs with methods; nothing runs them until the bridge does.
 
-This is a deliberate design choice. A missing generated file produces a clear compiler error that tells you what to do. The alternative, silently doing nothing when the bridge is absent, would be worse.
+If part of your workflow has to invoke `go test` directly, run `gotest generate ./...` first to materialize the bridge files on disk, and `gotest clean` to remove them afterwards.
 
-Day to day, the build step mostly disappears: the overlay cache means repeat runs skip generation entirely, so the edit-test loop stays as fast as plain `go test`. [Go Test Watch Mode and Focused Tests]({{< ref "/blog/the-inner-loop" >}}) covers what that loop looks like in practice.
+Day to day, the build step mostly disappears: generation operates on parse trees, and the overlay cache keeps the compile step warm, so the edit-test loop stays close to plain `go test`. [Go Test Watch Mode and Focused Tests]({{< ref "/blog/the-inner-loop" >}}) covers what that loop looks like in practice.
 
 The code generation approach aligns with Go's broader philosophy: explicit over implicit, compile-time over runtime, readable code over framework magic. The generated code is what a careful developer would write by hand. gotest just writes it for you.

--- a/site/content/blog/contract-testing-generics.md
+++ b/site/content/blog/contract-testing-generics.md
@@ -146,27 +146,27 @@ type SQLStorageTestSuite = StorageContractTestSuite[*SQLStorage]
 Each alias is a full, independent test suite. The code generator picks up each alias and generates the test wiring for it. The spec output shows each implementation separately:
 
 {{< spec title="gotest spec ./..." >}}
-MemoryStorage (StorageContract)
-  Put
-    when key is new
-      <span class="t-pass">✓</span> stores the value without error
-      <span class="t-pass">✓</span> makes the value retrievable
-    when key already exists
-      <span class="t-pass">✓</span> overwrites the value
-  Get
-    when key does not exist
-      <span class="t-pass">✓</span> returns ErrNotFound
-  Delete
-    when key exists
-      <span class="t-pass">✓</span> removes the value
-    when key does not exist
-      <span class="t-pass">✓</span> returns no error
+MemoryStorage <span class="t-time">(2ms)</span>
+  Put <span class="t-time">(1ms)</span>
+    key is new <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> stores the value without error <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> makes the value retrievable <span class="t-time">(<1ms)</span>
+    key already exists <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> overwrites the value <span class="t-time">(<1ms)</span>
+  Get <span class="t-time">(<1ms)</span>
+    key does not exist <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> returns ErrNotFound <span class="t-time">(<1ms)</span>
+  Delete <span class="t-time">(<1ms)</span>
+    key exists <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> removes the value <span class="t-time">(<1ms)</span>
+    key does not exist <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> returns no error <span class="t-time">(<1ms)</span>
 
-RedisStorage (StorageContract)
-  Put
-    when key is new
-      <span class="t-pass">✓</span> stores the value without error
-      <span class="t-pass">✓</span> makes the value retrievable
+RedisStorage <span class="t-time">(48ms)</span>
+  Put <span class="t-time">(23ms)</span>
+    key is new <span class="t-time">(14ms)</span>
+      <span class="t-pass">✓</span> stores the value without error <span class="t-time">(8ms)</span>
+      <span class="t-pass">✓</span> makes the value retrievable <span class="t-time">(6ms)</span>
     ...
 {{< /spec >}}
 
@@ -174,24 +174,24 @@ Same contract, same behaviors, different implementations. If Redis handles delet
 
 ## Providing implementation-specific setup
 
-The `factory` field in the generic suite is set during suite initialization. Each alias can provide its own factory through `BeforeAll` or the suite's struct fields.
+A type alias cannot add methods or fields of its own, so per-implementation setup lives on the generic suite itself. The straightforward way is a `BeforeAll` that picks the right constructor for the instantiated type:
 
-For simple cases (in-memory), the factory is trivial. For infrastructure-backed implementations, use [fixtures]({{< ref "/blog/test-fixtures-in-go" >}}):
-
-```go {title="redis_setup_test.go"}
-type RedisStorageTestSuite = StorageContractTestSuite[*RedisStorage]
-
-// The RedisStorageTestSuite uses a RedisFixture for connection management
-type redisSetup struct {
-    Redis *RedisFixture
+```go {title="storage_contract_test.go"}
+func (s *StorageContractTestSuite[T]) BeforeAll(t *gotest.T) {
+    switch any(s.store).(type) {
+    case *MemoryStorage:
+        s.factory = func() T { return any(NewMemoryStorage()).(T) }
+    case *RedisStorage:
+        s.factory = func() T { return any(NewRedisStorage(testRedisAddr)).(T) }
+    }
 }
 ```
 
-Or initialize the factory directly in a test helper. The point is that the contract tests are the same; only the setup differs. When multiple contract suites share the same backing infrastructure, [Advanced Go Test Fixtures]({{< ref "/blog/advanced-fixture-patterns" >}}) covers patterns for composing and reusing that setup across suites.
+Alternatively, skip the factory entirely and construct instances with a generic function inside the tests, the way the search index example below does. For infrastructure-backed implementations, keep connection management in [fixtures]({{< ref "/blog/test-fixtures-in-go" >}}) and let the factory close over them. The point is that the contract tests are the same; only the setup differs. When multiple contract suites share the same backing infrastructure, [Advanced Go Test Fixtures]({{< ref "/blog/advanced-fixture-patterns" >}}) covers patterns for composing and reusing that setup across suites.
 
 ## A real example: search index contract
 
-The gotest codebase itself uses this pattern. The search index is generic over any type that satisfies the `Indexable` constraint:
+The gotest repository's search example uses this pattern. The search index is generic over any type that satisfies the `Indexable` constraint:
 
 ```go {title="index_contract_test.go"}
 type Indexable interface {
@@ -226,7 +226,7 @@ type ArticleIndexTestSuite = IndexContractTestSuite[Article]
 type ProductIndexTestSuite = IndexContractTestSuite[Product]
 ```
 
-Two types, same contract, full parallel execution. The `SuiteConfig` method enables method-level parallelism, so all behaviors within a single suite run concurrently. Because each type alias produces an independent suite, the cross-suite parallelism is automatic.
+Two types, same contract, full parallel execution. The `SuiteConfig` method enables method-level parallelism, so the test methods within a single suite run concurrently. Because each type alias produces an independent suite, the cross-suite parallelism is automatic.
 
 ## Constraints and trade-offs
 
@@ -234,7 +234,7 @@ Generic suites are not universally applicable. The pattern has real constraints 
 
 ### Same-package only
 
-Generic aliases must be in the same package as the generic suite. This is a Go compiler constraint: type aliases with type parameters cannot cross package boundaries the same way non-generic aliases can. In gotest terms, this means the contract suite and its aliases live in the `ptest` (white-box) package, not `pxtest` (black-box). If the contract suite and the implementations are in different packages, the aliases must live alongside the generic suite definition.
+Generic aliases must live in the same package as the generic suite. Go only allows methods to be declared in the package that defines the type, and the generator discovers a suite's methods in the package where its aliases are declared — so the contract methods and the aliases that instantiate them have to travel together. gotest additionally requires generic aliases to live in the internal (white-box) test package: declaring one in an external `_test` package fails at generation time with *"generic alias suite … must not be in an external test package (pxtest); move it to the internal test file."* If the contract suite and the implementations are in different packages, the aliases must live alongside the generic suite definition.
 
 ### Factory pattern
 
@@ -251,10 +251,10 @@ This is a feature, not a limitation. It forces a clear distinction between "what
 gotest can generate a contract suite from an interface:
 
 ```sh
-gotest scaffold io.ReadCloser
+gotest scaffold ./pkg/storage.Storage
 ```
 
-This generates a generic suite with test method stubs for each method on the interface. You fill in the behavioral assertions; it handles the boilerplate. The generated suite follows the same naming conventions as any other gotest suite, so the code generator picks it up without additional configuration.
+When the target type is an interface, this generates a generic contract suite — a `StorageContractTestSuite[T Storage]` with a `factory` field, a `BeforeEach`, and test method stubs for each method on the interface. You fill in the behavioral assertions and add a type alias per implementation; the generated file ends with a comment showing exactly that. The suite follows the same naming conventions as any other gotest suite, so the code generator picks up the aliases without additional configuration.
 
 ## When to use contract testing
 

--- a/site/content/blog/go-test-lifecycle.md
+++ b/site/content/blog/go-test-lifecycle.md
@@ -132,8 +132,8 @@ There is an important signature difference. Fixture hooks use `(ctx context.Cont
 
 ```go {title="fixtures.go"}
 type DatabaseFixture struct {
-    DB    *sql.DB
-    store map[string]any
+    DB *sql.DB
+    Tx *sql.Tx
 }
 
 func (f *DatabaseFixture) BeforeAll(ctx context.Context) error {
@@ -150,17 +150,17 @@ func (f *DatabaseFixture) AfterAll(ctx context.Context) error {
 }
 
 func (f *DatabaseFixture) BeforeEach(ctx context.Context) error {
-    _, err := f.DB.ExecContext(ctx, "BEGIN")
+    tx, err := f.DB.BeginTx(ctx, nil)
+    f.Tx = tx
     return err
 }
 
 func (f *DatabaseFixture) AfterEach(ctx context.Context) error {
-    _, err := f.DB.ExecContext(ctx, "ROLLBACK")
-    return err
+    return f.Tx.Rollback()
 }
 ```
 
-The fixture's `BeforeEach` begins a transaction before each test, and `AfterEach` rolls it back afterward. The suite's own `BeforeEach` and test method run inside that transaction. This gives you per-test isolation at the database level without any coordination between the fixture and the suite.
+The fixture's `BeforeEach` begins a transaction before each test, and `AfterEach` rolls it back afterward. Suite hooks and test methods that query through the fixture's `Tx` run inside that transaction, so no test's writes survive into the next one. This gives you per-test isolation at the database level with no cleanup logic in the suite itself.
 
 ## Fixture composition: stacking lifecycles
 

--- a/site/content/blog/go-testing-at-scale.md
+++ b/site/content/blog/go-testing-at-scale.md
@@ -218,7 +218,7 @@ go test (package)
 
 The three suites from the earlier example now run in parallel by default. No `t.Parallel()`, no careful state management, no package splitting. The OS guarantees memory isolation. A panic in `PaymentSuite` cannot crash `UserSuite`. A goroutine leak in one process does not affect the others.
 
-The concurrency budget defaults to `2 x GOMAXPROCS`, split between inter-suite parallelism (number of concurrent processes) and intra-suite parallelism (goroutines within each process). On an 8-core machine, up to 8 suite processes run concurrently, each with its own goroutine budget for method-level parallelism.
+The concurrency budget defaults to `2 x GOMAXPROCS` (halved under `-race` and the sanitizers, whose instrumentation multiplies each process's footprint), split between inter-suite parallelism (number of concurrent processes) and intra-suite parallelism (goroutines within each process). On an 8-core machine, up to 8 suite processes run concurrently, each with its own goroutine budget for method-level parallelism.
 
 ### Method-level parallelism
 
@@ -269,16 +269,23 @@ func (f *DatabaseFixture) FixtureConfig() gotest.FixtureConfig {
     return gotest.ContainerFixtureConfig()
 }
 
-func (f *DatabaseFixture) BeforeAll(t *gotest.T) {
-    f.Container = startPostgres(t.T())
-    f.DB = connectDB(f.Container.DSN())
+func (f *DatabaseFixture) BeforeAll(ctx context.Context) error {
+    container, err := startPostgres(ctx)
+    if err != nil {
+        return err
+    }
+    f.Container = container
+    f.DB, err = connectDB(container.DSN())
+    return err
 }
 
-func (f *DatabaseFixture) AfterAll(t *gotest.T) {
+func (f *DatabaseFixture) AfterAll(ctx context.Context) error {
     f.DB.Close()
-    f.Container.Stop()
+    return f.Container.Stop(ctx)
 }
 ```
+
+Fixture hooks receive a `context.Context` and return an `error` — unlike suite hooks, which receive `*gotest.T`. A failed `BeforeAll` is reported with automatic attribution (`DatabaseFixture.BeforeAll failed: ...`) rather than a stack trace from deep inside a helper.
 
 `BeforeAll` runs once per suite process, not once per test. All test methods in the suite share the fixture. Dependencies between fixtures are expressed as pointer fields: if `DatabaseFixture` has a `*DockerFixture` field, the Docker fixture sets up first. The generator resolves the DAG automatically. [Advanced Go Test Fixtures]({{< ref "/blog/advanced-fixture-patterns" >}}) goes deeper into DAG design and fixture composition.
 

--- a/site/content/blog/gotest-in-ci.md
+++ b/site/content/blog/gotest-in-ci.md
@@ -24,7 +24,7 @@ If you haven't written a gotest suite yet, start with [Your First Go Test Suite 
 
 ## The problem with `go test -v` in CI
 
-The default `go test -v` output is verbose. For every test, it prints three lines: `=== RUN`, `=== CONT` (for parallel tests), and `--- PASS` or `--- FAIL`. In a 200-test suite, that is 600+ lines of output. When two tests fail, the failure messages are buried in the middle of 590 lines of passing noise.
+The default `go test -v` output is verbose. For every test, it prints two or three lines: `=== RUN`, `=== CONT` (for parallel tests), and `--- PASS` or `--- FAIL`. In a 200-test suite, that is 400–600 lines of output. When two tests fail, the failure messages are buried in the middle of hundreds of lines of passing noise.
 
 Most teams work around this by piping output through `grep` or `gotestfmt`. gotest has a built-in answer: the `summary` command.
 
@@ -150,7 +150,7 @@ If your project does not depend on gotest as a library, set `version: latest` or
 gotest has a CI mode that activates two safety behaviors:
 
 1. **Focus-prefix guard.** If any suite or method has an `F_` prefix (`F_TestSomething`, `F_MyTestSuite`), the build fails immediately. The `F_` prefix means "run only this" — useful during development, dangerous in CI. Without the guard, a committed `F_` prefix silently skips every other test in the package.
-1. **Snapshot read-only mode.** Snapshot files cannot be updated in CI. If a snapshot does not match, the test fails instead of silently updating the expected value.
+1. **Snapshot read-only mode.** Snapshot baselines cannot be created in CI. Locally, a first run writes the missing baseline file; in CI mode, a missing baseline fails the test instead — so a brand-new snapshot can never slip in unreviewed. (Mismatches fail in any mode; updating a baseline always requires an explicit `--update-snapshots` run.)
 
 How focus prefixes fit into day-to-day development is covered in depth in [the inner loop post]({{< ref "/blog/the-inner-loop" >}}).
 
@@ -258,10 +258,9 @@ steps:
       race: true
       coverage: true
       min-coverage: 80
-      go-test-flags: "-coverprofile=coverage-suites.out"
 ```
 
-`go test` runs standard test functions. gotest runs suite tests. Both produce coverage profiles that you can merge if needed. The gotest action's `--ci` mode (auto-detected) catches focus prefixes and locks snapshots regardless of which step they appear in.
+`go test` runs standard test functions. gotest runs suite tests — stdlib `func Test*` functions are reported but not executed by gotest, so nothing runs twice. Each step enforces its own coverage: the stdlib step writes `coverage-stdlib.out`, and the gotest step reports its percentage through the action's `coverage` output. The gotest step's CI mode (auto-detected via the `CI` environment variable) catches committed focus prefixes and locks snapshots.
 
 ## Project configuration with `.gotest.yml`
 
@@ -276,7 +275,7 @@ lint:
     - testify
 ```
 
-CLI flags override `.gotest.yml`, so a developer can always run `gotest --min=0 ./...` locally to skip the coverage check during development. But the default, both locally and in CI, is whatever the project file says.
+CLI flags override `.gotest.yml`, so a one-off `gotest --min=90 ./...` can tighten the gate for a single run. (A `--min` of zero is treated as unset, so it does not disable a configured threshold.) The default, both locally and in CI, is whatever the project file says.
 
 ## A complete workflow
 

--- a/site/content/blog/how-go-actually-tests.md
+++ b/site/content/blog/how-go-actually-tests.md
@@ -68,7 +68,7 @@ Golden testing is a 43% practice with a 7% workflow. Every team reinvents the re
 
 Postgres appears in 82 repos, nearly twice its closest rival. If you are building test infrastructure for Go, this ranking is a priority list.
 
-The structural finding matters more than the ranking: **26 repos have the multi-package `TestMain` container pattern** — several packages, each with a `TestMain` that starts its own container, directly or through a helper package. coder/coder has 61 such packages; telegraf has 477 test packages that reach container code. `go test` runs each package as a separate OS process, so these packages cannot share a container through Go code. Each one pays startup independently, or the team gives up and orchestrates containers outside the test run. gotest's `SharedFixture` exists for exactly this boundary: one setup process starts the container, and its state is serialized and rehydrated into each package's process. The full mechanics are in [Sharing Test Fixtures Across Go Packages]({{< ref "/blog/shared-fixtures" >}}).
+The structural finding matters more than the ranking: **26 repos have the multi-package `TestMain` container pattern** — several packages, each with a `TestMain` that starts its own container, directly or through a helper package. coder/coder has 61 such packages; telegraf has 477 test packages that reach container code. `go test` runs each package as a separate OS process, so these packages cannot share a container through Go code. Each one pays startup independently, or the team gives up and orchestrates containers outside the test run. gotest's `SharedFixture` exists for exactly this boundary: one setup process starts the container, and its state is serialized and rehydrated into each consuming suite's process. The full mechanics are in [Sharing Test Fixtures Across Go Packages]({{< ref "/blog/shared-fixtures" >}}).
 
 ## The workaround gradient
 
@@ -129,7 +129,7 @@ The census was a bet that the problems gotest targets are common, not local to o
 
 | The data says | The gotest answer |
 |---|---|
-| 68% of repos sleep in tests; 225+ hours of fixed waiting | `Eventually` / `Consistently` polling assertions |
+| 68% of repos sleep in tests; 251+ hours of fixed waiting | `Eventually` / `Consistently` polling assertions |
 | 11.2% of tests run in parallel; independence is the blocker | process-isolated suites, per-test state via returning `BeforeEach` |
 | 64% hand-annotate helpers with `t.Helper()` | assertions resolve the test-file caller automatically |
 | 42% wire `TestMain`; 53% scatter `t.Cleanup` | suite and fixture lifecycle with ordering guarantees |

--- a/site/content/blog/organizing-go-tests.md
+++ b/site/content/blog/organizing-go-tests.md
@@ -113,14 +113,14 @@ func TestUserService(t *testing.T) {
 
     t.Run("Create", func(t *testing.T) {
         t.Run("valid user", func(t *testing.T) {
-            err := db.CreateUser(User{Name: "Alice"})
+            err := db.CreateUser(User{Name: "Alice", Email: "alice@example.com"})
             if err != nil {
                 t.Fatal(err)
             }
         })
         t.Run("duplicate email", func(t *testing.T) {
-            err := db.CreateUser(User{Name: "Alice"})
-            // this fails: Create/valid_user already inserted Alice
+            err := db.CreateUser(User{Name: "Bob", Email: "alice@example.com"})
+            // only errors because Create/valid_user already inserted this email
             if err == nil {
                 t.Fatal("expected error")
             }
@@ -218,7 +218,7 @@ func (s *UserServiceTestSuite) BeforeEach(t *gotest.T) {
 }
 
 func (s *UserServiceTestSuite) TestCreateUser(t *gotest.T) {
-    t.When("the input is valid", func(w *gotest.T) {
+    t.When("when the input is valid", func(w *gotest.T) {
         err := s.db.CreateUser(User{Name: "Alice", Email: "alice@example.com"})
 
         w.It("succeeds without error", func(it *gotest.T) {
@@ -226,7 +226,7 @@ func (s *UserServiceTestSuite) TestCreateUser(t *gotest.T) {
         })
     })
 
-    t.When("the email already exists", func(w *gotest.T) {
+    t.When("when the email already exists", func(w *gotest.T) {
         s.db.CreateUser(User{Name: "Alice", Email: "alice@example.com"})
         err := s.db.CreateUser(User{Name: "Bob", Email: "alice@example.com"})
 
@@ -237,7 +237,7 @@ func (s *UserServiceTestSuite) TestCreateUser(t *gotest.T) {
 }
 
 func (s *UserServiceTestSuite) TestDeleteUser(t *gotest.T) {
-    t.When("the user exists", func(w *gotest.T) {
+    t.When("when the user exists", func(w *gotest.T) {
         s.db.CreateUser(User{Name: "Alice", Email: "alice@example.com"})
         err := s.db.DeleteUser("alice@example.com")
 
@@ -253,7 +253,7 @@ A few things to notice:
 - **No framework embedding.** The struct has only your fields. No `suite.Suite`, no interface to satisfy.
 - **Lifecycle via naming conventions.** `BeforeEach` is recognized by name. It runs before every `Test*` method, giving each test a fresh `db`. The full hook ordering is laid out in [Go Test Lifecycle]({{< ref "/blog/go-test-lifecycle" >}}).
 - **BDD structure inside methods.** `t.When` and `t.It` create labeled subtests via `t.Run`. They're just method calls: no DSL, no magic. [Readable Go Tests with BDD-Style Subtests]({{< ref "/blog/readable-tests-with-bdd" >}}) covers this structure in detail.
-- **Type-safe assertions.** `gotest.NoError`, `gotest.Equal`, and others are generic functions. Pass the wrong type and the compiler catches it.
+- **Type-safe assertions.** `gotest.NoError`, `gotest.Equal`, and the rest are standalone, type-safe functions; comparisons like `Equal` are generic, so passing mismatched types is a compile error.
 
 Running `gotest ./...` generates the `t.Run` nesting, lifecycle calls, and process isolation behind the scenes, then invokes `go test`. The generated code is injected via Go's `-overlay` flag; it never touches your source tree.
 
@@ -264,16 +264,16 @@ There's a useful consequence of this structure. Because test methods, `When` blo
 {{< terminal title="gotest spec ./..." >}}
 <span class="t-prompt">$</span> <span class="t-cmd">gotest spec ./...</span>
 
-<span class="t-suite">UserService</span>
-  <span class="t-test">CreateUser</span>
-    <span class="t-when">when the input is valid</span>
+<span class="t-suite">UserService</span> <span class="t-time">(9ms)</span>
+  <span class="t-test">CreateUser</span> <span class="t-time">(6ms)</span>
+    <span class="t-when">when the input is valid</span> <span class="t-time">(5ms)</span>
       <span class="t-pass">✓</span> succeeds without error <span class="t-time">(5ms)</span>
-    <span class="t-when">when the email already exists</span>
+    <span class="t-when">when the email already exists</span> <span class="t-time">(<1ms)</span>
       <span class="t-pass">✓</span> returns an error <span class="t-time">(<1ms)</span>
-  <span class="t-test">DeleteUser</span>
-    <span class="t-when">when the user exists</span>
+  <span class="t-test">DeleteUser</span> <span class="t-time">(3ms)</span>
+    <span class="t-when">when the user exists</span> <span class="t-time">(3ms)</span>
       <span class="t-pass">✓</span> succeeds without error <span class="t-time">(3ms)</span>
-<span class="t-summary">1 suite, 3 behaviors: <span class="t-pass">3 passed</span>, 0 failed, 0 skipped</span>
+<span class="t-summary">1 suites, 3 behaviors: <span class="t-pass">3 passed</span></span>
 {{< /terminal >}}
 
 This isn't generated documentation; it's a direct rendering of your test structure. If a test is missing, the spec has a gap. If a test fails, the spec shows it. The test *is* the specification.

--- a/site/content/blog/readable-tests-with-bdd.md
+++ b/site/content/blog/readable-tests-with-bdd.md
@@ -87,6 +87,10 @@ type UserServiceTestSuite struct {
     svc *UserService
 }
 
+func (s *UserServiceTestSuite) BeforeEach(t *gotest.T) {
+    s.svc = NewUserService()
+}
+
 func (s *UserServiceTestSuite) TestCreate(t *gotest.T) {
     t.When("email is valid", func(w *gotest.T) {
         user := User{Name: "Alice", Email: "alice@example.com"}
@@ -96,7 +100,7 @@ func (s *UserServiceTestSuite) TestCreate(t *gotest.T) {
             gotest.NoError(it, err)
         })
         w.It("sends a welcome email", func(it *gotest.T) {
-            gotest.Equal(it, s.svc.EmailsSent(), 1)
+            gotest.Equal(it, 1, s.svc.EmailsSent())
         })
     })
 
@@ -131,40 +135,42 @@ A few things to notice:
 The structure in the code is only half the value. The other half is what you see when the tests run. `gotest spec` transforms the test output into an indented tree:
 
 {{< spec title="gotest spec ./..." >}}
-<span class="t-suite">UserService</span>
-  <span class="t-test">Create</span>
-    <span class="t-when">when email is valid</span>
+<span class="t-suite">UserService</span> <span class="t-time">(136ms)</span>
+  <span class="t-test">Create</span> <span class="t-time">(130ms)</span>
+    <span class="t-when">email is valid</span> <span class="t-time">(129ms)</span>
       <span class="t-pass">✓</span> creates the user <span class="t-time">(8ms)</span>
       <span class="t-pass">✓</span> sends a welcome email <span class="t-time">(120ms)</span>
-    <span class="t-when">when email already exists</span>
+    <span class="t-when">email already exists</span> <span class="t-time">(<1ms)</span>
       <span class="t-pass">✓</span> returns ErrDuplicate <span class="t-time">(<1ms)</span>
-  <span class="t-test">Delete</span>
+  <span class="t-test">Delete</span> <span class="t-time">(5ms)</span>
     <span class="t-pass">✓</span> soft-deletes the user <span class="t-time">(5ms)</span>
 
-<span class="t-summary">1 suite, 4 passed in 0.34s</span>
+<span class="t-summary">1 suites, 4 behaviors: 4 passed</span>
 {{< /spec >}}
 
-Compare this with the `go test -v` output for the same tests. The spec output is:
+Compare this with the `gotest ./... -v` output for the same tests — the standard verbose stream, since suites run through the `gotest` runner. The spec output is:
 
-- **8 lines** instead of 20+. No repetition, no `=== RUN` / `--- PASS` noise.
-- **Hierarchical.** 2-space indentation shows structure at a glance. Suite name is bold. Method names are bold. Contexts are dimmed. Expectations get checkmarks.
+- **9 lines** instead of 20+. No repetition, no `=== RUN` / `--- PASS` noise.
+- **Hierarchical.** 2-space indentation shows structure at a glance. Suite and method names are bold. Expectations get checkmarks.
 - **Human-readable names.** `UserServiceTestSuite` becomes "UserService" (suffix stripped). `TestCreate` becomes "Create" (prefix stripped). No CamelCase, no underscores.
 
 When a test fails, the tree structure tells you exactly where:
 
 {{< spec title="gotest spec ./..." >}}
-<span class="t-suite">UserService</span>
-  <span class="t-test">Create</span>
-    <span class="t-when">when email is valid</span>
+<span class="t-suite">UserService</span> <span class="t-time">(136ms)</span>
+  <span class="t-test">Create</span> <span class="t-time">(130ms)</span>
+    <span class="t-when">email is valid</span> <span class="t-time">(129ms)</span>
       <span class="t-pass">✓</span> creates the user <span class="t-time">(8ms)</span>
       <span class="t-fail">✗</span> sends a welcome email <span class="t-time">(120ms)</span>
-    <span class="t-when">when email already exists</span>
+    <span class="t-when">email already exists</span> <span class="t-time">(<1ms)</span>
       <span class="t-pass">✓</span> returns ErrDuplicate <span class="t-time">(<1ms)</span>
+  <span class="t-test">Delete</span> <span class="t-time">(5ms)</span>
+    <span class="t-pass">✓</span> soft-deletes the user <span class="t-time">(5ms)</span>
 
-<span class="t-summary">1 suite, 2 passed, <span class="t-fail">1 failed</span> in 0.34s</span>
+<span class="t-summary">1 suites, 4 behaviors: 3 passed, <span class="t-fail">1 failed</span></span>
 {{< /spec >}}
 
-The red cross at "sends a welcome email" under "when email is valid" is a sentence: *UserService Create, when email is valid, fails to send a welcome email.* You know what's broken without reading any code.
+The red cross at "sends a welcome email" under "email is valid" is a sentence: *UserService Create, when email is valid, fails to send a welcome email.* You know what's broken without reading any code.
 
 ## When and It can nest arbitrarily
 
@@ -193,45 +199,47 @@ func (s *OrderServiceTestSuite) TestCheckout(t *gotest.T) {
 The spec output reflects the nesting:
 
 {{< spec title="gotest spec ./..." >}}
-<span class="t-suite">OrderService</span>
-  <span class="t-test">Checkout</span>
-    <span class="t-when">when the cart is not empty</span>
-      <span class="t-when">when payment succeeds</span>
+<span class="t-suite">OrderService</span> <span class="t-time">(19ms)</span>
+  <span class="t-test">Checkout</span> <span class="t-time">(18ms)</span>
+    <span class="t-when">the cart is not empty</span> <span class="t-time">(17ms)</span>
+      <span class="t-when">payment succeeds</span> <span class="t-time">(15ms)</span>
         <span class="t-pass">✓</span> creates an order <span class="t-time">(12ms)</span>
         <span class="t-pass">✓</span> clears the cart <span class="t-time">(3ms)</span>
-      <span class="t-when">when payment fails</span>
+      <span class="t-when">payment fails</span> <span class="t-time">(2ms)</span>
         <span class="t-pass">✓</span> does not create an order <span class="t-time">(2ms)</span>
 
-<span class="t-summary">1 suite, 3 passed in 0.21s</span>
+<span class="t-summary">1 suites, 3 behaviors: 3 passed</span>
 {{< /spec >}}
 
 Each level of `When` narrows the context. The spec reads as a decision tree: checkout, when the cart is not empty, when payment succeeds, creates an order. You can trace any path from root to leaf and get a complete behavioral statement.
 
 ## The spec command
 
-`gotest spec` works by running `gotest test` with `-json` output, then transforming the structured test events into the indented tree. It accepts the same package patterns as `go test`:
+`gotest spec` works by running your suites through the same pipeline as plain `gotest`, capturing the `go test -json` event stream, and transforming the structured test events into the indented tree. It accepts the same package patterns as `go test`:
 
 ```sh
 # spec output for all packages
 gotest spec ./...
 
-# verbose mode: show durations for passing tests
-gotest spec -v ./...
+# write a markdown spec to a file
+gotest spec --format=md --output=spec.md ./...
 
-# filter by test name
-gotest spec --run UserService ./...
+# filter by test name (a regular go test flag)
+gotest spec -run UserService ./...
 
 # disable color for CI logs
 gotest spec --no-color ./...
 ```
 
+There is also `gotest spec --static`, which renders the same tree straight from your source — no run, no status icons, no durations — for reviewing what the tests promise before executing anything.
+
 The rendering strips naming conventions automatically:
 
 - `UserServiceTestSuite` → **UserService** (drops `TestSuite` suffix)
 - `TestCreate` → **Create** (drops `Test` prefix)
-- Underscores in `When`/`It` labels → spaces
+- Underscored subtest names (`sends_a_welcome_email` in `go test` output) → the label as you wrote it ("sends a welcome email")
 
-Suite and method names are bold. Contexts are dimmed. Passing expectations get a green checkmark, failing ones a red cross. The summary line at the bottom shows total counts and duration. The same spec tree is also available inside your editor — see the [gotest VS Code Extension]({{< ref "/blog/your-editor-knows-your-tests" >}}).
+Suite and method names are bold. Passing expectations get a green checkmark, failing ones a red cross, skipped ones a yellow tilde. The summary line at the bottom shows suite and behavior counts. The same spec tree is also available inside your editor — see the [gotest VS Code Extension]({{< ref "/blog/your-editor-knows-your-tests" >}}).
 
 ## Tests that document themselves
 

--- a/site/content/blog/shared-fixtures.md
+++ b/site/content/blog/shared-fixtures.md
@@ -67,7 +67,7 @@ Both approaches have the same root cause: Go's process-per-package model has no 
 
 ## Shared fixtures: the model
 
-gotest's answer is **shared fixtures**: structs whose name ends in `SharedFixture`. A shared fixture runs in its own subprocess, once for the entire test run. Its state is serialized as JSON and transferred to every test package that needs it.
+gotest's answer is **shared fixtures**: structs whose name ends in `SharedFixture`. Shared fixtures run in a dedicated setup subprocess — one subprocess for all of them, separate from every test process — once for the entire test run. Their state is serialized as JSON and transferred to every test package that needs it.
 
 The lifecycle looks like this:
 
@@ -75,16 +75,16 @@ The lifecycle looks like this:
 1. gotest starts a fixture subprocess
 2. SharedFixture.BeforeAll runs (start container, run migrations)
 3. Exported fields are serialized to JSON (the "transfer state")
-4. For each test package that needs this fixture:
+4. For each suite process that needs this fixture (each suite runs in its own process):
    a. Transfer state is deserialized into a new instance
    b. SharedFixture.Hydrate runs (open connections from transfer state)
    c. Tests run
    d. SharedFixture.Dehydrate runs (close connections)
-5. All test packages finish
+5. All suite processes finish
 6. SharedFixture.AfterAll runs (stop container, cleanup)
 ```
 
-The key insight is the split between what can cross a process boundary (data) and what cannot (connections, file handles, goroutines). The fixture struct's **exported fields** are the transfer state: they get serialized to JSON and sent to each test process. The **unexported fields** hold local resources that are reconstructed by `Hydrate` in each process.
+The key insight is the split between what can cross a process boundary (data) and what cannot (connections, file handles, goroutines). The fixture's **transfer fields** — exported fields that `Hydrate` leaves alone — get serialized to JSON and sent to each test process. Its **local fields** — anything `Hydrate` assigns, plus all unexported fields — hold resources that are reconstructed by `Hydrate` in each process.
 
 ## A concrete example
 
@@ -101,8 +101,10 @@ import (
 )
 
 type PostgresSharedFixture struct {
-    DSN  string   // exported: serialized to JSON, transferred to test packages
-    conn *sql.DB  // unexported: local to each process, created by Hydrate
+    DSN string // transfer: serialized to JSON, sent to test packages
+
+    container *postgresContainer // local: only lives in the fixture subprocess
+    conn      *sql.DB            // local: created by Hydrate in each test process
 }
 
 func (f *PostgresSharedFixture) SharedFixtureConfig() gotest.FixtureConfig {
@@ -116,6 +118,7 @@ func (f *PostgresSharedFixture) BeforeAll(ctx context.Context) error {
     if err != nil {
         return err
     }
+    f.container = container
     f.DSN = container.DSN()
 
     f.conn, err = sql.Open("postgres", f.DSN)
@@ -130,8 +133,7 @@ func (f *PostgresSharedFixture) AfterAll(ctx context.Context) error {
     if f.conn != nil {
         f.conn.Close()
     }
-    // Stop the container.
-    return nil
+    return f.container.Terminate(ctx)
 }
 
 func (f *PostgresSharedFixture) Hydrate(ctx context.Context) error {
@@ -159,9 +161,9 @@ func (f *PostgresSharedFixture) Conn() *sql.DB {
 The lifecycle methods map to distinct moments:
 
 - **`BeforeAll`** runs once, in the fixture subprocess. Start the container, run migrations, set the DSN. The expensive work happens here, exactly once.
-- **`Hydrate`** runs in each test package's process, after the exported fields (`DSN`) have been deserialized from JSON. It reconstructs the local resources: opens a database connection from the DSN. This is cheap — the container is already running.
-- **`Dehydrate`** runs when a test package's process finishes. It cleans up local resources: closes the connection. The container stays running for the next package.
-- **`AfterAll`** runs once, after all test packages are done. Stop the container, delete temp files, release any remaining resources.
+- **`Hydrate`** runs in each suite's process (a package with two consuming suites hydrates twice), after the exported fields (`DSN`) have been deserialized from JSON. It reconstructs the local resources: opens a database connection from the DSN. This is cheap — the container is already running.
+- **`Dehydrate`** runs when a suite's process finishes. It cleans up local resources: closes the connection. The container stays running for the next suite.
+- **`AfterAll`** runs once, after all consuming suites are done. Stop the container, delete temp files, release any remaining resources.
 
 For the ordering and cleanup guarantees behind hooks like these — what runs when, and what still runs after a failure — see [Go Test Lifecycle]({{< ref "/blog/go-test-lifecycle" >}}).
 
@@ -224,14 +226,14 @@ Both suites reference `*testinfra.PostgresSharedFixture`. gotest sees the pointe
 
 ## Transfer fields vs. local fields
 
-The distinction between exported and unexported fields is the core of the shared fixture model. It maps directly to what can and cannot cross a process boundary:
+The distinction between transfer fields and local fields is the core of the shared fixture model. It maps directly to what can and cannot cross a process boundary:
 
-- **Exported fields** (`DSN string`, `Port int`, `Token string`) are serialized to JSON. They must be JSON-marshalable. These are the connection coordinates: the information another process needs to reach the same resource.
-- **Unexported fields** (`conn *sql.DB`, `handle *os.File`) are local to each process. They are assigned by `Hydrate`, cleaned up by `Dehydrate`. They represent the live connection, not the address.
+- **Transfer fields** (`DSN string`, `Port int`, `Token string`) are exported fields that `Hydrate` does not assign. They are serialized to JSON, so they must be JSON-marshalable. These are the connection coordinates: the information another process needs to reach the same resource.
+- **Local fields** (`conn *sql.DB`, `handle *os.File`) are local to each process. They are assigned by `Hydrate`, cleaned up by `Dehydrate`. They represent the live connection, not the address.
 
-This split is explicit and enforced by Go's export rules. You cannot accidentally serialize a `*sql.DB` because it is unexported and `encoding/json` ignores unexported fields.
+The classification goes by assignment, not just by export rules: the generator analyzes the `Hydrate` body (following one level of receiver method calls, so a `f.connect()` helper counts too), and any field assigned there is treated as local and excluded from the snapshot — even an exported one, such as a `Pool *pgxpool.Pool` that `Hydrate` populates. Unexported fields never cross the boundary regardless, because `encoding/json` ignores them.
 
-> Not every shared fixture needs `Hydrate` and `Dehydrate`. If the fixture's exported fields are sufficient for test code to work with (a port number, a URL, a token), you can skip them. `Hydrate`/`Dehydrate` are for resources that need to be opened and closed in each process.
+> Not every shared fixture needs `Hydrate` and `Dehydrate`. If the fixture's exported fields are sufficient for test code to work with (a port number, a URL, a token), you can skip them. `Hydrate`/`Dehydrate` are for resources that need to be opened and closed in each process — and they come as a pair: defining only one of the two is a generation error.
 
 ## Shared fixture dependencies
 

--- a/site/content/blog/snapshot-testing-in-go.md
+++ b/site/content/blog/snapshot-testing-in-go.md
@@ -95,7 +95,7 @@ No boilerplate. No manual file paths. No flag wiring. The test reads exactly lik
 Snapshot files are stored in `testdata/__snapshots__/`, next to the test file. One `.snap` file is created per top-level test suite. Each subtest gets its own named section within the file:
 
 ```text {title="testdata/__snapshots__/TestUserAPITestSuite.snap"}
-=== SNAP TestRenderProfile/when_the_user_has_roles/renders_the_profile ===
+=== SNAP TestRenderProfile/the_user_has_roles/renders_the_profile ===
 {
   "id": "usr-123",
   "name": "Alice Smith",
@@ -106,7 +106,7 @@ Snapshot files are stored in `testdata/__snapshots__/`, next to the test file. O
     "notifications": true
   }
 }
-=== SNAP TestRenderProfile/when_the_user_is_new/renders_the_profile ===
+=== SNAP TestRenderProfile/the_user_is_new/renders_the_profile ===
 {
   "id": "usr-456",
   "name": "Bob Jones",
@@ -127,6 +127,7 @@ Sections are sorted alphabetically within the file, so the order is deterministi
 
 1. **`string`** — used directly as the snapshot content.
 1. **`[]byte`** — converted to string.
+1. **`json.RawMessage`** — pretty-printed as JSON (an explicit case: since Go 1.27, `RawMessage` has a `String()` method and would otherwise fall through to the `Stringer` branch unindented).
 1. **`encoding.TextMarshaler`** — calls `MarshalText()`.
 1. **`fmt.Stringer`** — calls `String()`.
 1. **`json.Marshaler`** — marshals and pretty-prints the JSON.
@@ -157,7 +158,7 @@ gotest.MatchSnapshot(t, renderProfile(admin), "admin-profile")
 gotest.MatchSnapshot(t, renderProfile(guest), "guest-profile")
 ```
 
-The name becomes part of the section key in the snapshot file. Without it, multiple `MatchSnapshot` calls in the same test would overwrite each other. With it, each snapshot gets its own section and can be compared independently.
+The name becomes part of the section key in the snapshot file. Without it, both calls would resolve to the same section key — the second call gets compared against the first call's stored snapshot and fails. With it, each snapshot gets its own section and can be compared independently.
 
 ## Updating snapshots
 
@@ -186,7 +187,7 @@ Reviewers see the actual output, not an assertion about it. If a change to `rend
 In CI mode (`--ci` flag, or auto-detected from the `CI` environment variable), snapshots are read-only:
 
 - Existing snapshots are compared normally — mismatches still fail the test.
-- New baseline snapshots cannot be created. If a test calls `MatchSnapshot` and no snapshot file exists, the test fails with: *"no baseline snapshot — run tests locally to generate."*
+- New baseline snapshots cannot be created. If a test calls `MatchSnapshot` and no stored snapshot exists for that section, the test fails with: *"no baseline snapshot for … — run tests locally to generate."*
 
 This prevents a specific failure mode: a developer adds a new `MatchSnapshot` call, runs tests locally (which creates the baseline), but forgets to commit the snapshot file. Without CI protection, the test would silently pass in CI by creating a fresh snapshot, and the next run would compare against that. With CI protection, the missing file is caught immediately.
 
@@ -195,15 +196,20 @@ This prevents a specific failure mode: a developer adds a new `MatchSnapshot` ca
 `MatchSnapshot` is safe to call from parallel tests. Each snapshot file has its own mutex. Concurrent writes to the same file are serialized, and section ordering is deterministic regardless of execution order.
 
 ```go
-for i := range 10 {
-    t.It(fmt.Sprintf("goroutine %d", i), func(it *gotest.T) {
-        it.T().Parallel()
-        gotest.MatchSnapshot(it, fmt.Sprintf("value-%d", i))
-    })
+func (s *RenderTestSuite) SuiteConfig() gotest.SuiteConfig {
+    return gotest.SuiteConfig{Parallel: true}
+}
+
+func (s *RenderTestSuite) TestAdminProfile(t *gotest.T) {
+    gotest.MatchSnapshot(t, renderProfile(admin))
+}
+
+func (s *RenderTestSuite) TestGuestProfile(t *gotest.T) {
+    gotest.MatchSnapshot(t, renderProfile(guest))
 }
 ```
 
-All 10 goroutines can call `MatchSnapshot` concurrently. The snapshot file ends up with 10 sections, sorted alphabetically, and the result is identical whether the goroutines ran sequentially or in parallel.
+With `Parallel: true`, both test methods run concurrently and write to the same `.snap` file. The writes are serialized by the file's mutex, sections are sorted on write, and the resulting file is identical whether the methods ran sequentially or in parallel.
 
 ## When to use snapshot testing
 
@@ -221,7 +227,7 @@ All 10 goroutines can call `MatchSnapshot` concurrently. The snapshot file ends 
 - **Simple scalar values.** If the expected value is a single integer or a short string, `gotest.Equal` is clearer. Snapshots are for cases where writing out the expected value inline hurts readability.
 - **Binary data.** Snapshots are text-based. Binary content will produce unreadable diffs.
 
-## A complete example
+## Prior art
 
 Snapshot testing isn't a new idea. Jest popularized it in JavaScript, and the pattern exists in most testing ecosystems. In Go, cupaloy and go-snaps are established snapshot libraries that offer this workflow as standalone packages; gotest's version differs mainly in being integrated with its assertion set, safe to call from parallel tests, and read-only in CI mode.
 

--- a/site/content/blog/test-fixtures-in-go.md
+++ b/site/content/blog/test-fixtures-in-go.md
@@ -54,7 +54,7 @@ func TestListUsers(t *testing.T) {
 This works until it doesn't:
 
 - **Tests share state.** `TestListUsers` sees rows that `TestCreateUser` inserted. Tests become order-dependent. Add `t.Parallel()` and they become race-condition-dependent.
-- **Teardown is fragile.** If any test panics, `defer testDB.Close()` might not run. If `TestMain` itself fails, the process exits with no cleanup.
+- **Teardown is fragile.** `os.Exit(m.Run())` terminates the process without running deferred calls, so that `defer testDB.Close()` never fires at all. And if `TestMain` itself fails, the process exits with no cleanup either.
 - **One fixture per package.** `TestMain` can only be defined once. Need a database *and* a cache? Everything goes into one function.
 - **No per-test reset.** There's no hook to truncate tables between tests. You'd need to write that into every test function manually.
 
@@ -128,7 +128,7 @@ Looking at the patterns above, a fixture system needs to handle four concerns:
 
 1. **Lifecycle hooks.** Setup and teardown at both the suite level (once) and the test level (per-test). Fixtures that take `context.Context` and return `error`, so expensive operations can be cancelled and failures can be handled.
 1. **Dependency ordering.** If fixture B depends on fixture A, A's setup must complete before B's begins. Teardown runs in reverse order. This is a DAG (directed acyclic graph) problem.
-1. **Scope control.** Some fixtures are package-scoped (shared across suites in one package). Some are shared across multiple packages. The fixture system needs to understand these scopes.
+1. **Scope control.** Some fixtures are suite-scoped (set up once per suite). Some are shared across suites and packages. The fixture system needs to understand these scopes.
 1. **Isolation.** Per-test hooks that reset state between test methods, so tests don't inherit side effects from each other.
 
 ## Fixtures as structs with lifecycle conventions
@@ -163,7 +163,7 @@ func (f *DatabaseFixture) BeforeEach(_ context.Context) error {
 A few things to notice:
 
 - **Lifecycle methods take `context.Context` and return `error`.** This is different from suite lifecycle hooks (which take `*gotest.T`). Fixtures represent infrastructure; they need cancellation and error propagation.
-- **`BeforeAll`/`AfterAll`** run once for the package. The database is opened once and closed once.
+- **`BeforeAll`/`AfterAll`** run once per suite process. The database is opened once and closed once for each suite that uses the fixture.
 - **`BeforeEach`** runs before every test method in every suite that uses this fixture. Tables get truncated, so each test starts clean.
 - **`FixtureConfig`** controls timeout and retry behavior. `ContainerFixtureConfig()` gives a 5-minute timeout with one retry, appropriate for infrastructure that might need time to start.
 
@@ -202,7 +202,7 @@ The lifecycle order for each test method is:
 1. Suite `AfterEach`
 1. Fixture `AfterEach`
 
-If multiple suites in the same package reference `*DatabaseFixture`, they all share the same instance. `BeforeAll` runs once for the package, not once per suite.
+If multiple suites in the same package reference `*DatabaseFixture`, each suite runs in its own process and constructs its own instance — `BeforeAll` runs once per suite. When the setup cost should be paid once for the whole run, promote it to a `SharedFixture`.
 
 ## Fixture dependencies form a DAG
 
@@ -214,10 +214,10 @@ type CacheFixture struct {
     Cache *redis.Client
 }
 
-func (f *CacheFixture) BeforeAll(_ context.Context) error {
+func (f *CacheFixture) BeforeAll(ctx context.Context) error {
     f.Cache = redis.NewClient(&redis.Options{Addr: "localhost:6379"})
     // f.DB.DB is already initialized. DatabaseFixture.BeforeAll ran first
-    return f.Cache.Ping(context.Background()).Err()
+    return f.Cache.Ping(ctx).Err()
 }
 ```
 
@@ -237,7 +237,7 @@ The stdlib has no answer for this. Most teams fall back to external orchestratio
 
 ## Sharing fixtures across packages
 
-gotest has **shared fixtures** for this: structs whose name ends in `SharedFixture`. A shared fixture runs in its own subprocess, once for the entire test run. Its state is serialized as JSON and transferred to every test package that needs it.
+gotest has **shared fixtures** for this: structs whose name ends in `SharedFixture`. Shared fixtures run in a dedicated setup subprocess, separate from every test binary, once for the entire test run. Their state is serialized as JSON and transferred to every test package that needs it.
 
 The core idea is a split between transfer fields and local fields. Exported fields like a DSN are serialized and cross the process boundary; resources that can't be serialized — connections, file handles, goroutines — are reconstructed in each test package's process by a `Hydrate` method and cleaned up by `Dehydrate`. The container starts once; every package connects to it.
 

--- a/site/content/blog/testify-migration-guide.md
+++ b/site/content/blog/testify-migration-guide.md
@@ -9,16 +9,16 @@ cta_command: "gotest migrate ./..."
 howto:
   name: "Migrate a testify/suite codebase to gotest"
   steps:
-    - name: "Preview the changes"
-      text: "Run gotest migrate ./... --dry-run to see what the AST-level rewrite would change without writing any files."
+    - name: "Start from a clean tree"
+      text: "Commit or stash first — the tool rewrites files in place, so git diff is your preview and git checkout your undo."
     - name: "Migrate one package"
       text: "Run gotest migrate ./pkg/user on a package with a few well-understood suites and verify the tests still pass."
     - name: "Resolve manual-review TODOs"
-      text: "Search for the // TODO: manual review comments the tool leaves for s.T() calls, custom suite helpers, BeforeTest/AfterTest/SetupSubTest hooks, and direct testify/assert or testify/require usage."
+      text: "Search for the // TODO(gotest-migrate) comments the tool leaves for direct suite assertion calls like s.Equal, unmapped assertions, and BeforeTest/AfterTest/SetupSubTest/TearDownSubTest hooks."
     - name: "Run testify and gotest side by side"
-      text: "Leave unmigrated packages on testify; both run via go test without conflict while you migrate package by package."
+      text: "Leave unmigrated packages on testify; they keep running under go test while migrated suites run under gotest, without conflict."
     - name: "Track progress with the linter"
-      text: "Run gotest lint to flag testify/suite imports in packages that also use gotest suites, catching packages where migration is incomplete."
+      text: "Run gotest lint to flag remaining testify imports, catching packages where migration is incomplete."
     - name: "Drop testify"
       text: "Once the last suite is migrated, remove the testify dependency from go.mod."
 aliases: ["/blog/testify-migration-guide.html"]
@@ -32,14 +32,14 @@ aliases: ["/blog/testify-migration-guide.html"]
 
 ## What won't migrate automatically
 
-`gotest migrate` handles the mechanical bulk of the transformation. Four patterns are flagged with `// TODO: manual review` comments instead of being rewritten:
+`gotest migrate` handles the mechanical bulk of the transformation. Four patterns are flagged with `// TODO(gotest-migrate)` comments — or left to the compiler — instead of being silently rewritten:
 
-- **`s.T()` handoffs.** Helper functions that receive `s.T()` need to use the `t` parameter that test methods now receive.
-- **Custom suite helpers.** Methods that aren't lifecycle hooks or test methods are left unchanged; assertion calls via `s.Require()` inside them need manual conversion.
+- **Assertions called directly on the suite.** `s.Equal(a, b)`, `s.Contains(...)` — calls through the embedded `suite.Suite` — are left in place with a TODO naming the `gotest.*` replacement.
+- **Custom suite helpers.** Methods that aren't lifecycle hooks or test methods keep their shape; the tool doesn't add a `t *gotest.T` parameter to them, so rewritten assertions inside them need you to thread `t` through.
 - **`BeforeTest` / `AfterTest` / `SetupSubTest` / `TearDownSubTest`.** testify's per-test-name and subtest-level hooks have no direct gotest equivalent.
-- **Direct `testify/assert` or `testify/require` usage.** Calls that don't go through the suite aren't touched.
+- **Testify assertions outside suite methods.** `assert.*`/`require.*` calls in standalone functions aren't converted.
 
-Each of these gets a detailed treatment in the "What needs manual review" section below. And `--dry-run` makes the whole run a no-op preview, so you can see every change before a single file is written.
+Each of these gets a detailed treatment in the "What needs manual review" section below. The tool rewrites files in place, so run it on a clean working tree — `git diff` is your preview, `git checkout` your undo.
 
 ## testify to gotest: what maps to what
 
@@ -62,7 +62,7 @@ The biggest conceptual shift is that test methods now receive a `t` parameter. I
 
 ## Before and after: a full suite migration
 
-Here's a complete testify/suite test file and what it looks like after migration:
+Here's a complete testify/suite test file and what it looks like after migration — the tool's rewrite plus the handful of TODO fixes it flags (the direct `s.Equal`/`s.Contains`/`s.ErrorIs` calls below):
 
 ```go {title="before: user_test.go (testify/suite)"}
 package user
@@ -177,7 +177,7 @@ And what changed shape:
 
 Once a suite is migrated, several things change beyond the syntax:
 
-- **Compile-time safety.** A typo in a lifecycle hook name (`SetUpTest` instead of `SetupTest`) silently does nothing in testify. In gotest, the code generator validates hook names and signatures at generation time. Wrong name? Clear error with file and line number.
+- **Generation-time safety.** A typo in a lifecycle hook name (`SetUpTest` instead of `SetupTest`) silently does nothing in testify. In gotest, a hook with the wrong signature is a generation-time error with file and line number, and `gotest lint` flags near-miss hook names like `BeforEach` before they silently become ordinary methods.
 - **No framework in the stack trace.** When a test fails, the stack trace shows your code calling a gotest assertion function. There's no reflection layer, no `suite.Run` orchestration, no `reflect.Value.Call` in between.
 - **BDD structure.** Test methods can use `t.When()` and `t.It()` to create labeled subtests. Combined with `gotest spec`, your test hierarchy renders as a behavioral specification. [More on BDD-style tests.]({{< ref "/blog/readable-tests-with-bdd" >}})
 - **Process isolation.** Each suite runs as a separate OS process. A panicking test in one suite cannot crash another. Suite-level parallelism is safe by default.
@@ -194,10 +194,9 @@ $ gotest migrate ./...
 
 # migrate a specific package
 $ gotest migrate ./pkg/user
-
-# preview changes without writing (dry run)
-$ gotest migrate ./... --dry-run
 ```
+
+There is no dry-run mode — the tool writes rewritten files directly. Run it on a clean git tree and use `git diff` to review every change (and `git checkout` to back out).
 
 The tool performs an AST-level transformation, not a text find-and-replace. It parses your Go source files, identifies testify/suite patterns, and rewrites them while preserving comments, formatting, and non-suite code in the same file.
 
@@ -207,18 +206,18 @@ The migration tool covers the common cases that make up the bulk of a typical mi
 
 1. **Renames the suite struct** to follow the `*TestSuite` convention.
 1. **Renames lifecycle hooks:** `SetupSuite` to `BeforeAll`, `TearDownSuite` to `AfterAll`, `SetupTest` to `BeforeEach`, `TearDownTest` to `AfterEach`.
-1. **Transforms assertion calls:** `s.Require().Equal(a, b)` and `s.Equal(a, b)` both become `gotest.Equal(t, a, b)`.
+1. **Transforms assertion calls:** `s.Require().Equal(a, b)` and `s.Assert().Equal(a, b)` become `gotest.Equal(t, a, b)`, as do `require.Equal(s.T(), a, b)`-style calls inside suite methods. Direct `s.Equal(a, b)` calls are annotated with a TODO instead (see below).
 1. **Removes the `suite.Suite` embed** from the struct.
 1. **Removes the `suite.Run` boilerplate** function.
 1. **Updates imports:** removes `testify/suite`, adds `gotest`.
 
 ### What needs manual review
 
-The tool handles the 90% case. For the remaining edge cases, it leaves `// TODO: manual review` comments so you can find and address them:
+The tool handles the 90% case. For the remaining edge cases, it leaves `// TODO(gotest-migrate)` comments so you can find and address them:
 
-- **`s.T()` calls outside assertions.** If your suite passes `s.T()` to helper functions, you'll need to replace those with the `t` parameter that test methods now receive.
-- **Custom helper methods on the suite.** Methods that aren't lifecycle hooks or test methods are left unchanged. If they call assertions via `s.Require()`, those calls need manual conversion.
-- **Testify assertions not in `suite`.** If the same file uses `testify/assert` or `testify/require` directly (not through the suite), those imports and calls aren't touched. Replace them with the equivalent `gotest.*` functions.
+- **Assertions called directly on the suite.** `s.Equal(...)`, `s.Contains(...)` — testify's assert-flavored calls through the embedded `suite.Suite` — are left as written, each with a TODO naming the `gotest.*` replacement. Since the embedding is removed, they won't compile until you convert them.
+- **Custom helper methods on the suite.** Methods that aren't lifecycle hooks or test methods don't get a `t *gotest.T` parameter added. Assertion calls inside them are still rewritten to `gotest.*(t, ...)`, so you need to thread a `t` parameter through yourself. The same applies to `s.T()` handoffs, which the tool rewrites to `t.T()` everywhere.
+- **Testify assertions outside suite methods.** `assert.*` or `require.*` calls in standalone functions aren't converted — but the testify imports in a migrated file are removed, so the compiler will point you at every remaining call. Replace them with the equivalent `gotest.*` functions. (Inside suite methods, `assert.Equal(s.T(), ...)`-style calls are converted automatically.)
 - **`BeforeTest` / `AfterTest`.** testify has additional per-test hooks that receive the suite and test names as parameters: `BeforeTest(suiteName, testName string)` and `AfterTest(suiteName, testName string)`. These have no direct gotest equivalent and need manual conversion.
 - **`SetupSubTest` / `TearDownSubTest`.** testify/suite has subtest-level hooks that gotest doesn't map to directly. These are flagged for manual review.
 
@@ -239,7 +238,7 @@ The good news: it's a mechanical transformation. The assertion names are almost 
 | `s.Nil(ptr)` | `gotest.Nil(t, ptr)` |
 | `s.NotNil(ptr)` | `gotest.NotNil(t, ptr)` |
 
-`Nil` and `NotNil` deserve a note: testify's `Nil` checks specifically for `nil` using reflection, while gotest's `Zero` checks for the zero value of the type. They behave the same for pointers and interfaces (where `nil` is the zero value), but differ for other types. If your code uses `s.Nil` on non-pointer values, review those call sites manually.
+`Nil` and `NotNil` deserve a note: gotest's versions are type-guarded. They accept only nilable types — pointers, interfaces, slices, maps, channels, functions — and fail with a guard error on anything else, pointing you to `Zero`/`NotZero` for comparable value types. testify's `Nil` accepts any value and reports a plain assertion failure. If your code calls `s.Nil` on non-nilable values, switch those call sites to `gotest.Zero`.
 
 One difference worth noting: testify distinguishes between `s.Assert()` (continues on failure) and `s.Require()` (stops on failure). Calling assertions directly on the suite (`s.Equal(...)`, `s.Contains(...)`) also continues on failure, because the suite embeds `*assert.Assertions`. Only `s.Require().Equal(...)` stops. All gotest assertions stop on failure, like `Require`. This is a deliberate choice: a test that continues after a failed precondition typically produces confusing follow-on errors. If you need soft assertions, you can use `t.Errorf` directly.
 
@@ -250,11 +249,11 @@ Another difference: gotest assertions are generic. `gotest.Equal[V any](t, expec
 You don't have to migrate everything at once. gotest suites and `func Test*` functions coexist in the same package. A practical approach for larger codebases:
 
 1. **Start with one package.** Pick a package with a few well-understood suites. Run `gotest migrate ./pkg/user` and verify the tests pass.
-1. **Run both side by side.** Unmigrated packages keep using testify. Migrated packages use gotest. Both run via `go test` (or `gotest`) without conflict.
+1. **Run both side by side.** Unmigrated packages keep using testify under `go test`. Migrated suites run under `gotest` — the two runners partition the work and ignore each other's tests, so a complete run is both commands: `go test ./...` for the stdlib/testify half, `gotest ./...` for the suites.
 1. **Migrate package by package.** There's no deadline. Each package is independent. A half-migrated codebase works fine.
 1. **Remove testify when ready.** Once the last suite is migrated, drop the `testify` dependency from `go.mod`.
 
-The linter can help track progress. `gotest lint` flags `testify/suite` imports in packages that also use gotest suites, catching packages where migration is incomplete. Wiring that check into your pipeline keeps half-migrated packages from lingering; [Go Tests in GitHub Actions]({{< ref "/blog/gotest-in-ci" >}}) covers the CI setup.
+The linter can help track progress. `gotest lint` flags every remaining testify import ("testify import ... — consider migrating to gotest"), which makes half-migrated packages easy to list. Wiring that check into your pipeline keeps half-migrated packages from lingering; [Go Tests in GitHub Actions]({{< ref "/blog/gotest-in-ci" >}}) covers the CI setup.
 
 ## Common questions
 
@@ -272,4 +271,4 @@ Yes. All lifecycle hooks and test methods accept either `*gotest.T` or `*testing
 
 ### What if I have hundreds of suites?
 
-`gotest migrate ./...` processes all packages in one pass. Review the `// TODO: manual review` comments it leaves, fix the edge cases, and run your tests. For large codebases, doing this package by package is safer, but the tool handles batch migration too.
+`gotest migrate ./...` processes all packages in one pass. Review the `// TODO(gotest-migrate)` comments it leaves, fix the edge cases, and run your tests. For large codebases, doing this package by package is safer, but the tool handles batch migration too.

--- a/site/content/blog/testing-async-go.md
+++ b/site/content/blog/testing-async-go.md
@@ -69,8 +69,8 @@ func TestDeliverNotification(t *testing.T) {
 This is better. The test checks every 10ms and gives up after 500ms. If the dispatcher finishes in 20ms, the test returns in ~30ms instead of sleeping for the full 500. But it comes with its own problems:
 
 - **Verbose.** Seven lines of polling infrastructure to assert one thing. The actual check (`DeliveryCount() == 1`) is buried inside a select loop.
-- **Error handling is awkward.** You can't call `t.Fatal` inside a goroutine; it panics. So if you ever need to poll from a separate goroutine, this pattern breaks.
-- **No standard pattern.** Every team reinvents it. Different timeout values, different tick intervals, different error messages. Some use channels, some use contexts, some use `time.Tick` (which leaks). There's no shared vocabulary.
+- **Error handling is awkward.** `t.Fatal` only works from the goroutine running the test function — called from any other goroutine, it stops that goroutine, not the test. So if you ever need to poll from a separate goroutine, this pattern breaks.
+- **No standard pattern.** Every team reinvents it. Different timeout values, different tick intervals, different error messages. Some use channels, some use contexts, some use `time.Tick`. There's no shared vocabulary.
 
 ## Eventually: poll until true
 
@@ -82,7 +82,7 @@ This is better. The test checks every 10ms and gives up after 500ms. If the disp
 
 If the callback succeeds on any tick (no assertion failures), `Eventually` returns immediately. If the deadline passes without a successful tick, it reports the last failure message to the test runner.
 
-The vocabulary here has prior art worth crediting: gomega's `Eventually` and `Consistently` established this pattern in the Go ecosystem, and testify offers `require.Eventually` for the polling case. gotest's version is distinguished by the details the examples below rely on — the `*gotest.R` recorder that lets ordinary assertions run inside polling callbacks, and the explicit `waitFor`/`tick` separation.
+The vocabulary here has prior art worth crediting: gomega's `Eventually` and `Consistently` established this pattern in the Go ecosystem, and testify offers `require.Eventually` for the polling case. gotest's version is distinguished by the detail the examples below rely on — the `*gotest.R` recorder that lets ordinary assertions run inside polling callbacks.
 
 Here's the notification dispatcher test rewritten with `Eventually`, using [BDD-style structure]({{< ref "/blog/readable-tests-with-bdd" >}}):
 
@@ -145,7 +145,7 @@ func (s *NotificationServiceTestSuite) TestIdleDispatcher(t *gotest.T) {
 
 This checks every 50ms for 200ms that the delivery count remains zero. If a bug causes a spurious delivery, the test catches it on the tick where it happens rather than after a blind sleep.
 
-`Consistently` is especially useful for race condition tests. If you're verifying that a mutex correctly prevents concurrent access, `Consistently` gives you repeated checks over time rather than a single snapshot that might miss the race.
+`Consistently` is also useful for guarding invariants over time — verifying that a counter never goes negative or a queue never exceeds its bound while background work runs. For actual data races, though, use the race detector: `-race` passes through gotest just as it does with `go test`, and polling assertions are not a substitute for it.
 
 ## Eventually as a synchronization barrier
 
@@ -154,7 +154,6 @@ A powerful pattern is using `Eventually` to synchronize, then asserting properti
 ```go {title="dispatcher_test.go"}
 func (s *NotificationServiceTestSuite) TestDeliveryTimestamp(t *gotest.T) {
     t.When("a notification is delivered", func(t *gotest.T) {
-        before := time.Now()
         s.dispatcher.Send(Notification{To: "user@example.com", Subject: "Timestamp check"})
 
         gotest.Eventually(t, 500*time.Millisecond, 10*time.Millisecond, func(poll *gotest.R) {

--- a/site/content/blog/tests-as-documentation.md
+++ b/site/content/blog/tests-as-documentation.md
@@ -15,29 +15,31 @@ gotest's spec view renders the same test results as a structured document. Other
 
 ## From test output to specification
 
-The same tests, two views. First, standard `go test -v`:
+The same tests, two views. First, the standard verbose stream from `gotest ./... -v` (suites run through the `gotest` runner, which emits regular `go test` output):
 
-{{< gotest-output title="go test -v" >}}
+{{< gotest-output title="gotest ./... -v" >}}
 === RUN   TestCartTestSuite
 === RUN   TestCartTestSuite/TestAddItem
-=== RUN   TestCartTestSuite/TestAddItem/when_the_cart_is_empty/adds_the_item
---- PASS: TestCartTestSuite/TestAddItem/when_the_cart_is_empty/adds_the_item (0.00s)
-=== RUN   TestCartTestSuite/TestAddItem/when_the_cart_is_empty/sets_quantity_to_1
---- PASS: TestCartTestSuite/TestAddItem/when_the_cart_is_empty/sets_quantity_to_1 (0.00s)
-=== RUN   TestCartTestSuite/TestAddItem/when_the_item_already_exists/increments_the_quantity
---- PASS: TestCartTestSuite/TestAddItem/when_the_item_already_exists/increments_the_quantity (0.00s)
+=== RUN   TestCartTestSuite/TestAddItem/the_cart_is_empty
+=== RUN   TestCartTestSuite/TestAddItem/the_cart_is_empty/adds_the_item
+--- PASS: TestCartTestSuite/TestAddItem/the_cart_is_empty/adds_the_item (0.00s)
+=== RUN   TestCartTestSuite/TestAddItem/the_cart_is_empty/sets_quantity_to_1
+--- PASS: TestCartTestSuite/TestAddItem/the_cart_is_empty/sets_quantity_to_1 (0.00s)
+=== RUN   TestCartTestSuite/TestAddItem/the_item_already_exists
+=== RUN   TestCartTestSuite/TestAddItem/the_item_already_exists/increments_the_quantity
+--- PASS: TestCartTestSuite/TestAddItem/the_item_already_exists/increments_the_quantity (0.00s)
 {{< /gotest-output >}}
 
 Now the same results through `gotest spec`:
 
 {{< spec title="gotest spec ./..." >}}
-Cart
-  AddItem
-    when the cart is empty
-      <span class="t-pass">✓</span> adds the item
-      <span class="t-pass">✓</span> sets quantity to 1
-    when the item already exists
-      <span class="t-pass">✓</span> increments the quantity
+Cart <span class="t-time">(2ms)</span>
+  AddItem <span class="t-time">(2ms)</span>
+    the cart is empty <span class="t-time">(1ms)</span>
+      <span class="t-pass">✓</span> adds the item <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> sets quantity to 1 <span class="t-time">(<1ms)</span>
+    the item already exists <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> increments the quantity <span class="t-time">(<1ms)</span>
 {{< /spec >}}
 
 The second version is something a product manager can read. It describes what the Cart does, under what conditions, with what outcomes. It is not a test report. It is a behavioral specification, generated from tests that the build enforces. To be fair, tools like gotestsum and Ginkgo's reporters already improve the formatting of `go test` output; the spec view differs in that it renders the behavioral hierarchy itself — suite, method, `When`, `It` — rather than a better-formatted stream of test names.
@@ -69,7 +71,7 @@ The markdown output is a self-contained document with a summary header and per-s
 ```md {title="docs/behavior-spec.md"}
 # Behavior Specification
 
-4 suites, 12 behaviors: 28 passed, 0 failed, 0 skipped.
+4 suites, 28 behaviors: 28 passed, 0 failed, 0 skipped.
 
 ## Cart
 
@@ -77,10 +79,10 @@ The markdown output is a self-contained document with a summary header and per-s
 
 | Behavior | Status | Duration |
 |----------|--------|----------|
-| **when the cart is empty** | | |
+| **the cart is empty** | | |
 | &nbsp;&nbsp;adds the item | PASS | <1ms |
 | &nbsp;&nbsp;sets quantity to 1 | PASS | <1ms |
-| **when the item already exists** | | |
+| **the item already exists** | | |
 | &nbsp;&nbsp;increments the quantity | PASS | <1ms |
 ```
 
@@ -96,13 +98,23 @@ gotest spec ./... --format=json
 
 The JSON output includes full metadata: package names, node kinds (suite, method, block, test), status, duration, focused/excluded flags, and the complete child hierarchy. This is the machine-readable format for building custom reports, dashboards, or integrations.
 
+## A spec without a run: `--static`
+
+Everything above renders results. Since v1.27, `gotest spec --static` renders the same tree straight from source — no run, no event stream:
+
+```sh
+gotest spec --static ./...
+```
+
+The static view lists suites, methods, and `When`/`It` blocks with no status icons and no durations, because nothing has executed. It answers "what do these tests promise?" where a regular `spec` answers "what did they do?" — useful for reviewing a package's behavioral surface before running anything.
+
 ## Post-processing with `--input`
 
-You don't have to run tests to generate specs. The `--input` flag reads saved `go test -json` output:
+You also don't have to render the spec on the machine that ran the tests. The `--input` flag reads a saved test event stream in `go test -json` format — which `gotest ./... -json` emits for your suites:
 
 ```sh
 # Save test output in CI
-go test -json ./... > test-output.json
+gotest ./... -json > test-output.json
 
 # Generate spec from saved output (on any machine, later)
 gotest spec --input=test-output.json --format=md --output=spec.md
@@ -111,7 +123,7 @@ gotest spec --input=test-output.json --format=md --output=spec.md
 Or pipe directly:
 
 ```sh
-go test -json ./... | gotest spec --input=- --format=md
+gotest ./... -json | gotest spec --input=- --format=md
 ```
 
 This separation is powerful: run tests on one machine, generate documentation on another. Save test output as a CI artifact, then render specs from it in a post-processing step. The spec generation is fast because it doesn't compile or execute any code — it just transforms JSON into a structured view.
@@ -150,29 +162,29 @@ gotest spec ./... --format=md --output=new-spec.md
 diff old-spec.md new-spec.md
 ```
 
-When a PR adds or changes tests, the spec diff shows exactly which behaviors were added, modified, or removed — in plain English. "Added: UserService / Create / when email is duplicate / returns ErrDuplicate" is a more useful PR description than a list of changed files.
+When a PR adds or changes tests, the spec diff shows exactly which behaviors were added, modified, or removed — in plain English. "Added: UserService / Create / email is duplicate / returns ErrDuplicate" is a more useful PR description than a list of changed files.
 
 ## The specification as a contract
 
 When tests follow the BDD structure — suite as subject, method as capability, `When` as context, `It` as behavior — the spec output is more than a report. It is a behavioral contract. ([BDD in Go]({{< ref "/blog/what-bdd-means-in-go" >}}) explores why this structure maps so naturally onto Go's type system.)
 
 - **For developers:** the spec lists every behavior the system promises. Adding a feature means adding a behavior. Changing a behavior is visible in the spec diff.
-- **For reviewers:** the spec in a PR shows what changed at the behavior level, not just the code level. "Added: UserService / Create / when email is duplicate / returns ErrDuplicate" is easier to review than reading test code.
+- **For reviewers:** the spec in a PR shows what changed at the behavior level, not just the code level. "Added: UserService / Create / email is duplicate / returns ErrDuplicate" is easier to review than reading test code.
 - **For product:** the markdown spec is a living requirements document. If a requirement isn't in the spec, it isn't tested. If it's tested, it's in the spec.
 
 This works because the spec is not written separately from the tests. It *is* the tests, rendered in a format that non-developers can read. There is no synchronization problem because there is only one source of truth.
 
 ## Structured output for language models
 
-The JSON format from `gotest spec --format=json` contains the full behavioral tree of your project. Feeding this to an LLM gives it a structured understanding of what the system does — not how it's implemented, but what it promises. "UserService / Create / when email is valid / creates the user" communicates the system's contract without requiring the model to parse implementation details. This is more compact and more reliable than feeding raw source code.
+The JSON format from `gotest spec --format=json` contains the full behavioral tree of your project. Feeding this to an LLM gives it a structured understanding of what the system does — not how it's implemented, but what it promises. "UserService / Create / email is valid / creates the user" communicates the system's contract without requiring the model to parse implementation details. This is more compact and more reliable than feeding raw source code.
 
 ## Tests that don't document themselves
 
 Not all tests are good documentation. A test named `TestFoo` with no `When`/`It` blocks produces a spec line that says nothing:
 
 {{< spec title="gotest spec" >}}
-Foo
-  <span class="t-pass">✓</span> TestFoo
+Foo <span class="t-time">(<1ms)</span>
+  <span class="t-pass">✓</span> Foo <span class="t-time">(<1ms)</span>
 {{< /spec >}}
 
 The spec view rewards structure. When you invest in clear naming — descriptive suite names, verb-based method names, specific `When`/`It` descriptions — the spec output becomes genuinely useful documentation. When you don't, it reflects that too. The tool is honest.

--- a/site/content/blog/the-inner-loop.md
+++ b/site/content/blog/the-inner-loop.md
@@ -13,12 +13,12 @@ gotest has three features that compress the inner loop: watch mode for automatic
 
 The whole post in one command:
 
-{{< terminal title="gotest watch ./..." >}}
-$ gotest watch ./...
-UserService
-  Create
-    when email is valid
-      <span class="t-pass">✓</span> persists the user
+{{< terminal title="gotest watch ./... --spec" >}}
+$ gotest watch ./... --spec
+UserService <span class="t-time">(4ms)</span>
+  Create <span class="t-time">(4ms)</span>
+    email is valid <span class="t-time">(3ms)</span>
+      <span class="t-pass">✓</span> persists the user <span class="t-time">(3ms)</span>
 {{< /terminal >}}
 
 ## The default Go inner loop
@@ -36,7 +36,7 @@ This works. It is reliable and well-understood. But three things slow it down.
 
 **Manual re-runs.** Every save requires a conscious decision to switch to the terminal and re-run. This sounds trivial, but it breaks flow. The context switch is not just physical (alt-tab, type command, press enter). It is cognitive: you interrupt whatever you were thinking about to operate the test runner.
 
-**Verbose targeting.** The `-run` flag uses regex matching, which is powerful but verbose. If you want to run a single test method in a suite, you write something like `go test -run "TestUserService/TestCreate/when_email_is_valid" ./pkg/user/`. That is a lot to type, easy to get wrong, and fragile when test names change.
+**Verbose targeting.** The `-run` flag uses regex matching, which is powerful but verbose. If you want to run a single test method in a suite, you write something like `go test -run "TestUserService/TestCreate/email_is_valid" ./pkg/user/`. That is a lot to type, easy to get wrong, and fragile when test names change.
 
 **Flat output.** `go test -v` prints one line per test, interleaved with log output. When you have 40 tests in a package and three of them fail, finding the failures means scanning every line. There is no hierarchy, no grouping, no visual distinction between passing and failing branches.
 
@@ -50,7 +50,7 @@ The first friction point is the manual re-run. Watch mode eliminates it entirely
 gotest watch ./...
 ```
 
-That is the entire setup. After this command, the terminal clears and runs your tests. Every time you save a `.go` file, it clears the terminal and re-runs. You never switch to the terminal to type a command again.
+That is the entire setup. After this command, your tests run once. Every time you save a `.go` file, it clears the terminal and re-runs. Add `--spec` to render the spec tree after each run instead of the default output. You never switch to the terminal to type a command again.
 
 Under the hood, watch mode uses fsnotify to monitor your source tree for `.go` file changes. When a file changes, it waits 200 milliseconds for the save to settle (this debounce is configurable via `--debounce`), then converts the changed file's directory into a package pattern and re-runs only that package.
 
@@ -96,7 +96,7 @@ func (s *UserServiceTestSuite) X_TestSlowIntegration(t *gotest.T) {
 The rules are simple:
 
 - `F_` works on both suite types and test methods.
-- When any `F_` exists in a package, only focused items run.
+- A focused suite skips the other suites in its package; a focused method skips the other methods in its suite.
 - `X_` always skips, regardless of whether focus is active.
 - `X_` takes precedence over `F_`.
 
@@ -126,8 +126,8 @@ gotest's CI mode catches this. When running with the `--ci` flag (or when the `C
 
 {{< terminal title="CI output" >}}
 FAIL: focus prefix detected — remove F_ before merging:
-  type F_UserServiceTestSuite
-  OrderServiceTestSuite.F_TestCreate
+  pkg/user/user_test.go:12  type F_UserServiceTestSuite
+  pkg/order/order_test.go:48  OrderServiceTestSuite.F_TestCreate
 {{< /terminal >}}
 
 This turns a silent skip into a loud failure. The error message lists every focused item so you know exactly what to fix. No test suite runs with incomplete coverage because someone forgot to remove a prefix.
@@ -141,16 +141,16 @@ Watch mode handles re-running. Focus prefixes handle scoping. The third piece is
 Standard `go test -v` output looks like this:
 
 {{< gotest-output title="go test -v output" >}}
-=== RUN   TestUserService
-=== RUN   TestUserService/TestCreate
-=== RUN   TestUserService/TestCreate/when_email_is_valid
-=== RUN   TestUserService/TestCreate/when_email_is_valid/persists_the_user
---- PASS: TestUserService/TestCreate/when_email_is_valid/persists_the_user (0.00s)
-=== RUN   TestUserService/TestCreate/when_email_is_valid/returns_no_error
---- PASS: TestUserService/TestCreate/when_email_is_valid/returns_no_error (0.00s)
-=== RUN   TestUserService/TestCreate/when_email_is_duplicate
-=== RUN   TestUserService/TestCreate/when_email_is_duplicate/returns_ErrDuplicate
---- PASS: TestUserService/TestCreate/when_email_is_duplicate/returns_ErrDuplicate (0.00s)
+=== RUN   TestUserServiceTestSuite
+=== RUN   TestUserServiceTestSuite/TestCreate
+=== RUN   TestUserServiceTestSuite/TestCreate/email_is_valid
+=== RUN   TestUserServiceTestSuite/TestCreate/email_is_valid/persists_the_user
+--- PASS: TestUserServiceTestSuite/TestCreate/email_is_valid/persists_the_user (0.00s)
+=== RUN   TestUserServiceTestSuite/TestCreate/email_is_valid/returns_no_error
+--- PASS: TestUserServiceTestSuite/TestCreate/email_is_valid/returns_no_error (0.00s)
+=== RUN   TestUserServiceTestSuite/TestCreate/email_is_duplicate
+=== RUN   TestUserServiceTestSuite/TestCreate/email_is_duplicate/returns_ErrDuplicate
+--- PASS: TestUserServiceTestSuite/TestCreate/email_is_duplicate/returns_ErrDuplicate (0.00s)
 {{< /gotest-output >}}
 
 Every line repeats the full path. The hierarchy is encoded in the names, but the output is flat. With 40 tests, this becomes a wall of text where your eyes glaze over looking for the word "FAIL."
@@ -158,13 +158,13 @@ Every line repeats the full path. The hierarchy is encoded in the names, but the
 The `gotest spec` command renders the same information as a tree:
 
 {{< spec title="gotest spec output" >}}
-UserService
-  Create
-    when email is valid
-      <span class="t-pass">✓</span> persists the user
-      <span class="t-pass">✓</span> returns no error
-    when email is duplicate
-      <span class="t-pass">✓</span> returns ErrDuplicate
+UserService <span class="t-time">(7ms)</span>
+  Create <span class="t-time">(7ms)</span>
+    email is valid <span class="t-time">(5ms)</span>
+      <span class="t-pass">✓</span> persists the user <span class="t-time">(3ms)</span>
+      <span class="t-pass">✓</span> returns no error <span class="t-time">(2ms)</span>
+    email is duplicate <span class="t-time">(1ms)</span>
+      <span class="t-pass">✓</span> returns ErrDuplicate <span class="t-time">(1ms)</span>
 {{< /spec >}}
 
 The structure is immediately visible. Suite names become headings, methods become groups, `When`/`It` calls become nested branches. Passing tests get a checkmark. Failing tests get a clear marker with the failure message indented beneath them. You see the shape of your test coverage at a glance.
@@ -201,4 +201,4 @@ Watch mode eliminates manual re-runs. You save, results appear. Focus prefixes e
 
 Separately, each feature removes one friction point. Together, they compress the inner loop from a 30-second manual process to a sub-second automatic one. The shift is not just in speed. It is in how you think. When feedback is instant, you write differently: smaller steps, more experiments, fewer assumptions carried in your head.
 
-If you are new to gotest, [Your First Go Test Suite in 10 Minutes]({{< ref "/blog/zero-to-suite" >}}) walks through setting up your first test suite. For CI integration, [gotest in CI]({{< ref "/blog/gotest-in-ci" >}}) covers the `--ci` flag, caching, and parallel execution in detail. And the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest) brings the entire workflow into your editor.
+If you are new to gotest, [Your First Go Test Suite in 10 Minutes]({{< ref "/blog/zero-to-suite" >}}) walks through setting up your first test suite. For CI integration, [gotest in CI]({{< ref "/blog/gotest-in-ci" >}}) covers the `--ci` flag, coverage thresholds, and PR annotations in detail. And the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest) brings the entire workflow into your editor.

--- a/site/content/blog/what-bdd-means-in-go.md
+++ b/site/content/blog/what-bdd-means-in-go.md
@@ -65,13 +65,13 @@ func (s *UserServiceTestSuite) TestCreate(t *gotest.T) {
 And the spec output reads:
 
 {{< spec title="gotest spec" >}}
-UserService
-  Create
-    when email is valid
-      <span class="t-pass">✓</span> creates the user
-      <span class="t-pass">✓</span> assigns an ID
-    when email is duplicate
-      <span class="t-pass">✓</span> returns ErrDuplicate
+UserService <span class="t-time">(6ms)</span>
+  Create <span class="t-time">(6ms)</span>
+    email is valid <span class="t-time">(4ms)</span>
+      <span class="t-pass">✓</span> creates the user <span class="t-time">(3ms)</span>
+      <span class="t-pass">✓</span> assigns an ID <span class="t-time">(<1ms)</span>
+    email is duplicate <span class="t-time">(1ms)</span>
+      <span class="t-pass">✓</span> returns ErrDuplicate <span class="t-time">(1ms)</span>
 {{< /spec >}}
 
 That output is a behavioral specification. Not because it uses special keywords, but because the test structure — type, method, When, It — maps directly to subject, capability, context, behavior. The specification emerges from Go's own constructs.
@@ -104,7 +104,7 @@ Fewer keywords means less to learn, less to argue about ("should this be a `Cont
 
 ## The struct as subject
 
-In BDD, the "subject under test" is the thing whose behavior you are specifying. In RSpec, it is a string: `describe UserService do`. In Jest, it is a string: `describe('UserService', () => {})`. In both cases, the subject exists only at runtime, as a label.
+In BDD, the "subject under test" is the thing whose behavior you are specifying. In RSpec, it is a string: `describe "UserService" do`. In Jest, it is a string: `describe('UserService', () => {})`. In both cases, the subject exists only at runtime, as a label.
 
 In gotest, the subject is a Go type:
 
@@ -197,26 +197,26 @@ In closure-based BDD frameworks, parameterized tests are awkward. You either gen
 When every suite follows this convention — struct = subject, method = capability, When = context, It = behavior — the spec output for the entire project reads as a complete behavioral specification:
 
 {{< spec title="gotest spec ./..." >}}
-UserService
-  Create
-    when email is valid
-      <span class="t-pass">✓</span> creates the user
-      <span class="t-pass">✓</span> assigns an ID
-    when email is duplicate
-      <span class="t-pass">✓</span> returns ErrDuplicate
-  Delete
-    when user exists
-      <span class="t-pass">✓</span> removes the user
-    when user does not exist
-      <span class="t-pass">✓</span> returns ErrNotFound
+UserService <span class="t-time">(9ms)</span>
+  Create <span class="t-time">(6ms)</span>
+    email is valid <span class="t-time">(4ms)</span>
+      <span class="t-pass">✓</span> creates the user <span class="t-time">(3ms)</span>
+      <span class="t-pass">✓</span> assigns an ID <span class="t-time">(<1ms)</span>
+    email is duplicate <span class="t-time">(1ms)</span>
+      <span class="t-pass">✓</span> returns ErrDuplicate <span class="t-time">(1ms)</span>
+  Delete <span class="t-time">(3ms)</span>
+    user exists <span class="t-time">(2ms)</span>
+      <span class="t-pass">✓</span> removes the user <span class="t-time">(2ms)</span>
+    user does not exist <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> returns ErrNotFound <span class="t-time">(<1ms)</span>
 
-OrderService
-  Place
-    when stock is sufficient
-      <span class="t-pass">✓</span> creates the order
-      <span class="t-pass">✓</span> decrements stock
-    when stock is insufficient
-      <span class="t-pass">✓</span> returns ErrInsufficientStock
+OrderService <span class="t-time">(12ms)</span>
+  Place <span class="t-time">(12ms)</span>
+    stock is sufficient <span class="t-time">(9ms)</span>
+      <span class="t-pass">✓</span> creates the order <span class="t-time">(6ms)</span>
+      <span class="t-pass">✓</span> decrements stock <span class="t-time">(3ms)</span>
+    stock is insufficient <span class="t-time">(2ms)</span>
+      <span class="t-pass">✓</span> returns ErrInsufficientStock <span class="t-time">(2ms)</span>
 {{< /spec >}}
 
 This is not a testing report. It is a specification document — generated from tests that are also the implementation verification. The tests and the spec are the same artifact. A new team member reads this output and knows what the system does. A product manager reads it and confirms the feature coverage. This is what North meant by BDD: the tests *are* the specification. For how to export this output as markdown and treat it as a real documentation artifact, see [Go Tests as Living Documentation]({{< ref "/blog/tests-as-documentation" >}}).
@@ -239,7 +239,7 @@ In string-based BDD frameworks, the specification exists only at runtime. The `D
 
 When BDD structure maps to Go types, the compiler participates:
 
-- **Misspelled method name?** Compile error. In a closure-based framework, a misspelled `Describe` string silently creates a different spec path.
+- **Misspelled suite type in a receiver?** Compile error — the type doesn't exist. And `gotest lint` flags near-miss lifecycle names like `BeforEach`. In a closure-based framework, a misspelled `Describe` string silently creates a different spec path.
 - **Wrong lifecycle signature?** The code generator catches it at generation time with a clear error and line number. In a reflection-based framework, the method is silently ignored.
 - **Duplicate test names?** Two methods with the same name on the same type is a compile error. Two `It` blocks with the same string in the same `Describe` is... nothing. It runs both, and the output is confusing.
 - **Refactoring?** Rename a struct and your IDE updates every reference. Rename a string inside `Describe()` and you update that one call — every cross-reference is a manual search.

--- a/site/content/blog/why-gotest.md
+++ b/site/content/blog/why-gotest.md
@@ -18,7 +18,7 @@ gotest exists to fill those gaps without replacing what works. This post explain
 
 Most Go projects hit the same set of problems as their test suite grows past a few dozen files:
 
-- **No structural grouping.** The stdlib gives you `func TestX` and `t.Run` for subtests. But subtests are closures inside flat functions, not first-class groups. If you have 30 test functions for `UserService` and 20 for `OrderService` in the same package, they are an alphabetical list. There is no way to say "these tests belong together" at the structural level.
+- **No structural grouping.** The stdlib gives you `func TestX` and `t.Run` for subtests. But subtests are closures inside flat functions, not first-class groups. If you have 30 test functions for `UserService` and 20 for `OrderService` in the same package, they are one flat list. There is no way to say "these tests belong together" at the structural level.
 - **No lifecycle hooks.** There is no built-in "run this before each test" or "run this once before the suite." `TestMain` gives you one entry point per package, but it runs before all tests and has no per-test granularity. `t.Cleanup` runs after a test, but there is no corresponding setup hook. [Go Test Lifecycle]({{< ref "/blog/go-test-lifecycle" >}}) walks through what the stdlib gives you and where it stops.
 - **No fixture management.** If three test functions need a Postgres container, each one either starts its own (slow) or they share a package-level variable (fragile). The stdlib has no concept of "this resource has a lifecycle and these tests depend on it."
 - **No cross-package sharing.** `go test` runs each package as a separate OS process. There is no way for `pkg/user` and `pkg/order` to share a database container through Go code. Most teams fall back to Makefiles or CI scripts to start infrastructure before running tests. [Sharing Test Fixtures Across Go Packages]({{< ref "/blog/shared-fixtures" >}}) looks at this problem in depth.
@@ -55,7 +55,7 @@ This means there is no lock-in at the output level. CI pipelines that parse `go 
 
 ## Principle 2: The naming IS the API
 
-gotest has no configuration files, no struct tags, no annotations, and no registration calls. The entire API is naming conventions:
+Declaring a suite takes no configuration file, no struct tags, no annotations, and no registration calls. The entire API is naming conventions:
 
 - A struct whose name ends in `TestSuite` is a test suite.
 - A method whose name starts with `Test` is a test case.
@@ -79,6 +79,10 @@ func (s *UserServiceTestSuite) BeforeEach(t *gotest.T) {
     s.svc = NewUserService(s.db)
 }
 
+func (s *UserServiceTestSuite) AfterEach(t *gotest.T) {
+    s.db.Close()
+}
+
 func (s *UserServiceTestSuite) TestCreate(t *gotest.T) {
     t.When("email is valid", func(w *gotest.T) {
         w.It("creates the user", func(it *gotest.T) {
@@ -89,19 +93,19 @@ func (s *UserServiceTestSuite) TestCreate(t *gotest.T) {
 }
 ```
 
-There is no registration call, no embedded base type, no interface to implement. The struct name ends in `TestSuite`, so the generator recognizes it. The method name starts with `Test`, so it becomes a test case. `BeforeEach` runs before every test method. Everything else is plain Go.
+There is no registration call, no embedded base type, no interface to implement. The struct name ends in `TestSuite`, so the generator recognizes it. The method name starts with `Test`, so it becomes a test case. `BeforeEach` runs before every test method, and `AfterEach` cleans up after it. Everything else is plain Go.
 
 The code generator reads these source files with `go/parser`, walks the AST looking for the naming patterns, and produces the lifecycle wiring. Discovery is purely static: no code runs during the generation step.
 
 ## Principle 3: Zero runtime cost
 
-At test execution time, there is no framework orchestration code in your call stack. The only runtime component is the thin `gotest.T` wrapper that provides `When`/`It` methods and standalone assertion functions like `gotest.Equal`. Everything else is generated: struct initialization, `t.Run` calls, `t.Cleanup` calls, direct method invocations. No reflection, no interface dispatch, no type assertions.
+At test execution time, there is no discovery or dispatch machinery in your call stack. The runtime surface is thin: the `gotest.T` wrapper that provides `When`/`It` methods and standalone assertion functions like `gotest.Equal`, plus a small runtime package the generated code calls for timeouts and panic containment. The orchestration itself is generated: struct initialization, `t.Run` calls, `t.Cleanup` calls, direct method invocations. No reflection, no interface dispatch, no type assertions in the wiring.
 
 This has practical consequences. Stack traces point to your code, not to framework internals. Refactoring tools can follow the call chain because every call is a direct call. The `gotest` package that your tests import is a thin layer of helper types and functions; it has no transitive dependencies beyond the standard library.
 
 The code generator runs before `go test` and produces Go source files. Those files are injected via Go's `-overlay` flag, a built-in mechanism that maps virtual file paths to real files on disk. The compiler sees the generated files; your source directory does not. After the run, nothing is left behind. Your `git status` stays clean.
 
-This extends to isolation. Each suite runs in its own OS process: a generated test binary, compiled and executed separately. A panicking test in one suite cannot crash another. Memory is isolated by the OS, not by convention. Goroutine leaks, global state mutations, and port conflicts stay contained to the process that caused them.
+This extends to isolation. Each suite runs in its own OS process: the package's test binary is compiled once and executed separately per suite, filtered to just that suite. A panicking test in one suite cannot crash another. Memory is isolated by the OS, not by convention. Goroutine leaks, global state mutations, and port conflicts stay contained to the process that caused them.
 
 This structural isolation is what makes suite-level parallelism safe by default: suites run concurrently without any opt-in, because they cannot interfere with each other.
 
@@ -109,13 +113,13 @@ This structural isolation is what makes suite-level parallelism safe by default:
 
 A developer who has never heard of gotest can read a test suite struct and understand what it does. The struct has fields, methods with descriptive names, and assertions that are standalone function calls. There is nothing to decode.
 
-A developer who runs `go test` directly (without the CLI) gets a compilation error for the missing generated file, not silent wrong behavior. The error is clear and points to the solution.
+A developer who runs `go test` directly (without the CLI) loses nothing that was already there: existing flat `func Test*` tests run exactly as before. The suites simply stay inert — their `func Test*` entry points exist only in gotest's overlay, so `go test` never sees them. The two runners split the work: `go test` runs the flat tests, `gotest` runs the suites.
 
 And a developer who decides to stop using gotest can look at the generated code to see exactly what to write by hand. The generated file is a complete, readable Go test file. It is not a binary artifact or a compressed intermediate representation. It is the code you would have written yourself if you had the patience.
 
 ## Principle 5: Adopt incrementally, eject freely
 
-Existing `func Test*` tests coexist with suites in the same package. You do not need to convert everything at once. A single suite can live next to 50 flat test functions, and `gotest` handles both. If you want to try it, [Your First Go Test Suite in 10 Minutes]({{< ref "/blog/zero-to-suite" >}}) is the place to start.
+Existing `func Test*` tests coexist with suites in the same package. You do not need to convert everything at once. A single suite can live next to 50 flat test functions: `go test` keeps running the flat functions, `gotest` runs the suites (and reports the flat tests it leaves to `go test`), and a complete run is both commands. If you want to try it, [Your First Go Test Suite in 10 Minutes]({{< ref "/blog/zero-to-suite" >}}) is the place to start.
 
 Ejecting is real work, but it is straightforward work. You replace `*gotest.T` parameters with `*testing.T`, swap gotest assertions for your preferred alternative, and write the `func Test*` entry points that the generator was producing for you. The generated code shows exactly what those entry points look like. There is no data to migrate, no configuration to unwind, no runtime state to reconstruct.
 
@@ -139,6 +143,6 @@ These principles are not abstract. They directly shaped every feature in gotest:
 - **Parallel execution** is safe by default at the suite level: each suite runs as a separate OS process, so suites cannot interfere with each other. Method-level parallelism is opt-in via `SuiteConfig{Parallel: true}`, with a returning `BeforeEach` giving each test its own isolated state. [More in the reference.]({{< ref "/reference#lifecycle" >}})
 - **Fixtures** are structs with `Fixture` suffix. Dependencies between fixtures are expressed as pointer fields, forming a DAG that the generator resolves automatically. Shared fixtures cross the process boundary through JSON serialization. [More on fixtures.]({{< ref "/blog/test-fixtures-in-go" >}})
 - **BDD structure** uses `t.When()` and `t.It()` method calls that map directly to `t.Run`. The `gotest spec` command renders this structure as a behavioral specification, because the hierarchy is already there in the test code. [More on BDD-style tests.]({{< ref "/blog/readable-tests-with-bdd" >}})
-- **AST-based discovery** uses `go/parser` to read source files without importing or compiling them. This keeps the generation step fast and means the generator never executes user code. [More on code generation.]({{< ref "/blog/code-generation-not-reflection" >}})
+- **AST-based discovery** reads source files as syntax trees and never executes them. This keeps the generation step fast and means no user code runs during generation. [More on code generation.]({{< ref "/blog/code-generation-not-reflection" >}})
 
 Each of these deserves a deeper look. The common thread is the same: gotest is not trying to replace Go's testing model. It is trying to generate the code that Go's testing model requires you to write by hand once your project outgrows flat functions and subtests.

--- a/site/content/blog/your-editor-knows-your-tests.md
+++ b/site/content/blog/your-editor-knows-your-tests.md
@@ -12,7 +12,7 @@ You write gotest suites, open VS Code's Testing sidebar — and it's empty. No t
 
 The [gotest VS Code extension](https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest) exists to close this gap. Because it's purpose-built for suite-based testing rather than a generic test runner, it can surface things standard tooling can't: the suite hierarchy, the behavioral spec view, and coverage that survives across runs.
 
-Installation is one command — `code --install-extension mvrahden.gotest` — or grab it from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest) or [Open VSX](https://open-vsx.org/extension/mvrahden/gotest). The rest of this post is the feature tour.
+Installation is one command — `code --install-extension mvrahden.gotest` — or grab it from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=mvrahden.gotest) or [Open VSX](https://open-vsx.org/extension/mvrahden/gotest). The extension requires gotest v1.27.0 or newer and validates the CLI version on activation. The rest of this post is the feature tour.
 
 ## Why your editor can't see gotest suites
 
@@ -53,9 +53,9 @@ This is the gap the extension closes.
 
 The extension's first job is the most fundamental: making your suites visible as tests.
 
-On activation, it scans your workspace for Go files, parses the AST, and identifies suite types (structs ending in `TestSuite`) and their test methods (methods starting with `Test`). It registers these with VS Code's Test Controller, and they appear in the Testing sidebar as a structured tree: **Package > Suite > Method**, with a fourth level — **Subtests** — populated after the first execution.
+On activation, it runs the `gotest discover` subcommand, which loads your test packages, identifies suite types (structs ending in `TestSuite`) and their test methods (methods starting with `Test`), and reports them as structured JSON — the same discovery the test runner itself uses, so the editor and the CLI can never disagree about what counts as a suite. The extension registers these with VS Code's Test Controller, and they appear in the Testing sidebar as a structured tree: **Package > Suite > Method**, with a fourth level — **Subtests** — populated after the first execution.
 
-This is four levels of hierarchy. The standard Go Test Explorer, even in projects that use stdlib tests, shows two: Package > Function. And for testify/suite projects, it effectively shows one — the single `func TestRunSuite(t *testing.T)` entry point that wraps the entire suite. Individual methods are invisible.
+This is four levels of hierarchy. The standard Go Test Explorer, even in projects that use stdlib tests, has no structural level between the package and the test function — there is no suite level. And for testify/suite projects, it effectively shows a single entry — the `func TestRunSuite(t *testing.T)` entry point that wraps the entire suite. Individual methods are invisible until a run happens to reach them.
 
 Discovery re-runs automatically when `_test.go` files change. The tree stays in sync with your code without manual refresh.
 
@@ -63,7 +63,7 @@ Discovery re-runs automatically when `_test.go` files change. The tree stays in 
 
 Once suites are discovered, CodeLens buttons appear inline above every suite type and test method in your `_test.go` files: **Run** and **Debug**. Click to execute immediately.
 
-Package-level and file-level actions appear on the `package` declaration line. When a file contains multiple suites, a "Run File" action runs just the suites in that file.
+Package-level and file-level actions appear at the top of the file. When a file contains multiple suites, a "Run File" action runs just the suites in that file.
 
 You can also run from the Testing sidebar: click a suite to run all its methods, click a method to run just that one. Multi-select is fully supported — pick three methods across two suites and run them in one action.
 
@@ -80,15 +80,15 @@ After each test run, the **Spec View** panel renders your test results as a beha
 {{< spec title="Spec View" >}}
 Cart
   AddItem
-    when the cart is empty
+    the cart is empty
       <span class="t-pass">✓</span> adds the item
       <span class="t-pass">✓</span> sets quantity to 1
-    when the item already exists
+    the item already exists
       <span class="t-pass">✓</span> increments the quantity
   RemoveItem
-    when the item exists
+    the item exists
       <span class="t-pass">✓</span> removes it from the cart
-    when the item does not exist
+    the item does not exist
       <span class="t-fail">✗</span> returns ErrNotFound
 {{< /spec >}}
 
@@ -126,7 +126,7 @@ Combined with the Spec View, this creates a tight feedback loop: save a file, wa
 
 The extension's export capabilities — spec output, test results, and coverage summaries — produce structured data that feeds directly into AI-assisted development workflows.
 
-Copy the Spec View output and paste it into an AI conversation. The behavioral specification tells the model what the system does at the level stakeholders care about: "UserService / Create / when email is valid / creates the user." That's more useful context than raw source code for understanding system behavior.
+Copy the Spec View output and paste it into an AI conversation. The behavioral specification tells the model what the system does at the level stakeholders care about: "UserService / Create / email is valid / creates the user." That's more useful context than raw source code for understanding system behavior.
 
 Copy test results with status filtering — failures only, for instance — and paste them alongside the relevant source. The AI sees exactly which behaviors broke and what the assertion messages said, without wading through passing tests.
 
@@ -139,7 +139,7 @@ These aren't AI-specific features. They're structured export features that happe
 Reducing the friction of creating new suites matters, especially for teams adopting gotest incrementally. The extension offers scaffold generation through multiple entry points:
 
 - **Code action on a type declaration** — place your cursor on a type and use the Quick Fix menu to generate a test suite for it.
-- **Code action on a Go file** — generate suites for all types in the file.
+- **Code action on a Go file** — generate a suite covering the file's exported functions.
 - **Command palette** — manual target entry for full control.
 
 The generated file opens automatically, and discovery refreshes to include the new suite immediately.

--- a/site/content/blog/zero-to-suite.md
+++ b/site/content/blog/zero-to-suite.md
@@ -166,8 +166,7 @@ func (s *CounterTestSuite) TestInc(t *gotest.T) {
         })
     })
 
-    t.When("incrementing three times", func(w *gotest.T) {
-        s.c.Inc()
+    t.When("incrementing twice more", func(w *gotest.T) {
         s.c.Inc()
         s.c.Inc()
 
@@ -189,6 +188,7 @@ func (s *CounterTestSuite) TestDec(t *gotest.T) {
     })
 
     t.When("decrementing past zero", func(w *gotest.T) {
+        s.c.Dec()
         s.c.Dec()
 
         w.It("goes negative", func(it *gotest.T) {
@@ -213,6 +213,8 @@ func (s *CounterTestSuite) TestReset(t *gotest.T) {
 
 The structure reads like a specification: *Counter → Inc → when incrementing once → it has value 1*. Each `When` block establishes a context (the setup and action), and each `It` block makes an assertion about the outcome.
 
+One rule to internalize: `BeforeEach` runs once per test *method*, not once per `When` block. Within a method, the `When` blocks execute in order and share the suite's state — that is why the second block says "twice more" and asserts 3: it continues from the counter the first block left at 1, and `TestDec`'s last block needs two `Dec` calls to get below zero. If two contexts need genuinely independent state, put them in separate test methods.
+
 Run it again:
 
 ```sh
@@ -230,20 +232,20 @@ gotest spec ./...
 Output:
 
 {{< spec title="gotest spec ./..." >}}
-Counter
-  Inc
-    when incrementing once
-      <span class="t-pass">✓</span> has value 1
-    when incrementing three times
-      <span class="t-pass">✓</span> has value 3
-  Dec
-    when decrementing from 2
-      <span class="t-pass">✓</span> has value 1
-    when decrementing past zero
-      <span class="t-pass">✓</span> goes negative
-  Reset
-    when resetting after increments
-      <span class="t-pass">✓</span> returns to zero
+Counter <span class="t-time">(<1ms)</span>
+  Inc <span class="t-time">(<1ms)</span>
+    incrementing once <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> has value 1 <span class="t-time">(<1ms)</span>
+    incrementing twice more <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> has value 3 <span class="t-time">(<1ms)</span>
+  Dec <span class="t-time">(<1ms)</span>
+    decrementing from 2 <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> has value 1 <span class="t-time">(<1ms)</span>
+    decrementing past zero <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> goes negative <span class="t-time">(<1ms)</span>
+  Reset <span class="t-time">(<1ms)</span>
+    resetting after increments <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> returns to zero <span class="t-time">(<1ms)</span>
 {{< /spec >}}
 
 This is generated from the test names and `When`/`It` labels. The suite name is stripped of its `TestSuite` suffix, method names lose their `Test` prefix, and the hierarchy is indented. The result is a behavioral specification that non-developers can read.
@@ -287,27 +289,27 @@ func (s *BoundaryTestSuite) TestResetIdempotent(t *gotest.T) {
 Run `gotest spec ./...` again and both suites appear in the output:
 
 {{< spec title="gotest spec ./..." >}}
-Boundary
-  NewCounter
-    <span class="t-pass">✓</span> starts at zero
-  ResetIdempotent
-    when resetting a counter that is already zero
-      <span class="t-pass">✓</span> stays at zero
+Boundary <span class="t-time">(<1ms)</span>
+  NewCounter <span class="t-time">(<1ms)</span>
+    <span class="t-pass">✓</span> starts at zero <span class="t-time">(<1ms)</span>
+  ResetIdempotent <span class="t-time">(<1ms)</span>
+    resetting a counter that is already zero <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> stays at zero <span class="t-time">(<1ms)</span>
 
-Counter
-  Inc
-    when incrementing once
-      <span class="t-pass">✓</span> has value 1
-    when incrementing three times
-      <span class="t-pass">✓</span> has value 3
-  Dec
-    when decrementing from 2
-      <span class="t-pass">✓</span> has value 1
-    when decrementing past zero
-      <span class="t-pass">✓</span> goes negative
-  Reset
-    when resetting after increments
-      <span class="t-pass">✓</span> returns to zero
+Counter <span class="t-time">(<1ms)</span>
+  Inc <span class="t-time">(<1ms)</span>
+    incrementing once <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> has value 1 <span class="t-time">(<1ms)</span>
+    incrementing twice more <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> has value 3 <span class="t-time">(<1ms)</span>
+  Dec <span class="t-time">(<1ms)</span>
+    decrementing from 2 <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> has value 1 <span class="t-time">(<1ms)</span>
+    decrementing past zero <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> goes negative <span class="t-time">(<1ms)</span>
+  Reset <span class="t-time">(<1ms)</span>
+    resetting after increments <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> returns to zero <span class="t-time">(<1ms)</span>
 {{< /spec >}}
 
 Both suites ran in separate processes, concurrently. Neither can affect the other, even if one panics or leaks goroutines.

--- a/site/content/reference.html
+++ b/site/content/reference.html
@@ -167,14 +167,14 @@ AfterAll <span class="d">(via t.Cleanup — always runs)</span></div>
       <p><code>When</code> groups context. <code>It</code> specifies behavior. Nest them freely to build a specification tree:</p>
       <div class="code-block">
         <pre><span class="kw">func</span> (s *<span class="tp">MySuite</span>) <span class="fn">TestCreate</span>(t *gotest.T) {
-    t.When(<span class="st">"email is valid"</span>, <span class="kw">func</span>(w *gotest.T) {
+    t.When(<span class="st">"when email is valid"</span>, <span class="kw">func</span>(w *gotest.T) {
         w.It(<span class="st">"creates the user"</span>, <span class="kw">func</span>(it *gotest.T) {
             err := s.svc.Create(ctx, validUser)
             gotest.NoError(it, err)
         })
     })
 
-    t.When(<span class="st">"email already exists"</span>, <span class="kw">func</span>(w *gotest.T) {
+    t.When(<span class="st">"when email already exists"</span>, <span class="kw">func</span>(w *gotest.T) {
         w.It(<span class="st">"returns ErrDuplicate"</span>, <span class="kw">func</span>(it *gotest.T) {
             s.svc.Create(ctx, validUser)
             err := s.svc.Create(ctx, validUser)
@@ -376,6 +376,8 @@ CacheFixture.AfterAll <span class="d">─┘</span></div>
           <tr><td><code>NotEqual(t, a, b)</code></td><td>Inverse of Equal.</td></tr>
           <tr><td><code>Zero(t, value)</code></td><td>Value equals its zero value.</td></tr>
           <tr><td><code>NotZero(t, value)</code></td><td>Value is not zero.</td></tr>
+          <tr><td><code>Nil(t, obj)</code></td><td>Nil check for non-comparable nilables (slices, maps, funcs). Type-guarded; comparable nilables use <code>Zero</code>.</td></tr>
+          <tr><td><code>NotNil(t, obj)</code></td><td>Inverse of Nil.</td></tr>
           <tr><td><code>Empty(t, obj)</code></td><td>Slice, map, string, or channel is empty.</td></tr>
           <tr><td><code>NotEmpty(t, obj)</code></td><td>Not empty.</td></tr>
         </tbody>
@@ -438,6 +440,7 @@ CacheFixture.AfterAll <span class="d">─┘</span></div>
         <tbody>
           <tr><td><code>Eventually(t, timeout, tick, fn)</code></td><td>Poll <code>func(poll *R)</code> until assertions pass or timeout.</td></tr>
           <tr><td><code>Consistently(t, duration, tick, fn)</code></td><td>Assert <code>func(poll *R)</code> holds for the full duration.</td></tr>
+          <tr><td><code>Go(t, fn)</code></td><td>Run <code>fn</code> on a goroutine that captures panics and re-raises them on the test's goroutine. Returns a <code>wait</code> func; also registered as cleanup.</td></tr>
         </tbody>
       </table>
       <div class="callout">
@@ -462,7 +465,7 @@ CacheFixture.AfterAll <span class="d">─┘</span></div>
       <p><strong>Code scope</strong> — marker methods override built-in presets. These control individual suites and fixtures:</p>
       <div class="diagram">1. In-code config       <span class="d">SuiteConfig(), FixtureConfig(), SharedFixtureConfig()</span>
 2. Built-in defaults    <span class="d">DefaultSuiteConfig(), DefaultFixtureConfig()</span></div>
-      <p>The two scopes are independent — they don't override each other. For shared fixture timeouts specifically, <code>--setup-timeout</code> is an outer wall-clock budget on the entire setup phase, while <code>SharedFixtureConfig().Timeout</code> is an inner per-fixture deadline. Both run concurrently — whichever fires first wins. When <code>--setup-timeout</code> is omitted, only the per-fixture timeouts apply.</p>
+      <p>The two scopes are independent — they don't override each other. For shared fixture timeouts specifically, <code>--setup-timeout</code> is an outer wall-clock budget on the entire setup phase, while <code>SharedFixtureConfig().Timeout</code> is an inner per-fixture deadline. Both run concurrently — whichever fires first wins. When <code>--setup-timeout</code> is omitted, the default outer budget of 2 minutes applies; set it to <code>0</code> to disable the outer budget and let only the per-fixture timeouts govern.</p>
 
       <h3>Project file — <code>.gotest.yml</code></h3>
       <p>Place a <code>.gotest.yml</code> in your project root. gotest finds it by walking up from the working directory, stopping at the first match or at a <code>go.mod</code> boundary. CLI flags always take precedence; zero or omitted fields use defaults.</p>
@@ -470,9 +473,11 @@ CacheFixture.AfterAll <span class="d">─┘</span></div>
         <thead><tr><th>Field</th><th>Type</th><th>Default</th><th>CLI override</th><th>Effect</th></tr></thead>
         <tbody>
           <tr><td><code>tags</code></td><td>string</td><td><em>none</em></td><td><code>-tags</code></td><td>Build tags, comma-separated (e.g. <code>"integration,e2e"</code>).</td></tr>
-          <tr><td><code>setup-timeout</code></td><td>duration</td><td><em>none</em></td><td><code>--setup-timeout</code></td><td>Total budget for all shared fixture setup. Omit to let each fixture's own config govern. Negative disables.</td></tr>
+          <tr><td><code>setup-timeout</code></td><td>duration</td><td>2m</td><td><code>--setup-timeout</code></td><td>Total budget for all shared fixture setup. <code>0</code> disables.</td></tr>
+          <tr><td><code>timeout</code></td><td>duration</td><td>15m</td><td><code>--timeout</code></td><td>Global pipeline deadline. <code>0</code> disables.</td></tr>
           <tr><td><code>min-coverage</code></td><td>int</td><td>0 (off)</td><td><code>--min</code></td><td>Minimum coverage percentage, 0–100.</td></tr>
-          <tr><td><code>parallel</code></td><td>int</td><td>0 (auto)</td><td><code>--parallel</code></td><td>Total concurrent test method budget. 0 means 2×GOMAXPROCS.</td></tr>
+          <tr><td><code>parallel</code></td><td>int</td><td>0 (auto)</td><td><code>--parallel</code></td><td>Total concurrent test method budget. 0 means 2×GOMAXPROCS, auto-halved under <code>-race</code>/<code>-msan</code>/<code>-asan</code>.</td></tr>
+          <tr><td><code>compile-parallel</code></td><td>int</td><td>0 (auto)</td><td><code>--compile-parallel</code></td><td>Concurrent compilation processes. 0 means NumCPU, auto-halved under <code>-race</code>/<code>-msan</code>/<code>-asan</code>.</td></tr>
           <tr><td><code>debounce</code></td><td>duration</td><td>200ms</td><td><code>--debounce</code></td><td>Watch mode re-run delay.</td></tr>
           <tr><td><code>lint.skip</code></td><td>[string]</td><td><em>none</em></td><td>—</td><td>Non-integrity lint rules to disable: <code>assertion-simplify</code>, <code>assertion-redundant</code>, <code>fail-guard</code>, <code>t-escape</code>, <code>stdlib-test</code>, <code>testify</code>.</td></tr>
         </tbody>
@@ -495,9 +500,9 @@ lint:
         <tbody>
           <tr><td><code>Timeout</code></td><td>30s</td><td>Per-test-case deadline.</td></tr>
           <tr><td><code>SetupTimeout</code></td><td>30s</td><td>BeforeAll / AfterAll deadline.</td></tr>
-          <tr><td><code>Retries</code></td><td>0</td><td>Per-test-case retry attempts on failure.</td></tr>
           <tr><td><code>FailFast</code></td><td>false</td><td>Stop the suite on first failure.</td></tr>
           <tr><td><code>Parallel</code></td><td>false</td><td>Run test methods concurrently.</td></tr>
+          <tr><td><code>Exclusive</code></td><td>false</td><td>Schedule the suite's process strictly alone — after every non-exclusive suite has finished, one exclusive suite at a time. For wall-clock-sensitive or resource-contended suites.</td></tr>
         </tbody>
       </table>
 
@@ -524,7 +529,7 @@ lint:
       </table>
 
       <div class="callout">
-        Use a negative duration (<code>Timeout: -1</code>) to explicitly disable a timeout. Zero means "keep the default."
+        The returned config is used as-is: a zero (or omitted) duration means <em>no deadline</em>, not "keep the default." To inherit defaults and override individual fields, start from a preset: <code>cfg := gotest.DefaultSuiteConfig(); cfg.Parallel = true; return cfg</code>.
       </div>
     </section>
 
@@ -542,12 +547,8 @@ percentage = covered / total</div>
 
       <p>A directory's percentage is the weighted sum of its children, weighted by statement count. This means a parent's number is always derivable from its children — no rounding surprises, no averaging artifacts.</p>
 
-      <h3>Breadth indicator</h3>
-      <p>Coverage percentage answers: <em>"How well-tested is the code my tests reach?"</em></p>
-      <p>The breadth indicator answers a complementary question: <em>"How much of my codebase do my tests reach at all?"</em> It shows profiled source files vs. total source files per directory. A file at 0% still counts as reached — it was instrumented.</p>
-
-      <h3>Cross-package coverage</h3>
-      <p>Test-only packages (no production code) run with <code>-coverpkg=./...</code>, which instruments the entire module. These cross-package profiles are supplementary — they can increase coverage for files already in scope, but don't expand the file scope. This prevents integration test packages from inflating coverage numbers for code they touch incidentally.</p>
+      <h3>Merged and cross-package profiles</h3>
+      <p>Merged profiles — concatenated per-suite profiles, or overlapping <code>-coverpkg</code> runs — can repeat the same block. Each unique file and range is counted once, keeping the maximum execution count, matching <code>go tool cover</code> behavior. <code>-coverpkg</code> itself is a standard <code>go test</code> flag and passes through unchanged.</p>
 
       <div class="callout">
         Coverage uses the profile's <code>numStatements</code> as the sole metric. No line counting, no token scanning, no filesystem heuristics. The profile is the source of truth.
@@ -565,14 +566,18 @@ percentage = covered / total</div>
         <tbody>
           <tr><td><code>gotest ./...</code></td><td>Generate overlays and run tests. The default workflow.</td></tr>
           <tr><td><code>gotest watch ./...</code></td><td>Re-run on file changes. Only affected packages re-run.</td></tr>
-          <tr><td><code>gotest spec ./...</code></td><td>Run tests and render the behavioral specification.</td></tr>
+          <tr><td><code>gotest spec ./...</code></td><td>Run tests and render the behavioral specification. With <code>--static</code>, render it from source without running.</td></tr>
+          <tr><td><code>gotest discover ./...</code></td><td>Discover test suites and output JSON (feeds editor integrations).</td></tr>
           <tr><td><code>gotest summary ./...</code></td><td>Failure-focused summary for CI. Shows only failing tests with assertion output.</td></tr>
           <tr><td><code>gotest lint ./...</code></td><td>Static analysis for test suites — see <a href="#linter">Linter</a>.</td></tr>
           <tr><td><code>gotest scaffold ./pkg/user.Svc</code></td><td>Generate a suite skeleton from any Go type.</td></tr>
           <tr><td><code>gotest migrate ./...</code></td><td>Convert testify/suite tests automatically.</td></tr>
           <tr><td><code>gotest generate ./...</code></td><td>Generate suite files without running tests.</td></tr>
-          <tr><td><code>gotest clean ./...</code></td><td>Remove cached overlays (debugging).</td></tr>
+          <tr><td><code>gotest clean ./...</code></td><td>Remove orphaned generated files.</td></tr>
           <tr><td><code>gotest refactor toggle-focus &lt;file&gt; &lt;id&gt;</code></td><td>Toggle <code>F_</code>/<code>X_</code> prefixes programmatically.</td></tr>
+          <tr><td><code>gotest prepare ./...</code></td><td>Start shared fixtures for debugging; blocks until SIGTERM.</td></tr>
+          <tr><td><code>gotest version</code></td><td>Print version information.</td></tr>
+          <tr><td><code>gotest help [subcommand]</code></td><td>General or subcommand-specific help.</td></tr>
         </tbody>
       </table>
 
@@ -589,7 +594,12 @@ percentage = covered / total</div>
           <tr><td><code>--output=&lt;path&gt;</code></td><td>Write formatted output to file.</td></tr>
           <tr><td><code>--no-color</code></td><td>Strip ANSI codes from output.</td></tr>
           <tr><td><code>--debug</code></td><td>Preserve overlays after the run for inspection.</td></tr>
-          <tr><td><code>--setup-timeout=&lt;dur&gt;</code></td><td>Total budget for all shared fixture setup. Omit to let each fixture's own config govern. Use a negative value (e.g. <code>-1s</code>) to disable.</td></tr>
+          <tr><td><code>--setup-timeout=&lt;dur&gt;</code></td><td>Total budget for all shared fixture setup (default: 2m, <code>0</code> to disable).</td></tr>
+          <tr><td><code>--timeout=&lt;dur&gt;</code></td><td>Global pipeline deadline (default: 15m, <code>0</code> to disable).</td></tr>
+          <tr><td><code>--parallel=&lt;n&gt;</code></td><td>Total concurrent test method budget (default: 2×GOMAXPROCS, auto-halved for <code>-race</code>/<code>-msan</code>/<code>-asan</code>).</td></tr>
+          <tr><td><code>--compile-parallel=&lt;n&gt;</code></td><td>Concurrent compilation processes (default: NumCPU, auto-halved for <code>-race</code>/<code>-msan</code>/<code>-asan</code>).</td></tr>
+          <tr><td><code>--static</code></td><td>Read the specification from source without running the suites; nodes carry no verdict (<code>spec</code> command).</td></tr>
+          <tr><td><code>--render-only</code></td><td>With <code>--input</code>, exit 0 on a failing stream: report whether rendering succeeded, not the test verdict.</td></tr>
           <tr><td><code>--debounce=&lt;dur&gt;</code></td><td>Watch mode debounce interval (default 200ms).</td></tr>
           <tr><td><code>--input=&lt;path&gt;</code></td><td>Read test output from file instead of running tests (<code>spec</code>, <code>summary</code>).</td></tr>
           <tr><td><code>--github</code></td><td>GitHub CI mode: emit <code>::error</code> annotations and write step summary (<code>summary</code> command). Auto-detected via <code>$GITHUB_ACTIONS</code>.</td></tr>
@@ -605,7 +615,7 @@ percentage = covered / total</div>
     <!-- 9. Linter -->
     <section class="ref-section" id="linter">
       <h2>Linter</h2>
-      <p class="lead">Sixteen rules in three tiers. A rule's tier determines how it may be suppressed.</p>
+      <p class="lead">Seventeen rules in three tiers. A rule's tier determines how it may be suppressed.</p>
 
       <h3>Integrity rules</h3>
       <p>Violations can make test outcomes unreliable or leak resources. These rules can only be suppressed per line — never project-wide.</p>
@@ -621,6 +631,7 @@ percentage = covered / total</div>
           <tr><td><code>suite-lifecycle</code></td><td><code>Cleanup</code>/<code>Parallel</code>/<code>Run</code> via <code>t.T()</code> — they bypass the suite lifecycle.</td></tr>
           <tr><td><code>poll-scope</code></td><td>Assertions inside <code>Eventually</code>/<code>Consistently</code> callbacks using the outer <code>t</code> instead of <code>poll</code>.</td></tr>
           <tr><td><code>assertion-type-guard</code></td><td><code>Nil</code>/<code>Empty</code> on types their runtime guards would reject.</td></tr>
+          <tr><td><code>shared-fixture-undeclared</code></td><td>Suite reads a shared fixture it never declared — window scheduling only starts declared fixtures, so the read may hit one that never started or is already released.</td></tr>
           <tr><td><code>generated-file</code></td><td>Generated overlay files present in source control.</td></tr>
         </tbody>
       </table>

--- a/skills/writing-gotest-tests/reference/cli.md
+++ b/skills/writing-gotest-tests/reference/cli.md
@@ -11,7 +11,11 @@ invocation runs tests — there is NO `test` subcommand:
   captured `go test -json` stream WITHOUT running. `--input` exits
   non-zero when the stream contains failures (same rule as
   `summary --input`), so replaying a saved stream in CI needs no pipefail
-  gymnastics — the render step itself is the verdict.
+  gymnastics — the render step itself is the verdict; `--render-only`
+  lifts that rule for pure renderers (exit 0 on a failing stream, 2 on an
+  unreadable one). `--static` renders the spec from source without
+  running anything — nodes carry no verdict, and incompletely enumerable
+  methods are reported on stderr.
 - `go tool gotest watch ./...` — rerun on change; supports `--spec`.
 - `go tool gotest lint ./...` — the linter; `-fix` applies suggested
   fixes (textual only — follow with goimports, see SKILL.md; fixes can
@@ -35,7 +39,10 @@ Flags shared by run modes: `--ci` (or env `GOTEST_CI`/`CI`; values `0` and
 the run) AND makes snapshots read-only, so `MatchSnapshot` cannot write
 baselines in CI-detected environments. `--update-snapshots` rewrites
 `MatchSnapshot` baselines (outside CI). `--spec` renders the spec view
-instead of default output.
+instead of default output. `--timeout <dur>` is the global pipeline
+deadline (default 15m) and `--setup-timeout <dur>` the shared-fixture
+setup budget (default 2m) — `0` disables either; `--min <pct>` gates
+coverage, `--no-cache` forces fresh generation, `--debug` keeps overlays.
 
 Machine-readable capture, verified end-to-end:
 

--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -36,6 +36,7 @@ The **Spec View** renders your test structure as a behavioral specification — 
 
 The extension invokes the gotest CLI automatically — no separate install needed.
 It resolves the version from your `go.mod` and uses `go run` to execute it.
+The CLI must be **v1.27.0 or newer**; older versions are rejected at activation.
 
 ### Install
 
@@ -68,6 +69,7 @@ The tree itself is restored from disk on startup, so suites are browsable straig
 
 **Run** and **Debug** buttons appear inline above every suite and test method in `_test.go` files.
 Click to execute immediately.
+An **↻ Update Snapshots** lens additionally appears above methods that call `MatchSnapshot` (and their suite), re-running them with `--update-snapshots`.
 
 Package-level and file-level actions appear on the `package` declaration line:
 
@@ -143,6 +145,7 @@ Projects using `go.work` are also supported.
 | Go Test: Stop Watch | Stop all active watch processes |
 | Go Test: Scaffold Suite | Generate a test suite from a target |
 | Go Test: Scaffold Target | Generate a test suite for a specific target |
+| Go Test: Update Snapshots | Re-run tests with `--update-snapshots` to rewrite `MatchSnapshot` baselines (also a run profile and a CodeLens on snapshot tests) |
 | Go Test: Copy Coverage Summary | Copy coverage table to clipboard |
 | Go Test: Copy Test Results | Copy test results to clipboard (also available as context menu on test items) |
 | Go Test: Clear Results | Forget stored results, coverage and spec output, so a window reload does not restore them. The Test Explorer's own "Clear all results" only empties VS Code's in-memory view; clearing the icons in the tree is still its job, because no stable API lets an extension retract them. |


### PR DESCRIPTION
The documentation had drifted from what the tool actually does. This PR brings it back in line, with no code changes.

Changes:
- The README and reference now describe configuration, coverage, scheduling and the full set of lint rules as they really are.
- The architecture overview reflects how tests are dispatched and how fixtures are scoped today.
- The design documents match the shipped behavior instead of earlier drafts.
- The skill's CLI reference and the VS Code extension README mention flags and commands that were missing.
- Every blog post was checked against the current release. Outdated API names, flags, output samples and broken examples were corrected.