### PR TITLE
Spec trailers count in the singular

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ UserService (12ms)
     when email already exists (<1ms)
       ✓ returns ErrDuplicate (<1ms)
 
-1 suites, 2 behaviors: 2 passed
+1 suite, 2 behaviors: 2 passed
 ```
 
 No generated code leaks into your workflow.
@@ -179,7 +179,7 @@ UserService (133ms)
     ✓ soft-deletes the user (5ms)
     ~ hard-deletes after 30 days — SKIPPED (<1ms)
 
-1 suites, 5 behaviors: 4 passed, 1 skipped
+1 suite, 5 behaviors: 4 passed, 1 skipped
 ```
 
 Every row shows the wall clock it occupied, never the sum of the rows beneath it — so a row that exceeds its children is time it held itself, and one that falls short of their total is children that overlapped.
@@ -657,7 +657,7 @@ gotest bench --spec ./examples/notification -benchtime=10x
 BenchmarkNotificationDispatchBench
   ✓ Dispatch  810.6 ns/op · 596 B/op · 2 allocs/op
 
-1 suites, 1 benchmarks: 
+1 suite, 1 benchmark: 
 ```
 
 Each line reports `ns/op`, `B/op`, and `allocs/op` — the same numbers `go test -bench` prints, rendered as a spec.

--- a/cmd/gotest/gotest_suite_test.go
+++ b/cmd/gotest/gotest_suite_test.go
@@ -1432,7 +1432,7 @@ func (s *CmdGotestTestSuite) TestBenchSubcommand(t *gotest.T) {
 
 			summary, err := os.ReadFile(summaryPath)
 			gotest.NoError(it, err)
-			gotest.Contains(it, string(summary), "### 1 benchmarks ran (")
+			gotest.Contains(it, string(summary), "### 1 benchmark ran (")
 			gotest.Contains(it, string(summary), "| Benchmark | ns/op | B/op | allocs/op |")
 			gotest.Contains(it, string(summary), "| NotificationDispatchBenchTestSuite/BenchmarkDispatch | ")
 			gotest.NotContains(it, string(summary), "tests passed")
@@ -1513,7 +1513,7 @@ func (s *CmdGotestTestSuite) TestBenchSaveAgainstGate(t *gotest.T) {
 		// once, with no second, stacked "N tests passed (...)" trailer
 		// from a separate RenderSummary call. Benchmarks carry no
 		// pass/fail verdicts, so this trailer ends after the counts.
-		gotest.Contains(it, out, "1 suites, 1 benchmarks")
+		gotest.Contains(it, out, "1 suite, 1 benchmark")
 		gotest.NotContains(it, out, "tests passed (")
 	})
 }

--- a/examples/benchmarking/README.md
+++ b/examples/benchmarking/README.md
@@ -126,7 +126,7 @@ BenchmarkCache
   ✓ PutEviction  141.7 ns/op · 55 B/op · 1 allocs/op
   ✓ FillFromEmpty  291740 ns/op · 415091 B/op · 4114 allocs/op
 
-1 suites, 4 benchmarks: 
+1 suite, 4 benchmarks: 
 ```
 
 ### Baseline, compare, gate
@@ -139,7 +139,7 @@ BenchmarkCache
   ✓ PutEviction  146.1 ns/op · 55 B/op · 1 allocs/op
   ✓ FillFromEmpty  328712 ns/op · 415093 B/op · 4114 allocs/op
 
-1 suites, 4 benchmarks: 
+1 suite, 4 benchmarks: 
 ```
 
 ```
@@ -152,7 +152,7 @@ BenchmarkCache
 
 BENCHMARK  OLD ns/op  NEW ns/op  Δ
 
-1 suites, 4 benchmarks: 
+1 suite, 4 benchmarks: 
 ```
 
 ```
@@ -165,7 +165,7 @@ BenchmarkCache
 
 BENCHMARK  OLD ns/op  NEW ns/op  Δ
 
-1 suites, 4 benchmarks: 
+1 suite, 4 benchmarks: 
 ```
 
 The command above exits `0`.

--- a/internal/gotestspec/counts.go
+++ b/internal/gotestspec/counts.go
@@ -1,0 +1,36 @@
+package gotestspec
+
+import "fmt"
+
+// countNoun spells a count with its noun, singular for exactly one.
+func countNoun(n int, singular, plural string) string {
+	if n == 1 {
+		return fmt.Sprintf("1 %s", singular)
+	}
+	return fmt.Sprintf("%d %s", n, plural)
+}
+
+// countParts lists the populated kinds of a run in trailer order, or "0 suites"
+// when nothing was found at all.
+func countParts(stats Stats) []string {
+	var counts []string
+	if stats.Suites > 0 {
+		counts = append(counts, countNoun(stats.Suites, "suite", "suites"))
+	}
+	if stats.Behaviors > 0 {
+		counts = append(counts, countNoun(stats.Behaviors, "behavior", "behaviors"))
+	}
+	if stats.Tests > 0 {
+		counts = append(counts, countNoun(stats.Tests, "stdlib test", "stdlib tests"))
+	}
+	if stats.Benchmarks > 0 {
+		counts = append(counts, countNoun(stats.Benchmarks, "benchmark", "benchmarks"))
+	}
+	if stats.Fuzzers > 0 {
+		counts = append(counts, countNoun(stats.Fuzzers, "fuzz target", "fuzz targets"))
+	}
+	if len(counts) == 0 {
+		counts = append(counts, "0 suites")
+	}
+	return counts
+}

--- a/internal/gotestspec/fuzznode_suite_test.go
+++ b/internal/gotestspec/fuzznode_suite_test.go
@@ -158,7 +158,7 @@ func (s *FuzzNodeTestSuite) TestRendering(t *gotest.T) {
 		out := buf.String()
 		gotest.Contains(it, out, "RoundTrip  2 seeds")
 		gotest.NotContains(it, out, "seed #1")
-		gotest.Contains(it, out, "1 fuzz targets")
+		gotest.Contains(it, out, "1 fuzz target")
 	})
 
 	t.It("lists the seeds when one of them failed", func(it *gotest.T) {
@@ -178,7 +178,7 @@ func (s *FuzzNodeTestSuite) TestRendering(t *gotest.T) {
 	t.It("counts fuzz targets in the markdown trailer", func(it *gotest.T) {
 		var buf bytes.Buffer
 		gotestspec.RenderMarkdown(&buf, pkgs)
-		gotest.Contains(it, buf.String(), "1 fuzz targets")
+		gotest.Contains(it, buf.String(), "1 fuzz target")
 		gotest.Contains(it, buf.String(), "RoundTrip")
 	})
 }

--- a/internal/gotestspec/markdown.go
+++ b/internal/gotestspec/markdown.go
@@ -15,22 +15,7 @@ func RenderMarkdown(w io.Writer, packages []*Package, opts ...RenderOption) {
 
 	fmt.Fprintln(w, "# Behavior Specification")
 	fmt.Fprintln(w)
-	var counts []string
-	if stats.Suites > 0 {
-		counts = append(counts, fmt.Sprintf("%d suites", stats.Suites))
-	}
-	if stats.Behaviors > 0 {
-		counts = append(counts, fmt.Sprintf("%d behaviors", stats.Behaviors))
-	}
-	if stats.Tests > 0 {
-		counts = append(counts, fmt.Sprintf("%d stdlib tests", stats.Tests))
-	}
-	if stats.Benchmarks > 0 {
-		counts = append(counts, fmt.Sprintf("%d benchmarks", stats.Benchmarks))
-	}
-	if stats.Fuzzers > 0 {
-		counts = append(counts, fmt.Sprintf("%d fuzz targets", stats.Fuzzers))
-	}
+	counts := countParts(stats)
 	if cfg.withoutVerdicts {
 		// "0 passed, 0 failed, 0 skipped" beside a document nothing ran reads
 		// as a run that lost its results, rather than as a specification.

--- a/internal/gotestspec/render_suite_test.go
+++ b/internal/gotestspec/render_suite_test.go
@@ -93,7 +93,7 @@ func (s *RenderTestSuite) TestRenderTerminal_SummaryLine(t *gotest.T, _ *renderC
 	}{
 		{Desc: "suites only", stats: gotestspec.Stats{Suites: 2, Behaviors: 5, Passed: 5}, want: "2 suites, 5 behaviors: 5 passed"},
 		{Desc: "stdlib only", stats: gotestspec.Stats{Tests: 3, Passed: 2, Failed: 1}, want: "3 stdlib tests: 2 passed, 1 failed"},
-		{Desc: "mixed", stats: gotestspec.Stats{Suites: 1, Behaviors: 2, Tests: 1, Passed: 2, Skipped: 1}, want: "1 suites, 2 behaviors, 1 stdlib tests: 2 passed, 1 skipped"},
+		{Desc: "mixed", stats: gotestspec.Stats{Suites: 1, Behaviors: 2, Tests: 1, Passed: 2, Skipped: 1}, want: "1 suite, 2 behaviors, 1 stdlib test: 2 passed, 1 skipped"},
 	}) {
 		var buf bytes.Buffer
 		gotestspec.ExportRenderSummaryLine(&buf, tc.stats, gotestspec.ExportANSIColors)
@@ -166,7 +166,7 @@ func renderTerminalWith(packages []*gotestspec.Package, opts ...gotestspec.Rende
 
 func (s *RenderTestSuite) TestRenderTerminal_BenchmarkLeaf(t *gotest.T, _ *renderCtx) {
 	out := renderTerminal(benchmarkLeaf())
-	for _, want := range []string{"Parse", "985.2 ns/op", "24 B/op", "3 allocs/op", "1 benchmarks"} {
+	for _, want := range []string{"Parse", "985.2 ns/op", "24 B/op", "3 allocs/op", "1 benchmark"} {
 		gotest.Contains(t, out, want)
 	}
 }
@@ -182,7 +182,7 @@ func (s *RenderTestSuite) TestRenderTerminal_WithBenchDeltas(t *gotest.T, _ *ren
 	gotest.Contains(t, out, "p Foo/BenchmarkFoo  100.0  150.0  +50.0% ⚠", "regression row")
 	// A bench-only run has counts but no pass/fail verdicts, so the trailer
 	// stops at the counts: the colon would have nothing after it.
-	gotest.Contains(t, out, "1 benchmarks", "the trailing counts line")
+	gotest.Contains(t, out, "1 benchmark", "the trailing counts line")
 	gotest.NotContains(t, out, "tests passed (", "a single summary trailer, not a stacked one")
 }
 

--- a/internal/gotestspec/summary.go
+++ b/internal/gotestspec/summary.go
@@ -197,20 +197,20 @@ func RenderMarkdownSummary(w io.Writer, packages []*Package, opts ...RenderOptio
 	fmt.Fprint(w, "---\n")
 	var parts []string
 	if stats.Suites > 0 {
-		parts = append(parts, fmt.Sprintf("%d suites", stats.Suites))
+		parts = append(parts, countNoun(stats.Suites, "suite", "suites"))
 	}
 	if stats.Behaviors > 0 {
-		parts = append(parts, fmt.Sprintf("%d behaviors", stats.Behaviors))
+		parts = append(parts, countNoun(stats.Behaviors, "behavior", "behaviors"))
 	}
 	if stats.Tests > 0 {
-		parts = append(parts, fmt.Sprintf("%d stdlib tests", stats.Tests))
+		parts = append(parts, countNoun(stats.Tests, "stdlib test", "stdlib tests"))
 	}
 	if len(parts) == 0 {
 		parts = append(parts, "0 suites")
 	}
 	trailer := fmt.Sprintf("%d passed, %d failed, %d skipped", stats.Passed, stats.Failed, stats.Skipped)
 	if stats.FailedPackages > 0 {
-		trailer += fmt.Sprintf(", %d failed packages", stats.FailedPackages)
+		trailer += ", " + countNoun(stats.FailedPackages, "failed package", "failed packages")
 	}
 	fmt.Fprintf(w, "%s: %s\n", strings.Join(parts, ", "), trailer)
 }
@@ -249,7 +249,7 @@ func RenderMarkdownBenchSummary(w io.Writer, packages []*Package, opts ...Render
 	failures := collectFailures(packages)
 	dur := formatDuration(effectiveDuration(cfg, packages))
 	if len(failures) == 0 {
-		fmt.Fprintf(w, "### %d benchmarks ran (%s)\n", stats.Benchmarks, dur)
+		fmt.Fprintf(w, "### %s ran (%s)\n", countNoun(stats.Benchmarks, "benchmark", "benchmarks"), dur)
 	} else {
 		fmt.Fprintf(w, "### %d of %d benchmarks failed (%s)\n", len(failures), stats.Benchmarks, dur)
 		renderMarkdownFailures(w, failures)

--- a/internal/gotestspec/terminal.go
+++ b/internal/gotestspec/terminal.go
@@ -372,28 +372,10 @@ func renderSummary(w io.Writer, stats Stats, c colors) { //nolint:gocritic // hu
 		parts = append(parts, fmt.Sprintf("%s%d skipped%s", c.yellow, stats.Skipped, c.reset))
 	}
 	if stats.FailedPackages > 0 {
-		parts = append(parts, fmt.Sprintf("%s%d failed packages%s", c.red, stats.FailedPackages, c.reset))
+		parts = append(parts, fmt.Sprintf("%s%s%s", c.red, countNoun(stats.FailedPackages, "failed package", "failed packages"), c.reset))
 	}
 
-	var counts []string
-	if stats.Suites > 0 {
-		counts = append(counts, fmt.Sprintf("%d suites", stats.Suites))
-	}
-	if stats.Behaviors > 0 {
-		counts = append(counts, fmt.Sprintf("%d behaviors", stats.Behaviors))
-	}
-	if stats.Tests > 0 {
-		counts = append(counts, fmt.Sprintf("%d stdlib tests", stats.Tests))
-	}
-	if stats.Benchmarks > 0 {
-		counts = append(counts, fmt.Sprintf("%d benchmarks", stats.Benchmarks))
-	}
-	if stats.Fuzzers > 0 {
-		counts = append(counts, fmt.Sprintf("%d fuzz targets", stats.Fuzzers))
-	}
-	if len(counts) == 0 {
-		counts = append(counts, "0 suites")
-	}
+	counts := countParts(stats)
 
 	if len(parts) == 0 {
 		// A spec that has not run has counts but no verdicts. Printing the

--- a/site/content/blog/organizing-go-tests.md
+++ b/site/content/blog/organizing-go-tests.md
@@ -273,7 +273,7 @@ There's a useful consequence of this structure. Because test methods, `When` blo
   <span class="t-test">DeleteUser</span> <span class="t-time">(3ms)</span>
     <span class="t-when">when the user exists</span> <span class="t-time">(3ms)</span>
       <span class="t-pass">✓</span> succeeds without error <span class="t-time">(3ms)</span>
-<span class="t-summary">1 suites, 3 behaviors: <span class="t-pass">3 passed</span></span>
+<span class="t-summary">1 suite, 3 behaviors: <span class="t-pass">3 passed</span></span>
 {{< /terminal >}}
 
 This isn't generated documentation; it's a direct rendering of your test structure. If a test is missing, the spec has a gap. If a test fails, the spec shows it. The test *is* the specification.

--- a/site/content/blog/readable-tests-with-bdd.md
+++ b/site/content/blog/readable-tests-with-bdd.md
@@ -145,7 +145,7 @@ The structure in the code is only half the value. The other half is what you see
   <span class="t-test">Delete</span> <span class="t-time">(5ms)</span>
     <span class="t-pass">✓</span> soft-deletes the user <span class="t-time">(5ms)</span>
 
-<span class="t-summary">1 suites, 4 behaviors: 4 passed</span>
+<span class="t-summary">1 suite, 4 behaviors: 4 passed</span>
 {{< /spec >}}
 
 Compare this with the `gotest ./... -v` output for the same tests — the standard verbose stream, since suites run through the `gotest` runner. The spec output is:
@@ -167,7 +167,7 @@ When a test fails, the tree structure tells you exactly where:
   <span class="t-test">Delete</span> <span class="t-time">(5ms)</span>
     <span class="t-pass">✓</span> soft-deletes the user <span class="t-time">(5ms)</span>
 
-<span class="t-summary">1 suites, 4 behaviors: 3 passed, <span class="t-fail">1 failed</span></span>
+<span class="t-summary">1 suite, 4 behaviors: 3 passed, <span class="t-fail">1 failed</span></span>
 {{< /spec >}}
 
 The red cross at "sends a welcome email" under "email is valid" is a sentence: *UserService Create, when email is valid, fails to send a welcome email.* You know what's broken without reading any code.
@@ -208,7 +208,7 @@ The spec output reflects the nesting:
       <span class="t-when">payment fails</span> <span class="t-time">(2ms)</span>
         <span class="t-pass">✓</span> does not create an order <span class="t-time">(2ms)</span>
 
-<span class="t-summary">1 suites, 3 behaviors: 3 passed</span>
+<span class="t-summary">1 suite, 3 behaviors: 3 passed</span>
 {{< /spec >}}
 
 Each level of `When` narrows the context. The spec reads as a decision tree: checkout, when the cart is not empty, when payment succeeds, creates an order. You can trace any path from root to leaf and get a complete behavioral statement.

--- a/vscode-gotest/src/specView.test.ts
+++ b/vscode-gotest/src/specView.test.ts
@@ -130,7 +130,7 @@ describe("specDataToReport with a fuzz target", () => {
   it("marks the target as FUZZ with its seed count, and counts it in the trailer", () => {
     const report = specDataToReport(data as never, []);
     expect(report).toContain("RoundTrip — FUZZ (3 seeds)");
-    expect(report).toContain("1 suites, 1 behaviors, 1 fuzz targets:");
+    expect(report).toContain("1 suite, 1 behavior, 1 fuzz target:");
   });
 });
 
@@ -230,7 +230,7 @@ describe("specDataToReport", () => {
 
   it("preserves structural counts in summary", () => {
     const report = specDataToReport(data, [], new Set(["pass"]));
-    expect(report).toContain("1 suites");
+    expect(report).toContain("1 suite");
     expect(report).toContain("3 behaviors");
   });
 

--- a/vscode-gotest/src/specView.ts
+++ b/vscode-gotest/src/specView.ts
@@ -767,9 +767,10 @@ function formatDuration(seconds: number): string {
 
 function buildSummary(stats: SpecStats): string {
   const counts: string[] = [];
-  if (stats.suites > 0) counts.push(`${stats.suites} suites`);
-  if (stats.behaviors > 0) counts.push(`${stats.behaviors} behaviors`);
-  if ((stats.fuzzers ?? 0) > 0) counts.push(`${stats.fuzzers} fuzz targets`);
+  if (stats.suites > 0) counts.push(countNoun(stats.suites, "suite"));
+  if (stats.behaviors > 0) counts.push(countNoun(stats.behaviors, "behavior"));
+  if ((stats.fuzzers ?? 0) > 0)
+    counts.push(countNoun(stats.fuzzers ?? 0, "fuzz target"));
   if (stats.tests > 0) counts.push(`${stats.tests} stdlib tests`);
 
   const failedPackages = stats.failedPackages ?? 0;
@@ -828,6 +829,11 @@ function fmtTime(seconds: number): string {
 
 type ReportRow =
   { label: string; time: string; result: string } | { raw: string };
+
+/** Spells a count with its noun, singular for exactly one, as the CLI trailer does. */
+export function countNoun(n: number, noun: string): string {
+  return `${n} ${noun}${n === 1 ? "" : "s"}`;
+}
 
 export function specDataToReport(
   data: SpecData,
@@ -916,11 +922,11 @@ export function specDataToReport(
   lines.push(separator);
 
   const counts: string[] = [];
-  if (data.stats.suites > 0) counts.push(`${data.stats.suites} suites`);
+  if (data.stats.suites > 0) counts.push(countNoun(data.stats.suites, "suite"));
   if (data.stats.behaviors > 0)
-    counts.push(`${data.stats.behaviors} behaviors`);
+    counts.push(countNoun(data.stats.behaviors, "behavior"));
   if ((data.stats.fuzzers ?? 0) > 0)
-    counts.push(`${data.stats.fuzzers} fuzz targets`);
+    counts.push(countNoun(data.stats.fuzzers ?? 0, "fuzz target"));
   if (data.stats.tests > 0) counts.push(`${data.stats.tests} stdlib tests`);
   const results: string[] = [];
   if (totalAgg.passed > 0) results.push(`${totalAgg.passed} passed`);

--- a/vscode-gotest/test/integration/specSync.test.ts
+++ b/vscode-gotest/test/integration/specSync.test.ts
@@ -190,7 +190,7 @@ describe.each(MODES)("spec sync via $name", (mode) => {
     // The row is tagged as a property backed by seeds, and the trailer counts
     // the target the way the CLI does.
     expect(html).toContain('<span class="tag fuzz">FUZZ · 3 seeds</span>');
-    expect(html).toContain("1 fuzz targets");
+    expect(html).toContain("1 fuzz target");
     expect(recorder.errors).toEqual([]);
   });
 


### PR DESCRIPTION
`gotest spec` printed "1 suites, 1 behaviors". Every trailer (terminal, Markdown, CI summary, the step-summary heading, failed packages) now uses one helper that spells a count of one in the singular, and the VS Code Spec View's own summary line does the same. Pinned samples in the README, the benchmarking example, two blog posts and the tests follow. No behavior change beyond the wording.