### PR TITLE
Fail early with a clear message when a project's gotest dependency is too old

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,7 @@ The generated code is not hand-edited.
 
 All assertions accept both `*gotest.T` and `*testing.T` as first argument.
 
-Run the CLI through Go's tool directive — `go get -tool github.com/mvrahden/go-test/cmd/gotest`, then `go tool gotest <args>` — so its version and its Go toolchain follow go.mod.
-Never `go install` a global binary or call one already on PATH; it drifts from the pin and from the module's Go version, and the CLI refuses to run on either drift.
+Run the CLI as `go tool gotest <args>`, declared once with `go get -tool github.com/mvrahden/go-test/cmd/gotest@<the version go.mod already requires>` (unversioned `go get -tool` upgrades the pin). Never a global `go install` binary: it drifts from go.mod and the CLI refuses to run on drift.
 
 ## Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,9 @@ The generated code is not hand-edited.
 
 All assertions accept both `*gotest.T` and `*testing.T` as first argument.
 
+Run the CLI through Go's tool directive — `go get -tool github.com/mvrahden/go-test/cmd/gotest`, then `go tool gotest <args>` — so its version and its Go toolchain follow go.mod.
+Never `go install` a global binary or call one already on PATH; it drifts from the pin and from the module's Go version, and the CLI refuses to run on either drift.
+
 ## Rules
 
 These override any default instincts from stdlib `testing` or other Go test frameworks.

--- a/README.md
+++ b/README.md
@@ -29,13 +29,9 @@ go get -tool github.com/mvrahden/go-test/cmd/gotest@latest
 go tool gotest ./...
 ```
 
-`go get -tool` pins the CLI and the `pkg/gotest` runtime to the same release, and `go tool` rebuilds the CLI with the Go version your module declares. Upgrading is the same `go get -tool` command again.
+`go get -tool` pins the CLI and the `pkg/gotest` runtime to the same release, and `go tool` rebuilds the CLI with your module's Go. Upgrading is the same command again. Avoid a global `go install` binary: it drifts from `go.mod` on both axes, and gotest refuses to run on that drift.
 
-Do not install a standalone binary with `go install`. That binary is detached from your projects: it keeps the gotest version and the Go toolchain it was built with, and either one drifting from `go.mod` ends in compile errors inside generated code. If you need one anyway, keep it on the release your `go.mod` pins and rebuild it after every Go upgrade. gotest refuses to run against a pinned runtime older than v1.27.0.
-
-The examples below write `gotest …` for brevity. With the tool directive that is `go tool gotest …`, or `alias gotest='go tool gotest'`.
-
-The VS Code extension builds the CLI from the version your `go.mod` pins, so the same pin governs the editor. It does not run `go tool` yet, and it reads the pin only from the workspace folder's own `go.mod`: for a `go.work` root, open the module folder as the workspace folder.
+The examples below write `gotest` for brevity; with the tool directive, read `go tool gotest`. The VS Code extension and the GitHub action run the same CLI your `go.mod` selects.
 
 ## 30-Second Example
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,20 @@ No third-party runtime dependencies. No reflection in discovery or registration.
 
 ## Install
 
+Add gotest to your module as a Go tool. Its version and its Go toolchain then follow your `go.mod`:
+
 ```bash
-go install github.com/mvrahden/go-test/cmd/gotest@latest
+go get -tool github.com/mvrahden/go-test/cmd/gotest@latest
+go tool gotest ./...
 ```
+
+`go get -tool` pins the CLI and the `pkg/gotest` runtime to the same release, and `go tool` rebuilds the CLI with the Go version your module declares. Upgrading is the same `go get -tool` command again.
+
+Do not install a standalone binary with `go install`. That binary is detached from your projects: it keeps the gotest version and the Go toolchain it was built with, and either one drifting from `go.mod` ends in compile errors inside generated code. If you need one anyway, keep it on the release your `go.mod` pins and rebuild it after every Go upgrade. gotest refuses to run against a pinned runtime older than v1.27.0.
+
+The examples below write `gotest …` for brevity. With the tool directive that is `go tool gotest …`, or `alias gotest='go tool gotest'`.
+
+The VS Code extension builds the CLI from the version your `go.mod` pins, so the same pin governs the editor. It does not run `go tool` yet, and it reads the pin only from the workspace folder's own `go.mod`: for a `go.work` root, open the module folder as the workspace folder.
 
 ## 30-Second Example
 

--- a/README.md
+++ b/README.md
@@ -835,7 +835,7 @@ Use the official action for CI pipelines with failure summaries, inline PR annot
     min-coverage: 80
 ```
 
-By default (`version: gomod`), the action resolves `gotest` from your `go.mod` — no version drift between CI and local development. Set `version: latest` or a specific tag to install a standalone binary instead.
+By default (`version: gomod`), the action runs the `gotest` your `go.mod` selects (`go tool` when declared, else `go run -mod=mod`) — no version drift between CI and local development. Set `version: latest` or a specific tag to install a standalone binary instead.
 
 The action emits `::error` annotations that appear inline on PR diffs and writes a markdown summary to the GitHub step summary panel.
 
@@ -859,7 +859,7 @@ The tables below are the canonical action surface — a drift guard test keeps t
 | `bench-baseline` | Baseline JSON file to compare benchmarks against (`--against`) |
 | `bench-gate` | Fail if any benchmark regresses by more than this percent (`--gate`) |
 | `bench-save` | Save the run as a JSON baseline at this path (`--save`); an explicit empty string saves to `bench.baseline` from `.gotest.yml`; default `false` saves nothing |
-| `version` | `gomod` (default) resolves from go.mod; a tag (e.g. `v1.0.0`, `latest`) installs globally |
+| `version` | `gomod` (default) runs the CLI from go.mod; a tag (e.g. `v1.0.0`, `latest`) installs globally |
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
     description: "Save the benchmark run as a JSON baseline at this path (gotest bench --save); an explicit empty string saves to bench.baseline from .gotest.yml"
     default: "false"
   version:
-    description: "gotest version: 'gomod' (default) resolves from go.mod, or a version tag (e.g. v1.0.0, latest) to install globally."
+    description: "gotest version: 'gomod' (default) runs the CLI from go.mod, or a version tag (e.g. v1.0.0, latest) to install globally."
     default: "gomod"
 
 outputs:
@@ -71,6 +71,26 @@ runs:
       shell: bash
       run: go install github.com/mvrahden/go-test/cmd/gotest@${{ inputs.version }}
 
+    - name: Resolve the gotest command
+      if: ${{ inputs.version == 'gomod' }}
+      shell: bash
+      run: |
+        # Bare `go run <pkg>` fails on a tidy consumer (the CLI's own deps are
+        # pruned from go.sum); -mod=mod lets this throwaway checkout add them,
+        # except in workspace mode, where the flag is rejected and the
+        # workspace go.sum is the union of its modules'.
+        pkg=github.com/mvrahden/go-test/cmd/gotest
+        notice="::notice title=gotest::go.mod does not declare the gotest tool; declare it with: go get -tool $pkg@<pinned version>"
+        if go tool 2>/dev/null | grep -q "($pkg)"; then
+          echo "GOTEST_CMD=go tool $pkg" >> "$GITHUB_ENV"
+        elif [ -n "$(go env GOWORK)" ]; then
+          go list -m 2>/dev/null | grep -qx github.com/mvrahden/go-test || echo "$notice"
+          echo "GOTEST_CMD=go run $pkg" >> "$GITHUB_ENV"
+        else
+          echo "$notice"
+          echo "GOTEST_CMD=go run -mod=mod $pkg" >> "$GITHUB_ENV"
+        fi
+
     - name: Run tests
       id: test
       shell: bash
@@ -87,7 +107,7 @@ runs:
         if [ "$INPUT_VERSION" != "gomod" ]; then
           cmd=(gotest)
         else
-          cmd=(go run github.com/mvrahden/go-test/cmd/gotest)
+          read -ra cmd <<< "$GOTEST_CMD"
         fi
 
         args=(summary --github)
@@ -260,7 +280,7 @@ runs:
         if [ "$INPUT_VERSION" != "gomod" ]; then
           cmd=(gotest)
         else
-          cmd=(go run github.com/mvrahden/go-test/cmd/gotest)
+          read -ra cmd <<< "$GOTEST_CMD"
         fi
 
         # gotest bench writes its own markdown to $GITHUB_STEP_SUMMARY

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,9 @@ require (
 	github.com/dlclark/regexp2 v1.12.0
 	github.com/fsnotify/fsnotify v1.10.1
 	go.yaml.in/yaml/v3 v3.0.5
+	golang.org/x/mod v0.40.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/tools v0.49.0
 )
 
-require (
-	golang.org/x/mod v0.40.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
-)
+require golang.org/x/sync v0.22.0 // indirect

--- a/internal/gotestgen/generator.go
+++ b/internal/gotestgen/generator.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mvrahden/go-test/internal/about"
 	"github.com/mvrahden/go-test/internal/gotestast"
+	"github.com/mvrahden/go-test/internal/goversion"
 	"github.com/mvrahden/go-test/internal/x/slices"
 	"golang.org/x/tools/go/packages"
 )
@@ -137,6 +138,9 @@ func loadPackages(mode packages.LoadMode, targetPkgs []string, buildFlags []stri
 	}
 	totalFoundPkgs, err := packages.Load(cfg, targetPkgs...)
 	if err != nil {
+		return nil, nil, err
+	}
+	if err := goversion.Check(totalFoundPkgs); err != nil {
 		return nil, nil, err
 	}
 

--- a/internal/gotestgen/generator.go
+++ b/internal/gotestgen/generator.go
@@ -258,6 +258,9 @@ func GenerateFromLoaded(loadResults []*LoadResult) (GenerateResults, []SharedFix
 }
 
 func generateFromLoaded(loadResults []*LoadResult) (GenerateResults, []SharedFixtureInfo, error) {
+	if err := CheckRuntimeVersion(loadResults); err != nil {
+		return nil, nil, err
+	}
 	sharedSeen := map[string]bool{}
 	var allSharedFixtures []SharedFixtureInfo
 

--- a/internal/gotestgen/runtimeversion.go
+++ b/internal/gotestgen/runtimeversion.go
@@ -1,0 +1,45 @@
+package gotestgen
+
+import (
+	"fmt"
+
+	"github.com/mvrahden/go-test/internal/about"
+	"golang.org/x/mod/semver"
+	"golang.org/x/tools/go/packages"
+)
+
+// MinRuntimeVersion is the oldest gotest runtime generated code compiles
+// against. It equals the extension's MIN_CLI_VERSION (a test guards the pair);
+// bump both when the renderer uses a newer runtime symbol.
+const MinRuntimeVersion = "v1.27.0"
+
+// CheckRuntimeVersion refuses to generate against a runtime older than
+// MinRuntimeVersion. Replaced and main modules have no version to check.
+func CheckRuntimeVersion(loadResults []*LoadResult) error {
+	for _, lr := range loadResults {
+		for _, p := range []*packages.Package{lr.Ptest, lr.Pxtest} {
+			if p == nil {
+				continue
+			}
+			mod := gotestModule(p)
+			if mod == nil || mod.Main || mod.Replace != nil || mod.Version == "" {
+				continue
+			}
+			if semver.Compare(mod.Version, MinRuntimeVersion) < 0 {
+				return fmt.Errorf("%s %s requires %s %s or newer, but go.mod resolves %s; run: go get -tool %s/cmd/gotest@latest, then use go tool gotest (see README, Install)",
+					about.Application, about.ResolvedVersion(), about.Repo, MinRuntimeVersion, mod.Version, about.Repo)
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+func gotestModule(p *packages.Package) *packages.Module {
+	for _, imp := range p.Imports {
+		if imp.Module != nil && imp.Module.Path == about.Repo {
+			return imp.Module
+		}
+	}
+	return nil
+}

--- a/internal/gotestgen/runtimeversion_suite_test.go
+++ b/internal/gotestgen/runtimeversion_suite_test.go
@@ -1,0 +1,89 @@
+package gotestgen_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/mvrahden/go-test/internal/about"
+	"github.com/mvrahden/go-test/internal/gotestgen"
+	"github.com/mvrahden/go-test/pkg/gotest"
+	"golang.org/x/tools/go/packages"
+)
+
+// RuntimeVersionTestSuite covers the preflight that refuses to generate
+// against a gotest runtime older than the renderer targets.
+type RuntimeVersionTestSuite struct{}
+
+func (s *RuntimeVersionTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{Parallel: true}
+}
+
+func loadedWith(mod *packages.Module, external bool) []*gotestgen.LoadResult {
+	pkg := &packages.Package{
+		PkgPath: "example.com/app",
+		Imports: map[string]*packages.Package{
+			about.Repo + "/pkg/gotest": {PkgPath: about.Repo + "/pkg/gotest", Module: mod},
+			"fmt":                      {PkgPath: "fmt"},
+		},
+	}
+	lr := &gotestgen.LoadResult{PkgPath: "example.com/app"}
+	if external {
+		lr.Pxtest = pkg
+	} else {
+		lr.Ptest = pkg
+	}
+	return []*gotestgen.LoadResult{lr}
+}
+
+func (s *RuntimeVersionTestSuite) TestCheckRuntimeVersion(t *gotest.T) {
+	t.When("the module pins a runtime older than the generator's floor", func(w *gotest.T) {
+		w.It("fails with the pinned version, the floor and the upgrade command", func(it *gotest.T) {
+			err := gotestgen.CheckRuntimeVersion(loadedWith(&packages.Module{Path: about.Repo, Version: "v1.25.0"}, false))
+			gotest.ErrorContains(it, err, "v1.25.0")
+			gotest.ErrorContains(it, err, gotestgen.MinRuntimeVersion)
+			gotest.ErrorContains(it, err, "go get -tool "+about.Repo+"/cmd/gotest@latest")
+		})
+		w.It("checks external test packages too", func(it *gotest.T) {
+			err := gotestgen.CheckRuntimeVersion(loadedWith(&packages.Module{Path: about.Repo, Version: "v1.25.0"}, true))
+			gotest.Error(it, err)
+		})
+		w.It("treats a pseudo-version by its base version", func(it *gotest.T) {
+			err := gotestgen.CheckRuntimeVersion(loadedWith(&packages.Module{Path: about.Repo, Version: "v1.25.1-0.20260701120000-abcdefabcdef"}, false))
+			gotest.Error(it, err)
+		})
+	})
+
+	t.When("the module pins a runtime the generator can target", func(w *gotest.T) {
+		w.It("accepts the floor itself", func(it *gotest.T) {
+			gotest.NoError(it, gotestgen.CheckRuntimeVersion(loadedWith(&packages.Module{Path: about.Repo, Version: gotestgen.MinRuntimeVersion}, false)))
+		})
+		w.It("accepts newer releases", func(it *gotest.T) {
+			gotest.NoError(it, gotestgen.CheckRuntimeVersion(loadedWith(&packages.Module{Path: about.Repo, Version: "v1.99.0"}, false)))
+		})
+	})
+
+	t.When("the version says nothing about the code that will run", func(w *gotest.T) {
+		w.It("skips a replaced module", func(it *gotest.T) {
+			mod := &packages.Module{Path: about.Repo, Version: "v0.0.0-00010101000000-000000000000", Replace: &packages.Module{Path: "../go-test"}}
+			gotest.NoError(it, gotestgen.CheckRuntimeVersion(loadedWith(mod, false)))
+		})
+		w.It("skips the main module", func(it *gotest.T) {
+			gotest.NoError(it, gotestgen.CheckRuntimeVersion(loadedWith(&packages.Module{Path: about.Repo, Main: true}, false)))
+		})
+		w.It("skips packages that do not import gotest", func(it *gotest.T) {
+			lr := &gotestgen.LoadResult{PkgPath: "example.com/plain", Ptest: &packages.Package{PkgPath: "example.com/plain"}}
+			gotest.NoError(it, gotestgen.CheckRuntimeVersion([]*gotestgen.LoadResult{lr}))
+		})
+	})
+}
+
+func (s *RuntimeVersionTestSuite) TestFloorMatchesExtension(t *gotest.T) {
+	t.It("equals MIN_CLI_VERSION in vscode-gotest/src/cli.ts", func(it *gotest.T) {
+		src, err := os.ReadFile(filepath.Join("..", "..", "vscode-gotest", "src", "cli.ts"))
+		gotest.NoError(it, err)
+		m := regexp.MustCompile(`MIN_CLI_VERSION = "(v[^"]+)"`).FindSubmatch(src)
+		gotest.NotNil(it, m)
+		gotest.Equal(it, string(m[1]), gotestgen.MinRuntimeVersion)
+	})
+}

--- a/internal/goversion/export_test.go
+++ b/internal/goversion/export_test.go
@@ -1,0 +1,3 @@
+package goversion //nolint:stdlib-test
+
+var ExportCheck = check

--- a/internal/goversion/goversion.go
+++ b/internal/goversion/goversion.go
@@ -1,0 +1,40 @@
+// Package goversion refuses to run a gotest binary built by an older Go than
+// the module declares, naming the binary and the fix instead of the type
+// checker's "application" message. Only a stale `go install` binary trips it.
+package goversion
+
+import (
+	"fmt"
+	"go/version"
+	"os"
+	"runtime"
+
+	"github.com/mvrahden/go-test/internal/about"
+	"golang.org/x/tools/go/packages"
+)
+
+// Check compares this binary's Go with each package's module go directive.
+// Packages must be loaded with packages.NeedModule.
+func Check(pkgs []*packages.Package) error {
+	return check(pkgs, runtime.Version())
+}
+
+func check(pkgs []*packages.Package, builtWith string) error {
+	built := version.Lang(builtWith)
+	if built == "" {
+		return nil
+	}
+	for _, p := range pkgs {
+		if p.Module == nil || p.Module.GoVersion == "" {
+			continue
+		}
+		declared := version.Lang("go" + p.Module.GoVersion)
+		if declared == "" || version.Compare(built, declared) >= 0 {
+			continue
+		}
+		exe, _ := os.Executable()
+		return fmt.Errorf("%s %s (%s) was built with %s, but module %s declares go %s; run the CLI through the tool directive so the module's Go builds it: go get -tool %s/cmd/gotest@latest && go tool gotest ./... (see README, Install)",
+			about.Application, about.ResolvedVersion(), exe, builtWith, p.Module.Path, p.Module.GoVersion, about.Repo)
+	}
+	return nil
+}

--- a/internal/goversion/goversion_suite_test.go
+++ b/internal/goversion/goversion_suite_test.go
@@ -1,0 +1,62 @@
+package goversion_test
+
+import (
+	"github.com/mvrahden/go-test/internal/about"
+	"github.com/mvrahden/go-test/internal/goversion"
+	"github.com/mvrahden/go-test/pkg/gotest"
+	"golang.org/x/tools/go/packages"
+)
+
+// GoVersionTestSuite covers the preflight that refuses to run a gotest binary
+// built by an older Go than the module declares.
+type GoVersionTestSuite struct{}
+
+func (s *GoVersionTestSuite) SuiteConfig() gotest.SuiteConfig {
+	return gotest.SuiteConfig{Parallel: true}
+}
+
+func pkgsDeclaring(goVersion string) []*packages.Package {
+	return []*packages.Package{{
+		PkgPath: "example.com/app",
+		Module:  &packages.Module{Path: "example.com", Main: true, GoVersion: goVersion},
+	}}
+}
+
+func (s *GoVersionTestSuite) TestCheck(t *gotest.T) {
+	t.When("the binary's Go is older than the module's go directive", func(w *gotest.T) {
+		w.It("fails naming both versions and the rebuild command", func(it *gotest.T) {
+			err := goversion.ExportCheck(pkgsDeclaring("1.27.1"), "go1.26.3")
+			gotest.ErrorContains(it, err, "go1.26.3")
+			gotest.ErrorContains(it, err, "go 1.27.1")
+			gotest.ErrorContains(it, err, "go get -tool "+about.Repo+"/cmd/gotest@latest")
+			gotest.ErrorContains(it, err, "go tool gotest")
+		})
+		w.It("compares language versions, so a directive without patch still counts", func(it *gotest.T) {
+			gotest.Error(it, goversion.ExportCheck(pkgsDeclaring("1.27"), "go1.26.5"))
+		})
+	})
+
+	t.When("the binary's Go can process the module", func(w *gotest.T) {
+		w.It("accepts an equal language version regardless of patch level", func(it *gotest.T) {
+			gotest.NoError(it, goversion.ExportCheck(pkgsDeclaring("1.27.1"), "go1.27.0"))
+		})
+		w.It("accepts a release candidate of the same language version", func(it *gotest.T) {
+			gotest.NoError(it, goversion.ExportCheck(pkgsDeclaring("1.27.1"), "go1.27rc1"))
+		})
+		w.It("accepts a newer Go", func(it *gotest.T) {
+			gotest.NoError(it, goversion.ExportCheck(pkgsDeclaring("1.26"), "go1.27.0"))
+		})
+	})
+
+	t.When("a version cannot be compared", func(w *gotest.T) {
+		w.It("skips development toolchains", func(it *gotest.T) {
+			gotest.NoError(it, goversion.ExportCheck(pkgsDeclaring("1.27.1"), "devel go1.28-abcdef Mon Jan 1"))
+		})
+		w.It("skips packages without module information", func(it *gotest.T) {
+			gotest.NoError(it, goversion.ExportCheck([]*packages.Package{{PkgPath: "fmt"}}, "go1.26.3"))
+		})
+		w.It("skips a module without a go directive", func(it *gotest.T) {
+			gotest.NoError(it, goversion.ExportCheck(pkgsDeclaring(""), "go1.26.3"))
+		})
+	})
+}

--- a/internal/lint/preflight.go
+++ b/internal/lint/preflight.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mvrahden/go-test/internal/goversion"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -21,12 +22,15 @@ func PreflightLoad(dir string, patterns []string) error {
 		Dir: dir,
 		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
 			packages.NeedImports | packages.NeedDeps | packages.NeedTypes |
-			packages.NeedSyntax | packages.NeedTypesInfo,
+			packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedModule,
 		Tests: true,
 	}
 	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {
 		return fmt.Errorf("load packages: %w", err)
+	}
+	if err := goversion.Check(pkgs); err != nil {
+		return err
 	}
 
 	var broken []string

--- a/internal/lint/run.go
+++ b/internal/lint/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/mvrahden/go-test/internal/goversion"
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/checker"
 	"golang.org/x/tools/go/packages"
@@ -31,12 +32,15 @@ type Finding struct {
 func Run(dir string, patterns []string) ([]Finding, error) {
 	cfg := &packages.Config{
 		Dir:   dir,
-		Mode:  packages.LoadAllSyntax,
+		Mode:  packages.LoadAllSyntax | packages.NeedModule,
 		Tests: true,
 	}
 	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {
 		return nil, fmt.Errorf("load packages: %w", err)
+	}
+	if err := goversion.Check(pkgs); err != nil {
+		return nil, err
 	}
 	for _, p := range pkgs {
 		if len(p.Errors) > 0 {

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -13,6 +13,7 @@ import (
 	"unicode"
 
 	"github.com/mvrahden/go-test/internal/gotestgen"
+	"github.com/mvrahden/go-test/internal/goversion"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -90,13 +91,16 @@ func ParseTarget(target string) (pkgPattern, typeName string, err error) {
 // given type name. It works in non-test mode to access production types.
 func IntrospectType(pkgPattern, typeName string) (*TypeInfo, error) {
 	cfg := &packages.Config{
-		Mode:  packages.NeedName | packages.NeedTypes | packages.NeedImports | packages.NeedDeps | packages.NeedFiles,
+		Mode:  packages.NeedName | packages.NeedTypes | packages.NeedImports | packages.NeedDeps | packages.NeedFiles | packages.NeedModule,
 		Tests: false,
 	}
 
 	pkgs, err := packages.Load(cfg, pkgPattern)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load package %q: %w", pkgPattern, err)
+	}
+	if err := goversion.Check(pkgs); err != nil {
+		return nil, err
 	}
 
 	if len(pkgs) == 0 {
@@ -154,13 +158,16 @@ func IntrospectType(pkgPattern, typeName string) (*TypeInfo, error) {
 // from the specified file. It returns a FileInfo suitable for file-scoped scaffold generation.
 func IntrospectFile(pkgPattern, filename string) (*FileInfo, error) {
 	cfg := &packages.Config{
-		Mode:  packages.NeedName | packages.NeedTypes | packages.NeedSyntax | packages.NeedFiles,
+		Mode:  packages.NeedName | packages.NeedTypes | packages.NeedSyntax | packages.NeedFiles | packages.NeedModule,
 		Tests: false,
 	}
 
 	pkgs, err := packages.Load(cfg, pkgPattern)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load package %q: %w", pkgPattern, err)
+	}
+	if err := goversion.Check(pkgs); err != nil {
+		return nil, err
 	}
 
 	if len(pkgs) == 0 {

--- a/skills/writing-gotest-tests/SKILL.md
+++ b/skills/writing-gotest-tests/SKILL.md
@@ -96,29 +96,30 @@ The repo has the *library*; the CLI runs via Go's tool directive (requires
 Go ≥ 1.25). One-time:
 
 ```sh
-go get -tool github.com/mvrahden/go-test/cmd/gotest
+go get -tool github.com/mvrahden/go-test/cmd/gotest@$(go list -m -f '{{.Version}}' github.com/mvrahden/go-test)
 go tool gotest version
 ```
 
-Then every command is `go tool gotest <args>`. Never `go install` a global
-binary, and never call one that is already on PATH: it is detached from
-go.mod twice over — it keeps the gotest version it was installed at while
-the library pin moves, and it keeps the Go it was compiled with while the
-module's go directive moves. `go tool` rebuilds from the pin with the
-module's toolchain, so both stay aligned by construction. (Bare
+Keep the `@version`: without it `go get -tool` upgrades the library pin,
+which setup must never do (`@latest` only in a project with no pin yet). In
+a vendored module (`vendor/modules.txt`) the go.mod edit breaks every build
+until `go mod vendor` reruns, and gotest cannot run vendored at all (the
+overlay's `pkg/gotestruntime` import is never vendored) — report, do not
+work around.
+
+Then every command is `go tool gotest <args>`; if Go reports the short name
+ambiguous, use `go tool github.com/mvrahden/go-test/cmd/gotest`. Never a
+global `go install` binary: it drifts from the pin and from the module's Go,
+and releases after v1.28.1 refuse to run on either drift (`FAIL:` naming the
+version or the Go it was built with, exit 2). That refusal is never a fault
+in the tests; switch to `go tool gotest` instead of bumping the pin. (Bare
 `go run github.com/mvrahden/go-test/cmd/gotest` fails on fresh consumers:
 module pruning leaves the CLI's deps out of go.sum.)
 
-The CLI (v1.28.2+) refuses to run on either drift, with `FAIL:` and exit 2:
-"requires github.com/mvrahden/go-test v1.27.0 or newer, but go.mod resolves
-…" or "was built with go1.X, but module … declares go 1.Y". Both mean the
-CLI that ran is not the one go.mod pins — a global binary, or a `go run
-…@latest` — never a fault in the tests. Switch to `go tool gotest`; do not
-bump the project's pin to silence them unless the task is an upgrade.
-
-In a `go.work` workspace, run `go tool gotest` from the workspace root: Go
-finds the tool declared in any `use` module. The `go.work` go line must be
-at least the modules' go lines or every go command fails.
+In a `go.work` workspace the tool declared in any `use` module works from
+the root and inside each module, at the highest pin. `./...` is rejected at
+the root, so name each module (`go tool gotest ./svc/... ./lib/...`) or run
+inside one. The `go.work` go line must be at least the modules' go lines.
 
 ## The Two Runners — a complete run is BOTH commands
 

--- a/skills/writing-gotest-tests/SKILL.md
+++ b/skills/writing-gotest-tests/SKILL.md
@@ -101,9 +101,24 @@ go tool gotest version
 ```
 
 Then every command is `go tool gotest <args>`. Never `go install` a global
-binary — it goes stale against the pinned library version. (Bare
+binary, and never call one that is already on PATH: it is detached from
+go.mod twice over — it keeps the gotest version it was installed at while
+the library pin moves, and it keeps the Go it was compiled with while the
+module's go directive moves. `go tool` rebuilds from the pin with the
+module's toolchain, so both stay aligned by construction. (Bare
 `go run github.com/mvrahden/go-test/cmd/gotest` fails on fresh consumers:
 module pruning leaves the CLI's deps out of go.sum.)
+
+The CLI (v1.28.2+) refuses to run on either drift, with `FAIL:` and exit 2:
+"requires github.com/mvrahden/go-test v1.27.0 or newer, but go.mod resolves
+…" or "was built with go1.X, but module … declares go 1.Y". Both mean the
+CLI that ran is not the one go.mod pins — a global binary, or a `go run
+…@latest` — never a fault in the tests. Switch to `go tool gotest`; do not
+bump the project's pin to silence them unless the task is an upgrade.
+
+In a `go.work` workspace, run `go tool gotest` from the workspace root: Go
+finds the tool declared in any `use` module. The `go.work` go line must be
+at least the modules' go lines or every go command fails.
 
 ## The Two Runners — a complete run is BOTH commands
 

--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -254,6 +254,8 @@ The extension resolves the gotest CLI in this order:
 4. **`go.mod` pinned version** — If `go.mod` references the gotest module, uses `go run modulePath@version` with the pinned version.
 5. **`go run @latest`** — Fallback when none of the above apply.
 
+The pin is read from the workspace folder's own `go.mod`. A root that has only a `go.work` currently falls through to `@latest`, so open the module folder as the workspace folder. The `tool` directive (`go tool gotest`) is not used yet.
+
 ### Go binary resolution
 
 The extension resolves the Go toolchain per workspace folder:

--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -35,7 +35,7 @@ The **Spec View** renders your test structure as a behavioral specification — 
 - **[Delve](https://github.com/go-delve/delve)** (for debugging only)
 
 The extension invokes the gotest CLI automatically — no separate install needed.
-It resolves the version from your `go.mod` and uses `go run` to execute it.
+It runs the CLI your `go.mod` selects: `go tool` when the tool directive is declared, otherwise `go run` at the pinned version.
 The CLI must be **v1.27.0 or newer**; older versions are rejected at activation.
 
 ### Install
@@ -199,7 +199,8 @@ These can be set in `.vscode/settings.json` per workspace folder:
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `gotest.cliPath` | `""` | Path to a gotest binary (overrides all other resolution) |
-| `gotest.modulePath` | `github.com/mvrahden/go-test/cmd/gotest` | Go module path for the gotest CLI |
+| `gotest.modulePath` | `github.com/mvrahden/go-test/cmd/gotest` | Package path of the gotest CLI |
+| `gotest.suggestToolDirective` | `true` | Offer once per folder to declare the pinned CLI as a tool in `go.mod` |
 | `gotest.buildTags` | `""` | Comma-separated Go build tags (e.g. `integration,e2e`) |
 | `gotest.testFlags` | `[]` | Additional flags passed to gotest (`--` prefixed) and `go test` (`-` prefixed) |
 | `gotest.buildFlags` | `[]` | Additional build flags passed to Delve |
@@ -246,24 +247,25 @@ These can be set in `.vscode/settings.json` per workspace folder:
 
 ### Gotest CLI resolution
 
-The extension resolves the gotest CLI in this order:
+The extension runs whatever `go.mod` selects, in this order:
 
 1. **`gotest.cliPath`** — Explicit path to a binary. Highest priority; version-validated against the minimum required version.
 2. **Workspace is gotest module** — If the workspace's `go.mod` declares the gotest module itself (development or `go.work` overlap), uses `go run ./cmd/gotest`.
-3. **`go.mod` + replace directive** — If `go.mod` has a `replace` directive for the gotest module, uses `go run modulePath` (no version, respects replace resolution).
-4. **`go.mod` pinned version** — If `go.mod` references the gotest module, uses `go run modulePath@version` with the pinned version.
-5. **`go run @latest`** — Fallback when none of the above apply.
+3. **Tool directive** — If `go.mod` declares the CLI as a tool (`go get -tool github.com/mvrahden/go-test/cmd/gotest@<version>`), uses `go tool <modulePath>`.
+4. **`go.mod` + replace directive** — If `go.mod` has a `replace` directive for the gotest module, uses `go run modulePath` (no version, respects replace resolution).
+5. **`go.mod` pinned version** — If `go.mod` requires gotest at v1.27.0 or newer, uses `go run modulePath@version`, and offers once to declare the tool at that version (`gotest.suggestToolDirective`; never in a vendored module).
+6. **Pinned below v1.27.0** — Refused with an **Upgrade** action; a newer CLI would generate code the pinned runtime cannot compile.
+7. **`go run @latest`** — Only when no module requires gotest yet, so `scaffold` can run before a pin exists.
 
-The pin is read from the workspace folder's own `go.mod`. A root that has only a `go.work` currently falls through to `@latest`, so open the module folder as the workspace folder. The `tool` directive (`go tool gotest`) is not used yet.
+In a `go.work` root every `use` module is read: a tool declared by any of them counts, and the pin is the highest across modules, which is what the workspace builds.
 
 ### Go binary resolution
 
-The extension resolves the Go toolchain per workspace folder:
+The extension finds one `go` and leaves the toolchain to Go: `go run` and `go tool` honour the module's `go` directive and pass their own `go` to the CLI.
 
-1. **`go.mod` go directive** — If `go.mod` declares `go 1.26.2`, the extension looks for `~/sdk/go1.26.2/bin/go` or `go1.26.2` on PATH.
-2. **`GOROOT`** — `$GOROOT/bin/go` if set.
-3. **Login shell** — Runs `bash -lc 'command -v go'` to find Go on the user's full PATH.
-4. **Common paths** — `/usr/local/go/bin/go`, `~/go/bin/go`, `/usr/bin/go`, `~/sdk/go*/bin/go`.
+1. **`GOROOT`** — `$GOROOT/bin/go` if set.
+2. **Login shell** — Runs `bash -lc 'command -v go'` to find Go on the user's full PATH.
+3. **Common paths** — `/usr/local/go/bin/go`, `~/go/bin/go`, `/usr/bin/go`, `~/sdk/go*/bin/go`.
 
 ## Requirements
 

--- a/vscode-gotest/package.json
+++ b/vscode-gotest/package.json
@@ -161,13 +161,19 @@
           "type": "string",
           "default": "github.com/mvrahden/go-test/cmd/gotest",
           "scope": "resource",
-          "description": "Go module path for gotest CLI (used with 'go run')"
+          "description": "Package path of the gotest CLI ('go tool' when go.mod declares it, else 'go run' at the pinned version)"
         },
         "gotest.cliPath": {
           "type": "string",
           "default": "",
           "scope": "resource",
-          "description": "Override: path to a pre-installed gotest binary (bypasses 'go run')"
+          "description": "Override: path to a pre-installed gotest binary (bypasses go.mod resolution)"
+        },
+        "gotest.suggestToolDirective": {
+          "type": "boolean",
+          "default": true,
+          "scope": "resource",
+          "description": "Offer once per folder to declare the pinned gotest CLI as a tool in go.mod"
         },
         "gotest.discoverOnSave": {
           "type": "boolean",

--- a/vscode-gotest/src/benchRunner.ts
+++ b/vscode-gotest/src/benchRunner.ts
@@ -195,11 +195,18 @@ export class BenchRunner {
     }
 
     const outDir = await mkdtemp(path.join(os.tmpdir(), "gotest-bench-prof-"));
-    const cmd = await buildCliCommand(
-      buildProfileArgs(target, kind, outDir),
-      workspaceDir,
-      this.outputChannel,
-    );
+    let cmd: CliCommand;
+    try {
+      cmd = await buildCliCommand(
+        buildProfileArgs(target, kind, outDir),
+        workspaceDir,
+        this.outputChannel,
+      );
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      vscode.window.showErrorMessage(`gotest bench: ${message}`);
+      return;
+    }
     this.outputChannel.info(`[bench] ${formatCliCommand(cmd)}`);
 
     const cts = new vscode.CancellationTokenSource();
@@ -320,11 +327,19 @@ export class BenchRunner {
     workspaceDir: string,
     extra: string[],
   ): Promise<{ ok: true; report: BenchReport } | { ok: false; error: string }> {
-    const cmd = await buildCliCommand(
-      ["bench", "./...", ...extra, "--json"],
-      workspaceDir,
-      this.outputChannel,
-    );
+    let cmd: CliCommand;
+    try {
+      cmd = await buildCliCommand(
+        ["bench", "./...", ...extra, "--json"],
+        workspaceDir,
+        this.outputChannel,
+      );
+    } catch (err: unknown) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
     this.outputChannel.info(`[bench] ${formatCliCommand(cmd)}`);
 
     const cts = new vscode.CancellationTokenSource();
@@ -392,7 +407,15 @@ export class BenchRunner {
         args.push(`-count=${target.count}`);
       }
       args.push("--json");
-      const cmd = await buildCliCommand(args, workspaceDir, this.outputChannel);
+      let cmd: CliCommand;
+      try {
+        cmd = await buildCliCommand(args, workspaceDir, this.outputChannel);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.outputChannel.error(`[bench] ${msg}`);
+        hooks.onError?.(target, msg);
+        continue;
+      }
       this.outputChannel.info(`[bench] ${formatCliCommand(cmd)}`);
 
       let report: BenchReport;

--- a/vscode-gotest/src/buildCliCommand.test.ts
+++ b/vscode-gotest/src/buildCliCommand.test.ts
@@ -7,9 +7,23 @@ const {
   mockFileExists,
   mockResolveGoBinary,
   mockConfigValues,
+  mockConfigUpdate,
+  mockShowInformationMessage,
+  mockShowWarningMessage,
 } = vi.hoisted(() => ({
+  mockConfigUpdate: vi.fn(async () => undefined),
+  mockShowInformationMessage: vi.fn<
+    (message: string, ...items: string[]) => Promise<string | undefined>
+  >(async () => undefined),
+  mockShowWarningMessage: vi.fn<
+    (message: string, ...items: string[]) => Promise<string | undefined>
+  >(async () => undefined),
   mockExecFileAsync: vi.fn(
-    async (): Promise<{ stdout: string; stderr: string }> => ({
+    async (
+      _file: string,
+      _args: string[],
+      _opts?: unknown,
+    ): Promise<{ stdout: string; stderr: string }> => ({
       stdout: "",
       stderr: "",
     }),
@@ -17,7 +31,7 @@ const {
   mockReadFile: vi.fn(async (_path?: unknown): Promise<string> => {
     throw new Error("ENOENT");
   }),
-  mockFileExists: vi.fn(async () => false),
+  mockFileExists: vi.fn(async (_p: string) => false),
   mockResolveGoBinary: vi.fn(async () => "/usr/local/go/bin/go"),
   mockConfigValues: new Map<string, unknown>(),
 }));
@@ -30,11 +44,14 @@ vi.mock("vscode", () => ({
         (mockConfigValues.has(key)
           ? mockConfigValues.get(key)
           : defaultValue) as T | undefined,
+      update: mockConfigUpdate,
     })),
   },
   Uri: { file: (p: string) => ({ fsPath: p }) },
+  ConfigurationTarget: { WorkspaceFolder: 3 },
   window: {
-    showWarningMessage: vi.fn(async () => undefined),
+    showWarningMessage: mockShowWarningMessage,
+    showInformationMessage: mockShowInformationMessage,
     showErrorMessage: vi.fn(),
   },
 }));
@@ -56,14 +73,43 @@ vi.mock("node:child_process", async () => {
   return { execFile: execFileFn };
 });
 
-import { buildCliCommand } from "./cli.js";
+import {
+  buildCliCommand,
+  clearBinaryCache,
+  CliUnavailableError,
+} from "./cli.js";
 
 function setGoMod(dir: string, content: string) {
+  setFiles({ [path.join(dir, "go.mod")]: content });
+}
+
+// setFiles makes readFile answer for exactly these absolute paths. Both
+// sides are resolved so the fixtures read the same on Windows.
+function setFiles(files: Record<string, string>) {
+  const resolved = new Map(
+    Object.entries(files).map(([p, c]) => [path.resolve(p), c]),
+  );
   mockReadFile.mockImplementation(async (filePath: unknown) => {
-    if (filePath === path.join(dir, "go.mod")) return content;
+    const content = resolved.get(path.resolve(String(filePath)));
+    if (content !== undefined) return content;
     throw new Error("ENOENT");
   });
 }
+
+// flush lets the fire-and-forget prompt chains settle.
+async function flush() {
+  for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 0));
+}
+
+const PINNED = (version: string, extra: string[] = []) =>
+  [
+    "module github.com/myapp",
+    "go 1.25.0",
+    "require (",
+    `\tgithub.com/mvrahden/go-test ${version}`,
+    ")",
+    ...extra,
+  ].join("\n");
 
 const GOTEST_MODULE = "github.com/mvrahden/go-test/cmd/gotest";
 
@@ -75,6 +121,7 @@ describe("buildCliCommand", () => {
     mockFileExists.mockResolvedValue(false);
     mockResolveGoBinary.mockResolvedValue("/usr/local/go/bin/go");
     mockExecFileAsync.mockResolvedValue({ stdout: "", stderr: "" });
+    clearBinaryCache();
   });
 
   describe("step 1: cliPath override", () => {
@@ -430,21 +477,57 @@ describe("buildCliCommand", () => {
   });
 
   describe("version below minimum", () => {
-    it("falls through to fallback when pinned version is too old", async () => {
-      setGoMod(
-        "/workspace",
-        [
-          "module github.com/myapp",
-          "go 1.24.0",
-          "require (",
-          "\tgithub.com/mvrahden/go-test v1.0.0",
-          ")",
-        ].join("\n"),
+    it("refuses instead of substituting a newer CLI", async () => {
+      setGoMod("/workspace", PINNED("v1.0.0"));
+
+      await expect(buildCliCommand(["spec"], "/workspace")).rejects.toThrow(
+        CliUnavailableError,
       );
+      await expect(buildCliCommand(["spec"], "/workspace")).rejects.toThrow(
+        /v1\.0\.0.*v1\.27\.0/,
+      );
+      expect(mockExecFileAsync).not.toHaveBeenCalled();
+    });
 
-      const cmd = await buildCliCommand(["spec"], "/workspace");
+    it("shows the upgrade warning once per session", async () => {
+      setGoMod("/workspace", PINNED("v1.0.0"));
 
-      expect(cmd.args[1]).toBe(`${GOTEST_MODULE}@latest`);
+      await buildCliCommand(["spec"], "/workspace").catch(() => undefined);
+      await buildCliCommand(["spec"], "/workspace").catch(() => undefined);
+
+      expect(mockShowWarningMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("Upgrade declares the tool at latest in the module that pins", async () => {
+      setGoMod("/workspace", PINNED("v1.0.0"));
+      mockShowWarningMessage.mockResolvedValue("Upgrade");
+
+      await buildCliCommand(["spec"], "/workspace").catch(() => undefined);
+      await flush();
+
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        "/usr/local/go/bin/go",
+        ["get", "-tool", `${GOTEST_MODULE}@latest`],
+        expect.objectContaining({ cwd: "/workspace" }),
+      );
+    });
+
+    it("Upgrade re-vendors a vendored module", async () => {
+      setGoMod("/workspace", PINNED("v1.0.0"));
+      mockFileExists.mockImplementation(
+        async (p: string) =>
+          p === path.join("/workspace", "vendor", "modules.txt"),
+      );
+      mockShowWarningMessage.mockResolvedValue("Upgrade");
+
+      await buildCliCommand(["spec"], "/workspace").catch(() => undefined);
+      await flush();
+
+      const calls = mockExecFileAsync.mock.calls.map((c) => c[1]);
+      expect(calls).toEqual([
+        ["get", "-tool", `${GOTEST_MODULE}@latest`],
+        ["mod", "vendor"],
+      ]);
     });
   });
 
@@ -510,6 +593,259 @@ describe("buildCliCommand", () => {
 
       expect(cmd.args[1]).toBe(GOTEST_MODULE);
       expect(cmd.args).not.toContain(`${GOTEST_MODULE}@v1.27.0`);
+    });
+  });
+
+  describe("tool directive", () => {
+    it("runs go tool with the full package path when go.mod declares it", async () => {
+      setGoMod("/workspace", PINNED("v1.28.1", [`tool ${GOTEST_MODULE}`]));
+
+      const cmd = await buildCliCommand(["spec", "./..."], "/workspace");
+
+      expect(cmd).toEqual({
+        bin: "/usr/local/go/bin/go",
+        args: ["tool", GOTEST_MODULE, "spec", "./..."],
+      });
+    });
+
+    it("recognises the block form", async () => {
+      setGoMod(
+        "/workspace",
+        PINNED("v1.28.1", [
+          "tool (",
+          "\tgolang.org/x/tools/cmd/stringer",
+          `\t${GOTEST_MODULE}`,
+          ")",
+        ]),
+      );
+
+      const cmd = await buildCliCommand(["spec"], "/workspace");
+
+      expect(cmd.args.slice(0, 2)).toEqual(["tool", GOTEST_MODULE]);
+    });
+
+    it("ignores tool lines for other packages", async () => {
+      setGoMod(
+        "/workspace",
+        PINNED("v1.28.1", ["tool golang.org/x/tools/cmd/stringer"]),
+      );
+
+      const cmd = await buildCliCommand(["spec"], "/workspace");
+
+      expect(cmd.args.slice(0, 2)).toEqual(["run", `${GOTEST_MODULE}@v1.28.1`]);
+    });
+
+    it("uses the configured module path, so a fork resolves to its own tool", async () => {
+      const fork = "github.com/fork/go-test/cmd/gotest";
+      mockConfigValues.set("modulePath", fork);
+      setGoMod(
+        "/workspace",
+        [
+          "module github.com/myapp",
+          "go 1.25.0",
+          "require github.com/fork/go-test v1.28.1",
+          `tool ${fork}`,
+        ].join("\n"),
+      );
+
+      const cmd = await buildCliCommand(["spec"], "/workspace");
+
+      expect(cmd.args.slice(0, 2)).toEqual(["tool", fork]);
+    });
+
+    it("wins over a replace directive, which go tool honours natively", async () => {
+      setGoMod(
+        "/workspace",
+        PINNED("v0.0.0-00010101000000-000000000000", [
+          "replace github.com/mvrahden/go-test => ../go-test",
+          `tool ${GOTEST_MODULE}`,
+        ]),
+      );
+
+      const cmd = await buildCliCommand(["spec"], "/workspace");
+
+      expect(cmd.args.slice(0, 2)).toEqual(["tool", GOTEST_MODULE]);
+    });
+
+    it("still refuses a pin below the floor", async () => {
+      setGoMod("/workspace", PINNED("v1.26.0", [`tool ${GOTEST_MODULE}`]));
+
+      await expect(buildCliCommand(["spec"], "/workspace")).rejects.toThrow(
+        CliUnavailableError,
+      );
+    });
+
+    it("does not offer to add the directive when it is already declared", async () => {
+      setGoMod("/workspace", PINNED("v1.28.1", [`tool ${GOTEST_MODULE}`]));
+
+      await buildCliCommand(["spec"], "/workspace");
+      await flush();
+
+      expect(mockShowInformationMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("go.work root", () => {
+    const work = "go 1.25.0\n\nuse (\n\t./a\n\t./b\n)\n";
+
+    it("pins the workspace's selected version, the max over use modules", async () => {
+      setFiles({
+        "/workspace/go.work": work,
+        "/workspace/a/go.mod": PINNED("v1.28.0"),
+        "/workspace/b/go.mod": PINNED("v1.28.1"),
+      });
+
+      const cmd = await buildCliCommand(["spec"], "/workspace");
+
+      expect(cmd.args.slice(0, 2)).toEqual(["run", `${GOTEST_MODULE}@v1.28.1`]);
+    });
+
+    it("runs go tool when any use module declares the directive", async () => {
+      setFiles({
+        "/workspace/go.work": work,
+        "/workspace/a/go.mod": PINNED("v1.28.0"),
+        "/workspace/b/go.mod": PINNED("v1.28.1", [`tool ${GOTEST_MODULE}`]),
+      });
+
+      const cmd = await buildCliCommand(["spec"], "/workspace");
+
+      expect(cmd.args.slice(0, 2)).toEqual(["tool", GOTEST_MODULE]);
+    });
+
+    it("accepts single-line use directives and a dot entry", async () => {
+      setFiles({
+        "/workspace/go.work": "go 1.25.0\n\nuse .\nuse ./lib\n",
+        "/workspace/go.mod": "module github.com/myapp\n\ngo 1.25.0\n",
+        "/workspace/lib/go.mod": PINNED("v1.28.1"),
+      });
+
+      const cmd = await buildCliCommand(["spec"], "/workspace");
+
+      expect(cmd.args.slice(0, 2)).toEqual(["run", `${GOTEST_MODULE}@v1.28.1`]);
+    });
+
+    it("refuses when the workspace selects a version below the floor", async () => {
+      setFiles({
+        "/workspace/go.work": work,
+        "/workspace/a/go.mod": PINNED("v1.25.0"),
+        "/workspace/b/go.mod": PINNED("v1.26.0"),
+      });
+
+      await expect(buildCliCommand(["spec"], "/workspace")).rejects.toThrow(
+        /v1\.26\.0/,
+      );
+    });
+
+    it("keeps the bootstrap fallback when no use module requires gotest", async () => {
+      setFiles({
+        "/workspace/go.work": work,
+        "/workspace/a/go.mod": "module github.com/a\n\ngo 1.25.0\n",
+        "/workspace/b/go.mod": "module github.com/b\n\ngo 1.25.0\n",
+      });
+
+      const cmd = await buildCliCommand(["spec"], "/workspace");
+
+      expect(cmd.args[1]).toBe(`${GOTEST_MODULE}@latest`);
+    });
+
+    it("Upgrade runs in every use module that pins gotest", async () => {
+      setFiles({
+        "/workspace/go.work": work,
+        "/workspace/a/go.mod": PINNED("v1.25.0"),
+        "/workspace/b/go.mod": "module github.com/b\n\ngo 1.25.0\n",
+      });
+      mockShowWarningMessage.mockResolvedValue("Upgrade");
+
+      await buildCliCommand(["spec"], "/workspace").catch(() => undefined);
+      await flush();
+
+      expect(mockExecFileAsync).toHaveBeenCalledTimes(1);
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        "/usr/local/go/bin/go",
+        ["get", "-tool", `${GOTEST_MODULE}@latest`],
+        expect.objectContaining({ cwd: path.resolve("/workspace", "a") }),
+      );
+    });
+  });
+
+  describe("tool directive suggestion", () => {
+    it("offers once per root when the pin is usable but no directive exists", async () => {
+      setGoMod("/workspace", PINNED("v1.28.1"));
+
+      await buildCliCommand(["spec"], "/workspace");
+      await buildCliCommand(["discover"], "/workspace");
+      await flush();
+
+      expect(mockShowInformationMessage).toHaveBeenCalledTimes(1);
+      expect(mockShowInformationMessage.mock.calls[0][0]).toMatch(
+        /go get -tool/,
+      );
+    });
+
+    it("adds the directive at the pinned version, never at latest", async () => {
+      setGoMod("/workspace", PINNED("v1.28.1"));
+      mockShowInformationMessage.mockResolvedValue("Add to go.mod");
+
+      await buildCliCommand(["spec"], "/workspace");
+      await flush();
+
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        "/usr/local/go/bin/go",
+        ["get", "-tool", `${GOTEST_MODULE}@v1.28.1`],
+        expect.objectContaining({ cwd: "/workspace" }),
+      );
+    });
+
+    it("stays silent in a vendored module", async () => {
+      setGoMod("/workspace", PINNED("v1.28.1"));
+      mockFileExists.mockImplementation(
+        async (p: string) =>
+          p === path.join("/workspace", "vendor", "modules.txt"),
+      );
+
+      await buildCliCommand(["spec"], "/workspace");
+      await flush();
+
+      expect(mockShowInformationMessage).not.toHaveBeenCalled();
+    });
+
+    it("stays silent when the setting is off", async () => {
+      mockConfigValues.set("suggestToolDirective", false);
+      setGoMod("/workspace", PINNED("v1.28.1"));
+
+      await buildCliCommand(["spec"], "/workspace");
+      await flush();
+
+      expect(mockShowInformationMessage).not.toHaveBeenCalled();
+    });
+
+    it("Don't ask again turns the setting off for the folder", async () => {
+      setGoMod("/workspace", PINNED("v1.28.1"));
+      mockShowInformationMessage.mockResolvedValue("Don't ask again");
+
+      await buildCliCommand(["spec"], "/workspace");
+      await flush();
+
+      expect(mockConfigUpdate).toHaveBeenCalledWith(
+        "suggestToolDirective",
+        false,
+        3,
+      );
+      expect(mockExecFileAsync).not.toHaveBeenCalled();
+    });
+
+    it("does not offer when a replace directive is in play", async () => {
+      setGoMod(
+        "/workspace",
+        PINNED("v1.28.1", [
+          "replace github.com/mvrahden/go-test => ../go-test",
+        ]),
+      );
+
+      await buildCliCommand(["spec"], "/workspace");
+      await flush();
+
+      expect(mockShowInformationMessage).not.toHaveBeenCalled();
     });
   });
 });

--- a/vscode-gotest/src/cli.test.ts
+++ b/vscode-gotest/src/cli.test.ts
@@ -35,6 +35,15 @@ describe("compareVersions", () => {
     expect(compareVersions("v1.0.2", "v1.0.1")).toBeGreaterThan(0);
   });
 
+  it("orders a pseudo-version by its base version", () => {
+    // A commit pin such as v1.28.2-0.<timestamp>-<sha> sits after v1.28.1
+    // and must clear a v1.27.0 floor rather than parse as NaN.
+    const pseudo = "v1.28.2-0.20260901120000-abcdef012345";
+    expect(compareVersions(pseudo, "v1.27.0")).toBeGreaterThan(0);
+    expect(compareVersions(pseudo, "v1.28.1")).toBeGreaterThan(0);
+    expect(compareVersions("v1.27.0-rc.1+meta", "v1.27.0")).toBe(0);
+  });
+
   it("handles missing patch component", () => {
     expect(compareVersions("v1.0", "v1.0.0")).toBe(0);
     expect(compareVersions("v1.0", "v1.0.1")).toBeLessThan(0);

--- a/vscode-gotest/src/cli.ts
+++ b/vscode-gotest/src/cli.ts
@@ -13,7 +13,9 @@ const DEFAULT_MODULE_PATH = "github.com/mvrahden/go-test/cmd/gotest";
 // Raised to the release that introduced `spec --input --render-only`. The Spec
 // View passes that flag, so an older CLI would reject the invocation outright.
 // Treat this as a contract marker: bump it whenever the extension starts
-// depending on CLI behaviour that older versions do not have.
+// depending on CLI behaviour that older versions do not have. The CLI's
+// gotestgen.MinRuntimeVersion mirrors this value and a Go test keeps the two
+// equal, so bump both together.
 const MIN_CLI_VERSION = "v1.27.0";
 
 export interface CliCommand {

--- a/vscode-gotest/src/cli.ts
+++ b/vscode-gotest/src/cli.ts
@@ -1,10 +1,16 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
-import { readFile } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { resolveGoBinary, fileExists, clearGoBinaryCache } from "./goBinary.js";
-import { readModulePath } from "./gomod.js";
+import {
+  hasReplaceDirective,
+  parseToolDirectives,
+  readModulePath,
+  readModuleRoots,
+  requireVersion,
+  type ModuleRoot,
+} from "./gomod.js";
 
 export { resolveGoBinary } from "./goBinary.js";
 
@@ -13,9 +19,8 @@ const DEFAULT_MODULE_PATH = "github.com/mvrahden/go-test/cmd/gotest";
 // Raised to the release that introduced `spec --input --render-only`. The Spec
 // View passes that flag, so an older CLI would reject the invocation outright.
 // Treat this as a contract marker: bump it whenever the extension starts
-// depending on CLI behaviour that older versions do not have. The CLI's
-// gotestgen.MinRuntimeVersion mirrors this value and a Go test keeps the two
-// equal, so bump both together.
+// depending on CLI behaviour that older versions do not have. Equals the
+// CLI's gotestgen.MinRuntimeVersion; a Go test keeps them in step.
 const MIN_CLI_VERSION = "v1.27.0";
 
 export interface CliCommand {
@@ -102,51 +107,90 @@ export async function buildCliCommand(
     }
   }
 
-  // 3. Replace directive → go run without version (respects go.mod resolution)
-  //
-  // Checked before the version gate on purpose. A replace directive redirects
-  // the module to local source, and the require version beside it is
-  // conventionally a placeholder (v0.0.0-00010101000000-000000000000) that says
-  // nothing about the code that will actually run. Gating on it rejects the
-  // developer's own working tree and silently downloads a release instead.
-  if (effectiveDir && !modulePath.includes("@")) {
-    if (await hasReplaceDirective(effectiveDir, modulePath)) {
+  // 3. Module roots: the go.work `use` modules, else the folder's go.mod.
+  // A workspace builds from one list: the highest pin wins and a tool
+  // declared by any module is available at the root.
+  const roots =
+    effectiveDir && !modulePath.includes("@")
+      ? await readModuleRoots(effectiveDir)
+      : [];
+  const pinned = roots
+    .map((root) => ({ root, version: requireVersion(root.goMod, modulePath) }))
+    .filter((p): p is { root: ModuleRoot; version: string } => !!p.version);
+  const pin = pinned
+    .map((p) => p.version)
+    .sort(compareVersions)
+    .at(-1);
+  const replaced = roots.some((r) => hasReplaceDirective(r.goMod, modulePath));
+  const toolDeclared = roots.some((r) =>
+    parseToolDirectives(r.goMod).includes(modulePath),
+  );
+
+  // 4. Tool directive → go tool <package path>. Go builds it from the
+  // module's own build list, so replace applies. The full path is deliberate:
+  // a short name is shadowed by built-in tools and can be ambiguous.
+  // Checked before the version gate because a replaced module's require
+  // version is a placeholder.
+  if (toolDeclared && (replaced || (pin && meetsFloor(pin)))) {
+    const goBin = await resolveGoBinary(log, workspaceDir);
+    log?.debug(`[cli] go.mod declares the tool: ${goBin} tool ${modulePath}`);
+    return { bin: goBin, args: ["tool", modulePath, ...subcommandArgs] };
+  }
+
+  // 5. Replace directive → go run without version. The require version
+  // beside a replace is a placeholder, so it is not gated.
+  if (replaced) {
+    const goBin = await resolveGoBinary(log, workspaceDir);
+    log?.debug(
+      `[cli] go.mod has replace directive: ${goBin} run ${modulePath}`,
+    );
+    return { bin: goBin, args: ["run", modulePath, ...subcommandArgs] };
+  }
+
+  // 6. Project-pinned version from go.mod
+  if (pin && effectiveDir) {
+    if (meetsFloor(pin)) {
       const goBin = await resolveGoBinary(log, workspaceDir);
-      log?.debug(
-        `[cli] go.mod has replace directive: ${goBin} run ${modulePath}`,
-      );
-      return {
-        bin: goBin,
-        args: ["run", modulePath, ...subcommandArgs],
-      };
+      const qualified = `${modulePath}@${pin}`;
+      log?.debug(`[cli] using go.mod: ${goBin} run ${qualified}`);
+      suggestToolDirective(effectiveDir, modulePath, pinned, log);
+      return { bin: goBin, args: ["run", qualified, ...subcommandArgs] };
     }
+    // Below the floor a newer CLI would generate code the pinned runtime
+    // cannot compile, so refuse rather than substitute one.
+    log?.warn(`[cli] go.mod pins ${pin}, requires >= ${MIN_CLI_VERSION}`);
+    showVersionWarning(
+      pin,
+      modulePath,
+      pinned.map((p) => p.root.dir),
+      log,
+    );
+    throw new CliUnavailableError(
+      `go.mod pins gotest ${pin}, but >= ${MIN_CLI_VERSION} is required. ` +
+        `Run: go get -tool ${modulePath}@latest`,
+    );
   }
 
-  // 4. Project-pinned version from go.mod
-  if (effectiveDir && !modulePath.includes("@")) {
-    const version = await extractVersionFromGoMod(effectiveDir, modulePath);
-    if (version !== "latest") {
-      if (compareVersions(version, MIN_CLI_VERSION) >= 0) {
-        const goBin = await resolveGoBinary(log, workspaceDir);
-        const qualified = `${modulePath}@${version}`;
-        log?.debug(`[cli] using go.mod: ${goBin} run ${qualified}`);
-        return {
-          bin: goBin,
-          args: ["run", qualified, ...subcommandArgs],
-        };
-      }
-      log?.warn(`[cli] go.mod pins ${version}, requires >= ${MIN_CLI_VERSION}`);
-      showVersionWarning(version, effectiveDir, log);
-    }
-  }
-
-  // 5. Fallback: go run @latest
+  // 7. Fallback: go run @latest, only when no module requires gotest yet
+  // (scaffold runs before a pin exists) or modulePath carries its own @version.
   const goBin = await resolveGoBinary(log, workspaceDir);
   const qualified = modulePath.includes("@")
     ? modulePath
     : `${modulePath}@latest`;
   log?.debug(`[cli] using fallback: ${goBin} run ${qualified}`);
   return { bin: goBin, args: ["run", qualified, ...subcommandArgs] };
+}
+
+// CliUnavailableError carries the user-facing fix when no CLI can run.
+export class CliUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CliUnavailableError";
+  }
+}
+
+function meetsFloor(version: string): boolean {
+  return compareVersions(version, MIN_CLI_VERSION) >= 0;
 }
 
 function resolveCliPath(cliPath: string, workspaceDir?: string): string {
@@ -165,7 +209,8 @@ function resolveCliPath(cliPath: string, workspaceDir?: string): string {
 
 function showVersionWarning(
   version: string,
-  effectiveDir: string,
+  modulePath: string,
+  pinnedDirs: string[],
   log?: vscode.LogOutputChannel,
 ): void {
   if (versionWarningShown) {
@@ -180,16 +225,17 @@ function showVersionWarning(
     .then(async (choice) => {
       if (choice !== "Upgrade") return;
       try {
-        const goBin = await resolveGoBinary(log, effectiveDir);
-        const args = ["get", `${DEFAULT_MODULE_PATH}@latest`];
-        log?.info(`[cli] upgrading: ${goBin} ${args.join(" ")}`);
-        await execFileAsync(goBin, args, {
-          cwd: effectiveDir,
-          timeout: 30_000,
-        });
+        // One go get per pinning module: a go.work root has no module.
+        for (const dir of pinnedDirs) {
+          await runGoInModule(
+            dir,
+            ["get", "-tool", `${modulePath}@latest`],
+            log,
+          );
+        }
         log?.info("[cli] upgrade complete");
         vscode.window.showInformationMessage(
-          "gotest: gotest dependency upgraded to latest.",
+          "gotest: dependency upgraded to latest and declared as a tool.",
         );
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -197,6 +243,84 @@ function showVersionWarning(
         vscode.window.showErrorMessage(`gotest: upgrade failed. ${msg}`);
       }
     });
+}
+
+// suggestedRoots: folders already offered the directive this session.
+const suggestedRoots = new Set<string>();
+
+// suggestToolDirective offers once per folder to declare the pinned CLI as a
+// tool, at the pinned version. Silent in vendored modules, where a go.mod
+// edit breaks every build until `go mod vendor` reruns.
+function suggestToolDirective(
+  effectiveDir: string,
+  modulePath: string,
+  pinned: { root: ModuleRoot; version: string }[],
+  log?: vscode.LogOutputChannel,
+): void {
+  if (suggestedRoots.has(effectiveDir)) return;
+  suggestedRoots.add(effectiveDir);
+  const config = scopedConfig(effectiveDir);
+  if (!config.get<boolean>("suggestToolDirective", true)) return;
+  void (async () => {
+    for (const p of pinned) {
+      if (await isVendored(p.root.dir)) return;
+    }
+    const first = pinned[0];
+    const choice = await vscode.window.showInformationMessage(
+      `gotest: declare the CLI as a tool so the editor runs it through Go's tool directive ` +
+        `(faster, offline, replace-aware): go get -tool ${modulePath}@${first.version}`,
+      "Add to go.mod",
+      "Not now",
+      "Don't ask again",
+    );
+    if (choice === "Don't ask again") {
+      await config.update(
+        "suggestToolDirective",
+        false,
+        vscode.ConfigurationTarget.WorkspaceFolder,
+      );
+      return;
+    }
+    if (choice !== "Add to go.mod") return;
+    try {
+      for (const p of pinned) {
+        await runGoInModule(
+          p.root.dir,
+          ["get", "-tool", `${modulePath}@${p.version}`],
+          log,
+        );
+      }
+      vscode.window.showInformationMessage(
+        "gotest: tool directive added; the editor now runs go tool gotest.",
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log?.error(`[cli] go get -tool failed: ${msg}`);
+      vscode.window.showErrorMessage(`gotest: adding the tool failed. ${msg}`);
+    }
+  })();
+}
+
+async function isVendored(dir: string): Promise<boolean> {
+  return fileExists(path.join(dir, "vendor", "modules.txt"));
+}
+
+// runGoInModule runs a go command in a module, re-vendoring when it vendors.
+async function runGoInModule(
+  dir: string,
+  args: string[],
+  log?: vscode.LogOutputChannel,
+): Promise<void> {
+  const goBin = await resolveGoBinary(log, dir);
+  log?.info(`[cli] ${goBin} ${args.join(" ")} (cwd ${dir})`);
+  await execFileAsync(goBin, args, { cwd: dir, timeout: 60_000 });
+  if (await isVendored(dir)) {
+    log?.info(`[cli] ${goBin} mod vendor (cwd ${dir})`);
+    await execFileAsync(goBin, ["mod", "vendor"], {
+      cwd: dir,
+      timeout: 60_000,
+    });
+  }
 }
 
 async function queryBinaryVersion(
@@ -221,69 +345,15 @@ async function queryBinaryVersion(
   return undefined;
 }
 
-async function hasReplaceDirective(
-  workspaceDir: string,
-  modulePath: string,
-): Promise<boolean> {
-  try {
-    const content = await readFile(path.join(workspaceDir, "go.mod"), "utf-8");
-    let candidate = modulePath;
-    while (candidate) {
-      const escaped = escapeRegExp(candidate);
-      if (
-        new RegExp(`^\\s*replace\\s+${escaped}(?:\\s|$)`, "m").test(content)
-      ) {
-        return true;
-      }
-      const entryPattern = new RegExp(`^\\s*${escaped}(?:\\s|$)`, "m");
-      for (const block of content.matchAll(/^\s*replace\s*\(([\s\S]*?)\)/gm)) {
-        if (entryPattern.test(block[1])) {
-          return true;
-        }
-      }
-      const lastSlash = candidate.lastIndexOf("/");
-      if (lastSlash <= 0) break;
-      candidate = candidate.substring(0, lastSlash);
-    }
-  } catch {
-    // go.mod not found
-  }
-  return false;
-}
-
-async function extractVersionFromGoMod(
-  workspaceDir: string,
-  modulePath: string,
-): Promise<string> {
-  try {
-    const goModPath = path.join(workspaceDir, "go.mod");
-    const content = await readFile(goModPath, "utf-8");
-
-    let candidate = modulePath;
-    while (candidate) {
-      const escaped = escapeRegExp(candidate);
-      const patterns = [
-        new RegExp(`^\\s*${escaped}\\s+(v[^\\s]+)`, "m"),
-        new RegExp(`^\\s*require\\s+${escaped}\\s+(v[^\\s]+)`, "m"),
-      ];
-      for (const pattern of patterns) {
-        const match = pattern.exec(content);
-        if (match) return match[1];
-      }
-      const lastSlash = candidate.lastIndexOf("/");
-      if (lastSlash <= 0) {
-        break;
-      }
-      candidate = candidate.substring(0, lastSlash);
-    }
-  } catch {
-    // go.mod not found or unreadable
-  }
-  return "latest";
-}
-
+// compareVersions orders by major.minor.patch; pre-release and build suffixes
+// are dropped so a pseudo-version sorts by its base version.
 export function compareVersions(a: string, b: string): number {
-  const parse = (v: string) => v.replace(/^v/, "").split(".").map(Number);
+  const parse = (v: string) =>
+    v
+      .replace(/^v/, "")
+      .replace(/[-+].*$/, "")
+      .split(".")
+      .map(Number);
   const pa = parse(a);
   const pb = parse(b);
   for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
@@ -293,9 +363,7 @@ export function compareVersions(a: string, b: string): number {
   return 0;
 }
 
-export function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
+export { escapeRegExp } from "./gomod.js";
 
 export function formatCliCommand(cmd: CliCommand): string {
   return `${cmd.bin} ${cmd.args.join(" ")}`;
@@ -329,6 +397,7 @@ export function scopedConfig(
 export function clearBinaryCache(): void {
   clearGoBinaryCache();
   versionWarningShown = false;
+  suggestedRoots.clear();
 }
 
 // stripGoRunExitEcho drops the "exit status N" line `go run` appends to stderr

--- a/vscode-gotest/src/goBinary.test.ts
+++ b/vscode-gotest/src/goBinary.test.ts
@@ -1,0 +1,55 @@
+import * as path from "node:path";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockAccess, mockExecFileAsync } = vi.hoisted(() => ({
+  mockAccess: vi.fn(async (_p: unknown, _mode?: unknown): Promise<void> => {
+    throw new Error("ENOENT");
+  }),
+  mockExecFileAsync: vi.fn(async (): Promise<{ stdout: string }> => {
+    throw new Error("not found");
+  }),
+}));
+
+vi.mock("vscode", () => ({}));
+
+vi.mock("node:fs/promises", () => ({
+  access: mockAccess,
+  readFile: vi.fn(async () => "module github.com/myapp\n\ngo 1.24.0\n"),
+  readdir: vi.fn(async () => []),
+  constants: { F_OK: 0, X_OK: 1 },
+}));
+
+vi.mock("node:child_process", async () => {
+  const util = await import("node:util");
+  const execFileFn: Record<symbol, unknown> = vi.fn() as never;
+  execFileFn[util.promisify.custom] = mockExecFileAsync;
+  return { execFile: execFileFn };
+});
+
+import { resolveGoBinary, clearGoBinaryCache } from "./goBinary.js";
+
+describe("resolveGoBinary", () => {
+  const goExe = process.platform === "win32" ? "go.exe" : "go";
+  const gorootGo = path.join("/goroot", "bin", goExe);
+
+  beforeEach(() => {
+    clearGoBinaryCache();
+    vi.stubEnv("HOME", "/home/dev");
+    vi.stubEnv("USERPROFILE", "/home/dev");
+    vi.stubEnv("GOROOT", "/goroot");
+  });
+
+  it("does not derive a toolchain from the go directive", async () => {
+    // A go directive is a minimum, not a choice: GOTOOLCHAIN satisfies it
+    // from the default go. ~/sdk/go1.24.0 exists here and must be ignored.
+    const sdkGo = path.join("/home/dev", "sdk", "go1.24.0", "bin", goExe);
+    mockAccess.mockImplementation(async (p: unknown) => {
+      if (p === sdkGo || p === gorootGo) return;
+      throw new Error("ENOENT");
+    });
+
+    const go = await resolveGoBinary(undefined, "/workspace");
+
+    expect(go).toBe(gorootGo);
+  });
+});

--- a/vscode-gotest/src/goBinary.ts
+++ b/vscode-gotest/src/goBinary.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
-import { readFile, readdir, access, constants } from "node:fs/promises";
+import { readdir, access, constants } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
@@ -22,60 +22,12 @@ export async function resolveGoBinary(
     return cached;
   }
 
-  // 1. Try project-specific Go version from go.mod
-  if (workspaceDir) {
-    const projectGo = await resolveProjectGoBinary(workspaceDir, log);
-    if (projectGo) {
-      goBinaryCache.set(cacheKey, projectGo);
-      return projectGo;
-    }
-  }
-
+  // The go directive is a minimum, not a choice; GOTOOLCHAIN satisfies it
+  // from whichever go runs `go run`/`go tool`.
   // 2. Generic detection
   const generic = await resolveGenericGoBinary(log);
   goBinaryCache.set(cacheKey, generic);
   return generic;
-}
-
-async function resolveProjectGoBinary(
-  workspaceDir: string,
-  log?: vscode.LogOutputChannel,
-): Promise<string | undefined> {
-  const goVersion = await readGoVersionFromMod(workspaceDir);
-  if (!goVersion) {
-    return undefined;
-  }
-
-  log?.debug(`[go] go.mod declares go ${goVersion}`);
-
-  const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
-  const goBin = process.platform === "win32" ? "go.exe" : "go";
-  const sdkBin = path.join(home, "sdk", `go${goVersion}`, "bin", goBin);
-  if (await fileExists(sdkBin)) {
-    log?.debug(`[go] resolved go ${goVersion} via SDK: ${sdkBin}`);
-    return sdkBin;
-  }
-
-  // go1.26.2 on PATH (installed via `go install golang.org/dl/go1.26.2`)
-  // These can be wrapper stubs that fail when the SDK isn't downloaded,
-  // so validate before accepting.
-  const versionedName = `go${goVersion}`;
-  const shellVersioned = await whichFromShell(versionedName);
-  if (shellVersioned && (await validateBinary(shellVersioned))) {
-    log?.debug(`[go] resolved go ${goVersion} via shell: ${shellVersioned}`);
-    return shellVersioned;
-  }
-
-  const whichVersioned = await which(versionedName);
-  if (whichVersioned && (await validateBinary(whichVersioned))) {
-    log?.debug(`[go] resolved go ${goVersion} via PATH: ${whichVersioned}`);
-    return whichVersioned;
-  }
-
-  log?.debug(
-    `[go] go ${goVersion} not found, falling back to generic detection`,
-  );
-  return undefined;
 }
 
 async function resolveGenericGoBinary(
@@ -112,28 +64,6 @@ async function resolveGenericGoBinary(
 
   log?.warn("[go] could not resolve binary, using bare 'go'");
   return "go";
-}
-
-async function readGoVersionFromMod(
-  workspaceDir: string,
-): Promise<string | undefined> {
-  try {
-    const goModPath = path.join(workspaceDir, "go.mod");
-    const content = await readFile(goModPath, "utf-8");
-    const match = /^\s*go\s+(\d+\.\d+(?:\.\d+)?)\s*$/m.exec(content);
-    return match?.[1];
-  } catch {
-    return undefined;
-  }
-}
-
-async function validateBinary(bin: string): Promise<boolean> {
-  try {
-    await execFileAsync(bin, ["version"], { timeout: 5_000 });
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 export async function fileExists(p: string): Promise<boolean> {

--- a/vscode-gotest/src/gomod.ts
+++ b/vscode-gotest/src/gomod.ts
@@ -10,3 +10,114 @@ export async function readModulePath(dir: string): Promise<string | undefined> {
     return undefined;
   }
 }
+
+// A module root the resolver reasons about: its directory and go.mod text.
+export interface ModuleRoot {
+  dir: string;
+  goMod: string;
+}
+
+// readModuleRoots returns the go.work `use` modules, else the directory's own
+// go.mod. Entries without a readable go.mod are dropped.
+export async function readModuleRoots(dir: string): Promise<ModuleRoot[]> {
+  let dirs = [dir];
+  try {
+    const work = await readFile(path.join(dir, "go.work"), "utf-8");
+    dirs = parseUseDirectives(work).map((entry) => path.resolve(dir, entry));
+  } catch {
+    // no go.work
+  }
+  const roots: ModuleRoot[] = [];
+  for (const moduleDir of dirs) {
+    try {
+      const goMod = await readFile(path.join(moduleDir, "go.mod"), "utf-8");
+      roots.push({ dir: moduleDir, goMod });
+    } catch {
+      // not a module
+    }
+  }
+  return roots;
+}
+
+// parseUseDirectives lists a go.work's `use` entries as written.
+export function parseUseDirectives(content: string): string[] {
+  return parseDirective(content, "use");
+}
+
+// parseToolDirectives lists the package paths a go.mod declares as tools.
+export function parseToolDirectives(content: string): string[] {
+  return parseDirective(content, "tool");
+}
+
+function parseDirective(content: string, keyword: string): string[] {
+  const entries: string[] = [];
+  const block = new RegExp(`^\\s*${keyword}\\s*\\(([\\s\\S]*?)^\\s*\\)`, "gm");
+  for (const m of content.matchAll(block)) {
+    for (const line of m[1].split("\n")) {
+      const entry = line.replace(/\/\/.*$/, "").trim();
+      if (entry) entries.push(entry.split(/\s+/)[0]);
+    }
+  }
+  const single = new RegExp(`^\\s*${keyword}\\s+([^\\s(]\\S*)`, "gm");
+  for (const m of content.matchAll(single)) {
+    entries.push(m[1]);
+  }
+  return entries;
+}
+
+// requireVersion returns the required version of the module providing
+// `packagePath`, walking up the path to find the module.
+export function requireVersion(
+  content: string,
+  packagePath: string,
+): string | undefined {
+  for (const candidate of modulePathCandidates(packagePath)) {
+    const escaped = escapeRegExp(candidate);
+    const patterns = [
+      new RegExp(`^[ \\t]*${escaped}[ \\t]+(v\\S+)`, "m"),
+      new RegExp(`^[ \\t]*require[ \\t]+${escaped}[ \\t]+(v\\S+)`, "m"),
+    ];
+    for (const pattern of patterns) {
+      const match = pattern.exec(content);
+      if (match) return match[1];
+    }
+  }
+  return undefined;
+}
+
+// hasReplaceDirective reports whether go.mod replaces the module providing
+// `packagePath`.
+export function hasReplaceDirective(
+  content: string,
+  packagePath: string,
+): boolean {
+  for (const candidate of modulePathCandidates(packagePath)) {
+    const escaped = escapeRegExp(candidate);
+    if (new RegExp(`^\\s*replace\\s+${escaped}(?:\\s|$)`, "m").test(content)) {
+      return true;
+    }
+    const entryPattern = new RegExp(`^\\s*${escaped}(?:\\s|$)`, "m");
+    for (const block of content.matchAll(/^\s*replace\s*\(([\s\S]*?)\)/gm)) {
+      if (entryPattern.test(block[1])) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function modulePathCandidates(packagePath: string): string[] {
+  const candidates: string[] = [];
+  let candidate = packagePath;
+  while (candidate) {
+    candidates.push(candidate);
+    const lastSlash = candidate.lastIndexOf("/");
+    if (lastSlash <= 0) break;
+    candidate = candidate.substring(0, lastSlash);
+  }
+  return candidates;
+}
+
+export function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/vscode-gotest/src/scaffold.ts
+++ b/vscode-gotest/src/scaffold.ts
@@ -139,10 +139,9 @@ export async function executeScaffold(
     return;
   }
 
-  const cmd = await buildCliCommand(["scaffold", target], effectiveDir);
-  outputChannel.info(`[scaffold] ${formatCliCommand(cmd)}`);
-
   try {
+    const cmd = await buildCliCommand(["scaffold", target], effectiveDir);
+    outputChannel.info(`[scaffold] ${formatCliCommand(cmd)}`);
     const stdout = await captureStdout(cmd.bin, cmd.args, {
       cwd: effectiveDir,
     });

--- a/vscode-gotest/src/watch.ts
+++ b/vscode-gotest/src/watch.ts
@@ -261,7 +261,15 @@ export class WatchManager implements vscode.Disposable {
 
     const buildCmd = () =>
       buildCliCommand(["watch", "--", "-json", pkgScope], cwd);
-    const cmd = await buildCmd();
+    let cmd: CliCommand;
+    try {
+      cmd = await buildCmd();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.outputChannel.error(`[watch] ${message}`);
+      vscode.window.showErrorMessage(`gotest watch: ${message}`);
+      return;
+    }
 
     let cycleJsonAccumulator = "";
 


### PR DESCRIPTION
The gotest command and the gotest dependency pinned in a project must stay in step. When the command is newer than the dependency, tests stop compiling with a wall of "undefined" errors pointing into a generated file, with no hint about versions or how to fix it.

Now gotest checks the project's dependency before it generates anything. If the dependency is older than v1.27.0, it stops immediately with a one-line message that names the version it found, the version it needs, and the exact command to run.

The floor is deliberately the same number the VS Code extension already requires, so there is one version to remember, and a test keeps the two in sync.

Note for the release notes: projects still pinned at v1.26.0 will be asked to upgrade the dependency, even though they compile today. The message tells them exactly what to run.