### PR TITLE
The extension requires gotest v1.29.0

### DIFF
--- a/internal/gotestgen/runtimeversion.go
+++ b/internal/gotestgen/runtimeversion.go
@@ -9,8 +9,9 @@ import (
 )
 
 // MinRuntimeVersion is the oldest gotest runtime generated code compiles
-// against. It equals the extension's MIN_CLI_VERSION (a test guards the pair);
-// bump both when the renderer uses a newer runtime symbol.
+// against; bump it when the renderer uses a newer runtime symbol. The
+// extension's MIN_CLI_VERSION is a separate, CLI-side floor that must never
+// fall below it (a test guards the order).
 const MinRuntimeVersion = "v1.27.0"
 
 // CheckRuntimeVersion refuses to generate against a runtime older than

--- a/internal/gotestgen/runtimeversion_suite_test.go
+++ b/internal/gotestgen/runtimeversion_suite_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mvrahden/go-test/internal/about"
 	"github.com/mvrahden/go-test/internal/gotestgen"
 	"github.com/mvrahden/go-test/pkg/gotest"
+	"golang.org/x/mod/semver"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -78,12 +79,13 @@ func (s *RuntimeVersionTestSuite) TestCheckRuntimeVersion(t *gotest.T) {
 	})
 }
 
-func (s *RuntimeVersionTestSuite) TestFloorMatchesExtension(t *gotest.T) {
-	t.It("equals MIN_CLI_VERSION in vscode-gotest/src/cli.ts", func(it *gotest.T) {
+func (s *RuntimeVersionTestSuite) TestFloorOrdersWithExtension(t *gotest.T) {
+	t.It("is not above the extension's MIN_CLI_VERSION", func(it *gotest.T) {
 		src, err := os.ReadFile(filepath.Join("..", "..", "vscode-gotest", "src", "cli.ts"))
 		gotest.NoError(it, err)
 		m := regexp.MustCompile(`MIN_CLI_VERSION = "(v[^"]+)"`).FindSubmatch(src)
 		gotest.NotNil(it, m)
-		gotest.Equal(it, string(m[1]), gotestgen.MinRuntimeVersion)
+		gotest.True(it, semver.IsValid(string(m[1])), "MIN_CLI_VERSION %q", m[1])
+		gotest.GreaterOrEqual(it, semver.Compare(string(m[1]), gotestgen.MinRuntimeVersion), 0, "extension floor %s is below the runtime floor %s", m[1], gotestgen.MinRuntimeVersion)
 	})
 }

--- a/vscode-gotest/README.md
+++ b/vscode-gotest/README.md
@@ -36,7 +36,7 @@ The **Spec View** renders your test structure as a behavioral specification — 
 
 The extension invokes the gotest CLI automatically — no separate install needed.
 It runs the CLI your `go.mod` selects: `go tool` when the tool directive is declared, otherwise `go run` at the pinned version.
-The CLI must be **v1.27.0 or newer**; older versions are rejected at activation.
+The CLI must be **v1.29.0 or newer**; older versions are rejected at activation.
 
 ### Install
 
@@ -273,8 +273,8 @@ The extension runs whatever `go.mod` selects, in this order:
 2. **Workspace is gotest module** — If the workspace's `go.mod` declares the gotest module itself (development or `go.work` overlap), uses `go run ./cmd/gotest`.
 3. **Tool directive** — If `go.mod` declares the CLI as a tool (`go get -tool github.com/mvrahden/go-test/cmd/gotest@<version>`), uses `go tool <modulePath>`.
 4. **`go.mod` + replace directive** — If `go.mod` has a `replace` directive for the gotest module, uses `go run modulePath` (no version, respects replace resolution).
-5. **`go.mod` pinned version** — If `go.mod` requires gotest at v1.27.0 or newer, uses `go run modulePath@version`, and offers once to declare the tool at that version (`gotest.suggestToolDirective`; never in a vendored module).
-6. **Pinned below v1.27.0** — Refused with an **Upgrade** action; a newer CLI would generate code the pinned runtime cannot compile.
+5. **`go.mod` pinned version** — If `go.mod` requires gotest at v1.29.0 or newer, uses `go run modulePath@version`, and offers once to declare the tool at that version (`gotest.suggestToolDirective`; never in a vendored module).
+6. **Pinned below v1.29.0** — Refused with an **Upgrade** action; the pinned CLI lacks the bench and fuzz sessions the extension drives, and a newer CLI would generate code the pinned runtime cannot compile.
 7. **`go run @latest`** — Only when no module requires gotest yet, so `scaffold` can run before a pin exists.
 
 In a `go.work` root every `use` module is read: a tool declared by any of them counts, and the pin is the highest across modules, which is what the workspace builds.

--- a/vscode-gotest/src/buildCliCommand.test.ts
+++ b/vscode-gotest/src/buildCliCommand.test.ts
@@ -129,7 +129,7 @@ describe("buildCliCommand", () => {
       mockConfigValues.set("cliPath", "/usr/local/bin/gotest");
       mockFileExists.mockResolvedValue(true);
       mockExecFileAsync.mockResolvedValue({
-        stdout: "gotest v1.27.0\n",
+        stdout: "gotest v1.29.0\n",
         stderr: "",
       });
 
@@ -192,7 +192,7 @@ describe("buildCliCommand", () => {
       mockConfigValues.set("cliPath", "./bin/gotest");
       mockFileExists.mockResolvedValue(true);
       mockExecFileAsync.mockResolvedValue({
-        stdout: "gotest v1.27.0\n",
+        stdout: "gotest v1.29.0\n",
         stderr: "",
       });
 
@@ -240,7 +240,7 @@ describe("buildCliCommand", () => {
           "module github.com/myapp",
           "go 1.24.0",
           "require (",
-          "\tgithub.com/mvrahden/go-test v1.27.0",
+          "\tgithub.com/mvrahden/go-test v1.29.0",
           ")",
         ].join("\n"),
       );
@@ -259,7 +259,7 @@ describe("buildCliCommand", () => {
           "module github.com/myapp",
           "go 1.24.0",
           "require (",
-          "\tgithub.com/mvrahden/go-test v1.27.0",
+          "\tgithub.com/mvrahden/go-test v1.29.0",
           ")",
           `replace github.com/mvrahden/go-test => ../go-test`,
         ].join("\n"),
@@ -319,7 +319,7 @@ describe("buildCliCommand", () => {
           "module github.com/myapp",
           "go 1.24.0",
           "require (",
-          "\tgithub.com/mvrahden/go-test v1.27.0",
+          "\tgithub.com/mvrahden/go-test v1.29.0",
           ")",
           `replace github.com/mvrahden/go-test => ../go-test`,
         ].join("\n"),
@@ -337,7 +337,7 @@ describe("buildCliCommand", () => {
           "module github.com/myapp",
           "go 1.24.0",
           "require (",
-          "\tgithub.com/mvrahden/go-test v1.27.0",
+          "\tgithub.com/mvrahden/go-test v1.29.0",
           ")",
           "replace (",
           "\tgithub.com/mvrahden/go-test => ../go-test",
@@ -357,7 +357,7 @@ describe("buildCliCommand", () => {
           "module github.com/myapp",
           "go 1.24.0",
           "require (",
-          "\tgithub.com/mvrahden/go-test v1.27.0",
+          "\tgithub.com/mvrahden/go-test v1.29.0",
           ")",
           "replace github.com/mvrahden/go-testing => ../go-testing",
         ].join("\n"),
@@ -365,7 +365,7 @@ describe("buildCliCommand", () => {
 
       const cmd = await buildCliCommand(["spec"], "/workspace");
 
-      expect(cmd.args[1]).toBe(`${GOTEST_MODULE}@v1.27.0`);
+      expect(cmd.args[1]).toBe(`${GOTEST_MODULE}@v1.29.0`);
     });
   });
 
@@ -377,7 +377,7 @@ describe("buildCliCommand", () => {
           "module github.com/myapp",
           "go 1.24.0",
           "require (",
-          "\tgithub.com/mvrahden/go-test v1.27.0",
+          "\tgithub.com/mvrahden/go-test v1.29.0",
           ")",
         ].join("\n"),
       );
@@ -386,7 +386,7 @@ describe("buildCliCommand", () => {
 
       expect(cmd).toEqual({
         bin: "/usr/local/go/bin/go",
-        args: ["run", `${GOTEST_MODULE}@v1.27.0`, "spec", "./..."],
+        args: ["run", `${GOTEST_MODULE}@v1.29.0`, "spec", "./..."],
       });
     });
 
@@ -396,13 +396,13 @@ describe("buildCliCommand", () => {
         [
           "module github.com/myapp",
           "go 1.24.0",
-          "require github.com/mvrahden/go-test v1.27.0",
+          "require github.com/mvrahden/go-test v1.29.0",
         ].join("\n"),
       );
 
       const cmd = await buildCliCommand(["spec"], "/workspace");
 
-      expect(cmd.args[1]).toBe(`${GOTEST_MODULE}@v1.27.0`);
+      expect(cmd.args[1]).toBe(`${GOTEST_MODULE}@v1.29.0`);
     });
 
     it("finds version via parent module path walk", async () => {
@@ -412,14 +412,14 @@ describe("buildCliCommand", () => {
           "module github.com/myapp",
           "go 1.24.0",
           "require (",
-          "\tgithub.com/mvrahden/go-test v1.28.0",
+          "\tgithub.com/mvrahden/go-test v1.30.0",
           ")",
         ].join("\n"),
       );
 
       const cmd = await buildCliCommand(["spec"], "/workspace");
 
-      expect(cmd.args[1]).toBe(`${GOTEST_MODULE}@v1.28.0`);
+      expect(cmd.args[1]).toBe(`${GOTEST_MODULE}@v1.30.0`);
     });
 
     it("does not include -- separator", async () => {
@@ -429,7 +429,7 @@ describe("buildCliCommand", () => {
           "module github.com/myapp",
           "go 1.24.0",
           "require (",
-          "\tgithub.com/mvrahden/go-test v1.27.0",
+          "\tgithub.com/mvrahden/go-test v1.29.0",
           ")",
         ].join("\n"),
       );
@@ -468,11 +468,11 @@ describe("buildCliCommand", () => {
     });
 
     it("respects modulePath containing @ as-is", async () => {
-      mockConfigValues.set("modulePath", `${GOTEST_MODULE}@v1.28.0`);
+      mockConfigValues.set("modulePath", `${GOTEST_MODULE}@v1.30.0`);
 
       const cmd = await buildCliCommand(["spec"], "/workspace");
 
-      expect(cmd.args[1]).toBe(`${GOTEST_MODULE}@v1.28.0`);
+      expect(cmd.args[1]).toBe(`${GOTEST_MODULE}@v1.30.0`);
     });
   });
 
@@ -484,7 +484,7 @@ describe("buildCliCommand", () => {
         CliUnavailableError,
       );
       await expect(buildCliCommand(["spec"], "/workspace")).rejects.toThrow(
-        /v1\.0\.0.*v1\.27\.0/,
+        /v1\.0\.0.*v1\.29\.0/,
       );
       expect(mockExecFileAsync).not.toHaveBeenCalled();
     });
@@ -546,7 +546,7 @@ describe("buildCliCommand", () => {
       mockConfigValues.set("cliPath", "/usr/local/bin/gotest");
       mockFileExists.mockResolvedValue(true);
       mockExecFileAsync.mockResolvedValue({
-        stdout: "gotest v1.27.0\n",
+        stdout: "gotest v1.29.0\n",
         stderr: "",
       });
       setGoMod(
@@ -566,7 +566,7 @@ describe("buildCliCommand", () => {
           "module github.com/mvrahden/go-test",
           "go 1.24.0",
           "require (",
-          "\tgithub.com/mvrahden/go-test v1.27.0",
+          "\tgithub.com/mvrahden/go-test v1.29.0",
           ")",
         ].join("\n"),
       );
@@ -583,7 +583,7 @@ describe("buildCliCommand", () => {
           "module github.com/myapp",
           "go 1.24.0",
           "require (",
-          "\tgithub.com/mvrahden/go-test v1.27.0",
+          "\tgithub.com/mvrahden/go-test v1.29.0",
           ")",
           `replace github.com/mvrahden/go-test => ../go-test`,
         ].join("\n"),
@@ -592,13 +592,13 @@ describe("buildCliCommand", () => {
       const cmd = await buildCliCommand(["spec"], "/workspace");
 
       expect(cmd.args[1]).toBe(GOTEST_MODULE);
-      expect(cmd.args).not.toContain(`${GOTEST_MODULE}@v1.27.0`);
+      expect(cmd.args).not.toContain(`${GOTEST_MODULE}@v1.29.0`);
     });
   });
 
   describe("tool directive", () => {
     it("runs go tool with the full package path when go.mod declares it", async () => {
-      setGoMod("/workspace", PINNED("v1.28.1", [`tool ${GOTEST_MODULE}`]));
+      setGoMod("/workspace", PINNED("v1.30.1", [`tool ${GOTEST_MODULE}`]));
 
       const cmd = await buildCliCommand(["spec", "./..."], "/workspace");
 
@@ -611,7 +611,7 @@ describe("buildCliCommand", () => {
     it("recognises the block form", async () => {
       setGoMod(
         "/workspace",
-        PINNED("v1.28.1", [
+        PINNED("v1.30.1", [
           "tool (",
           "\tgolang.org/x/tools/cmd/stringer",
           `\t${GOTEST_MODULE}`,
@@ -627,12 +627,12 @@ describe("buildCliCommand", () => {
     it("ignores tool lines for other packages", async () => {
       setGoMod(
         "/workspace",
-        PINNED("v1.28.1", ["tool golang.org/x/tools/cmd/stringer"]),
+        PINNED("v1.30.1", ["tool golang.org/x/tools/cmd/stringer"]),
       );
 
       const cmd = await buildCliCommand(["spec"], "/workspace");
 
-      expect(cmd.args.slice(0, 2)).toEqual(["run", `${GOTEST_MODULE}@v1.28.1`]);
+      expect(cmd.args.slice(0, 2)).toEqual(["run", `${GOTEST_MODULE}@v1.30.1`]);
     });
 
     it("uses the configured module path, so a fork resolves to its own tool", async () => {
@@ -643,7 +643,7 @@ describe("buildCliCommand", () => {
         [
           "module github.com/myapp",
           "go 1.25.0",
-          "require github.com/fork/go-test v1.28.1",
+          "require github.com/fork/go-test v1.30.1",
           `tool ${fork}`,
         ].join("\n"),
       );
@@ -676,7 +676,7 @@ describe("buildCliCommand", () => {
     });
 
     it("does not offer to add the directive when it is already declared", async () => {
-      setGoMod("/workspace", PINNED("v1.28.1", [`tool ${GOTEST_MODULE}`]));
+      setGoMod("/workspace", PINNED("v1.30.1", [`tool ${GOTEST_MODULE}`]));
 
       await buildCliCommand(["spec"], "/workspace");
       await flush();
@@ -691,20 +691,20 @@ describe("buildCliCommand", () => {
     it("pins the workspace's selected version, the max over use modules", async () => {
       setFiles({
         "/workspace/go.work": work,
-        "/workspace/a/go.mod": PINNED("v1.28.0"),
-        "/workspace/b/go.mod": PINNED("v1.28.1"),
+        "/workspace/a/go.mod": PINNED("v1.30.0"),
+        "/workspace/b/go.mod": PINNED("v1.30.1"),
       });
 
       const cmd = await buildCliCommand(["spec"], "/workspace");
 
-      expect(cmd.args.slice(0, 2)).toEqual(["run", `${GOTEST_MODULE}@v1.28.1`]);
+      expect(cmd.args.slice(0, 2)).toEqual(["run", `${GOTEST_MODULE}@v1.30.1`]);
     });
 
     it("runs go tool when any use module declares the directive", async () => {
       setFiles({
         "/workspace/go.work": work,
-        "/workspace/a/go.mod": PINNED("v1.28.0"),
-        "/workspace/b/go.mod": PINNED("v1.28.1", [`tool ${GOTEST_MODULE}`]),
+        "/workspace/a/go.mod": PINNED("v1.30.0"),
+        "/workspace/b/go.mod": PINNED("v1.30.1", [`tool ${GOTEST_MODULE}`]),
       });
 
       const cmd = await buildCliCommand(["spec"], "/workspace");
@@ -716,12 +716,12 @@ describe("buildCliCommand", () => {
       setFiles({
         "/workspace/go.work": "go 1.25.0\n\nuse .\nuse ./lib\n",
         "/workspace/go.mod": "module github.com/myapp\n\ngo 1.25.0\n",
-        "/workspace/lib/go.mod": PINNED("v1.28.1"),
+        "/workspace/lib/go.mod": PINNED("v1.30.1"),
       });
 
       const cmd = await buildCliCommand(["spec"], "/workspace");
 
-      expect(cmd.args.slice(0, 2)).toEqual(["run", `${GOTEST_MODULE}@v1.28.1`]);
+      expect(cmd.args.slice(0, 2)).toEqual(["run", `${GOTEST_MODULE}@v1.30.1`]);
     });
 
     it("refuses when the workspace selects a version below the floor", async () => {
@@ -770,7 +770,7 @@ describe("buildCliCommand", () => {
 
   describe("tool directive suggestion", () => {
     it("offers once per root when the pin is usable but no directive exists", async () => {
-      setGoMod("/workspace", PINNED("v1.28.1"));
+      setGoMod("/workspace", PINNED("v1.30.1"));
 
       await buildCliCommand(["spec"], "/workspace");
       await buildCliCommand(["discover"], "/workspace");
@@ -783,7 +783,7 @@ describe("buildCliCommand", () => {
     });
 
     it("adds the directive at the pinned version, never at latest", async () => {
-      setGoMod("/workspace", PINNED("v1.28.1"));
+      setGoMod("/workspace", PINNED("v1.30.1"));
       mockShowInformationMessage.mockResolvedValue("Add to go.mod");
 
       await buildCliCommand(["spec"], "/workspace");
@@ -791,13 +791,13 @@ describe("buildCliCommand", () => {
 
       expect(mockExecFileAsync).toHaveBeenCalledWith(
         "/usr/local/go/bin/go",
-        ["get", "-tool", `${GOTEST_MODULE}@v1.28.1`],
+        ["get", "-tool", `${GOTEST_MODULE}@v1.30.1`],
         expect.objectContaining({ cwd: "/workspace" }),
       );
     });
 
     it("stays silent in a vendored module", async () => {
-      setGoMod("/workspace", PINNED("v1.28.1"));
+      setGoMod("/workspace", PINNED("v1.30.1"));
       mockFileExists.mockImplementation(
         async (p: string) =>
           p === path.join("/workspace", "vendor", "modules.txt"),
@@ -811,7 +811,7 @@ describe("buildCliCommand", () => {
 
     it("stays silent when the setting is off", async () => {
       mockConfigValues.set("suggestToolDirective", false);
-      setGoMod("/workspace", PINNED("v1.28.1"));
+      setGoMod("/workspace", PINNED("v1.30.1"));
 
       await buildCliCommand(["spec"], "/workspace");
       await flush();
@@ -820,7 +820,7 @@ describe("buildCliCommand", () => {
     });
 
     it("Don't ask again turns the setting off for the folder", async () => {
-      setGoMod("/workspace", PINNED("v1.28.1"));
+      setGoMod("/workspace", PINNED("v1.30.1"));
       mockShowInformationMessage.mockResolvedValue("Don't ask again");
 
       await buildCliCommand(["spec"], "/workspace");
@@ -837,7 +837,7 @@ describe("buildCliCommand", () => {
     it("does not offer when a replace directive is in play", async () => {
       setGoMod(
         "/workspace",
-        PINNED("v1.28.1", [
+        PINNED("v1.30.1", [
           "replace github.com/mvrahden/go-test => ../go-test",
         ]),
       );

--- a/vscode-gotest/src/cli.test.ts
+++ b/vscode-gotest/src/cli.test.ts
@@ -37,12 +37,12 @@ describe("compareVersions", () => {
   });
 
   it("orders a pseudo-version by its base version", () => {
-    // A commit pin such as v1.28.2-0.<timestamp>-<sha> sits after v1.28.1
-    // and must clear a v1.27.0 floor rather than parse as NaN.
-    const pseudo = "v1.28.2-0.20260901120000-abcdef012345";
-    expect(compareVersions(pseudo, "v1.27.0")).toBeGreaterThan(0);
-    expect(compareVersions(pseudo, "v1.28.1")).toBeGreaterThan(0);
-    expect(compareVersions("v1.27.0-rc.1+meta", "v1.27.0")).toBe(0);
+    // A commit pin such as v1.30.2-0.<timestamp>-<sha> sits after v1.30.1
+    // and must clear a v1.29.0 floor rather than parse as NaN.
+    const pseudo = "v1.30.2-0.20260901120000-abcdef012345";
+    expect(compareVersions(pseudo, "v1.29.0")).toBeGreaterThan(0);
+    expect(compareVersions(pseudo, "v1.30.1")).toBeGreaterThan(0);
+    expect(compareVersions("v1.29.0-rc.1+meta", "v1.29.0")).toBe(0);
   });
 
   it("handles missing patch component", () => {

--- a/vscode-gotest/src/cli.ts
+++ b/vscode-gotest/src/cli.ts
@@ -16,12 +16,14 @@ export { resolveGoBinary } from "./goBinary.js";
 
 const execFileAsync = promisify(execFile);
 const DEFAULT_MODULE_PATH = "github.com/mvrahden/go-test/cmd/gotest";
-// Raised to the release that introduced `spec --input --render-only`. The Spec
-// View passes that flag, so an older CLI would reject the invocation outright.
-// Treat this as a contract marker: bump it whenever the extension starts
-// depending on CLI behaviour that older versions do not have. Equals the
-// CLI's gotestgen.MinRuntimeVersion; a Go test keeps them in step.
-const MIN_CLI_VERSION = "v1.27.0";
+// Raised to the release that introduced `gotest bench` and `gotest fuzz`,
+// which the Bench and Fuzz surfaces drive; an older CLI rejects the
+// subcommands outright. Treat this as a contract marker: bump it whenever
+// the extension starts depending on CLI behaviour that older versions do
+// not have. Never below the CLI's gotestgen.MinRuntimeVersion (a Go test
+// guards the order): a CLI the extension accepts must enforce a runtime
+// floor no newer than itself.
+const MIN_CLI_VERSION = "v1.29.0";
 
 export interface CliCommand {
   bin: string;


### PR DESCRIPTION
The extension drives `gotest bench` and `gotest fuzz`, which a v1.27 or v1.28 CLI rejects as unknown subcommands. The minimum CLI version moves to v1.29.0, so a project pinned below it gets the Upgrade prompt instead of failing on the first Bench or Fuzz action.

The floor used to be tied by test to the CLI's own runtime floor. They are different contracts: generated code still compiles against a v1.27 runtime, since the v1.29 symbols are only referenced by suites that declare bench or fuzz methods, and those cannot compile on older runtimes anyway. The test now asserts the extension floor is not below the runtime floor, rather than equal to it.

Note for the release notes: projects pinned at v1.27.x or v1.28.x are asked to upgrade the dependency when the extension activates.