### PR TITLE
Install the agent skill from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1136,6 +1136,24 @@ All `go test` flags work unchanged: `-race`, `-cover`, `-count`, `-run`, `-json`
 | `SuiteConfig()` method | Suite timeout/parallelism/exclusive/failfast config |
 | `Hydrate` / `Dehydrate` | SharedFixture test-process resource reconstruction |
 
+## Coding Agents
+
+The repository ships a skill that teaches a coding agent to write suites the way gotest expects: lifecycle hooks instead of `defer`, polling instead of `time.Sleep`, the parallel recipe, condition-only `When` labels, and the version differences between releases.
+It is written in the open [Agent Skills](https://agentskills.io) format, which Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot and [many other agents](https://agentskills.io/clients) load on demand.
+Install it by unpacking the folder into the directory your agent reads skills from; each client documents that directory, and the client list above links to the instructions:
+
+```bash
+SKILLS_DIR=<your agent's skills directory>
+mkdir -p "$SKILLS_DIR" && curl -sL https://github.com/mvrahden/go-test/archive/refs/heads/main.tar.gz \
+  | tar -xz -C "$SKILLS_DIR" --strip-components=2 go-test-main/skills/writing-gotest-tests
+```
+
+> **Tip:** most agents can do this themselves. Ask yours to install the `writing-gotest-tests` skill from `github.com/mvrahden/go-test`, and it will fetch the folder and place it where it reads skills.
+
+An agent without skill support can still be pointed at the unpacked `SKILL.md` from its instructions file, such as `AGENTS.md`. The skill source lives in [`skills/writing-gotest-tests`](skills/writing-gotest-tests).
+
+Two commands give an agent the specification without the source. `gotest spec --static ./...` prints what a package promises before anything runs, and `gotest discover ./...` emits the same tree as JSON with a `behaviorsComplete` flag per method, so an agent never presents a partial list as the whole specification.
+
 ## VS Code Extension
 
 The **gotest** extension brings first-class IDE support: suite-aware Test Explorer, CodeLens run/debug buttons, coverage gutters, watch mode, spec view, focus/exclude quick fixes, and suite scaffolding.

--- a/site/layouts/blog/single.html
+++ b/site/layouts/blog/single.html
@@ -23,7 +23,7 @@
 
       <div class="cta">
         <p><strong>{{ .Params.cta_text | default "Try gotest on your next project." }}</strong></p>
-        {{ $cmd := .Params.cta_command | default "go install github.com/mvrahden/go-test/cmd/gotest@latest" }}
+        {{ $cmd := .Params.cta_command | default "go get -tool github.com/mvrahden/go-test/cmd/gotest@latest" }}
         <div class="install-cmd">
           <code>{{ $cmd }}</code>
           <button onclick="navigator.clipboard.writeText('{{ $cmd }}').then(()=>{this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',1500)})" aria-label="Copy command">Copy</button>


### PR DESCRIPTION
The README gains a Coding Agents section. It says what the writing-gotest-tests skill teaches, that it is in the open Agent Skills format loaded by Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot and the other clients the standard lists, and how to install it: one command that unpacks the folder into whichever directory your agent reads skills from. A note points out that most agents will do that themselves when asked. Agents without skill support can be pointed at the file from AGENTS.md.

The section also names the two CLI surfaces built for agents, `gotest spec --static` and `gotest discover`.

The blog's default call to action moves from `go install` to `go get -tool`, matching the README's install guidance.