### PR TITLE
gotest-openspec: join OpenSpec scenarios with the spec tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,15 @@ gotest spec ./... --static
 gotest spec ./... --static --format=md --output=docs/behavior-spec.md
 ```
 
+### Scenarios from OpenSpec
+
+If the project keeps [OpenSpec](https://openspec.dev/) specs, `gotest-openspec` joins them with the spec tree: each `#### Scenario:` heading is looked up among the `It` leaves (by its title, or by the `When` condition followed by the `It` label), and the command prints one verdict per scenario and exits 1 when any scenario has no behavior or a failing one.
+
+```bash
+go get -tool github.com/mvrahden/go-test/cmd/gotest-openspec@latest
+gotest spec --format=json ./... | go tool gotest-openspec openspec/specs
+```
+
 ## Isolation
 
 Each suite runs in its own process with zero shared state.

--- a/cmd/gotest-openspec/main.go
+++ b/cmd/gotest-openspec/main.go
@@ -1,0 +1,147 @@
+// Command gotest-openspec reports which OpenSpec scenarios have a gotest
+// behavior, and how that behavior fared.
+//
+//	go tool gotest spec --format=json ./... | go tool gotest-openspec openspec/specs
+//
+// A scenario matches a behavior when its title equals an It label, or a When
+// condition followed by an It label; case, punctuation and spacing are folded.
+// Exit 1 when any scenario has no behavior or a failing one, so the command
+// doubles as a verification gate; exit 2 when the inputs cannot be read.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// node is the subset of a gotest spec JSON node the reconciliation reads.
+type node struct {
+	Display  string `json:"display"`
+	Vocab    string `json:"vocab"`
+	Status   string `json:"status"`
+	Children []node `json:"children"`
+}
+
+type specTree struct {
+	Packages []struct {
+		Nodes []node `json:"nodes"`
+	} `json:"packages"`
+}
+
+var (
+	scenarioLine = regexp.MustCompile(`^#{3,4}\s+Scenario:\s*(.+?)\s*$`)
+	nonWord      = regexp.MustCompile(`[^a-z0-9 ]+`)
+)
+
+// key folds case, punctuation and spacing so "Clamps to zero." meets "clamps to zero".
+func key(s string) string {
+	return strings.Join(strings.Fields(nonWord.ReplaceAllString(strings.ToLower(s), " ")), " ")
+}
+
+// scenarios collects every "#### Scenario:" heading under dir, in file order.
+// Reads go through an os.Root so a symlink cannot lead outside dir.
+func scenarios(dir string) (out []string, err error) {
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	err = fs.WalkDir(root.FS(), ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(p, ".md") {
+			return err
+		}
+		src, err := root.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		for line := range strings.SplitSeq(string(src), "\n") {
+			if m := scenarioLine.FindStringSubmatch(line); m != nil {
+				out = append(out, m[1])
+			}
+		}
+		return nil
+	})
+	return out, err
+}
+
+// behaviors indexes every It leaf by its label and by "<condition> <label>",
+// so a scenario may spell its context too. Status is the leaf's verdict.
+func behaviors(tree specTree) map[string]string {
+	found := map[string]string{}
+	var walk func(n node, ctx string)
+	walk = func(n node, ctx string) {
+		switch n.Vocab {
+		case "it":
+			found[key(n.Display)] = n.Status
+			if ctx != "" {
+				found[key(ctx+" "+n.Display)] = n.Status
+			}
+		case "when":
+			ctx = strings.TrimPrefix(n.Display, "when ")
+		}
+		for _, c := range n.Children {
+			walk(c, ctx)
+		}
+	}
+	for _, p := range tree.Packages {
+		for _, n := range p.Nodes {
+			walk(n, "")
+		}
+	}
+	return found
+}
+
+var verdicts = map[string]string{
+	"pass": "✓ verified",
+	"fail": "✗ failing",
+	"skip": "~ skipped",
+	"none": "· declared",
+}
+
+const noBehavior = "? no behavior"
+
+// report prints one line per scenario and a summary, returning the exit code.
+func report(w io.Writer, names []string, found map[string]string) int {
+	counts := map[string]int{}
+	for _, name := range names {
+		v := noBehavior
+		if st, ok := found[key(name)]; ok {
+			v = verdicts[st]
+		}
+		counts[v]++
+		fmt.Fprintf(w, "%-14s %s\n", v, name)
+	}
+	fmt.Fprintf(w, "\n%d scenarios: %d verified, %d failing, %d declared, %d without a behavior\n",
+		len(names), counts[verdicts["pass"]], counts[verdicts["fail"]], counts[verdicts["none"]], counts[noBehavior])
+	if counts[noBehavior]+counts[verdicts["fail"]] > 0 {
+		return 1
+	}
+	return 0
+}
+
+func run(stdin io.Reader, stdout, stderr io.Writer, args []string) int {
+	if len(args) != 1 {
+		fmt.Fprintln(stderr, "usage: gotest spec --format=json ./... | gotest-openspec <specs-dir>")
+		return 2
+	}
+	var tree specTree
+	if err := json.NewDecoder(stdin).Decode(&tree); err != nil {
+		fmt.Fprintln(stderr, "read spec json:", err)
+		return 2
+	}
+	names, err := scenarios(args[0])
+	if err != nil {
+		fmt.Fprintln(stderr, "read scenarios:", err)
+		return 2
+	}
+	return report(stdout, names, behaviors(tree))
+}
+
+func main() {
+	os.Exit(run(os.Stdin, os.Stdout, os.Stderr, os.Args[1:]))
+}

--- a/cmd/gotest-openspec/openspec_suite_test.go
+++ b/cmd/gotest-openspec/openspec_suite_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mvrahden/go-test/pkg/gotest"
+)
+
+// specJSON is a two-suite spec tree as gotest spec --format=json emits it,
+// trimmed to the fields the reconciliation reads.
+const specJSON = `{"packages":[{"nodes":[
+  {"display":"Cart","vocab":"","status":"pass","children":[
+    {"display":"ApplyDiscount","vocab":"","status":"pass","children":[
+      {"display":"when the discount exceeds 100 percent","vocab":"when","status":"pass","children":[
+        {"display":"clamps to zero","vocab":"it","status":"pass","children":[]}]}]},
+    {"display":"Checkout","vocab":"","status":"fail","children":[
+      {"display":"when the cart is empty","vocab":"when","status":"fail","children":[
+        {"display":"returns an error","vocab":"it","status":"fail","children":[]}]}]}]},
+  {"display":"Pricing","vocab":"","status":"none","children":[
+    {"display":"LookupPrice","vocab":"","status":"none","children":[
+      {"display":"returns the catalog price","vocab":"it","status":"none","children":[]}]}]}
+]}]}`
+
+type ReconcileTestSuite struct {
+	specs string
+	out   bytes.Buffer
+	errs  bytes.Buffer
+}
+
+func (s *ReconcileTestSuite) BeforeEach(t *gotest.T) {
+	s.specs = t.TempDir()
+	s.out.Reset()
+	s.errs.Reset()
+}
+
+func (s *ReconcileTestSuite) write(t *gotest.T, name, body string) {
+	path := filepath.Join(s.specs, name)
+	gotest.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	gotest.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+}
+
+func (s *ReconcileTestSuite) reconcile(spec string) int {
+	return run(strings.NewReader(spec), &s.out, &s.errs, []string{s.specs})
+}
+
+func (s *ReconcileTestSuite) TestScenarioHeadings(t *gotest.T) {
+	s.write(t, "cart/spec.md", "### Requirement: A\n#### Scenario: clamps to zero\n- **THEN** x\n")
+	s.write(t, "nested/deeper/spec.md", "### Scenario: returns the catalog price\n")
+	s.write(t, "notes.txt", "#### Scenario: ignored, not markdown\n")
+
+	names, err := scenarios(s.specs)
+	gotest.NoError(t, err)
+
+	t.It("collects level-three and level-four headings from every markdown file", func(t *gotest.T) {
+		gotest.ElementsMatch(t, []string{"clamps to zero", "returns the catalog price"}, names)
+	})
+}
+
+func (s *ReconcileTestSuite) TestMatching(t *gotest.T) {
+	t.When("the scenario title equals an It label", func(t *gotest.T) {
+		s.write(t, "spec.md", "#### Scenario: Clamps to zero.\n")
+		code := s.reconcile(specJSON)
+		t.It("verifies it despite case and punctuation", func(t *gotest.T) {
+			gotest.Equal(t, 0, code)
+			gotest.Contains(t, s.out.String(), "✓ verified     Clamps to zero.")
+		})
+	})
+
+	t.When("the scenario title spells the condition before the outcome", func(t *gotest.T) {
+		s.write(t, "spec.md", "#### Scenario: the discount exceeds 100 percent clamps to zero\n")
+		code := s.reconcile(specJSON)
+		t.It("matches the When condition followed by the It label", func(t *gotest.T) {
+			gotest.Equal(t, 0, code)
+			gotest.Contains(t, s.out.String(), "1 scenarios: 1 verified, 0 failing, 0 declared, 0 without a behavior")
+		})
+	})
+
+	t.When("the behavior failed", func(t *gotest.T) {
+		s.write(t, "spec.md", "#### Scenario: returns an error\n")
+		code := s.reconcile(specJSON)
+		t.It("reports it failing and exits 1", func(t *gotest.T) {
+			gotest.Equal(t, 1, code)
+			gotest.Contains(t, s.out.String(), "✗ failing      returns an error")
+		})
+	})
+
+	t.When("the tree is static and carries no verdicts", func(t *gotest.T) {
+		s.write(t, "spec.md", "#### Scenario: returns the catalog price\n")
+		code := s.reconcile(specJSON)
+		t.It("reports the scenario as declared and exits 0", func(t *gotest.T) {
+			gotest.Equal(t, 0, code)
+			gotest.Contains(t, s.out.String(), "· declared     returns the catalog price")
+		})
+	})
+
+	t.When("no behavior carries the scenario's title", func(t *gotest.T) {
+		s.write(t, "spec.md", "#### Scenario: applies a coupon code\n")
+		code := s.reconcile(specJSON)
+		t.It("reports it without a behavior and exits 1", func(t *gotest.T) {
+			gotest.Equal(t, 1, code)
+			gotest.Contains(t, s.out.String(), "? no behavior  applies a coupon code")
+			gotest.Contains(t, s.out.String(), "1 without a behavior")
+		})
+	})
+}
+
+func (s *ReconcileTestSuite) TestInputs(t *gotest.T) {
+	t.When("the specs directory is missing", func(t *gotest.T) {
+		code := run(strings.NewReader(specJSON), &s.out, &s.errs, []string{filepath.Join(s.specs, "absent")})
+		t.It("exits 2 and says so", func(t *gotest.T) {
+			gotest.Equal(t, 2, code)
+			gotest.Contains(t, s.errs.String(), "read scenarios")
+		})
+	})
+
+	t.When("stdin is not a spec tree", func(t *gotest.T) {
+		code := s.reconcile("not json")
+		t.It("exits 2 and says so", func(t *gotest.T) {
+			gotest.Equal(t, 2, code)
+			gotest.Contains(t, s.errs.String(), "read spec json")
+		})
+	})
+
+	t.When("no directory is given", func(t *gotest.T) {
+		code := run(strings.NewReader(specJSON), &s.out, &s.errs, nil)
+		t.It("prints usage and exits 2", func(t *gotest.T) {
+			gotest.Equal(t, 2, code)
+			gotest.Contains(t, s.errs.String(), "usage:")
+		})
+	})
+}

--- a/cmd/gotest-openspec/testdata/cart.md
+++ b/cmd/gotest-openspec/testdata/cart.md
@@ -1,0 +1,35 @@
+# cart Specification
+
+## Purpose
+A shopping cart that tracks items, quantities, discounts and checkout.
+
+## Requirements
+
+### Requirement: Adding items
+The cart SHALL track each added item with its quantity and line total.
+
+#### Scenario: increases the item count
+- **WHEN** a single item is added to an empty cart
+- **THEN** the item count is 1
+
+#### Scenario: merges the quantities
+- **WHEN** the same item is added twice
+- **THEN** the quantities are merged into one entry
+
+### Requirement: Discounts
+The cart SHALL apply percentage discounts and never charge a negative total.
+
+#### Scenario: the discount exceeds 100 percent clamps to zero
+- **WHEN** a discount over 100% is applied
+- **THEN** the total is zero
+
+#### Scenario: applies a coupon code
+- **WHEN** a valid coupon code is entered
+- **THEN** the coupon's discount is applied
+
+### Requirement: Checkout
+The cart SHALL refuse to check out when empty.
+
+#### Scenario: the cart is empty returns an error
+- **WHEN** checkout is called on an empty cart
+- **THEN** an error is returned

--- a/docs/design/spec.md
+++ b/docs/design/spec.md
@@ -1188,6 +1188,21 @@ The repository's composite GitHub Action (`action.yml`) wraps this subcommand.
 
 ---
 
+## OpenSpec Reconciliation
+
+```
+$ gotest spec --format=json ./... | gotest-openspec openspec/specs
+```
+
+A separate binary (`cmd/gotest-openspec`) that joins an [OpenSpec](https://openspec.dev/) specs directory with a spec tree: every `#### Scenario:` heading (level three or four, any `.md` file under the directory, file order) is looked up among the tree's `It` leaves.
+A scenario matches when its title equals an `It` label, or a `When` condition (the `display` string minus its `when ` prefix) followed by the `It` label; case, punctuation and spacing are folded before comparison, so `Clamps to zero.` meets `clamps to zero`.
+The tree may come from a run or from `--static`; a static tree carries no verdicts and every match reads as declared.
+
+One line per scenario — `✓ verified`, `✗ failing`, `~ skipped`, `· declared`, `? no behavior` — then a summary line counting each.
+Exit 0 when every scenario has a behavior and none failed; 1 when a scenario has no behavior or a failing one, so the command gates a CI step or an agent's verify pass; 2 when the inputs cannot be read.
+
+---
+
 ## Machine-Readable Discovery
 
 ```

--- a/site/content/reference.html
+++ b/site/content/reference.html
@@ -568,6 +568,7 @@ percentage = covered / total</div>
           <tr><td><code>gotest watch ./...</code></td><td>Re-run on file changes. Only affected packages re-run.</td></tr>
           <tr><td><code>gotest spec ./...</code></td><td>Run tests and render the behavioral specification. With <code>--static</code>, render it from source without running.</td></tr>
           <tr><td><code>gotest discover ./...</code></td><td>Discover test suites and output JSON (feeds editor integrations).</td></tr>
+          <tr><td><code>gotest spec --format=json ./... | gotest-openspec openspec/specs</code></td><td>Join OpenSpec scenarios with the spec tree; one verdict per scenario, exit 1 on a missing or failing behavior.</td></tr>
           <tr><td><code>gotest summary ./...</code></td><td>Failure-focused summary for CI. Shows only failing tests with assertion output.</td></tr>
           <tr><td><code>gotest bench ./...</code></td><td>Run <code>Benchmark*</code> suite methods serially; <code>--save</code>, <code>--against</code> and <code>--gate</code> keep and compare baselines.</td></tr>
           <tr><td><code>gotest fuzz ./...</code></td><td>Search for new failing inputs with <code>Fuzz*</code> suite methods for a time budget (<code>--for</code>); <code>fuzz triage</code> and <code>fuzz promote</code> handle what it finds.</td></tr>


### PR DESCRIPTION
A second binary beside the CLI. It reads `gotest spec --format=json` on stdin and an OpenSpec specs directory, looks every `#### Scenario:` heading up among the `It` leaves (by title, or by the `When` condition followed by the `It` label), and prints one verdict per scenario: verified, failing, skipped, declared, or no behavior. Exit 1 on a missing or failing behavior, so it gates CI and an agent's verify step. Documented in the design spec, README and reference page. Ships in v1.29.1; the OpenSpec blog post depends on it.