### PR TITLE
A documentation pass after the bench and fuzz merges

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -320,34 +320,41 @@ Without a target — a top-level stdlib `FuzzX` using gotest as a library —
 `f.Fuzz` binds by reflection and accepts native argument types only.
 
 The fan is a pure function of the declared type, depth-first in
-declaration order: `string`, `[]byte` and `bool` leaves pass through;
-every number rides as a fixed-width little-endian `[]byte` (`pkg/gotestfuzz`
-`Leaf*` codecs, total by construction: short input zero-extends, long input
-truncates); a named type fans as its underlying kind; a nested struct
-inlines its leaves; a pointer becomes a `bool` nil-flag plus the pointee's
-leaves; a `[N]byte` is one `[]byte` leaf and a `[N]T` fans `T` N times; any
-other fuzzable shape (a slice of non-bytes) rides as one packed `[]byte`
-leaf. Numbers ride as bytes on purpose: Go's mutator gives a native integer
-only bounded ±100 arithmetic and a native float only bounded add/sub/mul/div,
+declaration order:
+
+| Declared shape | Engine leaves |
+|---|---|
+| `string`, `[]byte`, `bool` | one leaf, passed through |
+| any number | one fixed-width little-endian `[]byte` (`pkg/gotestfuzz` `Leaf*` codecs; short input zero-extends and long input truncates, so decoding is total) |
+| named type | fans as its underlying kind |
+| nested struct | its leaves, inlined |
+| pointer | a `bool` nil-flag, then the pointee's leaves |
+| `[N]byte` | one `[]byte` leaf |
+| `[N]T` | `T` fanned N times |
+| slice of non-bytes, any other fuzzable shape | one packed `[]byte` leaf |
+| unexported fields, maps, interfaces, channels, funcs, recursive types | refused at generation time with the alternative named (the README's "Struct arguments" table), because generated code that cannot round-trip faithfully would lie |
+
+Numbers ride as bytes on purpose. Go's mutator gives a native integer only
+bounded ±100 arithmetic and a native float only bounded add/sub/mul/div,
 while a `[]byte` gets interesting-value overwrites, bit flips and window
 arithmetic, so a boundary value, `NaN` or `Inf` is one mutation away instead
-of unreachable. The cost is that numeric corpus lines are unreadable; that is
+of unreachable. The cost is unreadable numeric corpus lines. That is
 acceptable only because a failing execution echoes the decoded literal
-(`Frame{Version: 7, …}`) and `triage`/`promote` decode by field path, so the
-two decisions are coupled. The flatten rules, leaf widths and nil-flag
-placement are part of the versioned generated identifier family
-(`ƒ_fuzzfan_v1_…`): changing any of them re-means every corpus position, so
-it is a `v1 → v2` bump. Go's corpus format is positional, which is why
-adding or removing a field invalidates the target's on-disk entries loudly
-(the runner's stale-corpus pre-flight names the entry and the change before
-the engine's own message), why swapping two same-kind fields is the one
-silent case (the `fuzz-struct-corpus` lint rule and `promote` are the
-mitigation), and why a promoted `f.Add(T{…})` literal is the durable
-artifact: `Explode` re-derives positions from the current type on every run.
-Unexported fields, maps, interfaces, channels, funcs and recursive types are
-refused at generation time with the alternative named (the README's
-"Struct arguments" table), because generating code that cannot round-trip
-faithfully would lie.
+(`Frame{Version: 7, …}`) and `triage`/`promote` decode by field path; the
+two decisions are coupled.
+
+The flatten rules, leaf widths and nil-flag placement are part of the
+versioned generated identifier family (`ƒ_fuzzfan_v1_…`): changing any of
+them re-means every corpus position, so it is a `v1 → v2` bump. Go's corpus
+format is positional, which has three consequences:
+
+- adding or removing a field invalidates the target's on-disk entries loudly
+  (the runner's stale-corpus pre-flight names the entry and the change
+  before the engine's own message);
+- swapping two same-kind fields is the one silent case (the
+  `fuzz-struct-corpus` lint rule and `promote` are the mitigation);
+- a promoted `f.Add(T{…})` literal is the durable artifact, because
+  `Explode` re-derives positions from the current type on every run.
 
 When seed harvesting is enabled (`gotestast.HarvestSeeds`, on by default —
 see the README's "Seed harvesting" section), the renderer additionally

--- a/README.md
+++ b/README.md
@@ -689,17 +689,19 @@ func (s *ParserTestSuite) FuzzParse(f *gotest.F) {
 }
 ```
 
-`Fuzz*` methods take `*gotest.F` only — unlike benchmarks, `*testing.F` is rejected: fuzz lifecycle interposition needs `gotest.F`'s `BeforeEach`/`AfterEach` wiring, which the stdlib type can't carry.
-Bodies call `f.Fuzz(func(t *gotest.T, ...) { ... })` exactly as they would `(*testing.F).Fuzz` — any number of fuzzed arguments after the `*gotest.T`.
-The callback's shape is checked when gotest generates, since `f.Fuzz` takes `any` like its stdlib counterpart: a callback without a leading `*gotest.T`, with results, or handed to `f.Fuzz` twice is refused with the method named.
-Each execution gets a fresh `*gotest.T`, with the suite's `BeforeEach`/`AfterEach` interposed around every single execution — not once for the whole fuzz target.
-`f.Add(...)` registers seeds exactly like stdlib.
-`F_`/`X_` focus/exclude prefixes carry over from tests.
+A fuzz method takes `*gotest.F` and calls `f.Fuzz` with a callback whose first parameter is `*gotest.T`; any number of fuzzed arguments follow, exactly as with `(*testing.F).Fuzz`.
+`f.Add(...)` registers seeds, and the `F_`/`X_` prefixes focus and exclude fuzz methods like tests.
+The suite's `BeforeEach` and `AfterEach` run around every single execution, seeds included, not once per target, so each execution starts from fresh state.
 
-The same suite-shape rejections as benchmarks apply, with fuzz-specific wording:
-a returning `BeforeEach` is rejected (`suite %s has fuzz methods but a returning BeforeEach — move fuzz targets to a dedicated suite`), any lifecycle hook still typed `*testing.T` is rejected (`suite %s has fuzz methods but %s uses *testing.T — fuzz lifecycles require *gotest.T hooks`), and a fixture with per-method `BeforeEach`/`AfterEach` bound to a fuzzing suite is rejected at generation time (`suite %s has fuzz methods but fixture %s defines BeforeEach/AfterEach — per-execution fixture hooks are not supported for fuzz targets`).
+Because `f.Fuzz` takes `any`, the callback's shape is checked when gotest generates, and the message names the method:
 
-Codegen emits one top-level function per `Fuzz*` method, named `Fuzz<SuiteIdentifier>_<MethodName>` — e.g. `FuzzParserTestSuite_FuzzParse` — since Go's fuzzing engine targets exactly one `FuzzX` symbol per run.
+- the callback must take a leading `*gotest.T` and return nothing;
+- `f.Fuzz` may be called once per method;
+- `*testing.F` is rejected, since the per-execution lifecycle needs `gotest.F`.
+
+The suite-shape rules match benchmarks, with fuzz-specific messages: a returning `BeforeEach` is rejected (move fuzz targets to a dedicated suite), every lifecycle hook must take `*gotest.T`, and a fixture with `BeforeEach`/`AfterEach` cannot bind to a fuzzing suite (per-execution fixture hooks are not supported).
+
+Each `Fuzz*` method becomes one top-level function named `Fuzz<SuiteIdentifier>_<MethodName>`, e.g. `FuzzParserTestSuite_FuzzParse`, because Go's fuzzing engine targets one `FuzzX` symbol per run.
 
 ### Struct arguments
 
@@ -718,25 +720,31 @@ func (s *UserServiceTestSuite) FuzzCreate(f *gotest.F) {
 }
 ```
 
-Every leaf is one of three shapes: `string`, `bool`, and `[]byte` pass through untouched; every number rides as a fixed-width little-endian `[]byte`, because Go's mutator gives a `[]byte` its richest operators (interesting-value overwrites, bit flips, window arithmetic) and gives a native number only bounded ±100 arithmetic — so boundary values, NaN, and Inf are one mutation away rather than unreachable.
-Nested structs, pointers (a `bool` nil-flag plus the pointee's leaves), and small arrays flatten into the same tuple; a variable-length non-byte slice rides as one packed `[]byte`, since its leaf count isn't fixed.
-The policy applies to every position of a multi-argument callback too — `f.Fuzz(func(t *gotest.T, h Header, n int))` fans `Header` into its leaves and `n` into one `[]byte` leaf — so two values as arguments and two values in a struct reach the engine identically; choose by what reads better, a struct when the values form a concept.
+What fans out:
 
-Seeds you write stay plain Go literals — `f.Add` buffers them and `f.Fuzz` explodes each one through the target's own fan, rejecting a seed whose type isn't the one the target fuzzes (`seed #1: value 1: f.Add was given []byte, but this fuzz target takes CreateUserRequest`) rather than letting it stand in for an unrelated value.
+- `string`, `bool` and `[]byte` fields pass through unchanged.
+- Numbers ride as fixed-width bytes, which gives the mutator its richest operators: bit flips, interesting values, boundary values. Why that beats a native number is in ARCHITECTURE.md, "Code Generation".
+- Nested structs, pointers and small arrays flatten into the same tuple; a variable-length slice of non-bytes rides as one packed `[]byte`.
+- Every position of a multi-argument callback fans on its own: `f.Fuzz(func(t *gotest.T, h Header, n int))` fans `Header` into its leaves and `n` into one leaf. Two values as arguments and two values in a struct reach the engine identically; use a struct when the values form a concept.
 
-Crashers stay readable in both directions.
-When a struct-typed execution fails, the decoded value is printed alongside the failure — `CreateUserRequest{Email: "a@\x00", Age: -1}`, not the raw corpus bytes — and `gotest fuzz promote` splices that same literal back into the target as a typed `f.Add(CreateUserRequest{...})` seed.
-A promoted seed is therefore ordinary Go source, which is what makes it outlive any future change to the encoding.
-Literal rendering covers every shape the fan itself accepts, so a promoted crasher is always typed source.
-Pointer fields included: a `*int` renders as `&[]int{5}[0]`, since `&5` is not valid Go and `new(5)` — added in Go 1.26 — would not compile in a module still declaring `go 1.24`.
+Seeds stay plain Go literals.
+`f.Add` buffers them and `f.Fuzz` explodes each one through the target's own fan; a seed of the wrong type is rejected with the position named (`seed #1: value 1: f.Add was given []byte, but this fuzz target takes CreateUserRequest`).
 
-Fields map to leaves in declaration order, so a corpus entry recorded on disk means what your type's current field list says it means.
-**Changing that list is loud**: adding or removing a field changes the leaf count, and Go's engine rejects every entry of the old shape outright.
-gotest names the drift before the engine's own message does — a pre-flight check runs ahead of `go test` on both plain runs and `gotest fuzz`, printing which entry no longer fits, what it holds, and what the target now takes.
-The one silent case left is swapping two same-kind fields: the count still matches, so the entry loads and quietly becomes a different test.
-Promoting crashers to source is the durable answer, and the `fuzz-struct-corpus` lint rule is the backstop: it flags any on-disk corpus entries for a shape-bound target and points at `gotest fuzz promote`, so a field-order-bound file can't quietly linger as a regression test that no longer tests what it caught.
+Crashers stay readable.
+A failing execution prints the decoded value beside the failure, `CreateUserRequest{Email: "a@\x00", Age: -1}` rather than corpus bytes, and `gotest fuzz promote` splices that literal back into the method as a typed `f.Add(...)` seed.
+Every shape the fan accepts renders as a literal, pointers included (`&[]int{5}[0]`, since `&5` is not Go and `new(5)` needs Go 1.26).
 
-Codegen refuses, at generation time, anything it cannot encode faithfully — permitting it would generate code that lies:
+**A struct target's corpus files are bound to its field order.**
+Fields map to leaves in declaration order, so an entry on disk means whatever the current field list says:
+
+- Adding or removing a field changes the leaf count. Go's engine rejects every old entry, and gotest names the drift first: a pre-flight check on plain runs and on `gotest fuzz` prints which entry no longer fits, what it holds and what the target now takes.
+- Swapping two fields of the same kind is silent: the entry loads and quietly becomes a different test.
+
+The rule that follows: promote crashers to `f.Add` seeds instead of committing corpus files for struct targets.
+A promoted seed is source and survives any change to the encoding.
+The `fuzz-struct-corpus` lint rule flags on-disk entries for a shape-bound target and points at `gotest fuzz promote`.
+
+Refused at generation time, with the alternative named in the message, because generated code that cannot round-trip faithfully would lie:
 
 | Refused | Do this instead |
 |---|---|
@@ -746,8 +754,8 @@ Codegen refuses, at generation time, anything it cannot encode faithfully — pe
 | recursive types | — |
 | `time.Time` and friends (unexported internals) | fuzz an `int64` and convert in the callback |
 
-Each rejection names the offending field path and its type, e.g. `fuzz target FuzzUserServiceTestSuite_FuzzCreate: CreateUserRequest.mu (sync.Mutex) is not fuzzable — unexported fields cannot be set — fuzz the constructor's input, or declare a local wrapper struct`.
-Nothing in the toolchain catches this for us — `go vet` only checks direct `(*testing.F).Fuzz` calls, and `f.Fuzz` takes `any`, so it never sees the callback — so generation time is the only place a useful message can be produced.
+Each rejection names the field path and its type, e.g. `fuzz target FuzzUserServiceTestSuite_FuzzCreate: CreateUserRequest.mu (sync.Mutex) is not fuzzable — unexported fields cannot be set — fuzz the constructor's input, or declare a local wrapper struct`.
+Generation is the only place this can be caught: `go vet` checks direct `(*testing.F).Fuzz` calls only, and `f.Fuzz` takes `any`.
 
 ### Seed harvesting
 
@@ -784,22 +792,26 @@ If a target must also run under stock tooling, write it as a top-level `func Fuz
 ### Running
 
 ```bash
-gotest fuzz ./...                     # one minute of fuzzing, shared across all targets
-gotest fuzz --for=5m ./...            # ~5 minutes of fuzzing wall-clock, shared across all targets
-gotest fuzz --for=1m --jobs=2 ./...   # cap concurrency to 2 targets at a time
+gotest fuzz ./...                     # one minute, shared across all targets
+gotest fuzz --for=5m ./...            # about five minutes across all targets
+gotest fuzz --for=1m --jobs=2 ./...   # two targets at a time
+gotest fuzz --target=FuzzParserTestSuite_FuzzParse ./pkg/parser
 ```
 
-`--target=<Fuzz...>` narrows a session to exactly one generated wrapper (an unmatched name errors with the available list) — this is also what the VS Code extension invokes: fuzz methods get **Fuzz** / **Debug Seeds** CodeLenses, budgeted cancellable sessions, crasher notifications wired to triage/promote/debug, and Test Explorer items whose runs replay seeds (see `vscode-gotest/README.md`).
+`gotest fuzz` finds every generated `Fuzz<Suite>_<Method>` target and runs each as its own `go test -fuzz=...` process.
+This is the one gotest subcommand that does not reuse the compiled suite binary: `cmd/go` weaves fuzz instrumentation in only when `-fuzz` is present on that `go test` invocation, so a binary from `go test -c` would fuzz without coverage guidance.
+Each target pays its own compile and gets a real search in return.
 
-`gotest fuzz` discovers every generated `Fuzz<Suite>_<Method>` target and runs each one as its own `go test -fuzz=...` subprocess — one target per invocation of `go test`.
-This is unlike every other gotest subcommand: a suite binary compiled once with `go test -c` has no native fuzz instrumentation, because `cmd/go` only weaves it in when `-fuzz` is present at `go test` invocation time.
-Reusing the shared compiled binary the way `gotest`/`gotest bench` do would run uninstrumented — coverage-guided mutation would silently degrade to undirected random input.
-So each target gets its own `go test -fuzz` process instead, at the cost of losing the binary-reuse speedup everywhere else in gotest.
+The budget:
 
-`--for=<dur>` is approximate wall-clock for the whole session: each target's `-fuzztime` share is `--for × min(--jobs, targets) / targets`, so concurrent waves multiply back out to ≈`--for` (shares floor at 10s, so a small `--for` on many targets doesn't starve any of them — the floor stretches the session instead, and gotest says so). The resolved schedule is printed before fuzzing starts, and the deadline it implies is printed beside it.
-Without `--for` the session gets one minute, so a bare `gotest fuzz ./...` always comes back and every target gets its share. `--for` is the session's only clock: the deadline follows it (the schedule plus headroom for builds), so `--for=20m` needs no second flag, a `.gotest.yml` `timeout` written for test runs never caps a search, and `gotest fuzz` refuses `--timeout` outright rather than letting two clocks compete. `--for=0` removes the budget: targets then fuzz until interrupted, with no deadline. Ending by deadline or interrupt is the normal end of an open-ended search, not a failure: the session exits 0 unless something was actually found (a failing target or a new crasher file — detected by scanning each target's `testdata/fuzz/<Func>/` directory, so a crash still counts even when the deadline killed the process mid-report).
-`--jobs=<n>` caps concurrent targets (default `max(1, GOMAXPROCS/2)`). If a deadline expires mid-run, gotest prints `[<Func>] skipped: session ended before this target started` for each target that never got a slot and summarizes which targets did not get their full share.
-Give `--for` an explicit value for a longer search; under `--for=0` only the first `--jobs` targets ever run, since each holds its slot until interrupted, and gotest says so up front.
+- `--for` is the session's wall clock, one minute by default. Each target's `-fuzztime` share is `--for × min(--jobs, targets) / targets`, so concurrent waves add back up to about `--for`. Shares never drop below 10s; a small `--for` on many targets stretches the session instead, and gotest says so. The resolved schedule and the deadline it implies print before the search starts.
+- `--for` is the only clock. The deadline follows it with headroom for builds, a `.gotest.yml` `timeout` never caps a search, and `gotest fuzz` refuses `--timeout` rather than let two clocks compete.
+- `--for=0` removes the budget: targets fuzz until interrupted. Only the first `--jobs` targets ever run then, since each holds its slot, and gotest says so up front.
+- `--jobs` caps concurrent targets (default `max(1, GOMAXPROCS/2)`). A target whose slot never opens before the deadline is reported as `[<Func>] skipped: session ended before this target started`, and the closing summary names the targets that did not get their full share.
+- `--target=<Fuzz...>` narrows a session to one wrapper; an unmatched name lists the available ones. This is what the VS Code extension invokes: fuzz methods get **Fuzz** / **Debug Seeds** CodeLenses, budgeted cancellable sessions, crasher notifications wired to triage/promote/debug, and Test Explorer items whose runs replay seeds (see `vscode-gotest/README.md`).
+
+Ending by deadline or interrupt is the normal end of an open-ended search, not a failure.
+The session exits 0 unless something was found: a failing target, or a new crasher file, detected by comparing each target's `testdata/fuzz/<Func>/` directory before and after, so a crash counts even when the deadline killed the process mid-report.
 
 Output streams live, line by line, each line prefixed `[<Func>] `:
 
@@ -812,11 +824,17 @@ Output streams live, line by line, each line prefixed `[<Func>] `:
 [FuzzNotificationServiceTestSuite_FuzzTrim] ok  	github.com/mvrahden/go-test/examples/notification	10.115s
 ```
 
-On a crashing input, the session exits 1 and gotest names each new corpus file it detected — `[<Func>] new crasher: <dir>/testdata/fuzz/<Func>/<hash>` — followed by a pointer to `gotest fuzz triage` (to see the decoded input) and `gotest fuzz promote` (to keep it as a typed `f.Add` seed that replays on every ordinary run). A target that fails without writing a new file (a failing seed or existing corpus entry) is called out as such: it reproduces on a regular `gotest` run.
+On a crashing input the session exits 1 and names each new corpus file, `[<Func>] new crasher: <dir>/testdata/fuzz/<Func>/<hash>`, followed by the two commands that handle it: `gotest fuzz triage` to see the decoded input and `gotest fuzz promote` to keep it as a typed seed that replays on every ordinary run.
+A target that fails without writing a new file (a failing seed or existing corpus entry) is called out as such; it reproduces on a regular `gotest` run.
 
-Every session closes with one line — `fuzzed 5 targets in 20.3s: 7,012,345 execs, 3 new interesting inputs, no crashers` — and under GitHub Actions the same session lands in the job's step summary as a table with one row per target.
-The "interesting" inputs are the ones that reached new coverage. Go keeps them in its build cache, under `fuzz/<package>/<Func>/` in `go env GOCACHE`, never beside your code, and the next session resumes from them, which is why a second run starts with a larger baseline; `go clean -fuzzcache` starts over. They are the search's own memory, not something to commit: the seeds you write and the crashers you promote are the corpus that travels with the code.
-The engine's own `To re-run: go test -run=...` advice is dropped from the stream, since plain `go test` cannot see a generated suite target; the hint that follows a crasher names the working commands instead.
+Every session closes with one line, `fuzzed 5 targets in 20.3s: 7,012,345 execs, 3 new interesting inputs, no crashers`.
+Under GitHub Actions the same session lands in the step summary as a table with one row per target.
+
+"Interesting" inputs are the ones that reached new coverage.
+Go keeps them in its build cache, under `fuzz/<package>/<Func>/` in `go env GOCACHE`, never beside your code.
+The next session resumes from them, which is why a second run starts with a larger baseline; `go clean -fuzzcache` starts over.
+They are the search's own memory, not something to commit: the seeds you write and the crashers you promote are the corpus that travels with the code.
+The engine's `To re-run: go test -run=...` advice is dropped from the stream, since plain `go test` cannot see a generated target; the hint after a crasher names the working commands.
 
 With no `Fuzz*` methods anywhere, `gotest fuzz` prints `no fuzz targets found` and exits 0 without invoking `go test`.
 

--- a/README.md
+++ b/README.md
@@ -1099,7 +1099,6 @@ Outside GitHub Actions, `gotest summary --badge=coverage.svg ./...` renders the 
 ```bash
 gotest ./... -v -race          # generate overlays and run tests (default)
 gotest bench ./...             # run BenchmarkX suite methods, serially
-
 gotest fuzz ./... --for=5m     # run FuzzX suite methods, budgeted
 gotest spec ./...              # behavioral specification view
 gotest summary ./...           # failure-focused summary for CI

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -364,130 +364,83 @@ Examples:
 }
 
 func printFuzzHelp() {
-	fmt.Print(`gotest fuzz — run FuzzX suite methods with go test -fuzz
+	fmt.Print(`gotest fuzz — search for failing inputs with FuzzX suite methods
 
 Usage:
   gotest fuzz [flags] [packages...]
   gotest fuzz triage [packages...]     Re-run each crasher, report if it still fails
   gotest fuzz promote [packages...]    Splice crashers into f.Add(...) seeds
 
-Discovers suites containing FuzzX methods (written with gotest.F and
-f.Fuzz, see "gotest help scaffold") and runs each one's generated
-Fuzz<SuiteName>_<MethodName> wrapper as its own "go test -fuzz=..." process,
-one target per invocation of go test. This is unlike every other gotest
-subcommand: a suite binary compiled once with "go test -c" has no native
-fuzz instrumentation, because cmd/go only weaves it in when -fuzz is present
-at "go test" time. So fuzzing cannot reuse the shared compiled binary and
-each target gets its own background "go test -fuzz" process instead.
+Runs every Fuzz<SuiteName>_<MethodName> wrapper the target packages
+generate as its own "go test -fuzz" process, several at a time (--jobs),
+for a shared time budget (--for). Output streams live, one line at a
+time, prefixed "[<Func>] ".
 
-Multiple targets run concurrently (bounded by --jobs) and each one streams
-its output live, line by line, prefixed with "[<Func>] ", so long-running
-fuzz sessions show progress rather than going silent until they exit.
-
-Seed corpus replay (the seeds added via f.Add in a FuzzX method, plus any
-corpus gotest fuzz has since discovered under testdata/fuzz/) already
-happens for free as part of an ordinary "gotest" or "gotest test" run —
-those replay as regular subtests, at zero extra cost, without -fuzz and
-without this subcommand. Reach for "gotest fuzz" specifically to spend time
-mutating and searching for new failing inputs.
-
-"gotest lint" flags common fuzz-writing mistakes: fuzz-determinism (reading
-time.Now/math-rand/os.Getenv from a fuzz target breaks corpus replay),
-fuzz-no-oracle (a callback that asserts nothing only catches panics),
-fuzz-seed (no f.Add seeds means coverage-guided exploration starts blind),
-fuzz-struct-corpus (on-disk corpus entries for a struct-typed target are
-bound to its field order and silently reinterpreted when two same-kind
-fields swap — promote them to typed seeds), fuzz-hook-io (a
-BeforeEach/AfterEach that does IO replays around every execution and
-throttles the fuzzer), and fuzz-raw-seed (a raw []byte seed on a position
-that does not take []byte is rejected outright).
-
-Seed harvesting (on by default): at generation time, gotest mines your
-test files' table-test literals and direct call-site arguments that flow
-into a fuzz target's function-under-test, and injects them as f.Add(...)
-seeds in the generated wrapper — turning your existing valid-input
-examples into a starting corpus without any extra authoring. Only literal
-primitive values from _test.go sources are harvested, never production
-code or computed expressions. Disable it for one run with --no-harvest, or
-persistently via "fuzz: harvest: false" in .gotest.yml (see "gotest help
-config").
+Seeds already replay without this subcommand: every f.Add seed and every
+corpus entry under testdata/fuzz/ runs as an ordinary subtest of a plain
+"gotest" run. Use "gotest fuzz" to spend time searching for new inputs.
 
 Flags:
-  --for=<dur>             Approximate wall-clock fuzz budget for the whole
-                           session: each target's -fuzztime share is
-                           --for × min(--jobs, targets) / targets, floored
-                           at 10s, so concurrent waves add back up to ≈--for.
-                           The resolved schedule is printed before fuzzing
-                           starts. Default: 1m. --for=0 removes the budget:
-                           targets then fuzz until interrupted (exit 0 when
-                           nothing was found).
-  --jobs=<n>               Max concurrent targets (default: max(1, GOMAXPROCS/2))
-  --target=<Fuzz...>       Fuzz exactly one generated target, named by its
-                           wrapper (e.g. FuzzParserTestSuite_FuzzParse, as
-                           shown in session output). An unmatched name is an
-                           error listing the available targets. This is the
-                           editor's unit of invocation; combined with --for
-                           the whole budget goes to that one target.
-  --no-cache               Disable overlay cache, force fresh generation
-  --debug                  Keep generated overlay for inspection
+  --for=<dur>             Wall-clock budget for the whole session (default 1m).
+                          Each target gets --for × min(--jobs, targets) / targets,
+                          never less than 10s; the resolved schedule prints
+                          before the search starts. --for=0 removes the budget:
+                          targets fuzz until interrupted.
+  --jobs=<n>              Max concurrent targets (default: max(1, GOMAXPROCS/2))
+  --target=<Fuzz...>      Fuzz one target, named by its wrapper as printed in
+                          session output; an unmatched name lists the targets
+  --no-harvest            Do not mine table-test literals into seeds for this run
+  --no-cache              Disable overlay cache, force fresh generation
+  --debug                 Keep generated overlay for inspection
 
---for is the session's only clock: the deadline follows it (the schedule
-plus headroom for builds), so --timeout is refused here rather than left to
-compete. If that deadline still expires, the targets that lost time are
-listed and gotest prints "[<Func>] skipped: ..." for each one that never
-started. With --for=0 there is no deadline and only the first --jobs targets
-run, since each holds its slot until interrupted.
+--for is the session's only clock: the deadline follows it, so --timeout
+is refused here. With --for=0 only the first --jobs targets run, since
+each holds its slot until interrupted.
 
-Every session closes with one line saying what ran and what was found
-(targets, executions, new interesting inputs, crashers); under GitHub
-Actions the session is also appended to $GITHUB_STEP_SUMMARY as a table.
+Exit codes:
+  0   The budget ran out or the session was interrupted with nothing found
+  1   A finding: a failing target or a new crasher file
+  2   The session could not run as requested
 
-If no packages contain any FuzzX methods, prints "no fuzz targets found"
-and exits 0 without invoking go test.
+A new crasher is named as it is found:
+  [FuzzParserTestSuite_FuzzParse] new crasher: <pkg>/testdata/fuzz/FuzzParserTestSuite_FuzzParse/1a2b3c
+Inspect it with "gotest fuzz triage", keep it with "gotest fuzz promote".
+Every session closes with one line (targets, executions, new interesting
+inputs, crashers); under GitHub Actions the same session is appended to
+$GITHUB_STEP_SUMMARY as a table. With no FuzzX methods anywhere, the
+command prints "no fuzz targets found" and exits 0.
 
-Triage and promote (crasher management):
+Triage:
+  "gotest fuzz triage" scans each target's testdata/fuzz/<Func>/ directory
+  and re-runs every entry via "go test -run='^<Func>/<hash>$'", printing
+  its decoded input and the failure cause, or "status: no longer failing":
+    FuzzParserTestSuite_FuzzParse: 1 crasher
+      file:  testdata/fuzz/FuzzParserTestSuite_FuzzParse/1a2b3c
+      input: string("a@\x00")
+      cause: panic: runtime error: index out of range [3] with length 3
+  Exits 1 while any crasher still fails, 0 otherwise. Entries of a type it
+  cannot decode are reported and skipped, one file at a time.
 
-"gotest fuzz triage [packages...]" scans every discovered fuzz target's
-testdata/fuzz/<Func>/ directory (a plain filesystem scan — no go test -fuzz
-invoked) and, for each corpus entry found there, prints its decoded input
-and re-runs just that entry via "go test -run='^<Func>/<hash>$'":
-  FuzzParserTestSuite_FuzzParse: 1 crasher
-    file:  testdata/fuzz/FuzzParserTestSuite_FuzzParse/1a2b3c
-    input: string("a@\x00")
-    cause: panic: runtime error: index out of range [3] with length 3
-A crasher whose re-run now passes (e.g. after a fix landed) is reported as
-"status: no longer failing" instead of a cause line. Exits 0 if there are no
-crashers, or every crasher found turns out to no longer fail; exits 1 if any
-crasher's re-run still fails. Corpus entries only decode Go's native
-primitive types (string, []byte, bool, and the int/uint/float variants) —
-one with an unsupported entry is reported and skipped, one file at a time.
+Promote:
+  "gotest fuzz promote" splices each crasher into its FuzzX method as a
+  permanent f.Add(...) seed, after the method's last f.Add, and deletes
+  the file; the seed then replays on every ordinary run:
+    promoted FuzzParserTestSuite_FuzzParse/1a2b3c -> f.Add("a@\x00") in parser_test.go:42
+  A crasher whose method cannot be located with confidence is left in
+  place with a warning; promote never partially edits source.
 
-"gotest fuzz promote [packages...]" does the same discovery, but instead of
-re-running each crasher, splices it into its originating FuzzX method as a
-permanent f.Add(...) seed (via internal/refactor's AST edit + go/format
-machinery, directly after the method's last existing f.Add call, or as the
-first statement if it has none), then deletes the crasher file — it's now a
-committed regression test that replays for free on every ordinary run:
-  promoted FuzzParserTestSuite_FuzzParse/1a2b3c -> f.Add("a@\x00") in parser_test.go:42
-If a crasher's originating method can't be located with confidence, it is
-skipped with a warning and the crasher file is left in place — promote never
-partially edits or corrupts user source.
-
-On a crashing input, the session exits 1 and gotest names each new corpus
-file it detected, e.g.:
-  [FuzzParserTestSuite_FuzzParse] new crasher: /abs/pkg/testdata/fuzz/FuzzParserTestSuite_FuzzParse/1a2b3c
-Inspect it with "gotest fuzz triage", then "gotest fuzz promote" to keep it
-as a typed f.Add seed that replays automatically in ordinary runs.
-
-A session that ends by the global --timeout or an interrupt without a
-finding exits 0 — time exhaustion is the normal end of an open-ended
-search, not a failure. Exit 1 means a finding (a failing target or a new
-crasher); exit 2 means the session could not run as requested.
+Seed harvesting is on by default: literal arguments from table tests and
+call sites in _test.go files become extra f.Add seeds at generation time
+(--no-harvest, or "fuzz: harvest: false" in .gotest.yml). "gotest lint"
+checks fuzz targets with the fuzz-* rules (see "gotest help lint"). Why
+each target needs its own "go test -fuzz" process, and how struct
+arguments fan out, is in the README's Fuzzing section.
 
 Examples:
   gotest fuzz ./pkg/parser/...                Fuzz for the default minute
-  gotest fuzz --for=5m ./...                  ~5 minutes of fuzzing wall-clock across all targets
-  gotest fuzz --for=1m --jobs=2 ./...         Cap concurrency to 2 targets at a time
+  gotest fuzz --for=5m ./...                  About five minutes across all targets
+  gotest fuzz --for=1m --jobs=2 ./...         Two targets at a time
+  gotest fuzz --target=FuzzParserTestSuite_FuzzParse ./pkg/parser
 `)
 }
 

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -33,7 +33,6 @@ func showHelp(topic string) {
 		printWatchHelp()
 	case "bench":
 		printBenchHelp()
-
 	case "fuzz":
 		printFuzzHelp()
 	case "discover":
@@ -71,7 +70,6 @@ Usage:
 
 Subcommands:
   bench       Run BenchmarkX suite methods serially
-
   fuzz        Run FuzzX suite methods with go test -fuzz
   spec        Render behavioral specification from test output
   summary     Show failure-focused test summary for CI
@@ -780,7 +778,6 @@ Fields:
   bench:
     baseline: <path>        Default --against baseline path for "gotest bench"
     gate: <float>           Default --gate regression percentage (0 disables)
-
   fuzz:
     harvest: <bool>         Seed harvesting for "gotest fuzz" (default: true;
                              the --no-harvest CLI flag overrides this per-run)
@@ -800,7 +797,6 @@ Example .gotest.yml:
   bench:
     baseline: bench-baseline.json
     gate: 10
-
   fuzz:
     harvest: false
 `)

--- a/cmd/gotest/help.go
+++ b/cmd/gotest/help.go
@@ -551,8 +551,10 @@ Target is one of:
   ./pkg/path.FuncName      With --fuzz: generate a fuzz skeleton for a
                            single-parameter package-level function
 
-Creates a new _test.go file with a suite struct, a runner function,
-and stub methods for each exported method on the target type.
+Creates a new _test.go file next to the target: a suite struct holding
+the subject, a BeforeEach that constructs it, and one Test method per
+exported method with It stubs (a happy path and an error case for
+methods that return an error). Existing files are never overwritten.
 
 Flags:
   --fuzz    Scaffold a Fuzz<Func> method for a package-level function
@@ -624,12 +626,21 @@ Rules:
   test-signature        Test methods not accepting *gotest.T or *testing.T
   x-lifecycle           X_ prefix on a lifecycle hook (a no-op)
   suite-lifecycle       Cleanup/Parallel/Run via t.T() — bypass the suite lifecycle
+  shared-fixture-undeclared
+                        Reads of a shared fixture the suite never declared as a
+                        field (only declared fixtures are started)
   assertion-simplify    Simplifiable assertions (True(t, a == b) → Equal, …)
   assertion-type-guard  Nil/Empty on types their runtime guards reject
   assertion-redundant   Assertions made redundant by the following assertion
   fail-guard            if cond { Fail/Fatal(...) } guards — use assertions directly
   t-escape              Unnecessary t.T() convenience escapes (incl. Helper/Fatal/Log)
   behavior-wording      When("when …") / It("it …") — the spec supplies those words
+  bench-loop            Benchmark methods that never call b.Loop()/b.N (nothing
+                        iterates, so the numbers lie)
+  bench-fixture-io      Fixture-backed reads inside the measured loop (times the
+                        fixture, not the code)
+  bench-wait            time.Sleep/Eventually/Consistently inside the measured
+                        loop (times the wait, not the code)
   fuzz-determinism      Fuzz targets reading time.Now/math-rand/os.Getenv
   fuzz-no-oracle        Fuzz callbacks that assert nothing (panic-only)
   fuzz-seed             Fuzz targets with no f.Add seeds
@@ -644,10 +655,10 @@ rules also accept a project-wide skip flag (mirrored by .gotest.yml lint.skip):
 
 Flags:
   -skip-<rule>            Disable a non-integrity rule, e.g. -skip-fail-guard
-                          (assertion-simplify, assertion-redundant, behavior-wording, fail-guard,
-                          t-escape, stdlib-test, testify,
-                          fuzz-no-oracle, fuzz-seed, fuzz-hook-io,
-                          fuzz-raw-seed)
+                          (assertion-simplify, assertion-redundant, behavior-wording,
+                          bench-fixture-io, bench-wait, fail-guard, t-escape,
+                          stdlib-test, testify, fuzz-no-oracle, fuzz-seed,
+                          fuzz-hook-io, fuzz-raw-seed)
   -disable-nolint         Ignore //nolint comments
   -fix                    Apply suggested fixes
   --github                Also emit GitHub ::error annotations and append a
@@ -783,8 +794,9 @@ Fields:
                              the --no-harvest CLI flag overrides this per-run)
 
 Skippable lint rules (non-integrity only): assertion-redundant,
-assertion-simplify, behavior-wording, fail-guard, fuzz-hook-io,
-fuzz-no-oracle, fuzz-raw-seed, fuzz-seed, stdlib-test, t-escape, testify
+assertion-simplify, behavior-wording, bench-fixture-io, bench-wait,
+fail-guard, fuzz-hook-io, fuzz-no-oracle, fuzz-raw-seed, fuzz-seed,
+stdlib-test, t-escape, testify
 
 Example .gotest.yml:
 

--- a/docs/design/fixtures.md
+++ b/docs/design/fixtures.md
@@ -77,7 +77,7 @@ TestKeyTestSuite/TestCreate            PASS
 
 Filter with `-run TestBatchTestSuite` to run only batch tests.
 
-## Fixture Dependencies (Level 2)
+## Fixture Dependencies
 
 Fixtures can reference other fixtures via named pointer fields to form a DAG.
 Setup runs in topological order (dependencies first; independent fixtures in parallel).
@@ -189,7 +189,7 @@ TestBatchTestSuite/TestDispatch     PASS
 
 Filter with `-run TestReconcilerTestSuite` to run only reconciler tests.
 
-## Shared Fixtures (Level 3, `*SharedFixture` suffix)
+## Shared Fixtures (`*SharedFixture` suffix)
 
 Shared fixtures run in a subprocess managed by the `gotest` CLI.
 They start once per CLI invocation and are shared across all packages.

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -640,7 +640,12 @@ type SuiteConfig struct {
 }
 ```
 
-`Exclusive` is resolved statically like `Parallel` and consumed by the runner, not the harness: exclusive suites are held back until every non-exclusive suite has finished, then dispatched one at a time in deterministic (package, suite) order — in batch and streaming pipelines alike. It exists for suites whose verdicts measure wall-clock behavior or fight over resources (timing budgets, containers, ports, per-invocation child builds): a budget verdict taken on a saturated machine is not a verdict you can act on. Shared fixture processes stay up for exclusive suites — they are infrastructure, not competing suites. Under `-race`/`-msan`/`-asan`, dispatch and compile concurrency defaults are additionally halved (an explicit `--parallel`/`--compile-parallel` always wins): instrumentation at least doubles the CPU cost per instruction stream, and the uninstrumented defaults would oversubscribe the machine.
+`Exclusive` is resolved statically like `Parallel` and consumed by the runner, not the harness:
+
+- Exclusive suites are held back until every non-exclusive suite has finished, then dispatched one at a time in deterministic (package, suite) order, in batch and streaming pipelines alike.
+- It exists for suites whose verdicts measure wall-clock behavior or fight over resources (timing budgets, containers, ports, per-invocation child builds): a budget verdict taken on a saturated machine is not a verdict you can act on.
+- Shared fixture processes stay up for exclusive suites; they are infrastructure, not competing suites.
+- Under `-race`/`-msan`/`-asan` the dispatch and compile concurrency defaults are halved, since instrumentation at least doubles the CPU cost per instruction stream; an explicit `--parallel`/`--compile-parallel` always wins.
 
 (Test-case retries are deliberately not offered — retrying flaky tests hides real defects; fixture `Retries` exist because infrastructure setup is legitimately flaky.)
 
@@ -1104,9 +1109,17 @@ UserService (133ms)
 
 Internally runs `go test -json`, parses the event stream, reconstructs the suite→method→When/It hierarchy from `/`-separated test paths, and strips Go naming conventions for display.
 
-**Labels come from the source.** A subtest name cannot be turned back into the description that produced it: `go test` writes an underscore for every space, so `returns snake_case keys` and `returns snake case keys` arrive as the same name. The renderer therefore reads the declared descriptions from source — the same walker that backs `--static` and `discover` — and shows each behavior under the words the developer actually wrote. A stream replayed with `--input` reads declarations too: the packages the stream names are loaded from the working directory, so an editor rendering a captured run shows the labels the run showed. Behaviors source cannot enumerate (a `When` behind a condition, a table that is not a literal), and packages a replay cannot reach (a stream from another module, a checkout without the source), fall back to reconstructing the label from the name, exactly as before — loading never fails a render. Subtest *names* are untouched either way, so `-run` filters, snapshot keys and saved baselines are unaffected.
+**Labels come from the source.** A subtest name cannot be turned back into the description that produced it: `go test` writes an underscore for every space, so `returns snake_case keys` and `returns snake case keys` arrive as the same name. The renderer therefore reads the declared descriptions from source, with the same walker that backs `--static` and `discover`, and shows each behavior under the words the developer wrote.
 
-**Vocabulary.** The `when` prefix above is applied by the renderer, not written in the label: `t.When("email is valid")` displays as `when email is valid`, while `It` labels render verbatim (the ✓/✗/~ icon plays the role of "it"). You write the condition; gotest supplies the connective. Which call declared a subtest is read from source alongside the description, and travels with it, so `gotest spec`, `gotest discover` and a replayed stream (`--input`) render one behavior one way. A label that already opens with a connective of its own is left alone rather than doubled — "when" itself, and also with, without, given, if, unless, after, before, while, once, on, upon, as, for, during, under, whenever — matched as a whole word in any case, whether the separator is a space or an underscore; "with an empty cache" stays as written, "withdrawing funds" becomes "when withdrawing funds". The vocabulary is display metadata only — `vocab` in the JSON tree, `kind` in discovery — and never reaches a subtest name. The `behavior-wording` lint rule flags a description that spells the connective anyway.
+- A stream replayed with `--input` reads declarations too: the packages the stream names are loaded from the working directory, so an editor rendering a captured run shows the labels the run showed.
+- Behaviors the source cannot enumerate (a `When` behind a condition, a table that is not a literal) and packages a replay cannot reach (a stream from another module, a checkout without the source) fall back to reconstructing the label from the name. Loading never fails a render.
+- Subtest *names* are untouched either way, so `-run` filters, snapshot keys and saved baselines are unaffected.
+
+**Vocabulary.** The `when` prefix above is applied by the renderer, not written in the label: `t.When("email is valid")` displays as `when email is valid`, while `It` labels render verbatim (the ✓/✗/~ icon plays the role of "it"). You write the condition; gotest supplies the connective.
+
+- Which call declared a subtest is read from source alongside the description and travels with it, so `gotest spec`, `gotest discover` and a replayed stream render one behavior one way.
+- A label that already opens with a connective of its own is left alone rather than doubled. The connectives: when, with, without, given, if, unless, after, before, while, once, on, upon, as, for, during, under, whenever, matched as a whole word in any case, with a space or an underscore after it. "with an empty cache" stays as written; "withdrawing funds" becomes "when withdrawing funds".
+- The vocabulary is display metadata only (`vocab` in the JSON tree, `kind` in discovery) and never reaches a subtest name. The `behavior-wording` lint rule flags a description that spells the connective anyway.
 
 ### Durations
 
@@ -1184,7 +1197,12 @@ $ gotest discover ./...
 Emits the static suite model as JSON — the integration surface for editors and AI tooling (the VS Code extension's test explorer runs on it).
 No tests are executed.
 
-`behaviors` carries the `When`/`It` tree each method declares, read from source: `name` is the subtest segment `go test` will produce (so it matches an observed run byte for byte), `display` is the text the developer wrote, spoken in its vocabulary — the same string `gotest spec` renders for this node, so an editor showing both never spells one behavior two ways — `kind` names the call it came from (`when`, `it`, `each`), and `line` locates it. Two rewrites the source does not spell out are applied so that `name` really does match: a description repeated among its siblings gains the `#01` suffix the testing package appends, and a description containing a single slash becomes one node per level (a run of slashes, as in `https://`, is not a separator and stays within one level). `behaviorsComplete` reports whether that tree is exhaustive — `false` means the method declares behaviors whose names or existence depend on runtime values (a condition, a loop, a non-literal description, a table that is not a literal), so the list is a floor rather than a total and the remainder appears only once the method has run. Consumers must not present an incomplete list as the whole specification.
+`behaviors` carries the `When`/`It` tree each method declares, read from source:
+
+- `name` is the subtest segment `go test` will produce, so it matches an observed run byte for byte. Two rewrites the source does not spell out make that true: a description repeated among its siblings gains the `#01` suffix the testing package appends, and a description containing a single slash becomes one node per level (a run of slashes, as in `https://`, is not a separator and stays within one level).
+- `display` is the text the developer wrote, spoken in its vocabulary: the same string `gotest spec` renders for this node, so an editor showing both never spells one behavior two ways.
+- `kind` names the call it came from (`when`, `it`, `each`); `line` locates it.
+- `behaviorsComplete` reports whether the tree is exhaustive. `false` means the method declares behaviors whose names or existence depend on runtime values (a condition, a loop, a non-literal description, a table that is not a literal), so the list is a floor rather than a total and the remainder appears only once the method has run. Consumers must not present an incomplete list as the whole specification.
 
 ```
 { "packages": [ {
@@ -1424,7 +1442,13 @@ Exit codes: 0 = pass, 1 = test failure, 2 = usage, generation, or build error (s
 
 The exit code of `spec --input` and `summary --input` answers two questions at once: whether the stream carried failures (1) and whether the command itself failed (2). A client that renders a stream rather than gating on it needs only the second, and passes `--render-only` to drop the first; 2 is never suppressed, so an unreadable input or an unparseable stream still fails. Consumers that treat any non-zero exit as "the command broke" — rather than reading the rendered document on stdout — will misread a failing test run as a broken tool.
 
-Every package a pattern matches ends in exactly one verdict. A package that fails to load or compile — a syntax error, a type error, a nonexistent path — is a failed package (exit 2): its diagnostics are booked into the same output stream as suite results, grouped under a `# <import-path>` header, so text output, `--json` events, `spec`, `summary`, and `--input` replays all carry the failure. Packages that did build still run; one broken package never blocks the rest. `run`, `watch`, `spec`, and `summary` book-and-continue this way; `generate` and `prepare` fail fast instead, because generated output for an unbuildable package is meaningless; `discover` reports such packages with `"broken": true` and their diagnostics as warnings. "no test suites to run" (exit 0) is reserved for runs where every matched package loaded and none defined suites.
+Every package a pattern matches ends in exactly one verdict. A package that fails to load or compile (a syntax error, a type error, a nonexistent path) is a failed package, exit 2:
+
+- Its diagnostics are booked into the same output stream as suite results, grouped under a `# <import-path>` header, so text output, `--json` events, `spec`, `summary` and `--input` replays all carry the failure.
+- Packages that did build still run; one broken package never blocks the rest. `run`, `watch`, `spec` and `summary` book and continue this way.
+- `generate` and `prepare` fail fast instead, because generated output for an unbuildable package is meaningless.
+- `discover` reports such packages with `"broken": true` and their diagnostics as warnings.
+- "no test suites to run" (exit 0) is reserved for runs where every matched package loaded and none defined suites.
 
 The `--ci` flag fails the run when any `F_` (focus) prefix is committed, preventing accidental focus leaks in CI.
 

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -1054,7 +1054,7 @@ $ gotest scaffold ./pkg/user/service.go
 ```
 
 Output is written as `<snake_case>_suite_test.go` next to the target; existing files are never overwritten.
-The subcommand takes no flags — unknown flags are rejected.
+`--fuzz` is the subcommand's only flag (a fuzz skeleton for a package-level function); unknown flags are rejected.
 Uses `packages.Load` for type introspection.
 
 ---
@@ -1408,8 +1408,9 @@ The repository root ships a composite GitHub Action (`action.yml`, "Go - Test Su
     min-coverage: "80"
 ```
 
-Inputs: `packages`, `race`, `coverage`, `min-coverage`, `flags`, `go-test-flags`, `version`.
-Outputs: `exit-code`, `coverage`.
+Inputs: `packages`, `race`, `coverage`, `min-coverage`, `flags`, `go-test-flags`, `badge`, `badge-branch`, `bench`, `bench-baseline`, `bench-gate`, `bench-save`, `fuzz`, `fuzz-for`, `fuzz-cache`, `version`.
+Outputs: `exit-code`, `coverage`, `badge`, `bench-report`, `bench-breached-keys`, `fuzz-crashers`.
+README.md's input and output tables are canonical; a drift guard keeps them in step with `action.yml`.
 
 Manual setup works without the action:
 

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -120,7 +120,6 @@ gotest [subcommand] [packages...] [go-test-flags...] [--gotest-flags...]
 | `spec` | Run tests and render behavioral specification |
 | `summary` | Run tests and render a failure-focused summary (CI mode) |
 | `bench` | Run `BenchmarkX` suite methods serially via `go test -bench` |
-
 | `fuzz` | Orchestrate `FuzzX` suite targets with a shared time budget |
 | `lint` | Run gotest-specific linter checks |
 | `refactor` | Toggle focus prefixes: `refactor toggle-focus <file> <Suite[.Method]>` |
@@ -158,7 +157,6 @@ gotest [subcommand] [packages...] [go-test-flags...] [--gotest-flags...]
 | `--against=<path>` | Compare a benchmark run against a saved baseline and print the delta table (`bench`; defaults to `bench.baseline`) |
 | `--gate=<pct>` | Fail (exit 1) if the worst significant benchmark regression exceeds the threshold (`bench`) |
 | `--json` | Emit one versioned JSON report to stdout — results, deltas, gate verdict — instead of human output (`bench`; for tooling) |
-
 | `--for=<dur>` | Approximate wall-clock fuzz budget for the session, split jobs-aware across targets (`fuzz`; default 1m or half of a shorter `--timeout`; `0` removes the budget; per-target share floors at 10s) |
 | `--target=<name>` | Fuzz exactly one generated wrapper by name; unmatched names error with the available list (`fuzz`) |
 | `--jobs=<n>` | Max concurrent fuzz targets (`fuzz`; default: max(1, GOMAXPROCS/2)) |
@@ -1357,7 +1355,6 @@ Rules are grouped into three tiers by what breaks when a finding is ignored; the
 | `generated-file` | `gotest_p(x)suite_test.go` files present in source control |
 | `shared-fixture-undeclared` | Suite-method reads of a `*SharedFixture` value the suite never declared as a pointer field (directly or through the fixture DAG) — window scheduling starts only declared fixtures, so the value may be absent; locally-constructed fixtures (fixture self-tests) are exempt |
 | `bench-loop` | `Benchmark*` suite methods that never touch `b.Loop()`/`b.N` — nothing iterates, so the numbers lie |
-
 | `fuzz-determinism` | Fuzz targets (one hop into same-package callees) reading nondeterministic state — `time.Now`, `math/rand{,/v2}`, `os.Getenv` — corpus replay and coverage guidance degrade |
 | `fuzz-struct-corpus` | On-disk corpus entries for a shape-bound fuzz target (struct, pointer, array, non-byte slice) — one value per leaf in field order, so a same-kind reorder silently reinterprets them and an added or removed field rejects them; `gotest fuzz promote` turns them into typed `f.Add` seeds |
 
@@ -1372,7 +1369,6 @@ Rules are grouped into three tiers by what breaks when a finding is ignored; the
 | `behavior-wording` | A `When` description that opens with "when", or an `It` description that opens with "it" — the spec renders the connective and the ✓ glyph plays "it", so the word is said twice; the fix drops it (whole word, any case except all capitals — `IT department…` is an acronym — space or underscore after it; a description that is only the word is left alone) |
 | `bench-fixture-io` | `Benchmark*` methods reading fixture-backed state inside the measured loop — times whatever backs the fixture, not the code under test (heuristic; hoist the read above the loop) |
 | `bench-wait` | `time.Sleep`/`gotest.Eventually`/`gotest.Consistently` inside the measured loop — times the wait, not the code |
-
 | `fuzz-no-oracle` | `f.Fuzz` callbacks that never use their `*gotest.T` — only panics are caught, which defeats property-based fuzzing |
 | `fuzz-seed` | Fuzz targets that never call `f.Add` — coverage-guided exploration starts blind (table-test harvesting may still seed them) |
 | `fuzz-hook-io` | IO-shaped calls (`net/*`, `os/exec`, `database/sql`, `time.Sleep`, filesystem `os` functions) in `BeforeEach`/`AfterEach` of fuzz-declaring suites — the hooks replay around every execution and throttle the fuzzer |

--- a/examples/benchmarking/README.md
+++ b/examples/benchmarking/README.md
@@ -1,8 +1,10 @@
 # benchmarking — LRU Cache Hot Path
 
-A fixed-capacity in-process LRU cache sitting in front of a slow store — the
-kind of thing almost every service ends up writing, and the one place "is
-this allocation-free?" is a question people actually ask about a hot path.
+This example shows benchmarks on a suite: `BeforeEach` outside the timer, a
+`BeforeAll`-only fixture, and the baseline, compare and gate loop. The subject
+is a fixed-capacity in-process LRU cache in front of a slow store, the kind of
+thing almost every service ends up writing, and the one place "is this
+allocation-free?" is a question people ask about a hot path.
 
 ## Structure
 
@@ -23,16 +25,16 @@ this allocation-free?" is a question people actually ask about a hot path.
 | `BenchmarkFillFromEmpty` | Building a cache from scratch: one op fills a fresh, exactly-sized cache end to end, so eviction is impossible by construction. |
 
 `BenchmarkFillFromEmpty`'s "op" is a full fill of `fillSize` (4096) entries,
-not a single `Put` — its ns/op and allocs/op measure that whole fill, so
-don't read it side by side with the single-`Put` numbers from the other
-three rows. An earlier version tried to get the same "never evicts"
-property from a single cache with headroom (`New(1<<20)`) instead of an
-exact-fit fresh cache per op; at default `-benchtime` it ran millions of
-iterations, filled that headroom about a fifth of the way through, and then
-quietly evicted for the remaining 77% of the run — measuring
-`BenchmarkPutEviction`'s path under `BenchmarkPutCold`'s name. Filling a
-cache whose capacity exactly equals what gets put into it makes eviction
-impossible by construction, independent of how many times `b.Loop()` runs.
+not a single `Put`. Its ns/op and allocs/op measure the whole fill, so do not
+read it beside the single-`Put` numbers of the other three rows.
+
+An earlier version tried to get the same "never evicts" property from a single
+cache with headroom (`New(1<<20)`) instead of a fresh exact-fit cache per op.
+At the default `-benchtime` it ran millions of iterations, filled the headroom
+about a fifth of the way through, and then quietly evicted for the remaining
+77% of the run, measuring `BenchmarkPutEviction`'s path under another name. A
+cache whose capacity equals what gets put into it cannot evict, however many
+times `b.Loop()` runs.
 
 ## The teaching point: `BeforeEach` is outside the timer
 
@@ -89,30 +91,30 @@ PASS
 ok  	github.com/mvrahden/go-test/examples/benchmarking	4.842s
 ```
 
-`BenchmarkGetHit` really is 0 B/op, 0 allocs/op — a map lookup plus a
-handful of pointer swaps to move the entry to the front of the list, never
-a heap allocation.
+`BenchmarkGetHit` really is 0 B/op, 0 allocs/op: a map lookup plus a handful
+of pointer swaps to move the entry to the front of the list, never a heap
+allocation.
 
-The two write benchmarks allocate for different reasons, not the same one.
-`BenchmarkPutEviction` puts a key that has never existed before on every
-call (an ever-incrementing counter through `strconv.Itoa`), so it allocates
-a new `*entry` on every call, and a new key string on nearly every call too
-(`strconv.Itoa` only avoids allocating for the first 100 integers, out of
-the millions this benchmark runs through) — that's 55 B/op here. Its
-reported allocs/op flips between 1 and 2 from run to run at that same 55
-B/op; that's not the code behaving differently, it's how the metric is
-computed. `testing.BenchmarkResult.AllocsPerOp()` is `int64(MemAllocs) /
-int64(N)` — integer division, so it can only ever report a whole number.
-The true per-call average sits close to 2 (essentially every call allocates
-twice) but drifts either side of that boundary run to run, from ordinary
-timing and allocation-count variance across a run's iterations — and
-integer truncation turns "close to 2" into a clean "1" or "2" depending on
-which side it lands on, never a fraction. `BenchmarkFillFromEmpty` reuses
-the corpus's pre-built key/value strings, so it never allocates a key; its
-4114 allocs/op is consistently just under one `*entry` per `fillSize`
-(4096) entries inserted, plus a handful of allocations from the destination
-cache's map growing to size as it fills. Both land far from
-`BenchmarkGetHit`'s zero — that's the contrast this example exists to show.
+The two write benchmarks allocate for different reasons:
+
+- `BenchmarkPutEviction` puts a key that never existed before on every call
+  (an ever-incrementing counter through `strconv.Itoa`), so it allocates a new
+  `*entry` every call and a new key string on nearly every call, since
+  `strconv.Itoa` only avoids allocating for the first 100 integers. That is
+  the 55 B/op.
+- Its allocs/op flips between 1 and 2 from run to run at that same 55 B/op.
+  The code does not behave differently; the metric does. `AllocsPerOp()` is
+  `int64(MemAllocs) / int64(N)`, integer division, so it reports a whole
+  number. The true average sits close to 2 and drifts either side of the
+  boundary with ordinary variance, and truncation turns "close to 2" into a
+  clean 1 or 2.
+- `BenchmarkFillFromEmpty` reuses the corpus's pre-built key/value strings, so
+  it never allocates a key. Its 4114 allocs/op is just under one `*entry` per
+  `fillSize` (4096) entries, plus a handful from the destination cache's map
+  growing as it fills.
+
+Both land far from `BenchmarkGetHit`'s zero, which is the contrast this
+example exists to show.
 
 ### Spec view
 
@@ -168,15 +170,12 @@ BENCHMARK  OLD ns/op  NEW ns/op  Δ
 
 The command above exits `0`.
 
-None of the four benchmarks appear in the delta table in this pair of
-runs — every old-vs-new difference here is small enough that it didn't
-clear the statistical significance test, so it's correctly reported as
-noise rather than a real change, and there's nothing for `--gate=10` to
-act on. Had a row cleared significance in the slow direction by more than
-10%, it would appear with a trailing `⚠` and the command would exit 1;
-`gotest bench`'s own `--against` docs (`gotest help bench`) describe the
-same delta table appearing with rows in it when that happens. Deltas alone
-never change the exit code — only `--gate` does.
+None of the four benchmarks appear in the delta table in this pair of runs:
+every difference is too small to clear the significance test, so it is
+reported as noise, and there is nothing for `--gate=10` to act on. A row that
+cleared significance in the slow direction by more than 10% would appear with
+a trailing `⚠` and the command would exit 1. Deltas alone never change the
+exit code; only `--gate` does.
 
 ## Why these numbers are trustworthy
 

--- a/examples/fuzzing/README.md
+++ b/examples/fuzzing/README.md
@@ -1,8 +1,8 @@
 # fuzzing — Wire Protocol Fuzzing, Crash to Regression Test
 
-A message broker's binary frame codec — the thing every service that speaks a custom protocol has,
-and the classic place adversarial input causes CVEs. Fuzzing a codec is not a toy; it is the single
-most common real use of fuzzing in Go.
+This example shows a fuzz-found bug becoming a committed regression test.
+The subject is a message broker's binary frame codec: the code every service with a custom
+protocol has, and the classic place where adversarial input causes CVEs.
 
 ## Structure
 
@@ -23,16 +23,16 @@ most common real use of fuzzing in Go.
 | `FuzzTopicMatches` | two pass-through string arguments, symmetry property |
 | `FuzzHeaderRoundTrip` | a struct beside a pass-through string, **round-trip** property |
 
-`BeforeEach` rebuilds `s.codec` before every execution, not just before every top-level test — fuzz
-targets replay `BeforeEach`/`AfterEach` around each individual execution, the same as any other test.
+`BeforeEach` rebuilds `s.codec` before every execution, not only before every top-level test:
+fuzz targets replay `BeforeEach`/`AfterEach` around each execution, the same as any other test.
 
 ## From crash to regression test
 
-`Frame` packed `Version` and `Kind` into a single byte to save space on the wire — a realistic
-trick that looked safe because `Kind` only ever needs 3 bits today. Neither field was actually
-bounded to fit its share of the byte, so a `Version >= 32` or a `Kind >= 8` silently corrupted the
-other field, breaking `FuzzFrameRoundTrip`'s round-trip property. `gotest fuzz` found it in 11
-executions, under a second:
+`Frame` packed `Version` and `Kind` into one byte to save space on the wire.
+`Kind` needs three bits today, so the trick looked safe.
+Neither field was bounded to its share of the byte, so a `Version >= 32` or a `Kind >= 8` silently
+corrupted the other field and broke `FuzzFrameRoundTrip`'s round-trip property.
+`gotest fuzz` found it in 11 executions, under a second:
 
 ```
 $ go run ./cmd/gotest fuzz ./examples/fuzzing --for=60s
@@ -76,28 +76,35 @@ $ go run ./cmd/gotest fuzz promote ./examples/fuzzing
 promoted FuzzFrameCodecTestSuite_FuzzFrameRoundTrip/582528ddfad69eb5 -> f.Add(Frame{Version: 48, Kind: Kind(0), Topic: "", Headers: nil, Payload: nil, Trace: nil}) in examples/fuzzing/suite_test.go:83
 ```
 
-`Version` and `Kind` were then given their own byte each, and `go run ./cmd/gotest ./examples/fuzzing -v`
-went green — the promoted seed now replays as `FuzzFrameRoundTrip/seed#1` on every run, a permanent
-regression test for the packed-byte bug. (The fuzzer reached the bug via `Version: 48` overflowing
-the 5 bits it shared with `Kind`, rather than via `Kind >= 8` — the same flaw, the byte just gives
-out from either direction.)
+`Version` and `Kind` were then given a byte each, and `go run ./cmd/gotest ./examples/fuzzing -v`
+went green. The promoted seed now replays as `FuzzFrameRoundTrip/seed#1` on every run: a permanent
+regression test for the packed-byte bug. (The fuzzer reached it through `Version: 48` overflowing
+the five bits it shared with `Kind`, not through `Kind >= 8`; the byte gives out from either
+direction.)
 
 ## What the fuzzer can and cannot take
 
 `Frame` exercises every struct shape gotest's fuzzing supports: a named basic (`Kind`, whose
 promoted literals render as `Kind(3)`), a nested struct slice (`[]Header`), a pointer-to-struct
-(`*TraceID`), `[]byte`, and `string`. Go's own fuzzing engine only accepts fifteen primitive types,
-and `Frame` isn't one of them — so `gotest generate` fans it out into one engine argument per leaf
-field and reassembles the `Frame` before each execution. `Frame` comes to eight leaves: `Version`
-and `Kind` each as their own little-endian `[]byte`, `Topic` as a `string` and `Payload` as a
-`[]byte` (both passed through untouched), `Headers` packed into one `[]byte`, and `Trace` as a
-`bool` nil-flag followed by `Hi` and `Lo`. Each leaf is something the mutator moves on its own,
-which is what puts a boundary value like `Version: 48` one mutation away.
+(`*TraceID`), `[]byte` and `string`. Go's engine accepts only fifteen primitive types, and `Frame`
+is not one of them, so `gotest generate` fans it into one engine argument per leaf field and
+reassembles the `Frame` before each execution. `Frame` comes to eight leaves:
 
-Every position of the callback fans on its own — `FuzzHeaderRoundTrip` mixes a `Header` with a
-plain `string`. Two arguments because the property is
-about two independent values, though: when they belong together, a named struct still says so
-better than a wider tuple, the way `FuzzFrameRoundTrip` uses `Frame`.
+| Field | Leaves |
+|---|---|
+| `Version`, `Kind` | one little-endian `[]byte` each |
+| `Topic` | one `string`, passed through |
+| `Payload` | one `[]byte`, passed through |
+| `Headers` | one packed `[]byte` |
+| `Trace` | a `bool` nil-flag, then `Hi` and `Lo` |
+
+Each leaf is something the mutator moves on its own, which is what puts a boundary value like
+`Version: 48` one mutation away. The mapping rules are in ARCHITECTURE.md, "Code Generation".
+
+Every position of the callback fans on its own: `FuzzHeaderRoundTrip` mixes a `Header` with a plain
+`string`. It takes two arguments because the property is about two independent values; when values
+belong together, a named struct says so better than a wider tuple, the way `FuzzFrameRoundTrip`
+uses `Frame`.
 
 Some shapes are rejected at generation time rather than silently mis-encoded:
 
@@ -111,15 +118,15 @@ Some shapes are rejected at generation time rather than silently mis-encoded:
 
 A rejection is a generation-time error naming the offending field, not a runtime surprise.
 
-A careful reader may wonder whether a nil `Headers`/`Payload` and a genuinely empty one are
-distinguishable after a round trip: they aren't, by convention parity — `Decode` collapses a
-zero-length read to `nil`, and so does the fan on its way in (the engine does not preserve the
-distinction either: a nil `[]byte` seed comes back as `[]byte{}` after a trip through the corpus
-format). Both sides agree on which one to produce, under replay and under `-fuzz` alike.
+Two details a careful reader may check:
 
-`go run ./cmd/gotest lint ./examples/fuzzing/...` reports nothing and exits 0 — but only because
-`FuzzNormalizeTopicIdempotent` carries a `//nolint:fuzz-seed` directive. Without it the `fuzz-seed`
-rule would flag that target for having no explicit `f.Add` seed of its own, which is intentional
-here, not an oversight: its seeds are harvested from `TestNormalizeTopicTable`'s literals (see the
-Targets table above). Suppressing a rule you can justify — and leaving the reason in the source —
-is the intended workflow.
+- A nil `Headers`/`Payload` and an empty one are not distinguishable after a round trip, by
+  convention parity: `Decode` collapses a zero-length read to `nil`, and so does the fan on its way
+  in. The engine does not preserve the distinction either; a nil `[]byte` seed comes back as
+  `[]byte{}` after a trip through the corpus format. Both sides agree, under replay and under
+  `-fuzz` alike.
+- `go run ./cmd/gotest lint ./examples/fuzzing/...` reports nothing only because
+  `FuzzNormalizeTopicIdempotent` carries a `//nolint:fuzz-seed` directive. Its seeds are harvested
+  from `TestNormalizeTopicTable`'s literals (see the Targets table), so the missing `f.Add` is
+  intentional. Suppressing a rule you can justify, with the reason in the source, is the intended
+  workflow.

--- a/site/content/blog/gotest-in-ci.md
+++ b/site/content/blog/gotest-in-ci.md
@@ -220,8 +220,7 @@ For GitLab CI, CircleCI, or any other system, run `gotest summary` directly. CI 
 test:
   image: golang:1.25
   script:
-    - go install github.com/mvrahden/go-test/cmd/gotest@latest
-    - gotest summary ./... -race -coverprofile=coverage.out
+    - go tool gotest summary ./... -race -coverprofile=coverage.out
     - go tool cover -html=coverage.out -o coverage.html
   artifacts:
     paths:

--- a/site/content/blog/zero-to-suite.md
+++ b/site/content/blog/zero-to-suite.md
@@ -1,17 +1,17 @@
 ---
 title: "Your First Go Test Suite in 10 Minutes: A gotest Tutorial"
 date: 2026-07-12
-description: "Go test suite tutorial: from go install to a running gotest suite with lifecycle hooks, BDD structure, and readable spec output — in 10 minutes."
+description: "Go test suite tutorial: from an empty module to a running gotest suite with lifecycle hooks, BDD structure, and readable spec output — in 10 minutes."
 tags: ["Tutorial"]
 keywords: ["go test suite tutorial", "gotest getting started", "go testing framework", "go bdd tutorial"]
 cta_text: "Scaffold your first suite today."
 howto:
   name: "Write your first gotest suite"
   steps:
-    - name: "Install gotest"
-      text: "Install the gotest binary with go install and verify it with gotest version."
     - name: "Set up a project"
       text: "Create a small Go module with a counter package to test."
+    - name: "Install gotest"
+      text: "Add gotest to the module as a Go tool with go get -tool and verify it with go tool gotest version."
     - name: "Write the suite"
       text: "Declare a struct whose name ends in TestSuite, add a BeforeEach hook, and write Test methods that use gotest's generic assertions."
     - name: "Run the suite"
@@ -26,23 +26,9 @@ howto:
       text: "Run gotest watch ./... to re-run affected packages automatically on every save."
 ---
 
-Plain `go test` carries you a long way — until you need setup that runs before every test, related cases grouped under a shared context, and output you can actually read. At that point most of us start hand-rolling lifecycle helpers and squinting at walls of `--- PASS` lines. In the next 10 minutes you'll go from `go install` to a structured test suite with lifecycle hooks, BDD-style grouping, and spec output — all running on standard `go test`.
+Plain `go test` carries you a long way — until you need setup that runs before every test, related cases grouped under a shared context, and output you can actually read. At that point most of us start hand-rolling lifecycle helpers and squinting at walls of `--- PASS` lines. In the next 10 minutes you'll go from an empty module to a structured test suite with lifecycle hooks, BDD-style grouping, and spec output — all running on standard `go test`.
 
 No prior gotest knowledge required. You need Go 1.25+ and a terminal.
-
-## Install gotest
-
-gotest is a single binary. Install it with `go install`:
-
-```sh
-go install github.com/mvrahden/go-test/cmd/gotest@latest
-```
-
-Verify the installation:
-
-```sh
-gotest version
-```
 
 ## Set up a project
 
@@ -71,15 +57,27 @@ func (c *Counter) Reset()       { c.value = 0 }
 
 Nothing special so far. Now let's test it.
 
+## Install gotest
+
+gotest is a Go tool. Add it to the module with the tool directive, which pins the CLI and the `gotest` library to the same release:
+
+```sh
+go get -tool github.com/mvrahden/go-test/cmd/gotest@latest
+```
+
+Verify the installation:
+
+```sh
+go tool gotest version
+```
+
+The rest of this post writes `gotest` for brevity; run every command as `go tool gotest`.
+
 ## Write a test suite
 
 A gotest suite is a Go struct whose name ends in `TestSuite`. Test methods are pointer-receiver methods whose names start with `Test`. That is the entire API — naming conventions.
 
-Add the gotest library to your module and create a test file:
-
-```sh
-go get github.com/mvrahden/go-test/pkg/gotest
-```
+Create a test file:
 
 ```go {title="counter_test.go"}
 package counter

--- a/site/content/reference.html
+++ b/site/content/reference.html
@@ -569,6 +569,8 @@ percentage = covered / total</div>
           <tr><td><code>gotest spec ./...</code></td><td>Run tests and render the behavioral specification. With <code>--static</code>, render it from source without running.</td></tr>
           <tr><td><code>gotest discover ./...</code></td><td>Discover test suites and output JSON (feeds editor integrations).</td></tr>
           <tr><td><code>gotest summary ./...</code></td><td>Failure-focused summary for CI. Shows only failing tests with assertion output.</td></tr>
+          <tr><td><code>gotest bench ./...</code></td><td>Run <code>Benchmark*</code> suite methods serially; <code>--save</code>, <code>--against</code> and <code>--gate</code> keep and compare baselines.</td></tr>
+          <tr><td><code>gotest fuzz ./...</code></td><td>Search for new failing inputs with <code>Fuzz*</code> suite methods for a time budget (<code>--for</code>); <code>fuzz triage</code> and <code>fuzz promote</code> handle what it finds.</td></tr>
           <tr><td><code>gotest lint ./...</code></td><td>Static analysis for test suites — see <a href="#linter">Linter</a>.</td></tr>
           <tr><td><code>gotest scaffold ./pkg/user.Svc</code></td><td>Generate a suite skeleton from any Go type.</td></tr>
           <tr><td><code>gotest migrate ./...</code></td><td>Convert testify/suite tests automatically.</td></tr>
@@ -598,6 +600,14 @@ percentage = covered / total</div>
           <tr><td><code>--timeout=&lt;dur&gt;</code></td><td>Global pipeline deadline (default: 15m, <code>0</code> to disable).</td></tr>
           <tr><td><code>--parallel=&lt;n&gt;</code></td><td>Total concurrent test method budget (default: 2×GOMAXPROCS, auto-halved for <code>-race</code>/<code>-msan</code>/<code>-asan</code>).</td></tr>
           <tr><td><code>--compile-parallel=&lt;n&gt;</code></td><td>Concurrent compilation processes (default: NumCPU, auto-halved for <code>-race</code>/<code>-msan</code>/<code>-asan</code>).</td></tr>
+          <tr><td><code>--save=&lt;path&gt;</code></td><td>Save a benchmark run as a JSON baseline (<code>bench</code>).</td></tr>
+          <tr><td><code>--against=&lt;path&gt;</code></td><td>Compare a benchmark run against a saved baseline and print the delta table (<code>bench</code>).</td></tr>
+          <tr><td><code>--gate=&lt;pct&gt;</code></td><td>Fail if the worst significant benchmark regression exceeds the threshold (<code>bench</code>).</td></tr>
+          <tr><td><code>--json</code></td><td>Emit one versioned JSON report instead of human output (<code>bench</code>).</td></tr>
+          <tr><td><code>--for=&lt;dur&gt;</code></td><td>Approximate wall-clock budget for the whole fuzz session, split across targets (<code>fuzz</code>; default 1m, <code>0</code> removes the budget).</td></tr>
+          <tr><td><code>--jobs=&lt;n&gt;</code></td><td>Maximum concurrent fuzz targets (<code>fuzz</code>; default max(1, GOMAXPROCS/2)).</td></tr>
+          <tr><td><code>--target=&lt;name&gt;</code></td><td>Fuzz exactly one generated target by its wrapper name (<code>fuzz</code>).</td></tr>
+          <tr><td><code>--no-harvest</code></td><td>Do not mine table-test literals into fuzz seeds for this run.</td></tr>
           <tr><td><code>--static</code></td><td>Read the specification from source without running the suites; nodes carry no verdict (<code>spec</code> command).</td></tr>
           <tr><td><code>--render-only</code></td><td>With <code>--input</code>, exit 0 on a failing stream: report whether rendering succeeded, not the test verdict.</td></tr>
           <tr><td><code>--debounce=&lt;dur&gt;</code></td><td>Watch mode debounce interval (default 200ms).</td></tr>
@@ -634,6 +644,9 @@ percentage = covered / total</div>
           <tr><td><code>assertion-type-guard</code></td><td><code>Nil</code>/<code>Empty</code> on types their runtime guards would reject.</td></tr>
           <tr><td><code>shared-fixture-undeclared</code></td><td>Suite reads a shared fixture it never declared — window scheduling only starts declared fixtures, so the read may hit one that never started or is already released.</td></tr>
           <tr><td><code>generated-file</code></td><td>Generated overlay files present in source control.</td></tr>
+          <tr><td><code>bench-loop</code></td><td><code>Benchmark*</code> methods that never touch <code>b.Loop()</code>/<code>b.N</code> — nothing iterates, so the numbers lie.</td></tr>
+          <tr><td><code>fuzz-determinism</code></td><td>Fuzz targets reading <code>time.Now</code>, <code>math/rand</code> or <code>os.Getenv</code> — corpus replay and coverage guidance degrade.</td></tr>
+          <tr><td><code>fuzz-struct-corpus</code></td><td>On-disk corpus entries for a struct-typed fuzz target — bound to the field order; <code>gotest fuzz promote</code> turns them into typed seeds.</td></tr>
         </tbody>
       </table>
 
@@ -647,6 +660,12 @@ percentage = covered / total</div>
           <tr><td><code>fail-guard</code></td><td><code>if cond { Fail/Fatal(...) }</code> guards — the assertion expresses the check directly.</td></tr>
           <tr><td><code>t-escape</code></td><td>Unnecessary <code>t.T()</code> convenience escapes (<code>Errorf</code>, <code>Helper</code>, <code>Log</code>, <code>Fatal</code>, …).</td></tr>
           <tr><td><code>behavior-wording</code></td><td><code>When("when …")</code> or <code>It("it …")</code> — the spec renders the connective and the ✓ glyph plays "it"; the fix drops the word.</td></tr>
+          <tr><td><code>bench-fixture-io</code></td><td>Fixture-backed reads inside the measured loop — times the fixture, not the code.</td></tr>
+          <tr><td><code>bench-wait</code></td><td><code>time.Sleep</code>/<code>Eventually</code>/<code>Consistently</code> inside the measured loop — times the wait.</td></tr>
+          <tr><td><code>fuzz-no-oracle</code></td><td>Fuzz callbacks that assert nothing — only panics are caught.</td></tr>
+          <tr><td><code>fuzz-seed</code></td><td>Fuzz targets with no <code>f.Add</code> seed — exploration starts blind.</td></tr>
+          <tr><td><code>fuzz-hook-io</code></td><td>IO in <code>BeforeEach</code>/<code>AfterEach</code> of a fuzzing suite — the hooks replay around every execution.</td></tr>
+          <tr><td><code>fuzz-raw-seed</code></td><td>Raw <code>[]byte</code> seeds on a position that does not take <code>[]byte</code> — write a typed literal.</td></tr>
         </tbody>
       </table>
 

--- a/skills/writing-gotest-tests/SKILL.md
+++ b/skills/writing-gotest-tests/SKILL.md
@@ -84,6 +84,10 @@ Sections tagged **v1.29+** need v1.29.0 or newer. What v1.29 adds:
    lint rules; see `reference/fuzzing.md`. Below v1.29 write no fuzz
    targets at all: a stdlib `func FuzzX(*testing.F)` is invisible to gotest
    on every version, and the suite form does not compile there.
+5. **Benchmark methods on suites** — `Benchmark*` methods taking
+   `*gotest.B`, `gotest bench` with baselines and gates, the action's
+   `bench` inputs, and the three `bench-*` lint rules; see
+   `reference/cli.md`. Below v1.29 `*gotest.B` does not exist.
 
 Exit codes on v1.25.x are weaker than they look — never treat a green
 gotest exit alone as proof there: a package failing to compile mid-run, a

--- a/skills/writing-gotest-tests/evals/RUBRIC.md
+++ b/skills/writing-gotest-tests/evals/RUBRIC.md
@@ -12,9 +12,10 @@ grade it.
 A skill makes three separable claims; each needs its own experiment:
 
 - **T (trigger):** the skill loads when it should and never when it
-  shouldn't. Requires REAL installation (`~/.claude/skills/` or the
-  consumer's `.claude/skills/`) — "read this file first" instructions test
-  content, not discovery, and cannot measure T.
+  shouldn't. Requires REAL installation in the harness's skills directory
+  (user-level or in the consumer repository, wherever the client under
+  test looks) — "read this file first" instructions test content, not
+  discovery, and cannot measure T.
 - **C (content):** with the skill loaded, behavior improves on the target
   gaps versus a paired baseline run.
 - **H (harm / over-application):** the skill does not cause damage where

--- a/skills/writing-gotest-tests/reference/ci.md
+++ b/skills/writing-gotest-tests/reference/ci.md
@@ -45,7 +45,7 @@ jobs:
   `permissions: contents: write`. Embed it as
   `https://raw.githubusercontent.com/<owner>/<repo>/ci/badges/coverage.svg`.
   The badge needs no shields.io, gist or token setup — do not add any.
-- **v1.27+ bench inputs:** `bench: true` runs `gotest bench --spec --json`
+- **v1.29+ bench inputs:** `bench: true` runs `gotest bench --spec --json`
   after the tests (the `flags` input is forwarded to it — the place for
   `-benchtime=1x` smoke runs); `bench-baseline` compares (`--against`),
   `bench-gate` fails on regressions above the percentage, and `bench-save`

--- a/skills/writing-gotest-tests/reference/ci.md
+++ b/skills/writing-gotest-tests/reference/ci.md
@@ -46,23 +46,24 @@ jobs:
   `https://raw.githubusercontent.com/<owner>/<repo>/ci/badges/coverage.svg`.
   The badge needs no shields.io, gist or token setup — do not add any.
 - **v1.29+ bench inputs:** `bench: true` runs `gotest bench --spec --json`
-  after the tests (the `flags` input is forwarded to it — the place for
-  `-benchtime=1x` smoke runs); `bench-baseline` compares (`--against`),
+  after the tests. The `flags` input is forwarded to it, which is where a
+  `-benchtime=1x` smoke run goes. `bench-baseline` compares (`--against`),
   `bench-gate` fails on regressions above the percentage, and `bench-save`
-  writes a baseline (a path; an explicit empty string saves to
-  `bench.baseline` from `.gotest.yml`; the `false` default saves nothing).
+  writes a baseline: a path, or an explicit empty string for
+  `bench.baseline` from `.gotest.yml`; the `false` default saves nothing.
   Outputs: `bench-report` (path to the `--json` report file) and
-  `bench-breached-keys` (comma-joined gate offenders). README.md's inputs/
-  outputs tables are canonical and drift-guarded.
+  `bench-breached-keys` (comma-joined gate offenders). README.md's input
+  and output tables are canonical and drift-guarded.
 - **v1.29+ fuzz inputs:** `fuzz: true` runs `gotest fuzz` over the same
-  packages after the tests, for `fuzz-for` (default: the CLI's own minute); the session's
-  table lands in the step summary, a new crasher fails the step and its
-  corpus file stays in the checkout, listed in the `fuzz-crashers` output
-  for an upload-artifact step or `gotest fuzz promote`. Seed replay needs
-  no input: every ordinary run already replays seeds. The step carries
-  Go's fuzz cache between runs by default (`fuzz-cache: false` opts out),
-  so sessions compound; setup-go's build cache alone would not, since it
-  is never re-saved on a key hit.
+  packages after the tests, for `fuzz-for` (default: the CLI's own
+  minute). The session's table lands in the step summary. A new crasher
+  fails the step; its corpus file stays in the checkout and is listed in
+  the `fuzz-crashers` output, for an upload-artifact step or
+  `gotest fuzz promote`. Seed replay needs no input, since every ordinary
+  run already replays seeds. The step carries Go's fuzz cache between
+  runs by default, so sessions compound; `fuzz-cache: false` opts out.
+  setup-go's build cache alone would not carry it: that cache is never
+  re-saved on a key hit.
 - CI environments auto-arm `--ci` (any non-falsy `CI`/`GOTEST_CI` value):
   committed `F_` focus prefixes FAIL the run, and snapshots become
   read-only (`--update-snapshots` will not write). Opt out with

--- a/skills/writing-gotest-tests/reference/cli.md
+++ b/skills/writing-gotest-tests/reference/cli.md
@@ -53,7 +53,7 @@ deadline (default 15m) and `--setup-timeout <dur>` the shared-fixture
 setup budget (default 2m) — `0` disables either; `--min <pct>` gates
 coverage, `--no-cache` forces fresh generation, `--debug` keeps overlays.
 
-## Benchmarks — `gotest bench` (v1.27+)
+## Benchmarks — `gotest bench` (v1.29+)
 
 `go tool gotest bench ./...` runs `Benchmark*` suite methods (signature
 `func (s *X) BenchmarkParse(b *gotest.B)`, or stdlib `*testing.B`) through


### PR DESCRIPTION
This is a documentation pass over the reference material after the bench and fuzz merges. It corrects what those merges left inconsistent and rewrites the passages that had become hard to read. The CLI's behaviour does not change.