### PR TITLE
CI Coverage badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,10 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    # The coverage badge is pushed to ci/badges; the action publishes it from
+    # main only, so pull-request runs never use the write scope.
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -54,6 +58,9 @@ jobs:
           race: true
           min-coverage: 40
           go-test-flags: "-coverprofile=coverage-suites.out"
+          # One matrix cell publishes the badge; the others would only race
+          # it for the same number.
+          badge: ${{ matrix.go-version == '1.27' }}
       - name: Merge coverage
         run: |
           awk '

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![Tests](https://github.com/mvrahden/go-test/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/mvrahden/go-test/actions/workflows/test.yml?query=branch%3Amain)
 [![Quality](https://github.com/mvrahden/go-test/actions/workflows/quality.yml/badge.svg?branch=main)](https://github.com/mvrahden/go-test/actions/workflows/quality.yml?query=branch%3Amain)
+[![Coverage](https://raw.githubusercontent.com/mvrahden/go-test/ci/badges/coverage.svg)](https://github.com/mvrahden/go-test/actions/workflows/test.yml?query=branch%3Amain)
 [![Go Reference](https://pkg.go.dev/badge/github.com/mvrahden/go-test.svg)](https://pkg.go.dev/github.com/mvrahden/go-test)
 [![Go 1.25+](https://img.shields.io/badge/Go-1.25%2B-00ADD8?logo=go)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -763,6 +763,37 @@ By default (`version: gomod`), the action resolves `gotest` from your `go.mod` â
 
 The action emits `::error` annotations that appear inline on PR diffs and writes a markdown summary to the GitHub step summary panel. See the [reference](https://mvrahden.github.io/go-test/reference/#ci-integration) for the full inputs/outputs table.
 
+### Coverage Badge
+
+The action can add a coverage badge to your README. `gotest` draws the badge as an SVG file and the workflow commits it to a branch of your own repository using the built-in `GITHUB_TOKEN`. Nothing outside GitHub is involved and there is no account or secret to set up.
+
+```yaml
+permissions:
+  contents: write
+
+steps:
+  - uses: actions/checkout@v4
+  - uses: mvrahden/go-test@v1
+    with:
+      packages: ./...
+      min-coverage: 80
+      badge: true
+```
+
+`badge: true` turns coverage reporting on by itself. The badge lands on the `ci/badges` branch (change it with `badge-branch`); embed it from there:
+
+```markdown
+![Coverage](https://raw.githubusercontent.com/<owner>/<repo>/ci/badges/coverage.svg)
+```
+
+Three rules keep the badge trustworthy:
+
+- It is published from the default branch only. Pull requests and feature branches never change it.
+- It is published only when the suites ran to completion. A build failure publishes nothing, while a failed test run or a missed `min-coverage` still publishes the coverage that run measured.
+- It never affects test results. Several jobs publishing at once (a version matrix, for example) simply take turns, and a missing permission or a protected branch produces a warning, not a failed build.
+
+Outside GitHub Actions, `gotest summary --badge=coverage.svg ./...` renders the same file for you to publish however you like.
+
 ## Commands
 
 ```bash

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,12 @@ inputs:
   go-test-flags:
     description: "Additional go test flags (-single-dash style)"
     required: false
+  badge:
+    description: "Render a coverage badge and, on the default branch, publish it as coverage.svg to the badge-branch of this repository (needs contents: write). Turns coverage on."
+    default: "false"
+  badge-branch:
+    description: "Branch the coverage badge is published to; created automatically on first use"
+    default: "ci/badges"
   version:
     description: "gotest version: 'gomod' (default) resolves from go.mod, or a version tag (e.g. v1.0.0, latest) to install globally."
     default: "gomod"
@@ -35,6 +41,9 @@ outputs:
   coverage:
     description: "Coverage percentage (empty if coverage not enabled)"
     value: ${{ steps.test.outputs.coverage }}
+  badge:
+    description: "Path of the rendered coverage badge SVG (empty unless badge is enabled and the tests ran)"
+    value: ${{ steps.test.outputs.badge }}
 
 runs:
   using: "composite"
@@ -54,6 +63,7 @@ runs:
         INPUT_MIN_COVERAGE: ${{ inputs.min-coverage }}
         INPUT_FLAGS: ${{ inputs.flags }}
         INPUT_GO_TEST_FLAGS: ${{ inputs.go-test-flags }}
+        INPUT_BADGE: ${{ inputs.badge }}
         INPUT_VERSION: ${{ inputs.version }}
       run: |
         if [ "$INPUT_VERSION" != "gomod" ]; then
@@ -65,9 +75,16 @@ runs:
         args=(summary --github)
 
         cover_profile=""
-        if [ "$INPUT_COVERAGE" = "true" ]; then
+        if [ "$INPUT_COVERAGE" = "true" ] || [ "$INPUT_BADGE" = "true" ]; then
           cover_profile="$(mktemp -t gotest-cover-XXXXXX.out)"
           args+=("--coverage=$cover_profile")
+        fi
+
+        badge_file=""
+        if [ "$INPUT_BADGE" = "true" ]; then
+          badge_file="${RUNNER_TEMP}/gotest-coverage-badge.svg"
+          rm -f "$badge_file"
+          args+=("--badge=$badge_file")
         fi
 
         if [ -n "$INPUT_MIN_COVERAGE" ]; then
@@ -108,4 +125,79 @@ runs:
           rm -f "$cover_profile"
         fi
 
+        if [ -n "$badge_file" ] && [ -f "$badge_file" ]; then
+          echo "badge=$badge_file" >> "$GITHUB_OUTPUT"
+        fi
+
         exit "$exit_code"
+
+    # The badge follows the default branch only: a pull request or feature
+    # branch must never rewrite it. Exit code 2 means the suites did not run
+    # to completion (build failure, bad invocation), so there is nothing
+    # trustworthy to publish; 0 and 1 (tests failed or the minimum was
+    # missed) still describe the real coverage of the branch.
+    - name: Publish coverage badge
+      if: ${{ !cancelled() && inputs.badge == 'true' && steps.test.outputs.badge != '' && steps.test.outputs.exit-code != '2' }}
+      shell: bash
+      env:
+        BADGE_FILE: ${{ steps.test.outputs.badge }}
+        BADGE_BRANCH: ${{ inputs.badge-branch }}
+        COVERAGE: ${{ steps.test.outputs.coverage }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        if [ -z "$DEFAULT_BRANCH" ] && command -v gh >/dev/null 2>&1; then
+          DEFAULT_BRANCH=$(gh api "repos/${GITHUB_REPOSITORY}" --jq .default_branch 2>/dev/null || true)
+        fi
+        if [ "$GITHUB_REF" != "refs/heads/${DEFAULT_BRANCH}" ]; then
+          echo "Coverage badge is published from ${DEFAULT_BRANCH:-the default branch} only; skipping on ${GITHUB_REF}"
+          exit 0
+        fi
+
+        remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        work="${RUNNER_TEMP}/gotest-badge-publish"
+        trap 'rm -rf "$work"' EXIT
+
+        # Each attempt starts from the branch's current tip, so a concurrent
+        # job's push (e.g. another matrix cell) only costs a retry.
+        for attempt in 1 2 3; do
+          rm -rf "$work"
+          mkdir -p "$work"
+          cd "$work"
+          git init -q
+          git remote add origin "$remote"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git fetch -q --depth 1 origin "refs/heads/${BADGE_BRANCH}" 2>/dev/null; then
+            git checkout -q -B "$BADGE_BRANCH" FETCH_HEAD
+          else
+            git checkout -q --orphan "$BADGE_BRANCH"
+          fi
+
+          cp "$BADGE_FILE" coverage.svg
+          {
+            echo "# ${BADGE_BRANCH}"
+            echo
+            echo "Files on this branch are written by the gotest GitHub Action (\`badge: true\`); edits are overwritten on the next run."
+            echo
+            echo "![Coverage](https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${BADGE_BRANCH}/coverage.svg)"
+          } > README.md
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Coverage badge unchanged (${COVERAGE}%)"
+            exit 0
+          fi
+          git commit -q -m "coverage: ${COVERAGE}%"
+          if git push -q origin "HEAD:refs/heads/${BADGE_BRANCH}" 2>push.log; then
+            echo "Coverage badge published: https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${BADGE_BRANCH}/coverage.svg"
+            exit 0
+          fi
+          echo "push attempt ${attempt} failed:"
+          cat push.log
+          sleep "$attempt"
+        done
+
+        echo "::warning::Coverage badge not published: could not push to ${BADGE_BRANCH}. Does the job grant 'contents: write'?"
+        exit 0

--- a/action.yml
+++ b/action.yml
@@ -74,9 +74,30 @@ runs:
 
         args=(summary --github)
 
+        gtflags=()
+        if [ -n "$INPUT_GO_TEST_FLAGS" ]; then
+          read -ra gtflags <<< "$INPUT_GO_TEST_FLAGS"
+        fi
+
+        # A -coverprofile the caller passes through go-test-flags is the
+        # run's profile; the action only adds a temporary one when nobody did.
+        user_profile=""
+        for ((i = 0; i < ${#gtflags[@]}; i++)); do
+          case "${gtflags[i]}" in
+            -coverprofile=*) user_profile="${gtflags[i]#-coverprofile=}" ;;
+            -coverprofile) user_profile="${gtflags[i+1]:-}" ;;
+          esac
+        done
+
         cover_profile=""
+        temp_profile=""
         if [ "$INPUT_COVERAGE" = "true" ] || [ "$INPUT_BADGE" = "true" ]; then
-          cover_profile="$(mktemp -t gotest-cover-XXXXXX.out)"
+          if [ -n "$user_profile" ]; then
+            cover_profile="$user_profile"
+          else
+            cover_profile="$(mktemp -t gotest-cover-XXXXXX.out)"
+            temp_profile="$cover_profile"
+          fi
           args+=("--coverage=$cover_profile")
         fi
 
@@ -103,12 +124,11 @@ runs:
           args+=(-race)
         fi
 
-        if [ -n "$cover_profile" ]; then
-          args+=("-coverprofile=$cover_profile")
+        if [ -n "$temp_profile" ]; then
+          args+=("-coverprofile=$temp_profile")
         fi
 
-        if [ -n "$INPUT_GO_TEST_FLAGS" ]; then
-          read -ra gtflags <<< "$INPUT_GO_TEST_FLAGS"
+        if [ ${#gtflags[@]} -gt 0 ]; then
           args+=("${gtflags[@]}")
         fi
 
@@ -120,9 +140,14 @@ runs:
         echo "exit-code=$exit_code" >> "$GITHUB_OUTPUT"
 
         if [ -n "$cover_profile" ] && [ -f "$cover_profile" ]; then
-          cov=$(go tool cover -func="$cover_profile" | tail -1 | awk '{print $NF}' | sed 's/%//')
-          echo "coverage=$cov" >> "$GITHUB_OUTPUT"
-          rm -f "$cover_profile"
+          # A profile go tool cover rejects must not fail a step whose tests
+          # already have their verdict; the coverage output just stays empty.
+          if cov=$(go tool cover -func="$cover_profile" | tail -1 | awk '{print $NF}' | sed 's/%//'); then
+            echo "coverage=$cov" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Could not compute the coverage output from ${cover_profile}"
+          fi
+          [ -n "$temp_profile" ] && rm -f "$temp_profile"
         fi
 
         if [ -n "$badge_file" ] && [ -f "$badge_file" ]; then

--- a/cmd/gotest/badge_suite_test.go
+++ b/cmd/gotest/badge_suite_test.go
@@ -1,0 +1,116 @@
+package main_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	main "github.com/mvrahden/go-test/cmd/gotest"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// SummaryBadgeTestSuite covers `summary --badge=<file>`: the flag is
+// accepted, forces a coverage profile when none is requested, and renders
+// the badge from whatever profile the summary reports on.
+type SummaryBadgeTestSuite struct{}
+
+func (s *SummaryBadgeTestSuite) SuiteConfig() gotest.SuiteConfig {
+	cfg := gotest.DefaultSuiteConfig()
+	cfg.Parallel = true
+	return cfg
+}
+
+type badgeCtx struct{ dir string }
+
+func (s *SummaryBadgeTestSuite) BeforeEach(t *gotest.T) *badgeCtx {
+	return &badgeCtx{dir: t.TempDir()}
+}
+
+func (s *SummaryBadgeTestSuite) TestFlagIsASummaryValueFlag(t *gotest.T, _ *badgeCtx) {
+	t.It("is registered as a value flag", func(it *gotest.T) {
+		gotest.Equal(it, main.ValueFlag, main.ExportGotestFlags["--badge"])
+	})
+
+	t.It("is accepted by summary and routed to gotest's own args", func(it *gotest.T) {
+		own, goTest, err := main.SplitArgs([]string{"--badge=coverage.svg", "-race", "./..."}, main.ExportSummaryAllowed)
+		gotest.NoError(it, err)
+		gotest.Equal(it, []string{"--badge=coverage.svg"}, own)
+		gotest.Equal(it, []string{"-race", "./..."}, goTest)
+	})
+
+	t.It("is rejected by the plain run mode", func(it *gotest.T) {
+		_, _, err := main.SplitArgs([]string{"--badge=coverage.svg"}, main.ExportTestAllowed)
+		gotest.Error(it, err)
+	})
+}
+
+func (s *SummaryBadgeTestSuite) TestBadgeForcesACoverageProfile(t *gotest.T, _ *badgeCtx) {
+	t.When("neither --min nor -coverprofile asks for coverage", func(w *gotest.T) {
+		w.It("leaves the go test args alone when no badge is requested", func(it *gotest.T) {
+			args, profile, cleanup, err := main.ExportEnsureCoverProfile([]string{"-race"}, false)
+			cleanup()
+			gotest.NoError(it, err)
+			gotest.Empty(it, profile)
+			gotest.Equal(it, []string{"-race"}, args)
+		})
+
+		w.It("adds a temporary -coverprofile when one is needed", func(it *gotest.T) {
+			args, profile, cleanup, err := main.ExportEnsureCoverProfile([]string{"-race"}, true)
+			cleanup()
+			gotest.NoError(it, err)
+			gotest.NotEmpty(it, profile)
+			gotest.Equal(it, []string{"-race", "-coverprofile=" + profile}, args)
+		})
+	})
+
+	t.When("the caller already passes -coverprofile", func(w *gotest.T) {
+		w.It("reuses that profile", func(it *gotest.T) {
+			args, profile, cleanup, err := main.ExportEnsureCoverProfile([]string{"-coverprofile=c.out"}, true)
+			cleanup()
+			gotest.NoError(it, err)
+			gotest.Equal(it, "c.out", profile)
+			gotest.Equal(it, []string{"-coverprofile=c.out"}, args)
+		})
+	})
+}
+
+func (s *SummaryBadgeTestSuite) TestRendersBadgeFromReportedProfile(t *gotest.T, ctx *badgeCtx) {
+	stream := filepath.Join(ctx.dir, "events.json")
+	gotest.NoError(t, os.WriteFile(stream, []byte(`{"Action":"run","Package":"example.com/pkg","Test":"TestOK"}
+{"Action":"pass","Package":"example.com/pkg","Test":"TestOK"}
+{"Action":"pass","Package":"example.com/pkg"}
+`), 0o600))
+	profile := filepath.Join(ctx.dir, "cover.out")
+	// 3 of 4 statements covered: 75.0%.
+	gotest.NoError(t, os.WriteFile(profile, []byte("mode: set\n"+
+		"example.com/pkg/a.go:1.1,2.2 3 1\n"+
+		"example.com/pkg/a.go:3.1,4.2 1 0\n"), 0o600))
+	out := filepath.Join(ctx.dir, "summary.txt")
+	badge := filepath.Join(ctx.dir, "nested", "coverage.svg")
+
+	t.When("summary replays a stream with a coverage profile", func(w *gotest.T) {
+		code := main.ExportRunSummaryFromInput(stream, "terminal", out, profile, true, false, true, badge)
+
+		w.It("exits by the stream's verdict", func(it *gotest.T) {
+			gotest.Equal(it, 0, code)
+		})
+
+		w.It("writes the badge, creating parent directories, with the profile's total", func(it *gotest.T) {
+			data, err := os.ReadFile(badge)
+			gotest.NoError(it, err)
+			svg := string(data)
+			gotest.True(it, strings.HasPrefix(svg, "<svg"), "not an svg: %q", svg)
+			gotest.Contains(it, svg, ">75.0%<")
+		})
+	})
+
+	t.When("summary has no coverage profile to report on", func(w *gotest.T) {
+		noBadge := filepath.Join(ctx.dir, "none.svg")
+		main.ExportRunSummaryFromInput(stream, "terminal", out, "", true, false, true, noBadge)
+
+		w.It("writes no badge rather than a badge for 0%", func(it *gotest.T) {
+			_, err := os.Stat(noBadge)
+			gotest.ErrorIs(it, err, os.ErrNotExist)
+		})
+	})
+}

--- a/cmd/gotest/cli.go
+++ b/cmd/gotest/cli.go
@@ -97,7 +97,7 @@ func runTest(inv Invocation) int { //nolint:gocritic // hugeParam: stable API
 		minCoverage = inv.Config.MinCoverage
 	}
 
-	goTestArgs, coverProfile, coverCleanup, err := ensureCoverProfile(goTestArgs, minCoverage)
+	goTestArgs, coverProfile, coverCleanup, err := ensureCoverProfile(goTestArgs, minCoverage > 0)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2
@@ -226,9 +226,12 @@ func parseExecFlags(ownArgs, goTestArgs []string, projCfg *config.ProjectConfig)
 	}, nil
 }
 
-func ensureCoverProfile(goTestArgs []string, minCoverage int) ([]string, string, func(), error) {
+// ensureCoverProfile makes sure a -coverprofile is in play when a coverage
+// consumer (--min, --badge) needs one: the caller's own profile wins, else
+// a temporary one is added and removed by the returned cleanup.
+func ensureCoverProfile(goTestArgs []string, needed bool) ([]string, string, func(), error) {
 	noop := func() {}
-	if minCoverage <= 0 {
+	if !needed {
 		return goTestArgs, "", noop, nil
 	}
 	for _, arg := range goTestArgs {

--- a/cmd/gotest/export_test.go
+++ b/cmd/gotest/export_test.go
@@ -39,3 +39,5 @@ var ExportGotestFlags = gotestFlags
 var ExportTestAllowed = testAllowed
 var ExportSpecAllowed = specAllowed
 var ExportWatchAllowed = watchAllowed
+var ExportSummaryAllowed = summaryAllowed
+var ExportEnsureCoverProfile = ensureCoverProfile

--- a/cmd/gotest/flags.go
+++ b/cmd/gotest/flags.go
@@ -20,6 +20,7 @@ var gotestFlags = map[string]FlagKind{
 	"--render-only":      BoolFlag,
 	"--static":           BoolFlag,
 	"--coverage":         ValueFlag,
+	"--badge":            ValueFlag,
 	"--min":              ValueFlag,
 	"--setup-timeout":    ValueFlag,
 	"--debounce":         ValueFlag,
@@ -47,7 +48,7 @@ var summaryAllowed = flagSet(
 	"--debug", "--ci", "--update-snapshots", "--no-cache",
 	"--min", "--setup-timeout", "--timeout", "--parallel", "--compile-parallel",
 	"--format", "--output", "--input", "--no-color", "--github",
-	"--coverage", "--render-only",
+	"--coverage", "--render-only", "--badge",
 )
 
 var watchAllowed = flagSet(

--- a/cmd/gotest/gotest_suite_test.go
+++ b/cmd/gotest/gotest_suite_test.go
@@ -919,7 +919,7 @@ func (s *CmdGotestTestSuite) TestInputModesShareOneExitRule(t *gotest.T) {
 		})
 
 		w.It("summary --input agrees", func(it *gotest.T) {
-			gotest.Equal(it, 1, ExportRunSummaryFromInput(input, "terminal", out, "", true, false, false))
+			gotest.Equal(it, 1, ExportRunSummaryFromInput(input, "terminal", out, "", true, false, false, ""))
 		})
 	})
 
@@ -929,7 +929,7 @@ func (s *CmdGotestTestSuite) TestInputModesShareOneExitRule(t *gotest.T) {
 
 		w.It("both exit zero", func(it *gotest.T) {
 			gotest.Equal(it, 0, ExportRunSpecFromInput(input, "terminal", out, true, false))
-			gotest.Equal(it, 0, ExportRunSummaryFromInput(input, "terminal", out, "", true, false, false))
+			gotest.Equal(it, 0, ExportRunSummaryFromInput(input, "terminal", out, "", true, false, false, ""))
 		})
 	})
 }
@@ -961,7 +961,7 @@ func (s *CmdGotestTestSuite) TestRenderOnlySeparatesVerdictFromRendering(t *gote
 		})
 
 		w.It("summary agrees, keeping the two input modes on one rule", func(it *gotest.T) {
-			gotest.Equal(it, 0, ExportRunSummaryFromInput(input, "terminal", out, "", true, false, true))
+			gotest.Equal(it, 0, ExportRunSummaryFromInput(input, "terminal", out, "", true, false, true, ""))
 		})
 
 		w.It("still renders the failure into the output", func(it *gotest.T) {
@@ -983,7 +983,7 @@ func (s *CmdGotestTestSuite) TestRenderOnlySeparatesVerdictFromRendering(t *gote
 		})
 
 		w.It("summary still fails too", func(it *gotest.T) {
-			gotest.Equal(it, 2, ExportRunSummaryFromInput(missing, "terminal", out, "", true, false, true))
+			gotest.Equal(it, 2, ExportRunSummaryFromInput(missing, "terminal", out, "", true, false, true, ""))
 		})
 	})
 

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -215,6 +215,7 @@ Flags:
   --github                GitHub CI mode: emit annotations and step summary
                           (auto-detected via $GITHUB_ACTIONS)
   --coverage=<file>       Include coverage from profile in summary output
+  --badge=<file>          Write a coverage badge SVG (enables -coverprofile)
   --ci                    CI mode: fail on F_ prefixes, snapshot read-only
   --debug                 Keep generated overlay
   --update-snapshots      Regenerate snapshot files

--- a/cmd/gotest/spec.go
+++ b/cmd/gotest/spec.go
@@ -61,7 +61,7 @@ func runSpec(inv Invocation) int { //nolint:gocritic // hugeParam: stable API
 		minCoverage = inv.Config.MinCoverage
 	}
 
-	goTestArgs, coverProfile, coverCleanup, err := ensureCoverProfile(goTestArgs, minCoverage)
+	goTestArgs, coverProfile, coverCleanup, err := ensureCoverProfile(goTestArgs, minCoverage > 0)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2

--- a/cmd/gotest/summary.go
+++ b/cmd/gotest/summary.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ func runSummary(inv Invocation) int { //nolint:gocritic // hugeParam: stable API
 	output := extractStringFlag(ownArgs, "--output", "")
 	input := extractStringFlag(ownArgs, "--input", "")
 	coverageProfile := extractStringFlag(ownArgs, "--coverage", "")
+	badgePath := extractStringFlag(ownArgs, "--badge", "")
 	noColor := hasFlag(ownArgs, "--no-color")
 	github := hasFlag(ownArgs, "--github") || os.Getenv("GITHUB_ACTIONS") == "true"
 	renderOnly := hasFlag(ownArgs, "--render-only")
@@ -36,7 +38,7 @@ func runSummary(inv Invocation) int { //nolint:gocritic // hugeParam: stable API
 	}
 
 	if input != "" {
-		return runSummaryFromInput(input, format, output, coverageProfile, noColor, github, renderOnly)
+		return runSummaryFromInput(input, format, output, coverageProfile, noColor, github, renderOnly, badgePath)
 	}
 
 	minCoverage, err := parseMinFlag(ownArgs)
@@ -48,7 +50,7 @@ func runSummary(inv Invocation) int { //nolint:gocritic // hugeParam: stable API
 		minCoverage = inv.Config.MinCoverage
 	}
 
-	goTestArgs, coverProfile, coverCleanup, err := ensureCoverProfile(goTestArgs, minCoverage)
+	goTestArgs, coverProfile, coverCleanup, err := ensureCoverProfile(goTestArgs, minCoverage > 0 || badgePath != "")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FAIL: %s\n", err)
 		return 2
@@ -135,12 +137,12 @@ func runSummary(inv Invocation) int { //nolint:gocritic // hugeParam: stable API
 	}
 
 	elapsed := time.Since(pipelineStart)
-	writeSummaryOutput(tree, format, output, coverageProfile, noColor, github, elapsed)
+	writeSummaryOutput(tree, format, output, coverageProfile, noColor, github, elapsed, badgePath)
 
 	return enforceCoverage(coverProfile, minCoverage, code)
 }
 
-func runSummaryFromInput(input, format, output, coverageProfile string, noColor, github, renderOnly bool) int {
+func runSummaryFromInput(input, format, output, coverageProfile string, noColor, github, renderOnly bool, badgePath string) int {
 	var r io.Reader
 	if input == "-" {
 		r = os.Stdin
@@ -162,7 +164,7 @@ func runSummaryFromInput(input, format, output, coverageProfile string, noColor,
 
 	tree := gotestspec.BuildTree(events)
 
-	writeSummaryOutput(tree, format, output, coverageProfile, noColor, github, 0)
+	writeSummaryOutput(tree, format, output, coverageProfile, noColor, github, 0, badgePath)
 
 	if !renderOnly && gotestspec.HasFailures(tree) {
 		return 1
@@ -170,7 +172,7 @@ func runSummaryFromInput(input, format, output, coverageProfile string, noColor,
 	return 0
 }
 
-func writeSummaryOutput(tree []*gotestspec.Package, format, output, coverageProfile string, noColor, github bool, elapsed time.Duration) {
+func writeSummaryOutput(tree []*gotestspec.Package, format, output, coverageProfile string, noColor, github bool, elapsed time.Duration, badgePath string) {
 	var w io.Writer = os.Stdout
 	var closeFunc func()
 	if output != "" {
@@ -200,6 +202,9 @@ func writeSummaryOutput(tree []*gotestspec.Package, format, output, coverageProf
 			fmt.Fprintf(os.Stderr, "warning: reading coverage profile: %s\n", err)
 		} else {
 			renderOpts = append(renderOpts, gotestspec.WithCoverage(report))
+			if badgePath != "" {
+				writeCoverageBadge(badgePath, report.Total)
+			}
 		}
 	}
 
@@ -224,5 +229,23 @@ func writeSummaryOutput(tree []*gotestspec.Package, format, output, coverageProf
 				sf.Close()
 			}
 		}
+	}
+}
+
+// writeCoverageBadge renders the badge SVG to path. It never fails the run:
+// the badge is a by-product of the summary, so problems are warnings.
+func writeCoverageBadge(path string, pct float64) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: writing coverage badge: %s\n", err)
+		return
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: writing coverage badge: %s\n", err)
+		return
+	}
+	defer f.Close()
+	if err := gotestspec.RenderCoverageBadge(f, pct); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: writing coverage badge: %s\n", err)
 	}
 }

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -147,6 +147,7 @@ gotest [subcommand] [packages...] [go-test-flags...] [--gotest-flags...]
 | `--input=<path>` | Replay a saved `go test -json` stream in `spec`/`summary` (`-` reads stdin) |
 | `--github` | Emit GitHub annotations and step summary (auto-enabled in GitHub Actions) |
 | `--coverage=<path>` | Coverage profile path for `summary` subcommand |
+| `--badge=<path>` | Write a self-contained coverage badge SVG (`summary` only); adds `-coverprofile` when neither the caller nor `--min` did |
 | `--render-only` | With `--input`, exit 0 on a failing stream: the code reports whether rendering succeeded, not whether the tests passed (requires `--input`) |
 | `--static` | Render the specification from source without running the suites (`spec` only); nodes carry no verdict, and methods whose behaviors depend on runtime values are reported as incomplete on stderr |
 

--- a/internal/gotestspec/badge.go
+++ b/internal/gotestspec/badge.go
@@ -1,0 +1,77 @@
+package gotestspec
+
+import (
+	"fmt"
+	"io"
+	"math"
+)
+
+// coverageBadgeColor maps a percentage to its band's fill color (shields.io
+// palette, so the badge matches what people expect a coverage badge to
+// look like). Boundaries are inclusive at the lower end.
+func coverageBadgeColor(pct float64) string {
+	switch {
+	case pct >= 90:
+		return "#4c1"
+	case pct >= 80:
+		return "#97ca00"
+	case pct >= 70:
+		return "#a4a61d"
+	case pct >= 60:
+		return "#dfb317"
+	case pct >= 40:
+		return "#fe7d37"
+	default:
+		return "#e05d44"
+	}
+}
+
+// badgeTextWidth estimates the rendered width of s in the badge's 11px
+// Verdana. The estimate only has to be stable, not exact: the SVG pins the
+// text to this width via textLength, so the layout never overflows.
+func badgeTextWidth(s string) int {
+	return int(math.Round(float64(len(s))*6.5)) + 10
+}
+
+// RenderCoverageBadge writes a flat-style SVG badge reading "coverage
+// <pct>%" to w. The SVG is self-contained: no fonts, images or links are
+// fetched when it is displayed.
+func RenderCoverageBadge(w io.Writer, pct float64) error {
+	label := "coverage"
+	message := fmt.Sprintf("%.1f%%", pct)
+	color := coverageBadgeColor(pct)
+
+	lw := badgeTextWidth(label)
+	mw := badgeTextWidth(message)
+	total := lw + mw
+
+	_, err := fmt.Fprintf(w, `<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="20" role="img" aria-label="%s: %s">
+  <title>%s: %s</title>
+  <linearGradient id="s" x2="0" y2="100%%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
+  <clipPath id="r"><rect width="%d" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="%d" height="20" fill="#555"/>
+    <rect x="%d" width="%d" height="20" fill="%s"/>
+    <rect width="%d" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+    <text aria-hidden="true" x="%d" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="%d">%s</text>
+    <text x="%d" y="140" transform="scale(.1)" textLength="%d">%s</text>
+    <text aria-hidden="true" x="%d" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="%d">%s</text>
+    <text x="%d" y="140" transform="scale(.1)" textLength="%d">%s</text>
+  </g>
+</svg>
+`,
+		total, label, message,
+		label, message,
+		total,
+		lw,
+		lw, mw, color,
+		total,
+		lw*5, (lw-10)*10, label,
+		lw*5, (lw-10)*10, label,
+		(lw*2+mw)*5, (mw-10)*10, message,
+		(lw*2+mw)*5, (mw-10)*10, message,
+	)
+	return err
+}

--- a/internal/gotestspec/badge_suite_test.go
+++ b/internal/gotestspec/badge_suite_test.go
@@ -1,0 +1,91 @@
+package gotestspec_test
+
+import (
+	"bytes"
+	"encoding/xml"
+	"strings"
+
+	"github.com/mvrahden/go-test/internal/gotestspec"
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// BadgeTestSuite tests the coverage badge renderer: a self-contained SVG
+// whose color band follows the coverage percentage.
+type BadgeTestSuite struct{}
+
+func (s *BadgeTestSuite) SuiteConfig() gotest.SuiteConfig {
+	cfg := gotest.DefaultSuiteConfig()
+	cfg.Parallel = true
+	return cfg
+}
+
+type badgeCtx struct{}
+
+func (s *BadgeTestSuite) BeforeEach(t *gotest.T) *badgeCtx { return &badgeCtx{} }
+
+func render(t *gotest.T, pct float64) string {
+	var buf bytes.Buffer
+	gotest.NoError(t, gotestspec.RenderCoverageBadge(&buf, pct))
+	return buf.String()
+}
+
+func (s *BadgeTestSuite) TestRendersWellFormedSVG(t *gotest.T, _ *badgeCtx) {
+	svg := render(t, 82.34)
+
+	t.It("is parseable XML rooted at <svg>", func(it *gotest.T) {
+		var root struct {
+			XMLName xml.Name
+		}
+		gotest.NoError(it, xml.Unmarshal([]byte(svg), &root))
+		gotest.Equal(it, "svg", root.XMLName.Local)
+	})
+
+	t.It("labels the badge and prints the percentage with one decimal", func(it *gotest.T) {
+		gotest.Contains(it, svg, ">coverage<")
+		gotest.Contains(it, svg, ">82.3%<")
+	})
+
+	t.It("does not link or embed any external resource", func(it *gotest.T) {
+		gotest.NotContains(it, svg, "href")
+		gotest.NotContains(it, svg, "<image")
+		gotest.NotContains(it, svg, "@import")
+	})
+}
+
+func (s *BadgeTestSuite) TestColorFollowsCoverageBand(t *gotest.T, _ *badgeCtx) {
+	for sub, tc := range gotest.Each(t, []struct {
+		Desc  string
+		pct   float64
+		color string
+	}{
+		{Desc: "90 and above is bright green", pct: 90, color: "#4c1"},
+		{Desc: "80 to 89 is green", pct: 89.9, color: "#97ca00"},
+		{Desc: "70 to 79 is yellow-green", pct: 70, color: "#a4a61d"},
+		{Desc: "60 to 69 is yellow", pct: 69.9, color: "#dfb317"},
+		{Desc: "40 to 59 is orange", pct: 40, color: "#fe7d37"},
+		{Desc: "below 40 is red", pct: 39.9, color: "#e05d44"},
+		{Desc: "zero is red", pct: 0, color: "#e05d44"},
+		{Desc: "full is bright green", pct: 100, color: "#4c1"},
+	}) {
+		svg := render(sub, tc.pct)
+		gotest.Contains(sub, svg, `fill="`+tc.color+`"`)
+	}
+}
+
+func (s *BadgeTestSuite) TestWidthGrowsWithTheMessage(t *gotest.T, _ *badgeCtx) {
+	short := render(t, 5)
+	long := render(t, 100)
+
+	t.It("reserves more width for a longer percentage", func(it *gotest.T) {
+		gotest.Less(it, widthOf(it, short), widthOf(it, long))
+	})
+}
+
+func widthOf(t *gotest.T, svg string) int {
+	var root struct {
+		Width int `xml:"width,attr"`
+	}
+	gotest.NoError(t, xml.Unmarshal([]byte(svg), &root))
+	gotest.NotZero(t, root.Width, "width attribute missing in %s", strings.SplitN(svg, "\n", 2)[0])
+	return root.Width
+}

--- a/site/content/reference.html
+++ b/site/content/reference.html
@@ -604,6 +604,7 @@ percentage = covered / total</div>
           <tr><td><code>--input=&lt;path&gt;</code></td><td>Read test output from file instead of running tests (<code>spec</code>, <code>summary</code>).</td></tr>
           <tr><td><code>--github</code></td><td>GitHub CI mode: emit <code>::error</code> annotations and write step summary (<code>summary</code> command). Auto-detected via <code>$GITHUB_ACTIONS</code>.</td></tr>
           <tr><td><code>--coverage=&lt;file&gt;</code></td><td>Include coverage from profile in summary output (<code>summary</code> command).</td></tr>
+          <tr><td><code>--badge=&lt;file&gt;</code></td><td>Write a self-contained coverage badge SVG; enables <code>-coverprofile</code> when nothing else does (<code>summary</code> command).</td></tr>
         </tbody>
       </table>
 
@@ -731,6 +732,8 @@ FAIL  pkg/bar TestProcessOrder / concurrent writes (1.2s)
           <tr><td><code>min-coverage</code></td><td><em>none</em></td><td>Minimum coverage percentage (0–100). Fails the step if below.</td></tr>
           <tr><td><code>flags</code></td><td><em>none</em></td><td>Additional gotest flags (<code>--double-dash</code> style).</td></tr>
           <tr><td><code>go-test-flags</code></td><td><em>none</em></td><td>Additional go test flags (<code>-single-dash</code> style).</td></tr>
+          <tr><td><code>badge</code></td><td><code>false</code></td><td>Render a coverage badge and publish it as <code>coverage.svg</code> to <code>badge-branch</code>, from the default branch only. Turns <code>coverage</code> on; needs <code>contents: write</code>.</td></tr>
+          <tr><td><code>badge-branch</code></td><td><code>ci/badges</code></td><td>Branch the badge is published to; created automatically on first use.</td></tr>
           <tr><td><code>version</code></td><td><code>gomod</code></td><td>Version to install, or <code>gomod</code> to resolve from <code>go.mod</code>.</td></tr>
         </tbody>
       </table>
@@ -741,6 +744,7 @@ FAIL  pkg/bar TestProcessOrder / concurrent writes (1.2s)
         <tbody>
           <tr><td><code>exit-code</code></td><td>Test process exit code.</td></tr>
           <tr><td><code>coverage</code></td><td>Coverage percentage (empty if coverage not enabled).</td></tr>
+          <tr><td><code>badge</code></td><td>Path of the rendered coverage badge SVG (empty unless <code>badge</code> is enabled and the tests ran).</td></tr>
         </tbody>
       </table>
 

--- a/skills/writing-gotest-tests/reference/ci.md
+++ b/skills/writing-gotest-tests/reference/ci.md
@@ -36,8 +36,15 @@ jobs:
   resolved from the consumer's go.mod — the same skew-free property as the
   tool directive. Other inputs: `packages`, `race`, `coverage`,
   `min-coverage`, `flags` (`--double-dash` style), `go-test-flags`
-  (`-single-dash` style). The action adds a failure-focused summary,
-  GitHub annotations, and coverage reporting on top of the plain CLI run.
+  (`-single-dash` style), `badge` (+ `badge-branch`, default `ci/badges`).
+  The action adds a failure-focused summary, GitHub annotations, and
+  coverage reporting on top of the plain CLI run.
+- **Coverage badge:** `badge: true` makes gotest render `coverage.svg` and
+  the action commit it to the `badge-branch` of the consumer's own repo —
+  from the default branch only, never from a PR — so the job needs
+  `permissions: contents: write`. Embed it as
+  `https://raw.githubusercontent.com/<owner>/<repo>/ci/badges/coverage.svg`.
+  The badge needs no shields.io, gist or token setup — do not add any.
 - CI environments auto-arm `--ci` (any non-falsy `CI`/`GOTEST_CI` value):
   committed `F_` focus prefixes FAIL the run, and snapshots become
   read-only (`--update-snapshots` will not write). Opt out with


### PR DESCRIPTION
Projects using the gotest GitHub Action can now show a coverage badge in their README with a single setting. No external service, no account, no secret to manage: gotest draws the badge itself and the workflow's own permissions publish it to a small branch inside the project's repository.

What this means in practice:
- Turn it on with `badge: true` and add one image line to your README.
- The badge only ever reflects the main branch. Pull requests and feature branches cannot overwrite it.
- A broken build publishes nothing. A failed test run still shows its real coverage.
- Parallel jobs are safe, and a missing permission produces a warning rather than a failed build.
- The badge can also be generated locally or on any other CI with `gotest summary --badge=coverage.svg`.