### PR TITLE
Blog: spec-driven development series

### DIFF
--- a/site/content/blog/how-go-names-its-subtests.md
+++ b/site/content/blog/how-go-names-its-subtests.md
@@ -1,0 +1,71 @@
+---
+title: "How Go Names Its Subtests"
+date: 2026-09-25
+draft: true
+description: "How many subtest names in the 1,000 most-starred Go repositories are written for a reader, how many are identifiers, and how many come from a table?"
+tags: ["Research", "AI Engineering"]
+keywords: ["go subtest naming", "t.Run naming convention", "go testing statistics", "readable go test names", "go tests for coding agents"]
+cta_text: "Measure your own repository with the census scanner."
+cta_command: "go run github.com/mvrahden/go-test/research/test-census@research/subtest-naming -out census.csv ."
+---
+
+<!--
+DRAFT. Every number marked [[…]] below is a placeholder awaiting the corpus rerun.
+The scanner change that produces them lives on branch research/subtest-naming
+(three new columns: subtest_literal_names, subtest_prose_names, subtest_dynamic_names).
+Rerun: ./run.sh corpus/census-full.csv results.csv 50 — pinned SHAs, so the
+existing numbers reproduce and the new columns are attributable to the same commits.
+Do not publish with a placeholder left in.
+-->
+
+A test function name is an identifier. It cannot contain a space, so `TestCreateUser_WhenEmailInvalid_ReturnsError` is the best a Go developer can do to state a scenario there, and [36.7% of test functions in the top 1,000 repositories]({{< ref "/blog/how-go-actually-tests" >}}) do exactly that. A subtest name is different. `t.Run` takes a string, and a string can say "when the email is invalid, returns an error" in words. It is the one place the standard library lets a test state a behavior the way a person would say it.
+
+So we asked the corpus a question the [July census]({{< ref "/blog/how-go-actually-tests" >}}) did not: when Go developers get a string, what do they put in it?
+
+## What we measured
+
+Same corpus, same commits, one new classification. For every `t.Run` call site in the 917 repositories with tests, the scanner looks at the first argument and sorts it into one of three bins.
+
+- **Prose.** A string literal containing a space: `t.Run("returns an error when the email is invalid", …)`. Written for a reader.
+- **Identifier.** A string literal without a space: `t.Run("InvalidEmail", …)`, `t.Run("case_3", …)`. Written for `-run`.
+- **Computed.** Anything that is not a literal: `t.Run(tc.name, …)`, `t.Run(fmt.Sprintf("%d", i), …)`. The name lives in a table row or is built at runtime, and the scanner cannot see it without executing the test.
+
+The classification is syntactic and errs toward the identifier bin: a literal with a hyphen or a slash and no space counts as an identifier even when a human would read it fine. Computed names are neither good nor bad in this framing. They are the table-driven pattern, and the July census found it in 21.8% of test functions. What the bin tells us is that the behavior's name is data, and data is only readable once the test has run.
+
+## What the corpus does
+
+Of [[N]] subtest call sites, [[P]]% are prose, [[I]]% are identifiers, and [[C]]% are computed.
+
+<!-- chart: three-way split, full corpus vs top 100 vs long tail; charts.py needs a new function for it -->
+
+[[Interpretation paragraph. Candidate readings, to be chosen once the numbers exist:
+- If prose is the minority: the one place Go lets a test speak, most tests still write identifiers. Structure demand without a home, again.
+- If prose is the majority among literals but computed dominates overall: developers do write behaviors in words when they write them by hand; the table-driven pattern moves the words into data where no tool can read them before a run.
+- Top-100 vs long-tail split: does readability track with the maturity gradient, or invert like t.Helper did?]]
+
+## Why this matters more than it did in July
+
+Two months ago this would have been a curiosity about style. It is not anymore, for a reason the [first post in this series]({{< ref "/blog/spec-driven-development-go" >}}) laid out: coding agents now read tests as the specification of what a system does, and the tools that organize that work, OpenSpec and Spec Kit among them, ask for scenarios stated "so plainly you could hand it to someone else to test".
+
+A subtest named `"InvalidEmail"` is a test. It is not a scenario. An agent handed the `-v` output of a package full of identifiers learns which functions exist, not what the system promises. A subtest named `"returns an error when the email is invalid"` is both, and it costs nothing extra to write. The [[P]]% figure is, in that light, a measure of how much of the ecosystem's test suite is already a specification an agent can read, and the [[I]]% figure is how much of it could be with a rename.
+
+The computed bin is the interesting one. [[C]]% of subtest names come from a table row, which means the behaviors exist, are usually well named, and are invisible to anything that reads source without running it. `gotest spec --static` reports exactly this case as `incomplete:` for an `Each` over a computed table, because a static spec that silently omits them would be lying. That design choice was made before this measurement, and the measurement is the first time we can say how often it applies.
+
+## Reproducing it
+
+The scanner change is small: a new function that classifies the first argument of each `t.Run` and three new CSV columns. It is on the [research/subtest-naming branch](https://github.com/mvrahden/go-test/tree/research/subtest-naming/research/test-census), and the full rerun uses the pinned SHAs from the published dataset so every earlier number in the July post reproduces alongside the new ones.
+
+```sh
+go build -o test-census . && export PATH=$PWD:$PATH
+./run.sh corpus/census-full.csv results.csv 50
+```
+
+To measure one repository, point the binary at it:
+
+```sh
+test-census -out census.csv path/to/repo
+```
+
+The summary line reads `subtest names: 76.3% literal (100.0% of those prose, with a space) | 23.7% computed at runtime`, which is what gotest's own stdlib tests report, and which is the kind of number we would like to see the ecosystem move toward.
+
+[[Closing paragraph once numbers exist: what the July "structure demand" reading looks like with this column added; link to readable-tests-with-bdd as the practical follow-up.]]

--- a/site/content/blog/openspec-scenarios-gotest.md
+++ b/site/content/blog/openspec-scenarios-gotest.md
@@ -96,7 +96,7 @@ Cart
     when the discount exceeds 100 percent
       clamps to zero
 
-1 suites, 1 behaviors
+1 suite, 1 behavior
 {{< /spec >}}
 
 Nothing has run. This is the list of promises the code currently makes, read from source. Put it next to the delta spec and the missing coupon scenario is visible without reading any Go. The reconciliation program below does that comparison for you; for now, note that this is the point at which the spec and the test are the same document, and the document compiles.
@@ -121,7 +121,7 @@ Cart <span class="t-time">(<1ms)</span>
     when the discount exceeds 100 percent <span class="t-time">(<1ms)</span>
       <span class="t-pass">✓</span> clamps to zero <span class="t-time">(<1ms)</span>
 
-1 suites, 1 behaviors: 1 passed
+1 suite, 1 behavior: 1 passed
 {{< /spec >}}
 
 Same tree, now with verdicts. Every line that was a promise in step 3 is a result here, and the result came from executing the behavior, not from an agent's reading of the code.

--- a/site/content/blog/openspec-scenarios-gotest.md
+++ b/site/content/blog/openspec-scenarios-gotest.md
@@ -1,0 +1,205 @@
+---
+title: "Verify OpenSpec Scenarios by Running Them, in Go"
+date: 2026-09-10
+description: "OpenSpec says every scenario could become an automated test. In Go it can: GIVEN/WHEN/THEN becomes When/It, a run verifies it, and verify reads verdicts."
+tags: ["AI Engineering"]
+keywords: ["openspec go", "openspec testing", "openspec verify", "spec-driven development go", "spec kit go tests", "scenario coverage go"]
+cta_text: "Add the reconciliation command to your module."
+cta_command: "go get -tool github.com/mvrahden/go-test/cmd/gotest-openspec@latest"
+---
+
+[OpenSpec](https://openspec.dev/) is the most used spec-driven development framework right now, and its [writing guide](https://github.com/Fission-AI/OpenSpec/blob/main/docs/writing-specs.md) contains the sentence this post is built on: a scenario is "a concrete GIVEN / WHEN / THEN that could become an automated test." We are going to take that literally. In a Go repository with gotest, a scenario becomes a behavior with one transcription, a run turns it into a verdict, and `/opsx:verify` gets to read those verdicts instead of searching the code for evidence.
+
+[The previous post]({{< ref "/blog/spec-driven-development-go" >}}) made the argument. This one is the workflow, command by command, with a small program at the end that answers the question OpenSpec's verify step currently answers by opinion: which scenarios have a behavior, and did it pass?
+
+## The mapping
+
+OpenSpec specs are Markdown with two levels: a requirement stating what the system SHALL do, and scenarios giving concrete examples of it. gotest suites have four: a suite type as the subject, a method as the capability, `When` as the condition, and `It` as the outcome. They line up like this.
+
+| OpenSpec | gotest | Where it goes |
+|---|---|---|
+| spec file (`specs/cart/spec.md`) | suite type (`CartTestSuite`) | one struct per capability area |
+| `### Requirement:` | test method (`TestApplyDiscount`) | the SHALL sentence becomes the method's doc comment |
+| `#### Scenario:` | `When` + `It` | the scenario title is the `It` label, or the `When` label followed by the `It` label |
+| `- **GIVEN**` | `BeforeEach`, or an outer `When` | state the world is in before the action |
+| `- **WHEN**` | `When("…")` | the action, written as a condition without the word "when" |
+| `- **THEN**` | `It("…")` | the observable outcome |
+| `- **AND**` | a second `It` under the same `When` | outcomes are separate leaves so each gets its own verdict |
+
+Two conventions make the reconciliation at the end of the post work. First, the scenario title is written so that it reads as an outcome, or as a condition followed by an outcome. "the discount exceeds 100 percent clamps to zero" is a `When("the discount exceeds 100 percent")` around an `It("clamps to zero")`. Second, `When` labels are written as bare conditions. gotest renders the connective, so `When("the cart is empty")` shows as `when the cart is empty` everywhere, and its `behavior-wording` lint rule flags a label that spells the word itself. A GIVEN that opens with its own connective keeps it: `When("given an expired session")` renders as written.
+
+## The loop
+
+Here is an OpenSpec change for a cart, from proposal to archive, with gotest inserted at the two points where the tools currently ask an agent to form an opinion.
+
+### 1. Propose
+
+```sh
+/opsx:propose add discount clamping
+```
+
+The agent drafts `proposal.md`, `design.md`, `tasks.md` and the delta spec. The delta is what we care about:
+
+```md {title="openspec/changes/add-discount-clamping/specs/cart/spec.md"}
+## ADDED Requirements
+
+### Requirement: Discounts
+The cart SHALL apply percentage discounts and never charge a negative total.
+
+#### Scenario: the discount exceeds 100 percent clamps to zero
+- **WHEN** a discount over 100% is applied
+- **THEN** the total is zero
+
+#### Scenario: applies a coupon code
+- **WHEN** a valid coupon code is entered
+- **THEN** the coupon's discount is applied
+```
+
+You review this as OpenSpec intends. The review is the plan review, and nothing about it changes.
+
+### 2. Transcribe before implementing
+
+Add one task at the top of `tasks.md`: write the scenarios as gotest behaviors, with assertions, before any implementation. If the agent has the [writing-gotest-tests skill](https://github.com/mvrahden/go-test#coding-agents) loaded, it knows the shape:
+
+```go {title="cart_test.go"}
+type CartTestSuite struct {
+    cart *Cart
+}
+
+func (s *CartTestSuite) BeforeEach(t *gotest.T) {
+    s.cart = NewCart()
+    s.cart.Add("widget", 1, 10.00)
+}
+
+// The cart SHALL apply percentage discounts and never charge a negative total.
+func (s *CartTestSuite) TestApplyDiscount(t *gotest.T) {
+    t.When("the discount exceeds 100 percent", func(t *gotest.T) {
+        s.cart.ApplyDiscount(150)
+        t.It("clamps to zero", func(t *gotest.T) {
+            gotest.Equal(t, 0.0, s.cart.Total())
+        })
+    })
+}
+```
+
+Notice what is missing: the coupon scenario. The agent skipped it, or forgot it, or decided it was out of scope. In a Markdown-only workflow that omission surfaces when a reviewer notices, or when verify happens to grep for the right word. Here it surfaces in the next command.
+
+### 3. Read the declared spec
+
+```sh
+go tool gotest spec --static ./cart
+```
+
+{{< spec title="gotest spec --static ./cart" >}}
+Cart
+  ApplyDiscount
+    when the discount exceeds 100 percent
+      clamps to zero
+
+1 suites, 1 behaviors
+{{< /spec >}}
+
+Nothing has run. This is the list of promises the code currently makes, read from source. Put it next to the delta spec and the missing coupon scenario is visible without reading any Go. The reconciliation program below does that comparison for you; for now, note that this is the point at which the spec and the test are the same document, and the document compiles.
+
+### 4. Apply
+
+```sh
+/opsx:apply
+```
+
+The agent implements the tasks. This is where OpenSpec's fluidity matters: the agent learns while implementing, and when it learns that a negative percentage also needs handling, the right move is to add a `When` block, not to edit a Markdown file it may or may not remember to keep in sync. The delta spec gets the same scenario added, and step 6 will confirm that the two agree.
+
+### 5. Run
+
+```sh
+go tool gotest spec ./cart
+```
+
+{{< spec title="gotest spec ./cart" >}}
+Cart <span class="t-time">(<1ms)</span>
+  ApplyDiscount <span class="t-time">(<1ms)</span>
+    when the discount exceeds 100 percent <span class="t-time">(<1ms)</span>
+      <span class="t-pass">✓</span> clamps to zero <span class="t-time">(<1ms)</span>
+
+1 suites, 1 behaviors: 1 passed
+{{< /spec >}}
+
+Same tree, now with verdicts. Every line that was a promise in step 3 is a result here, and the result came from executing the behavior, not from an agent's reading of the code.
+
+### 6. Verify with verdicts, not opinions
+
+This is the step the whole post exists for. OpenSpec's `/opsx:verify` "searches codebase for implementation evidence" and reports what it finds as CRITICAL, WARNING or SUGGESTION. Replace the search with a join. `gotest-openspec` ships beside the CLI from v1.29.1 on; it reads the spec JSON on stdin and the specs directory as its argument, and prints one line per scenario:
+
+```sh
+go get -tool github.com/mvrahden/go-test/cmd/gotest-openspec@latest
+go tool gotest spec --format=json ./cart | go tool gotest-openspec openspec/specs
+```
+
+```text {title="output"}
+✓ verified     increases the item count
+✓ verified     merges the quantities
+✓ verified     the discount exceeds 100 percent clamps to zero
+? no behavior  applies a coupon code
+✓ verified     the cart is empty returns an error
+
+5 scenarios: 4 verified, 0 failing, 0 declared, 1 without a behavior
+```
+
+That output is from gotest's own [cart example](https://github.com/mvrahden/go-test/tree/main/examples/cart) reconciled against a five-scenario spec that ships [with the command's tests](https://github.com/mvrahden/go-test/blob/main/cmd/gotest-openspec/testdata/cart.md). The coupon scenario has no behavior, so the command exits 1. Pipe the static JSON instead and the verified lines read `· declared`, which is the same check before implementation. Point the agent at this output in `/opsx:verify` and its job shrinks to explaining the `?` lines, which is the part that needs judgment.
+
+We call the last line **scenario coverage**: the share of scenarios in the spec that have a behavior in the code, and of those, the share that passed. It is a small number to compute and it is the one the WARNING line in OpenSpec's example output is trying to estimate.
+
+### 7. Archive
+
+```sh
+/opsx:archive
+```
+
+The delta merges into `openspec/specs/`. The suite is already in `main`. From now on, the living spec and the living test say the same thing, and step 6 is the command that keeps it that way. Run it in CI after the test step and a scenario without a behavior fails the build the same way a failing behavior does.
+
+## The command
+
+It is one file with no dependencies beyond the standard library, small enough to read in a sitting. The full source is [in the repository](https://github.com/mvrahden/go-test/blob/main/cmd/gotest-openspec/main.go); the two pieces that matter are how it reads scenarios and how it matches them.
+
+```go {title="cmd/gotest-openspec/main.go"}
+var scenarioLine = regexp.MustCompile(`^#{3,4}\s+Scenario:\s*(.+?)\s*$`)
+
+// behaviors indexes every It leaf by its label and by "<condition> <label>",
+// so a scenario may spell its context too. Status is the leaf's verdict.
+func behaviors(tree specTree) map[string]string {
+    found := map[string]string{}
+    var walk func(n node, ctx string)
+    walk = func(n node, ctx string) {
+        switch n.Vocab {
+        case "it":
+            found[key(n.Display)] = n.Status
+            if ctx != "" {
+                found[key(ctx+" "+n.Display)] = n.Status
+            }
+        case "when":
+            ctx = strings.TrimPrefix(n.Display, "when ")
+        }
+        for _, c := range n.Children {
+            walk(c, ctx)
+        }
+    }
+    for _, p := range tree.Packages {
+        for _, n := range p.Nodes {
+            walk(n, "")
+        }
+    }
+    return found
+}
+```
+
+The `vocab` field is what makes this trivial. gotest's spec JSON records whether each node came from a `When` or an `It`, and the `display` field carries the label as the developer wrote it, with the connective rendered. Matching is case- and punctuation-insensitive, so "Clamps to zero." in the spec meets `It("clamps to zero")` in the code. Everything else is a walk over two trees.
+
+## If you use Spec Kit instead
+
+Spec Kit's [constitution](https://github.com/github/spec-kit/blob/main/spec-driven.md) is stricter than OpenSpec about this: "test scenarios aren't written after code, they're part of the specification", and Article III mandates that no implementation is written before tests exist and fail. That is steps 2 and 3 above, stated as policy. A gotest suite is the artifact Article III requires, and `gotest spec --static` is how you show a reviewer the red tests before anything is green. The reconciliation command reads any Markdown with `#### Scenario:` headings, so a Spec Kit `spec.md` written with that heading works unchanged.
+
+## What the agent reads back
+
+Two more commands close the loop from the agent's side. `gotest discover ./... --json` emits the same behavior tree with a `behaviorsComplete` flag per method, so an agent asked to "list what this package promises" can answer without running or reading the tests, and knows when the list is a floor rather than a total. And when a run fails, the [VS Code extension's]({{< ref "/blog/your-editor-knows-your-tests" >}}) copy-test-results command, filtered to failures, gives the agent the broken behaviors and their assertion messages in a few hundred bytes. The agent gets the spec as text, the tooling gets it as JSON, and neither has to guess what the other meant.
+
+An agent can claim a scenario is covered. Only a run can prove it. The scenarios were always meant to become tests; in Go, with one small command, they are the tests.

--- a/site/content/blog/spec-driven-development-go.md
+++ b/site/content/blog/spec-driven-development-go.md
@@ -71,7 +71,7 @@ Cart
     when the discount exceeds 100 percent
       clamps to zero
 
-1 suites, 1 behaviors
+1 suite, 1 behavior
 {{< /spec >}}
 
 That is the spec as declared so far. No verdicts, no durations, because nothing has executed. It is the artifact you review at the stage where OpenSpec has you review `proposal.md`, and it is already a compiling Go file. Then the implementation lands, and the same command without `--static` runs the suite:
@@ -85,7 +85,7 @@ Cart <span class="t-time">(<1ms)</span>
                 expected: 0
                 actual:   -5
 
-1 suites, 1 behaviors: 1 failed
+1 suite, 1 behavior: 1 failed
 {{< /spec >}}
 
 The scenario now carries a verdict, and the verdict came from execution rather than from an agent's reading of the code. Fix the clamp, run again, and the `✗` becomes a `✓`. Render with `--format=md` and the same tree becomes the document you attach to the pull request. [Go Tests as Living Documentation]({{< ref "/blog/tests-as-documentation" >}}) covers the terminal, Markdown and JSON forms; the point of this post is only that all three are views of one artifact, and that artifact is the test.

--- a/site/content/blog/spec-driven-development-go.md
+++ b/site/content/blog/spec-driven-development-go.md
@@ -1,0 +1,135 @@
+---
+title: "Specs Calcify. Tests Don't."
+date: 2026-09-10
+description: "Spec-driven development in Go without the waterfall: make the specification the test, so it grows with the code, a run verifies it, and it reads as prose."
+tags: ["AI Engineering"]
+keywords: ["spec-driven development go", "spec driven development", "executable specification go", "openspec go", "spec kit go", "tests as specification", "coding agents go tests"]
+cta_text: "Add gotest to your module, then read what your suites promise."
+cta_command: "go get -tool github.com/mvrahden/go-test/cmd/gotest@latest"
+---
+
+The loudest objection to spec-driven development is that it is waterfall with a chat window. "In that sense, SDD reminds me of the Waterfall model, which required massive documentation before coding so that developers could simply translate specifications into code," wrote François Zaninotto in [Spec-Driven Development: The Waterfall Strikes Back](https://marmelab.com/blog/2025/11/12/spec-driven-development-waterfall-strikes-back.html), and the [Hacker News thread](https://news.ycombinator.com/item?id=45935763) split down the middle over it. A second post put the same point more gently: "[You learn what you're building by trying to make a computer understand it](https://publish.obsidian.md/deontologician/Posts/Spec-driven+development+doesn%27t+work+if+you%27re+too+confused+to+write+the+spec)." A spec written before that learning is a guess, and a guess in a Markdown file has no way of finding out it is wrong.
+
+We think the critics are right about Markdown and wrong about specs. The problem is not that the spec exists before the code. The problem is that the spec lives somewhere the code cannot reach it. Move the spec into the one artifact the compiler and the build already enforce, the test, and every objection above turns into a feature. This post is about what that looks like in Go, and what it does not solve.
+
+## What the tools have in common
+
+Four tools define the practice today: GitHub's [Spec Kit](https://github.com/github/spec-kit), AWS's Kiro, Tessl, and [OpenSpec](https://openspec.dev/), which by its own published numbers is the most widely used. They differ in ceremony. Birgitta Böckeler's [review of the first three on martinfowler.com](https://www.martinfowler.com/articles/exploring-gen-ai/sdd-3-tools.html) watched Kiro's requirements document turn a small bug "into 4 'user stories' with a total of 16 acceptance criteria", and OpenSpec positions itself as the lightweight alternative to exactly that. They agree on three things.
+
+The spec is prose in a Markdown file. An agent turns the prose into code. And whether the code matches the prose is a judgment the agent makes by reading.
+
+That third point is the one to look at closely. Böckeler noted that "often it's left vague or totally open what the spec maintenance strategy over time is meant to be", and that Spec Kit's branch-per-spec layout treats a spec as "a living artifact for the lifetime of a change request, not the lifetime of a feature". OpenSpec answered the maintenance half of that: it keeps a living `openspec/specs/` folder, records each change as ADDED, MODIFIED and REMOVED requirements, and merges the deltas back on archive. That is real progress, and it is why OpenSpec is winning.
+
+The verification half is still open. OpenSpec's [`/opsx:verify`](https://github.com/Fission-AI/OpenSpec/blob/main/docs/commands.md) "searches codebase for implementation evidence" and lists "scenarios covered" as one of the things it checks. Its example output includes the line `⚠ Scenario "System preference detection" has no test coverage`. Nothing ran to produce that warning. An agent read the code, formed an opinion, and printed it. [Issue #880](https://github.com/Fission-AI/OpenSpec/issues/880) asks for a way to check code against the living specs at all, and it is labeled future roadmap.
+
+None of this is a complaint about OpenSpec. Its own [writing guide](https://github.com/Fission-AI/OpenSpec/blob/main/docs/writing-specs.md) says a scenario is "a concrete GIVEN / WHEN / THEN that could become an automated test", and that a good requirement is "one behavior, stated so plainly you could hand it to someone else to test". The tools know where the scenarios want to go. They just stop one step short of sending them there.
+
+An agent can claim a scenario is covered. Only a run can prove it. One commenter in the waterfall thread put it more strongly than we would: "Once specs are captured as tests, the LLM can no longer hallucinate." It can still hallucinate. It can no longer hallucinate quietly.
+
+## A spec that grows with the code
+
+Here is a scenario in the shape OpenSpec asks for:
+
+```md {title="openspec/specs/cart/spec.md"}
+### Requirement: Discounts
+The cart SHALL apply percentage discounts and never charge a negative total.
+
+#### Scenario: the discount exceeds 100 percent clamps to zero
+- **WHEN** a discount over 100% is applied
+- **THEN** the total is zero
+```
+
+And here is the same scenario as a gotest behavior:
+
+```go {title="cart_test.go"}
+type CartTestSuite struct {
+    cart *Cart
+}
+
+func (s *CartTestSuite) BeforeEach(t *gotest.T) {
+    s.cart = NewCart()
+    s.cart.Add("widget", 1, 10.00)
+}
+
+func (s *CartTestSuite) TestApplyDiscount(t *gotest.T) {
+    t.When("the discount exceeds 100 percent", func(t *gotest.T) {
+        s.cart.ApplyDiscount(150)
+        t.It("clamps to zero", func(t *gotest.T) {
+            gotest.Equal(t, 0.0, s.cart.Total())
+        })
+    })
+}
+```
+
+The suite is the subject, the method is the capability, `When` is the condition, `It` is the outcome. [BDD in Go]({{< ref "/blog/what-bdd-means-in-go" >}}) explains why those four map onto Go's type system rather than onto a DSL. What matters here is what you can do with the file before and after the implementation exists.
+
+Before anything runs, `gotest spec --static` reads the behaviors straight from source:
+
+{{< spec title="gotest spec --static ./cart" >}}
+Cart
+  ApplyDiscount
+    when the discount exceeds 100 percent
+      clamps to zero
+
+1 suites, 1 behaviors
+{{< /spec >}}
+
+That is the spec as declared so far. No verdicts, no durations, because nothing has executed. It is the artifact you review at the stage where OpenSpec has you review `proposal.md`, and it is already a compiling Go file. Then the implementation lands, and the same command without `--static` runs the suite:
+
+{{< spec title="gotest spec ./cart" >}}
+Cart <span class="t-time">(<1ms)</span>
+  ApplyDiscount <span class="t-time">(<1ms)</span>
+    when the discount exceeds 100 percent <span class="t-time">(<1ms)</span>
+      <span class="t-fail">✗</span> clamps to zero <span class="t-time">(<1ms)</span>
+          cart_test.go:18: Equal failed:
+                expected: 0
+                actual:   -5
+
+1 suites, 1 behaviors: 1 failed
+{{< /spec >}}
+
+The scenario now carries a verdict, and the verdict came from execution rather than from an agent's reading of the code. Fix the clamp, run again, and the `✗` becomes a `✓`. Render with `--format=md` and the same tree becomes the document you attach to the pull request. [Go Tests as Living Documentation]({{< ref "/blog/tests-as-documentation" >}}) covers the terminal, Markdown and JSON forms; the point of this post is only that all three are views of one artifact, and that artifact is the test.
+
+In Böckeler's terms this is spec-anchored development, with the anchor being the compiler. The spec cannot drift from the code because the spec is compiled with the code. It cannot be stale because CI runs it. It cannot claim a scenario is covered, because a scenario with no `It` is not in the spec, and an `It` that fails is in the spec with a `✗` beside it.
+
+## The three objections, taken seriously
+
+**You cannot enumerate scenarios before you build.** Correct, and nothing here asks you to. The static spec renders what is declared so far, not what should exist. When implementation teaches you that the discount also needs to reject negative percentages, you add a `When` block, and the spec grows by one line. The most-agreed objection to the [Verified Spec-Driven Development proposal](https://news.ycombinator.com/item?id=47197595) was that implementing is how you discover the edge cases, so a spec sealed before implementation is a guess. Treat the declared spec as a hypothesis, then. A hypothesis that compiles and runs is still a hypothesis. It is just one that tells you when it is wrong. gotest even reports the cases it cannot enumerate. A `When` inside a loop or an `Each` over a computed table shows up on stderr as `incomplete:` with a file and line, because a partial spec that presents itself as whole is worse than none.
+
+**Tests fix an API too early.** A commenter in the same thread warned that writing tests first "will cause the AI to hallucinate the API". This is true of tests whose names are function signatures. It is not true of behaviors, because the label is prose and the API call lives in the body. "when the discount exceeds 100 percent, clamps to zero" tells an agent what must hold, not which method to write. Two implementations with different signatures satisfy the same spec line, and the spec line is what the reviewer reads.
+
+**A spec carries intent that a test cannot.** Also correct. Why the discount is clamped rather than rejected, which alternative was considered, what the migration plan is, none of that belongs in a `When` block, and OpenSpec's `proposal.md` and `design.md` are the right place for it. What we are claiming is narrower: the scenarios are the part of the spec that moves. They are what an agent implements, what verify checks and what archive merges. That is the part worth making executable. The rest can stay prose, because prose is what it is for.
+
+## What it costs to read
+
+Agents read specs, and reading costs tokens. We measured the artifacts a model might be handed for the 23 suites and 111 behaviors in gotest's own [examples](https://github.com/mvrahden/go-test/tree/main/examples), in bytes, because byte counts are reproducible and token counts depend on the tokenizer.
+
+| Artifact | Bytes |
+|---|---|
+| `gotest spec --static --no-color` | 7,966 |
+| `gotest spec --no-color` (with verdicts) | 10,058 |
+| `gotest spec --format=md` | 14,882 |
+| the `_test.go` sources | 41,200 |
+| `go test -v` output | 50,441 |
+| `gotest spec --format=json` | 107,019 |
+
+The rendered spec is a third to a fifth the size of the sources it was read from, and it says what the sources promise rather than how they check it. The JSON is the largest artifact of all. It carries every node's status, timing, flags and captured output, which is what an editor or a script wants and what a model does not. Hand a model the text and hand a tool the JSON.
+
+## Where this stops
+
+Three limits, stated plainly.
+
+It is Go only. The scenario-to-behavior mapping depends on suites being structs and behaviors being nested calls the generator can read from source. Other languages have their own ways to do this. This is ours.
+
+The spec is only as good as its labels. A `When("case 3")` renders as `when case 3`, and no tool can make that mean anything. gotest pushes in the right direction, rendering the connective for you and flagging a `When("when …")` or an `It("it …")` with the `behavior-wording` lint rule, but the discipline of writing the condition and the outcome in words is yours. [The next post]({{< ref "/blog/openspec-scenarios-gotest" >}}) shows what happens when an agent does that transcription from OpenSpec scenarios, and how to check its work.
+
+And behaviors cover the behavioral requirements. "The parser SHALL not panic on any input" and "checkout SHALL complete within 200ms" are requirements too, and a `When`/`It` cannot state them. gotest's fuzz targets and benchmark gates can, and a later post in this series takes them up.
+
+If you want to see your own project through this lens, two commands get you there:
+
+```sh
+go get -tool github.com/mvrahden/go-test/cmd/gotest@latest
+go tool gotest spec --static ./...
+```
+
+The second one needs a package that already has suites. If none of yours do, the [migration guide]({{< ref "/blog/testify-migration-guide" >}}) turns a `testify/suite` into one in a single command, and the [writing-gotest-tests skill](https://github.com/mvrahden/go-test#coding-agents) teaches a coding agent to write the next one in this shape from the start.

--- a/site/content/blog/tests-as-documentation.md
+++ b/site/content/blog/tests-as-documentation.md
@@ -176,7 +176,7 @@ This works because the spec is not written separately from the tests. It *is* th
 
 ## Structured output for language models
 
-The JSON format from `gotest spec --format=json` contains the full behavioral tree of your project. Feeding this to an LLM gives it a structured understanding of what the system does — not how it's implemented, but what it promises. "UserService / Create / email is valid / creates the user" communicates the system's contract without requiring the model to parse implementation details. This is more compact and more reliable than feeding raw source code.
+The spec is also the right thing to hand a language model when you want it to understand what a system does — not how it's implemented, but what it promises. "UserService / Create / email is valid / creates the user" communicates the contract without asking the model to parse implementation details. Pick the format by the reader: the JSON from `--format=json` carries every node's status, timing, flags and captured output, which is what a script or an editor wants, and it is the largest of the artifacts — on gotest's own examples it is more than twice the size of the test sources. The terminal and Markdown renderings are a third to a fifth the size of those sources and say the same thing in prose, so they are what a model should read. [Specs Calcify. Tests Don't.]({{< ref "/blog/spec-driven-development-go" >}}) has the measurements.
 
 ## Tests that don't document themselves
 

--- a/site/content/blog/what-a-coding-agent-writes.md
+++ b/site/content/blog/what-a-coding-agent-writes.md
@@ -1,0 +1,91 @@
+---
+title: "What a Coding Agent Writes When You Ask for a Go Test"
+date: 2026-09-24
+draft: true
+description: "Same package, same prompt, thirty runs: how a coding agent's Go tests change with no guidance, with a one-line AGENTS.md, and with the gotest skill installed."
+tags: ["Research", "AI Engineering"]
+keywords: ["coding agent go tests", "claude code go testing", "ai generated tests go", "agent skills go", "cursor go tests quality"]
+cta_text: "Install the skill and ask your agent for the next test."
+cta_command: "mkdir -p .claude/skills && curl -sL https://github.com/mvrahden/go-test/archive/refs/heads/main.tar.gz | tar -xz -C .claude/skills --strip-components=2 go-test-main/skills/writing-gotest-tests"
+---
+
+<!--
+DRAFT. Every number marked [[…]] is a placeholder for the experiment described in
+research/agent-skill-experiment/ (branch research/subtest-naming). Run the protocol,
+paste results.csv into the tables, then choose the interpretation paragraphs.
+Do not publish with a placeholder left in.
+-->
+
+Ask a coding agent for a Go test and it writes one. It compiles, it passes, and it looks like the tests it learned from. That last part is the problem. The [July census]({{< ref "/blog/how-go-actually-tests" >}}) measured what those tests look like across the 1,000 most-starred Go repositories: 68% of repos sleep in tests, 64% hand-annotate helpers with `t.Helper()`, 11.2% of test functions run in parallel. An agent trained on that corpus reproduces that corpus. Ask it for a test of anything asynchronous and the odds of a `time.Sleep` are the odds in the data.
+
+We wanted to know how much of that an instruction can change, and which instruction. So we ran an experiment.
+
+## The setup
+
+One package, one prompt, three arms, ten runs each, every run in a fresh session with no memory of the others.
+
+**The package.** A rate limiter with a background refill goroutine and a file-backed audit log. It is [in the repository](https://github.com/mvrahden/go-test/tree/research/subtest-naming/research/agent-skill-experiment/target), about eighty lines, and it is built to tempt. Timing invites a sleep. The goroutine invites a data race. The log file invites `defer os.Remove`. The three behaviors the prompt asks for cannot be tested well without confronting all three.
+
+**The prompt**, identical in every run:
+
+> Write tests for package `ratelimit`. Cover the refill timing, the burst limit, and the audit log. Run them and make sure they pass.
+
+**The arms.**
+
+- **Bare.** No instructions in the repository beyond the package.
+- **AGENTS.md.** One sentence: "Tests in this repository use github.com/mvrahden/go-test suites." Nothing about how.
+- **Skill.** The [writing-gotest-tests skill](https://github.com/mvrahden/go-test#coding-agents) installed in `.claude/skills/`, and nothing else.
+
+**The scoring.** Every run's output is scored the same way the census scores a repository, by parsing, plus three checks that need execution:
+
+| Metric | How it is measured |
+|---|---|
+| compiles | `go vet` on the package |
+| passes | both runners green with `-race` (`go test` and `gotest`) |
+| sleeps | `time.Sleep` call sites in test code |
+| helper annotations | `t.Helper()` call sites |
+| ad hoc teardown | `defer` and `t.Cleanup` in test functions |
+| parallel | test functions or suites declared parallel |
+| prose names | subtest or behavior labels containing a space |
+| lint findings | `gotest lint` findings, for the arms that produce suites |
+
+The scoring script, the prompt, and the per-run outputs are in the same directory as the target, so the whole thing reruns with one command against whichever agent you use.
+
+## What came out
+
+[[Table: one row per arm, columns = the eight metrics above, values = mean over ten runs with min–max in parentheses. Add a row for the census baseline where a metric exists there (sleeps per repo, helper share, parallel share).]]
+
+[[Interpretation, chosen once the numbers exist. The three readings we expect to choose among:
+- The bare arm reproduces the census: sleeps in most runs, helpers annotated, nothing parallel, teardown by defer. That is the training data speaking.
+- The AGENTS.md arm changes the framework and little else: suites appear, but the sleeps and the defers come along, because one sentence says what to use and nothing about how. This is the most important row if it holds: naming the tool is not the same as teaching it.
+- The skill arm removes the sleeps (Eventually), the helpers (automatic attribution), and the defers (BeforeEach/AfterEach), and parallelizes when the recipe allows. The interesting failures are the ones the skill did not prevent; list them honestly.]]
+
+[[One paragraph on the runs that did not pass, per arm, and why. Agents that wrote a flaky sleep and got a green run by luck count as passing; note how many.]]
+
+## What the skill actually says
+
+The skill is a Markdown file the agent reads before it starts. It does not contain examples to copy. It contains the rules that invert the habits above, with the reason for each, because an agent that knows why is harder to argue out of it mid-task. The four that did the most work in this experiment:
+
+- **Lifecycle hooks own resources.** Setup in `BeforeEach`, teardown in `AfterEach`, never `defer` or `t.Cleanup` in a test method. A `defer` lints clean and still skips teardown verification and blocks parallelization.
+- **Poll, never sleep.** `Eventually` with a deadline and a tick, asserting a stable fixed point rather than a transient state.
+- **Ask why the suite is not parallel.** The recipe is five lines, and the skill names the two legitimate reasons to stay sequential so the agent does not invent a third.
+- **Write the condition, not the connective.** `When("the bucket is empty")`, so the spec renders `when the bucket is empty` and the behavior reads as a sentence.
+
+Each rule is tagged with the gotest version it needs, and the skill tells the agent to check the version first, because advice for v1.29 applied to a v1.26 pin fails in ways the agent cannot see.
+
+## Why this is a spec-driven development post
+
+The [first post in this series]({{< ref "/blog/spec-driven-development-go" >}}) argued that the spec should be the test, because a test is the one spec a run can verify. That argument has a dependency it did not state: the tests have to be good enough to be a spec. A test that sleeps for a second and asserts a transient state is a spec of nothing. A test named `TestRefill2` is a spec nobody can read.
+
+[[Sentence with the prose-names number: in the skill arm, [[P]]% of behaviors read as sentences; in the bare arm, [[Q]]% of subtests did.]] The agent that writes the spec is the agent you gave the rules to. The experiment above is what those rules are worth, in numbers you can reproduce.
+
+## Reproducing it
+
+```sh
+git clone -b research/subtest-naming https://github.com/mvrahden/go-test
+cd go-test/research/agent-skill-experiment
+./run.sh bare 10 && ./run.sh agentsmd 10 && ./run.sh skill 10
+./score.sh runs/ > results.csv
+```
+
+`run.sh` prepares a fresh copy of the target for each run and prints the prompt to paste into your agent; the session itself is yours to drive, because the point is to measure the agent you use. `score.sh` parses every run's test files with the census scanner, runs both runners with `-race`, and writes one CSV row per run. Send us yours.


### PR DESCRIPTION
Two posts ready to publish and two data drafts. "Specs Calcify. Tests Don't." makes the argument against Markdown specs and for executable ones, with every quote verified against its source. "Verify OpenSpec Scenarios by Running Them, in Go" is the workflow, ending in `gotest-openspec`, so merge after that command ships. The two drafts wait on the census rerun and the agent experiment. Also corrects the older Living Documentation post, which claimed the JSON spec is more compact than source; measured, it is the largest artifact. New tag: AI Engineering.